### PR TITLE
fix(dispatch): build rules travel with the dispatch, not with the directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Build rules reached only Claude Code projects
+
+The four rules that keep an agent from over-building — think first, minimum that
+solves it, surgical changes, verifiable done — lived only in the project contract
+`nrv init` writes. Two independent ways to miss them: most projects never run
+`nrv init`, and the file a runtime reads differs across the eight adapters
+(`AGENTS.md` for antigravity/codex/grok/kimi/pi, `CLAUDE.md` for claude-code,
+`GEMINI.md` for gemini-cli). Anything depending on a project file is unreliable
+twice over.
+
+They now travel with what is always present: the dispatch instruction for the
+entity that builds, the skill itself for the orchestrator. A test walks every
+adapter and fails if one declares a contract file `nrv init` does not write, so
+no runtime can be silently left without a contract.
+
 ### Prose was judged by a rule it never received
 
 The writing contract lives in a project's `CLAUDE.md`/`AGENTS.md`, written there

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,21 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### As regras de construção só chegavam a projetos Claude Code
+
+As quatro regras que impedem um agente de construir demais — pensar antes, o
+mínimo que resolve, mudanças cirúrgicas, pronto verificável — viviam só no
+contrato de projeto que o `nrv init` escreve. Dois jeitos independentes de
+perdê-las: a maioria dos projetos nunca roda `nrv init`, e o arquivo que cada
+runtime lê é diferente entre os oito adapters (`AGENTS.md` para
+antigravity/codex/grok/kimi/pi, `CLAUDE.md` para o claude-code, `GEMINI.md` para
+o gemini-cli). O que depende de arquivo de projeto é frágil duas vezes.
+
+Agora elas viajam no que sempre existe: a instrução de dispatch para quem
+constrói, a própria skill para o orquestrador. Um teste percorre todos os
+adapters e reprova se algum declarar um arquivo de contrato que o `nrv init` não
+escreve, para que nenhum runtime fique sem contrato em silêncio.
+
 ### A prosa era julgada por uma regra que nunca recebeu
 
 O contrato de escrita vive no `CLAUDE.md`/`AGENTS.md` do projeto, escrito lá pelo

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -340,6 +340,30 @@ Registries come from a project-local `.nirvana/` (inside a project tree) or the 
 
 ---
 
+## How you orchestrate (the same four rules, applied to dispatching)
+
+Section 9 of every `DISPATCH-INSTRUCTION.md` carries these for the entity that
+builds. They bind you too, aimed at the dispatch rather than the diff — and they
+are here, in the skill, rather than in a project file, because the file each
+runtime reads differs (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) and most projects
+have none of them.
+
+- **Think before dispatching.** Name the target and why before you send it. An
+  ambiguous brief gets a briefing question, not a guess. Two cascades fit? State
+  both instead of picking silently.
+- **Minimum viable dispatch.** The smallest cascade that satisfies the brief. Do
+  not convene a business when one squad capability answers it, or pull five
+  mind-clones when the work needs one voice. Building org structure to feel
+  thorough is the over-orchestration this rule exists to prevent.
+- **Surgical scope.** Never mutate `~/squads`, `~/businesses` or the DNA library
+  as a side effect of a dispatch. You write to the trace output path, the briefs
+  dir and the logs. Spot a real defect in a squad you were only asked to invoke?
+  Report it; do not edit it mid-run.
+- **Gate-driven execution.** Your "tests pass" is the `gate_passed` event. State
+  the rubric for the artifact type up front, then dispatch → judge → revise →
+  re-judge. No `gate_passed`, no delivery; a "done" message without that chain is
+  fiction.
+
 ## Core principles (HP1–HP8)
 - **HP1** Stateless between briefs. All state on filesystem.
 - **HP2** Routing is explicit. The model emits `target_plan_committed` with reasoning.

--- a/skills/harness/templates/DISPATCH-INSTRUCTION.template.md
+++ b/skills/harness/templates/DISPATCH-INSTRUCTION.template.md
@@ -99,3 +99,29 @@ bun ~/.nirvana/skills/harness/scripts/quality-gate.ts <your-artifact> --auto
 Exit 0 means it passes. Fix what it flags and re-run until it does, **before**
 writing `_SUMMARY.md` and handing back. Catching it here costs one re-read;
 catching it at the gate costs a full rewrite of a finished document.
+
+## 9. How to build (applies to code and to any constructed artifact)
+
+Carried here for the same reason as section 8: these rules live in the project's
+`AGENTS.md` / `CLAUDE.md` / `GEMINI.md`, which exist only when the project was
+created with `nrv init`. Most were not, and the file each runtime reads differs
+anyway — so the rules travel with the dispatch instead of with the directory.
+
+- **Think before building.** State assumptions; if two readings of the brief lead
+  to materially different work, say so rather than picking silently. If a simpler
+  approach exists, name it.
+- **Minimum that solves it.** No feature beyond the ask, no abstraction for
+  single-use code, no configurability nobody requested, no error handling for
+  impossible states. If it took 200 lines and 50 would do, rewrite it.
+- **Surgical changes.** Touch only what your part requires. Do not improve
+  adjacent code, comments or formatting; do not refactor what is not broken;
+  match the surrounding style even where you would do it differently. Remove
+  orphans YOUR change created — nothing else. Notice unrelated dead code? Say so
+  in `_SUMMARY.md`; do not delete it.
+- **Verifiable done.** Turn the acceptance criteria into a check you can run —
+  a test that fails before and passes after, a command whose exit code says yes.
+  "It looks right" is not a criterion.
+
+The test for every diff you produce: each changed line traces back to something
+in section 2. A reviewer who cannot make that trace will assume you went
+exploring, and they will be right.

