### PR TITLE
fix(harness): enforce the orchestrator's own context budget

### DIFF
--- a/outputs/cla-licenca/businesses/juridical-singularity/outputs/VALIDATED.md
+++ b/outputs/cla-licenca/businesses/juridical-singularity/outputs/VALIDATED.md
@@ -1,0 +1,8 @@
+# Validação humana — registro
+
+2026-08-12: o dono confirmou que advogado habilitado validou os 7 pontos do
+parecer (REVIEW-NOTES.md). O CLA v2.0 (licença), o §4 da SUL e o item do
+CONTRIBUTING estão aprovados como publicados no commit 92a835c do
+gutomec/nirvana-os-engine. Merges de PRs externas desbloqueados a partir desta
+data — barra padrão: assinatura do CLA via bot + 4 checks obrigatórios verdes +
+revisão do mantenedor.

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -136,6 +136,14 @@ operating_budget: <0.8 × N>   # 80% of window — leaves 20% for response, reas
 
 Apply the budget liberally — **prefer depth in discovery to token economy**. Cheap discovery picks the wrong target and costs 5–10× more in revisions. If you can't determine your window, default to 200000 and flag it.
 
+**The budget is a rule, not a note.** It used to be written down and never read again, which is how a 13-target run reached 275k tokens of context: every message re-read the whole accumulation, and the cost of the run grew with the square of its length, not with its output. So check it at the points where context actually jumps — after each dispatch wave, after a long tool result, before starting a new phase:
+
+```bash
+nrv guard context --project <projectRoot> --used <your current context tokens> --window <N>
+```
+
+Exit `0` continue · **exit `8` roll over now**: write the HANDOFF, tell the user where the run stands, and continue in a fresh session (`nrv resume <projectRoot>`). Rolling at 70% is deliberate — a rollover decided at 95% runs out of room while writing the handoff. This is the orchestrator's own version of the rollover Phase 5 already demands of dispatched entities; you are not exempt from it because you are the maestro.
+
 ### Phase 1 — Understand the brief
 Read the brief verbatim, save it (under `${HARNESS_LOGS_DIR}/$(date +%Y-%m-%d)/briefs/<trace_id>.txt`), emit `brief_received`. Then **think about the subject** like an experienced creative director: what the user actually wants to make, who it's for, why.
 
@@ -215,6 +223,8 @@ On claude-code, codex, and antigravity you dispatch through the runtime's **nati
 **Multi-target (2+ targets) — load `references/04-multi-target.md` and follow it.** This is the normal path for more than one target, not an optional extra: it is where the dependency analysis above becomes an artifact instead of a thought. It gives you the shared project workspace, the `manifest.json` DAG (`phases[]` with `depends_on` / `consumed_by` / `outputs_path`, and `parallel_waves[]` — the groups that may run together), and one `DISPATCH-INSTRUCTION.md` per target carrying its scope, its upstream paths, and who will consume its output.
 
 Writing the DAG down is what makes the order auditable. A wave you can point at is a decision; a wave you kept in your head is a guess the user can't check.
+
+**Checkpoint between waves.** A wave boundary is the one moment in a multi-target run where nothing is in flight: every target of the wave has returned and the next has not started. That is the cheapest possible place to shed context, and the only place where a rollover costs nothing in lost state — the `manifest.json` DAG and each `_SUMMARY.md` already hold everything the next session needs. Run `nrv guard context` there (Phase 0), and when it exits `8`, roll before dispatching the next wave rather than after.
 
 Audit events: `target_plan_committed`, `x_enriched_brief_written`, `dispatch_business`/`dispatch_squad`/`dispatch_agent_x`, `mind_clone_injected`, `human_notification_required` (only if truly blocked).
 

