### PR TITLE
feat(doctor): name a project that never ran nrv init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### An uninitialised project degraded silently
+
+`nrv init` writes AGENTS.md + CLAUDE.md + GEMINI.md so every adapter finds one,
+and whichever the runtime reads carries the instruction to invoke Nirvana
+"regardless of skill activation". A project with none of them still orchestrates
+once the skill is active — the skill carries the protocol, and the dispatch
+instruction now carries the build and writing rules — but nothing tells the
+runtime to reach for the skill in the first place, so a brief can be answered
+inline with no dispatch, no gate and no audit trail.
+
+`nrv doctor` now names it, checking all three filenames rather than any one
+runtime's, and only when the working directory actually looks like a project.
+
 ### Build rules reached only Claude Code projects
 
 The four rules that keep an agent from over-building — think first, minimum that

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,20 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Projeto sem inicializar degradava em silêncio
+
+O `nrv init` escreve AGENTS.md + CLAUDE.md + GEMINI.md para que todo adapter ache
+um, e o que o runtime lê carrega a instrução de invocar o Nirvana
+"independentemente da ativação da skill". Um projeto sem nenhum deles ainda
+orquestra depois que a skill ativa — a skill carrega o protocolo, e a instrução
+de dispatch agora carrega as regras de construção e de escrita — mas nada manda o
+runtime buscar a skill, então um brief pode ser respondido inline, sem dispatch,
+sem gate e sem trilha de auditoria.
+
+O `nrv doctor` agora aponta isso, conferindo os três nomes de arquivo em vez do
+de um runtime só, e apenas quando o diretório de trabalho de fato parece um
+projeto.
+
 ### As regras de construção só chegavam a projetos Claude Code
 
 As quatro regras que impedem um agente de construir demais — pensar antes, o

--- a/skills/_shared/lib/runtime-dirs.ts
+++ b/skills/_shared/lib/runtime-dirs.ts
@@ -29,6 +29,15 @@ export const RUNTIME_SKILL_DIRS = [
   join(homedir(), ".pi/agent/skills"),   // Pi Coding Agent (Agent Skills standard)
 ];
 
+/**
+ * The instruction files agent runtimes read from a project root. `nrv init`
+ * writes all three so every supported adapter finds one: AGENTS.md serves
+ * antigravity, codex, grok, kimi and pi; CLAUDE.md serves claude-code;
+ * GEMINI.md serves gemini-cli. Checking for any ONE of them is how you ask
+ * "was this project initialised?" without assuming a runtime.
+ */
+export const PROJECT_CONTRACT_FILES = ["AGENTS.md", "CLAUDE.md", "GEMINI.md"];
+
 /** The skill trees the engine ships, copies to ~/.nirvana/skills and links into every runtime dir. */
 export const SKILLS = ["harness", "businesses", "squads", "_shared", "nirvana-os"];
 

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -26,7 +26,7 @@ import * as os from "node:os";
 import { execSync, spawnSync } from "node:child_process";
 import { paths as nrvPaths } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope } from "../../_shared/lib/scope.ts";
-import { RUNTIME_SKILL_DIRS } from "../../_shared/lib/runtime-dirs.ts";
+import { RUNTIME_SKILL_DIRS, PROJECT_CONTRACT_FILES } from "../../_shared/lib/runtime-dirs.ts";
 import { scanLibrary, authorsPacks, STRIP_HINT } from "../../_shared/lib/watermark-scan.ts";
 
 const ANSI = {
@@ -300,6 +300,29 @@ if (fs.existsSync(agentsSkillsDir)) {
     add("skills: backup litter", "WARN", parts.join("; ") + ". Safe to delete.");
   } else {
     add("skills: backup litter", "PASS", "no *.bak inside skills dirs, at most one skills-backup");
+  }
+}
+
+// Project contract. `nrv init` writes AGENTS.md + CLAUDE.md + GEMINI.md into a
+// project root; whichever one the runtime reads carries the invocation contract
+// "before touching the project, regardless of skill activation". A working
+// directory with none of them still orchestrates — the skill carries the
+// protocol, and since 2026-08-13 the dispatch instruction carries the build and
+// writing rules — but nothing tells the runtime to reach for the skill in the
+// first place. That is a real degradation and it should be visible, not
+// inferred. Checked only when the cwd looks like a working project, so running
+// the doctor from a home directory is not scolded.
+{
+  const cwd = process.cwd();
+  const looksLikeProject = [".git", "package.json", "outputs", ".nirvana"].some((m) => fs.existsSync(path.join(cwd, m)));
+  const found = PROJECT_CONTRACT_FILES.filter((f) => fs.existsSync(path.join(cwd, f)));
+  if (!looksLikeProject) {
+    add("project: contract", "PASS", "cwd is not a project — nothing to check");
+  } else if (found.length) {
+    add("project: contract", "PASS", `${found.join(", ")} present`);
+  } else {
+    add("project: contract", "WARN",
+      `no ${PROJECT_CONTRACT_FILES.join(" / ")} in ${cwd.replace(HOME, "~")} — the runtime has no instruction to invoke Nirvana, so a brief may be answered inline instead of dispatched. Fix: nrv init .`);
   }
 }
 

