### PR TITLE
fix(protocol): gate on return, not at the end of the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The gate waited for the slowest sibling
+
+Phase 6 opened with "Before declaring done, run TWO checks in order". For one
+target that reads fine; for a wave it means nothing gets checked until everything
+is home. Measured on a real run: one target returned at 04:51:15, its sibling at
+05:05:27, and both were gated in a single loop at 05:06 — the first target's
+output sat fourteen minutes unverified.
+
+The wall clock is the small part. A failure found late cannot be fixed
+concurrently: a revision that could have run alongside its still-working
+siblings becomes another serial round. The gate is now anchored to a target
+handing back its work, per target, before the next dispatch goes out.
+
 ## 0.3.5 — 2026-08-13
 
 ### Dispatched work never came back

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,21 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### O gate esperava o irmão mais lento
+
+A Phase 6 começava com "antes de declarar pronto, rode DUAS checagens". Para um
+alvo só, isso lê bem; para uma onda, significa que nada é conferido até tudo
+voltar. Medido num run real: um alvo voltou às 04:51:15, o irmão às 05:05:27, e
+os dois foram julgados num laço só às 05:06 — a saída do primeiro ficou quatorze
+minutos sem conferência.
+
+O relógio é a parte pequena. Uma falha descoberta tarde não pode mais ser
+corrigida em paralelo: uma revisão que poderia ter rodado junto com os irmãos
+ainda trabalhando vira mais uma rodada em série. O gate agora está ancorado no
+alvo devolvendo o trabalho, por alvo, antes do próximo dispatch sair.
+
 ## 0.3.5 — 2026-08-13
 
 ### O trabalho despachado nunca voltava

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -256,7 +256,13 @@ Memory is scoped, because a lesson is only as portable as the assumptions under 
 **Promotion is proposed, not taken.** When a lesson genuinely holds beyond this project — true for any project this business runs, carrying no client-specific or one-off assumption — list it in the final report as a **promotion candidate**, with the level you'd promote it to and the reason it generalizes. The human promotes it (`*business memory edit` for business level). You never promote it yourself: judging whether your own lesson generalizes is exactly the judgment a model is worst at, and a wrong promotion is paid for silently by every later project.
 
 ### Phase 6 — Quality gate