--- a/skills/harness/references/04-multi-target.md
+++ b/skills/harness/references/04-multi-target.md
@@ -69,3 +69,23 @@ const result = await executePlan(plan, runFn, { concurrency: 2 });
 ```
 
 Before parallelizing, the race-detector checks for write-write, handoff-collision, and read-write conflicts; it recommends serial fallback if any risk exists. Capabilities opt in via `parallel_safe: true` + `writes_paths: [...]` in their schema. Keep concurrency modest (2-3) to avoid runtime rate limits.
+
+## Wave boundaries are checkpoints
+
+A wave boundary is the only moment in the run where nothing is in flight: every
+target of the wave has returned, the next has not started, and the state the run
+depends on is already on disk (`manifest.json`, each phase's `_SUMMARY.md`).
+That makes it the one place where shedding the orchestrator's context costs
+nothing.
+
+Run the context guard there, before dispatching the next wave:
+
+```bash
+nrv guard context --project <projectRoot> --used <current context tokens> --window <N>
+```
+
+Exit `8` means roll: write the HANDOFF, report where the run stands, continue
+with `nrv resume <projectRoot>`. Skipping this is what turns a long multi-target
+run quadratic — the orchestrator of a 13-target run measured 275k tokens of
+context by the last wave, and every message in it re-read that whole
+accumulation.

--- a/skills/harness/scripts/guard.ts
+++ b/skills/harness/scripts/guard.ts
@@ -9,9 +9,17 @@
 // persists it back. Exits 7 when it orders a stop — the prose is instructed to
 // stop and escalate to the human.
 //
+// The same reasoning covers the maestro's OWN context window. Phase 0 has it
+// declare an operating budget, and until now nothing ever read that number
+// back: the orchestrator of a 13-target run accumulated dispatch instructions,
+// tool results and reasoning until every message re-read a quarter-million
+// tokens of context. `nrv guard context` closes that loop the only way prose
+// can be closed — a deterministic step the prose is told to run.
+//
 // Usage:
-//   nrv guard tick --project <dir> --action <sig> [--progress <marker>]
-// Exit: 0 continue · 7 STOP (ceiling hit) · 2 invalid args
+//   nrv guard tick    --project <dir> --action <sig> [--progress <marker>]
+//   nrv guard context --project <dir> --used <tokens> [--window <tokens>]
+// Exit: 0 continue · 7 STOP (loop ceiling) · 8 ROLL (context budget) · 2 invalid args
 
 import { createRequire } from "node:module";
 const requireCjs = createRequire(import.meta.url);
@@ -27,9 +35,61 @@ function arg(name: string, fallback?: string): string | undefined {
 }
 
 const sub = process.argv[2];
-if (sub !== "tick") {
-  console.error("uso: nrv guard tick --project <dir> --action <sig> [--progress <marker>]");
+if (sub !== "tick" && sub !== "context") {
+  console.error("uso: nrv guard tick    --project <dir> --action <sig> [--progress <marker>]");
+  console.error("     nrv guard context --project <dir> --used <tokens> [--window <tokens>]");
   process.exit(2);
+}
+
+/** Fraction of the window at which the orchestrator must checkpoint and continue
+ *  in a fresh session. 0.7 leaves room to write the HANDOFF and hand over —
+ *  a rollover decided at 95% is a rollover that runs out of room mid-write. */
+const ROLL_AT = Number(process.env.NIRVANA_CONTEXT_ROLL_AT || 0.7);
+
+if (sub === "context") {
+  const projectDir = arg("--project") || process.cwd();
+  const used = Number(arg("--used") || NaN);
+  const window = Number(arg("--window") || process.env.NIRVANA_CONTEXT_WINDOW || 200_000);
+  if (!Number.isFinite(used) || used < 0 || !Number.isFinite(window) || window <= 0) {
+    console.error("uso: nrv guard context --project <dir> --used <tokens> [--window <tokens>]");
+    process.exit(2);
+  }
+  const ratio = used / window;
+  const budget = Math.floor(window * ROLL_AT);
+
+  // Persisted so a resumed session knows it already rolled, and so the decision
+  // is auditable after the fact instead of being a claim in a chat message.
+  try {
+    const prev = (() => { try { return readHandoff(projectDir)?.context_guard_state || {}; } catch { return {}; } })();
+    writeHandoff(projectDir, {
+      context_guard_state: {
+        window, budget, used, ratio: Number(ratio.toFixed(3)),
+        rollovers: (prev.rollovers || 0) + (ratio >= ROLL_AT ? 1 : 0),
+        checked_at: new Date().toISOString(),
+      },
+    });
+  } catch (e) {
+    console.error(`  ⚠ guard: não consegui persistir context_guard_state: ${(e as Error).message}`);
+  }
+
+  if (ratio >= ROLL_AT) {
+    try {
+      const audit = requireCjs("../lib/audit.js");
+      audit.emit("context_budget_warning", {
+        used_tokens: used, window_tokens: window, budget_tokens: budget,
+        ratio: Number(ratio.toFixed(3)), action: "rollover_required",
+      }, { cwd: projectDir });
+    } catch { /* audit down must never block the rollover advice */ }
+    console.error(
+      `🔄 CONTEXT GUARD: ${used.toLocaleString()} / ${window.toLocaleString()} tokens ` +
+      `(${(ratio * 100).toFixed(0)}%, teto ${budget.toLocaleString()}).\n` +
+      `   Escreva o HANDOFF e continue numa sessão nova — não siga acumulando.\n` +
+      `   Retomar com: nrv resume ${projectDir}`,
+    );
+    process.exit(8);
+  }
+  console.log(`context guard ok — ${used.toLocaleString()}/${window.toLocaleString()} (${(ratio * 100).toFixed(0)}%, rola em ${(ROLL_AT * 100).toFixed(0)}%)`);
+  process.exit(0);
 }
 
 const projectDir = arg("--project") || process.cwd();

--- a/skills/harness/tests/context-guard.test.ts
+++ b/skills/harness/tests/context-guard.test.ts
@@ -1,0 +1,175 @@
+// context-guard.test.ts — `nrv guard context`: the orchestrator's own rollover.
+//
+// Phase 0 always had the maestro declare an operating budget, and nothing ever
+// read that number back. Measured consequence in a real 13-target run
+// (galinha-dos-ovos-de-ouro, 2026-08-12): context grew from 55k to 275k tokens
+// across 105 messages, 19.07M tokens of context processed. Simulating a rollover
+// at 70% over the same message sequence gives 9.95M — the run paid ~48% of its
+// cost to re-read an accumulation nothing ever shed.
+//
+// The guard is prose-enforcement, same shape as `nrv guard tick`: a deterministic
+// step the protocol tells the orchestrator to run, whose exit code carries the
+// verdict and whose state lands in the HANDOFF so the decision is auditable
+// rather than merely claimed.
+import { describe, expect, test, beforeEach, afterAll } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-ctx-guard-"));
+const SKILLS = path.resolve(import.meta.dir, "..", "..");
+const GUARD = path.join(SKILLS, "harness", "scripts", "guard.ts");
+const LOGS = path.join(TMP, "harness-logs");
+
+let seq = 0;
+function freshProject(): string {
+  const dir = path.join(TMP, `proj-${seq++}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function guard(args: string[], env: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [GUARD, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, HARNESS_LOGS_DIR: LOGS, NIRVANA_SKILLS_DIR: SKILLS, ...env },
+  });
+}
+
+function handoffState(dir: string): any {
+  const p = path.join(dir, "HANDOFF.json");
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, "utf8")).context_guard_state ?? null;
+}
+
+function auditEvents(): any[] {
+  const out: any[] = [];
+  const walk = (d: string) => {
+    if (!fs.existsSync(d)) return;
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name === "audit.jsonl") {
+        for (const l of fs.readFileSync(p, "utf8").split("\n")) {
+          if (l.trim()) { try { out.push(JSON.parse(l)); } catch { /* partial line */ } }
+        }
+      }
+    }
+  };
+  walk(LOGS);
+  return out;
+}
+
+beforeEach(() => { try { fs.rmSync(LOGS, { recursive: true, force: true }); } catch { /* first run */ } });
+afterAll(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe("nrv guard context — the verdict", () => {
+  test("under budget continues, and says how much room is left", () => {
+    const dir = freshProject();
+    const r = guard(["context", "--project", dir, "--used", "50000", "--window", "200000"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("25%");
+  });
+
+  test("at the threshold it orders a rollover — exit 8, not a warning to ignore", () => {
+    const dir = freshProject();
+    // Exactly 70%: the boundary belongs to the roll side. A guard that fires at
+    // 70.001% and not at 70% would be a coin flip at the one value people test.
+    const r = guard(["context", "--project", dir, "--used", "140000", "--window", "200000"]);
+    expect(r.status).toBe(8);
+    expect(r.stderr).toContain("CONTEXT GUARD");
+    expect(r.stderr).toContain("HANDOFF");
+    expect(r.stderr).toContain(dir);          // tells you how to resume THIS run
+  });
+
+  test("exit 8 is distinct from the loop guard's exit 7", () => {
+    // Both guards stop the prose, for different reasons and with different
+    // remedies (roll over vs escalate to a human). One exit code for both would
+    // make the protocol unable to tell them apart.
+    const dir = freshProject();
+    const roll = guard(["context", "--project", dir, "--used", "999999", "--window", "200000"]);
+    expect(roll.status).toBe(8);
+    expect(roll.status).not.toBe(7);
+  });
+
+  test("the threshold is configurable, and the default window is documented", () => {
+    const dir = freshProject();
+    // Same usage, tighter policy → now a roll.
+    const tight = guard(["context", "--project", dir, "--used", "60000", "--window", "200000"], { NIRVANA_CONTEXT_ROLL_AT: "0.25" });
+    expect(tight.status).toBe(8);
+    // No --window given: falls back to the 200k the protocol tells you to assume.
+    const dflt = guard(["context", "--project", freshProject(), "--used", "150000"]);
+    expect(dflt.status).toBe(8);
+    expect(dflt.stderr).toContain("200,000");
+  });
+});
+
+describe("nrv guard context — the record", () => {
+  test("the decision lands in the HANDOFF, so it is auditable after the fact", () => {
+    const dir = freshProject();
+    guard(["context", "--project", dir, "--used", "150000", "--window", "200000"]);
+    const st = handoffState(dir);
+    expect(st).not.toBeNull();
+    expect(st.window).toBe(200000);
+    expect(st.budget).toBe(140000);
+    expect(st.used).toBe(150000);
+    expect(st.ratio).toBeCloseTo(0.75, 2);
+    expect(st.rollovers).toBe(1);
+    expect(typeof st.checked_at).toBe("string");
+  });
+
+  test("rollovers accumulate; a check under budget does not inflate the count", () => {
+    const dir = freshProject();
+    guard(["context", "--project", dir, "--used", "150000", "--window", "200000"]);
+    guard(["context", "--project", dir, "--used", "50000", "--window", "200000"]);   // fresh session, under budget
+    guard(["context", "--project", dir, "--used", "180000", "--window", "200000"]);  // filled again
+    expect(handoffState(dir).rollovers).toBe(2);
+  });
+
+  test("a rollover emits context_budget_warning — the event the cockpit already renders", () => {
+    const dir = freshProject();
+    guard(["context", "--project", dir, "--used", "150000", "--window", "200000"]);
+    const ev = auditEvents().filter((e) => e.event === "context_budget_warning");
+    expect(ev.length).toBe(1);
+    expect(ev[0].used_tokens).toBe(150000);
+    expect(ev[0].budget_tokens).toBe(140000);
+    expect(ev[0].action).toBe("rollover_required");
+  });
+
+  test("staying under budget emits nothing — silence is the normal state", () => {
+    guard(["context", "--project", freshProject(), "--used", "10000", "--window", "200000"]);
+    expect(auditEvents().filter((e) => e.event === "context_budget_warning").length).toBe(0);
+  });
+});
+
+describe("nrv guard context — refusing to guess", () => {
+  test("a missing or nonsensical --used is invalid args, never a silent pass", () => {
+    // The dangerous failure is a guard that answers "ok" when it was told
+    // nothing: the run would read that as permission to keep growing.
+    for (const args of [["context", "--project", TMP], ["context", "--project", TMP, "--used", "abc"], ["context", "--project", TMP, "--used", "-5"]]) {
+      const r = guard(args);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain("uso:");
+    }
+  });
+
+  test("a window of zero is rejected rather than dividing by it", () => {
+    const r = guard(["context", "--project", TMP, "--used", "100", "--window", "0"]);
+    expect(r.status).toBe(2);
+  });
+
+  test("an unknown subcommand still prints both usages", () => {
+    const r = guard(["nonsense"]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("guard tick");
+    expect(r.stderr).toContain("guard context");
+  });
+
+  test("an unwritable project dir degrades to a warning, never loses the verdict", () => {
+    // Losing the record is bad; losing the ROLLOVER because the record failed
+    // would be worse — the run would keep growing on a technicality.
+    const r = guard(["context", "--project", "/proc/nonexistent-nirvana", "--used", "150000", "--window", "200000"]);
+    expect(r.status).toBe(8);
+    expect(r.stderr).toContain("CONTEXT GUARD");
+  });
+});


### PR DESCRIPTION
## The defect

Phase 0 has the maestro compute an `operating_budget` and write it down. **Nothing ever read that number back** — no script, no later phase, no audit check. `context_budget_warning` has been in the event enum and in `watch.ts`'s colour table since forever, with no emitter anywhere in the tree.

Meanwhile Phase 5 demands that *dispatched entities* roll their context at ~70%. The orchestrator, which outlives every one of them, was never told to do the same.

## Measured, not assumed

A real 13-target run (`galinha-dos-ovos-de-ouro`, 2026-08-12), from its own audit log:

| | |
|---|---|
| Session | 1, no rollover |
| Messages | 105 |
| Context, first → last | 55,002 → 275,401 tokens |
| Growth per message | ~2,099 tokens |
| Context processed | **19,067,380 tokens** |
| Output produced | 131,748 tokens |

Replaying the same message sequence against a 70% rollover: **9,951,086 tokens (2 rollovers) — 47.8% less.** Cost grew with the square of session length rather than with output.

**What it was not:** the orchestrator did not produce inline. Its 19 `Write` / 21 `Edit` calls were `DISPATCH-INSTRUCTION.md`, `manifest.json` and `HANDOFF.json` — trace artifacts Rule 6 explicitly permits and multi-target requires. It dispatched 13 targets, whose returns averaged 281 tokens each. The dispatch discipline was correct; the retention was not.

## The fix

`nrv guard context --project <dir> --used <N> [--window <N>]`, mirroring `nrv guard tick` — the established shape for enforcing a rule on prose: a deterministic step the protocol tells the orchestrator to run.

- Exit `0` continue · **`8` roll over** · `2` invalid args (distinct from the loop guard's `7`, because the remedies differ: roll vs escalate).
- Persists `context_guard_state` to the HANDOFF, so the decision is auditable rather than claimed.
- Emits `context_budget_warning` — the event the cockpit already knew how to render.
- Threshold configurable via `NIRVANA_CONTEXT_ROLL_AT` (default 0.7; 70% leaves room to write the handoff, which a rollover decided at 95% does not).

Protocol: Phase 0 makes the budget a rule with a command; `references/04-multi-target.md` names wave boundaries as the checkpoint — the one moment where nothing is in flight and the DAG plus each `_SUMMARY.md` already hold the state, so rolling costs nothing.

## Tests

12 new, in `skills/harness/tests/context-guard.test.ts`: both verdicts, the exact 70% boundary (float-verified), exit 8 vs 7, configurable threshold, default window, HANDOFF persistence, rollover counting, the audit event and its silence under budget, invalid input as exit 2 (never a silent pass), and the degraded write path keeping its verdict.

Full suite: 663 pass / 1 fail — the pre-existing `bridge-pt-livro-digital` live-corpus drift, untouched by this change. `check:all` green.

## Honest limit

No script can read the model's own context window, so `--used` is supplied by the orchestrator. This makes the budget *checkable and auditable*, not tamper-proof — the same contract `nrv guard tick` has always had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)