--- a/skills/harness/tests/behavioral-rules-travel.test.ts
+++ b/skills/harness/tests/behavioral-rules-travel.test.ts
@@ -1,0 +1,74 @@
+// behavioral-rules-travel.test.ts — the four build rules reach every runtime.
+//
+// They lived only in the project contract, which `nrv init` writes as AGENTS.md
+// + CLAUDE.md + GEMINI.md. Two independent failure modes: most projects never
+// run `nrv init`, and the file a runtime reads differs across the eight adapters
+// (AGENTS.md for antigravity/codex/grok/kimi/pi, CLAUDE.md for claude-code,
+// GEMINI.md for gemini-cli). Anything that depends on a project file is
+// therefore unreliable twice over.
+//
+// So the rules travel with what is always present: the dispatch instruction for
+// the entity that builds, the skill itself for the orchestrator.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const tpl = fs.readFileSync(path.join(ROOT, "skills/harness/templates/DISPATCH-INSTRUCTION.template.md"), "utf8");
+const skill = fs.readFileSync(path.join(ROOT, "skills/harness/SKILL.md"), "utf8");
+const ADAPTERS = path.join(ROOT, "skills/_shared/adapters");
+
+describe("the builder's rules ride the dispatch", () => {
+  test("all four are present", () => {
+    for (const rule of [/Think before building/i, /Minimum that solves it/i, /Surgical changes/i, /Verifiable done/i]) {
+      expect(tpl).toMatch(rule);
+    }
+  });
+
+  test("the anti-patterns are named concretely, not gestured at", () => {
+    expect(tpl).toMatch(/do not refactor what is not broken/i);
+    expect(tpl).toMatch(/abstraction for\s+single-use code/i);
+    expect(tpl).toMatch(/Remove\s+orphans YOUR change created/i);
+  });
+
+  test("it says why it is carried rather than assumed", () => {
+    expect(tpl).toMatch(/nrv init/);
+    expect(tpl).toMatch(/the file each runtime reads differs/i);
+  });
+});
+
+describe("the orchestrator's version rides the skill", () => {
+  test("all four are restated for dispatching", () => {
+    for (const rule of [/Think before dispatching/i, /Minimum viable dispatch/i, /Surgical scope/i, /Gate-driven execution/i]) {
+      expect(skill).toMatch(rule);
+    }
+  });
+
+  test("it protects the shared libraries from dispatch side effects", () => {
+    expect(skill).toMatch(/Never mutate `~\/squads`/);
+  });
+});
+
+describe("no runtime is left out", () => {
+  test("every adapter's contract file is one nrv init writes", () => {
+    // If an adapter ever declares a file `nrv init` does not create, a project
+    // on that runtime would silently get no contract at all.
+    const init = fs.readFileSync(path.join(ROOT, "skills/_shared/scripts/init-project.ts"), "utf8");
+    const written = new Set((init.match(/"(AGENTS|CLAUDE|GEMINI|QWEN)\.md"/g) || []).map((s) => s.replace(/"/g, "")));
+    const missing: string[] = [];
+    for (const f of fs.readdirSync(ADAPTERS)) {
+      if (!f.endsWith(".md") || f === "README.md") continue;
+      const text = fs.readFileSync(path.join(ADAPTERS, f), "utf8");
+      for (const decl of new Set(text.match(/\b(AGENTS|CLAUDE|GEMINI|QWEN)\.md\b/g) || [])) {
+        if (!written.has(decl)) missing.push(`${f} → ${decl}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("the rules do not depend on any project file to reach the builder", () => {
+    // The template is written per dispatch by the orchestrator; it exists
+    // regardless of whether the project was ever initialised.
+    expect(tpl).toMatch(/travel with the dispatch instead of with the directory/i);
+  });
+});


### PR DESCRIPTION
## The defect

The four rules that keep an agent from over-building — think first, minimum that solves it, surgical changes, verifiable done — lived **only** in the project contract `nrv init` writes.

That is unreliable twice over:

1. **Most projects never run `nrv init`.**
2. **The file a runtime reads differs.** Across the eight adapters: `AGENTS.md` (antigravity, codex, grok, kimi, pi), `CLAUDE.md` (claude-code), `GEMINI.md` (gemini-cli).

A fix that assumed `CLAUDE.md` would have covered one runtime out of eight.

Without these rules a code subagent never receives "do not refactor what is not broken", "no abstraction for single-use code", "remove only the orphans your change created" — and the code gate (`tests-pass`, `lint-clean`) does not catch over-building.

## The fix

They ride what is always present regardless of runtime:

- **Section 9 of `DISPATCH-INSTRUCTION.template.md`** — for the entity that builds. Concrete, not gestured at: the anti-patterns are named, and the test for every diff is that each changed line traces to section 2.
- **The skill itself** — the dispatch-shaped restatement for the orchestrator: smallest cascade that satisfies the brief, never mutate `~/squads` / `~/businesses` / the DNA library as a side effect, `gate_passed` is the passing test.

## Coverage guard

A test walks every adapter and fails if one declares a contract file `nrv init` does not write — so a newly added runtime cannot slip into silent contractlessness.

## Tests

7 in `skills/harness/tests/behavioral-rules-travel.test.ts`: all four builder rules, the concrete anti-patterns, the stated reason they travel, all four orchestrator rules, the shared-library protection, adapter/init coverage, and independence from project files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)