--- a/skills/harness/tests/project-contract-check.test.ts
+++ b/skills/harness/tests/project-contract-check.test.ts
@@ -1,0 +1,49 @@
+// project-contract-check.test.ts — the doctor names an uninitialised project.
+//
+// `nrv init` writes AGENTS.md + CLAUDE.md + GEMINI.md so every adapter finds
+// one; whichever the runtime reads carries the instruction to invoke Nirvana
+// "regardless of skill activation". A project with none of them still
+// orchestrates once the skill is active — the skill carries the protocol, the
+// dispatch instruction carries the build and writing rules — but nothing tells
+// the runtime to reach for the skill at all. That degradation was invisible.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { PROJECT_CONTRACT_FILES } from "../../_shared/lib/runtime-dirs.ts";
+
+const DOCTOR = path.resolve(import.meta.dir, "..", "scripts", "doctor-system.ts");
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-contract-"));
+
+function doctorIn(dir: string): string {
+  const r = spawnSync(process.execPath, [DOCTOR], { cwd: dir, encoding: "utf8" });
+  return (r.stdout || "") + (r.stderr || "");
+}
+
+describe("the contract check", () => {
+  test("warns when a project has none of the contract files", () => {
+    const dir = path.join(TMP, "bare"); fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+    const out = doctorIn(dir);
+    // The doctor renders add("project: contract") as a PROJECT section with a
+    // "contract" row, not as the literal key.
+    expect(out).toMatch(/PROJECT/);
+    expect(out).toMatch(/no AGENTS\.md \/ CLAUDE\.md \/ GEMINI\.md/);
+    expect(out).toMatch(/nrv init \./);
+  }, 20_000);
+
+  test("each contract file alone is enough — no runtime is privileged", () => {
+    // A gemini-cli project has GEMINI.md and no CLAUDE.md; it is initialised.
+    for (const f of PROJECT_CONTRACT_FILES) {
+      const dir = path.join(TMP, `only-${f}`);
+      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+      fs.writeFileSync(path.join(dir, f), "# contract\n");
+      expect(doctorIn(dir)).toContain(`${f} present`);
+    }
+  }, 45_000);   // one full doctor run per contract file, ~3s each
+
+  test("a non-project directory is not scolded", () => {
+    const dir = path.join(TMP, "plain"); fs.mkdirSync(dir, { recursive: true });
+    expect(doctorIn(dir)).toMatch(/not a project/);
+  }, 20_000);
+});


### PR DESCRIPTION
Third of three closing the "projects without `nrv init` deserve quality too" gap (after #8 writing contract, #9 build rules).

## What is missing without init

`nrv init` writes AGENTS.md + CLAUDE.md + GEMINI.md so every adapter finds one. Whichever the runtime reads carries the instruction to invoke Nirvana *"before touching the project, regardless of skill activation"* — the init script's own words.

A project with none of them **still orchestrates** once the skill is active: the skill carries the protocol, and #8/#9 put the writing contract and build rules into the dispatch instruction. What is missing is the **trigger** — nothing tells the runtime to reach for the skill, so a brief can be answered inline with no dispatch, no gate, no audit trail.

## Why a warning and not a fix

The engine cannot fix activation: a skill cannot activate before it activates. Making the gap visible is the honest remedy — the alternative would be pretending it is solved.

## Runtime-agnostic by construction

Checks all three filenames via `PROJECT_CONTRACT_FILES`, exported from `runtime-dirs.ts` next to the adapter dirs. A gemini-cli project has GEMINI.md and no CLAUDE.md; it is initialised, and a test pins that. Fires only when the cwd looks like a project, so the doctor run from a home directory is not scolded.

## Tests

3, with explicit timeouts — a full doctor run takes ~3s because it scans 12k files for watermarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)