-**MANDATORY.** Before declaring done, run TWO checks in order:
+**MANDATORY, and it runs the moment a target returns — not at the end of the run.**
+
+The trigger is a target handing back its work, and the gate runs on *that* target's output before you dispatch anything else. Batching the checks until every target is home is the failure this timing exists to prevent: measured on a real run, one target returned at 04:51:15 and its siblings at 05:05:27, so the first target's output sat **fourteen minutes unverified** and both were finally gated in a single loop at 05:06. The wasted wall clock is the small part. The real cost is that a failure discovered late can no longer be fixed concurrently — a revision that could have run alongside its still-working siblings becomes another serial round.
+
+So: a business finishes, the gate runs on what it produced, and only then does the next dispatch go out. In a wave, gate each return as it lands; you do not wait for the slowest sibling to start checking the fastest.
+
+Run TWO checks in order:
 
 **1. Deliverable verification** — disk-truth:
 ```bash

--- a/skills/harness/references/04-multi-target.md
+++ b/skills/harness/references/04-multi-target.md
@@ -85,6 +85,18 @@ is reduced to scanning the output directory to guess what finished. Measured on
 a real 13-target run: 13 dispatches, 13 launch receipts, zero results, and a
 9-hour wall clock spent largely on polling.
 
+## Gate each return, not the wave
+
+A wave returns its targets together only when they finish together, which they
+rarely do. Each result that lands is verified and gated immediately — on its own
+output, before the next dispatch — so a target that fails is re-dispatched while
+its siblings are still working, instead of after everyone is home.
+
+Waiting for the wave to complete before checking anything looks tidier and costs
+a full serial round on every failure. Measured on a real run: first return
+04:51:15, last return 05:05:27, both gated at 05:06 in one loop — fourteen
+minutes in which a rejected artifact would have gone unnoticed and unfixed.
+
 ## Wave boundaries are checkpoints
 
 A wave boundary is the only moment in the run where nothing is in flight: every

--- a/skills/harness/tests/gate-timing.test.ts
+++ b/skills/harness/tests/gate-timing.test.ts
@@ -1,0 +1,79 @@
+// gate-timing.test.ts — the quality gate is anchored to a target's RETURN,
+// not to the end of the run.
+//
+// Phase 6 used to open with "Before declaring done, run TWO checks in order".
+// In a single-target brief that reads fine. In a multi-target run it batches:
+// nothing is checked until everything is home. Measured on a real run
+// (galinha-dos-ovos-de-ouro, 2026-08-13): first target returned 04:51:15, its
+// sibling at 05:05:27, and both were gated in one loop at 05:06 — the first
+// target's output sat fourteen minutes unverified.
+//
+// The wall clock is the small part. A failure found late cannot be fixed
+// concurrently: a revision that could have run alongside still-working siblings
+// becomes another serial round. So the trigger is the return, per target.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const harness = fs.readFileSync(path.join(ROOT, "skills/harness/SKILL.md"), "utf8");
+const multi = fs.readFileSync(path.join(ROOT, "skills/harness/references/04-multi-target.md"), "utf8");
+
+/** Phase 6's opening lines — where the timing is set. */
+function phase6(): string {
+  const start = harness.indexOf("### Phase 6 — Quality gate");
+  const end = harness.indexOf("### Phase 7");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return harness.slice(start, end);
+}
+
+describe("Phase 6 fires on return", () => {
+  test("the timing is stated in the heading area, not left to inference", () => {
+    const p6 = phase6();
+    expect(p6).toMatch(/the moment a target returns/i);
+    expect(p6).toMatch(/not at the end of the run/i);
+  });
+
+  test("the old end-of-run anchor is gone", () => {
+    // "Before declaring done" is what produced the batching: it names the end of
+    // the whole run as the trigger, so a multi-target run naturally waits.
+    expect(phase6()).not.toMatch(/\*\*MANDATORY\.\*\* Before declaring done/);
+  });
+
+  test("gating the next dispatch on the previous check is explicit", () => {
+    // Without this the instruction reads as advisory and the orchestrator keeps
+    // dispatching while unverified output piles up.
+    expect(phase6()).toMatch(/before you dispatch anything else|only then does the next dispatch/i);
+  });
+
+  test("a wave gates each return rather than waiting for the slowest sibling", () => {
+    expect(phase6()).toMatch(/gate each return as it lands/i);
+    expect(multi).toMatch(/Gate each return, not the wave/);
+  });
+
+  test("the reason a late failure costs more is stated, not just the latency", () => {
+    // The latency alone would not justify the rule; the serialisation of the fix
+    // is the actual cost, and an instruction that omits its reason gets dropped
+    // the first time it is inconvenient.
+    const both = phase6() + multi;
+    expect(both).toMatch(/concurrent|alongside its still-working siblings|while its siblings are still working/i);
+    expect(both).toMatch(/serial round/i);
+  });
+});
+
+describe("the rule keeps its evidence", () => {
+  test("both documents cite the measurement that produced the rule", () => {
+    // Rules whose evidence is stripped get re-litigated. These timestamps are
+    // from the run that exposed the batching.
+    expect(phase6()).toContain("04:51:15");
+    expect(multi).toContain("05:05:27");
+  });
+
+  test("the two mandatory checks survived the rewrite", () => {
+    const p6 = phase6();
+    expect(p6).toContain("verify-deliverable.ts");
+    expect(p6).toContain("quality-gate.ts");
+    expect(p6).toMatch(/Without verify=PASS, no `gate_passed` is legitimate/);
+  });
+});


### PR DESCRIPTION
## The defect

Phase 6 opened with:

> **MANDATORY.** Before declaring done, run TWO checks in order

"Before declaring done" anchors verification to the end of the **whole run**. For a single target that reads fine. For a wave it batches — nothing is checked until everything is home.

## Measured

A real run, `galinha-dos-ovos-de-ouro`, 2026-08-13:

```
04:51:15  P0  returned
05:05:27  P9e returned          ← 14m12s later
05:06:00  gate  (one `for f in ...` loop over both)
```

P0's output sat **14 minutes 45 seconds unverified**.

The wall clock is the small part. A failure found late cannot be fixed concurrently: a revision that could have run alongside its still-working siblings becomes another serial round — precisely the serialisation the wave structure exists to avoid.

## The fix

The trigger is a target handing back its work. A business finishes, the gate runs on what it produced, and only then does the next dispatch go out. In a wave, each return is gated as it lands; you do not wait for the slowest sibling to start checking the fastest.

Same rule added to `references/04-multi-target.md` where waves are described.

Both mandatory checks (`verify-deliverable` then `quality-gate`) are unchanged — only their timing moved.

## Tests

7 in `skills/harness/tests/gate-timing.test.ts`: the stated timing, the removal of the old end-of-run anchor, the next-dispatch dependency, the per-return wave rule, the stated *reason* (a rule without its reason gets dropped the first time it is inconvenient), the measured evidence surviving in both documents, and both mandatory checks still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)