### PR TITLE
feat(install): lead with nrv init, and say what skipping it costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The install taught the wrong first step
+
+The engine installer ended with a flat list of four commands, `nrv init` last and
+`nrv glance` above it. The pack installer was worse: "open any AI CLI you use and
+just talk to it" — which is precisely the inline path, taught to a buyer on their
+first run, in whatever directory they happened to be standing in.
+
+`nrv init` writes the contract (AGENTS.md / CLAUDE.md / GEMINI.md, one per
+runtime family) that tells an AI CLI to orchestrate through Nirvana-OS. Without
+it a brief is answered inline by a single agent: no dispatch to the businesses
+and squads the user installed, no quality gate, no audit trail. Nothing errors —
+they just get a worse product and no way to know why.
+
+Both installers now lead with `nrv init`, show it for a new directory and for an
+existing one, and state that consequence in those words. `nrv glance` is gone
+from both: the cockpit is unfinished, and a first screen should not point at the
+weakest surface.
+
 ## 0.3.6 — 2026-08-13
 
 ### An uninitialised project degraded silently

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,26 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### A instalação ensinava o primeiro passo errado
+
+O instalador do engine terminava com uma lista de quatro comandos, o `nrv init`
+por último e o `nrv glance` acima dele. O do pack era pior: "abra qualquer CLI de
+IA e simplesmente converse" — que é exatamente o caminho inline, ensinado ao
+comprador na primeira execução, no diretório em que ele estivesse parado.
+
+O `nrv init` escreve o contrato (AGENTS.md / CLAUDE.md / GEMINI.md, um por
+família de runtime) que manda a CLI orquestrar pelo Nirvana-OS. Sem ele, um brief
+é respondido inline por um agente só: sem dispatch para as empresas e squads que
+o usuário instalou, sem quality gate e sem auditoria. Nada dá erro — ele só
+recebe um produto pior, sem como saber por quê.
+
+Os dois instaladores agora começam pelo `nrv init`, mostram a forma para
+diretório novo e para pasta existente, e dizem a consequência nessas palavras. O
+`nrv glance` saiu dos dois: o cockpit está inacabado, e a primeira tela não
+deveria apontar para a superfície mais fraca.
+
 ## 0.3.6 — 2026-08-13
 
 ### Projeto sem inicializar degradava em silêncio

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1003,15 +1003,41 @@ function checkOnly(): void {
   process.exit(allReady ? 0 : 1);
 }
 
+/**
+ * The last thing a new user reads, so it says the one thing that decides whether
+ * they experience Nirvana at all.
+ *
+ * `nrv init` writes the agent contract (AGENTS.md + CLAUDE.md + GEMINI.md, one
+ * per runtime family) into the project root. That contract is what tells the
+ * runtime to invoke the orchestrator. Without it the skill has to activate by
+ * description match alone, and when it does not, the brief is answered inline:
+ * no dispatch, no quality gate, no audit trail — a normal coding session
+ * wearing the system's name. Users who skip init do not see an error; they see
+ * a worse product and blame it.
+ *
+ * `nrv glance` is deliberately absent: the cockpit is not finished, and the
+ * first screen a new user sees should not be the weakest one.
+ */
 function summary(): void {
   console.log();
   console.log("Done.");
   console.log();
-  console.log("Next steps:");
-  console.log("  nrv install --check     # verify all hooks are wired");
-  console.log("  nrv validate            # smoke-test registries");
-  console.log("  nrv glance              # open the cockpit");
-  console.log("  nrv init ~/my-project   # bootstrap a new project");
+  console.log("\x1b[1mStart every project with nrv init — this is the important part.\x1b[0m");
+  console.log();
+  console.log("  nrv init ~/my-project     # creates the dir + the agent contract");
+  console.log("  cd ~/my-project           # then just talk to your AI CLI");
+  console.log();
+  console.log("  Already have a folder? Run it there:  cd ~/existing && nrv init .");
+  console.log();
+  console.log("Why it matters: nrv init writes the contract (AGENTS.md / CLAUDE.md /");
+  console.log("GEMINI.md) that tells your AI CLI to orchestrate through Nirvana-OS.");
+  console.log("WITHOUT it, a brief is answered inline by a single agent — no dispatch");
+  console.log("to your businesses and squads, no quality gate, no audit trail. It still");
+  console.log("works; it just is not Nirvana-OS. Check any project with: nrv doctor");
+  console.log();
+  console.log("Verify this install:");
+  console.log("  nrv install --check       # hooks wired");
+  console.log("  nrv validate              # registries smoke-test");
 }
 
 async function main(): Promise<void> {

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -409,8 +409,10 @@ WHAT IT DOES
   4. Smoke-tests the audit pipe (writes a sentinel event)
 
 After install, every Write/Edit/Bash by Claude Code OR Gemini-CLI lands in
-~/.harness-logs/<today>/audit.jsonl automatically. Watch with 'nrv watch'
-or open the cockpit with 'nrv glance'.
+~/.harness-logs/<today>/audit.jsonl automatically. Watch with 'nrv watch'.
+
+Then create projects with 'nrv init <dir>' — without it a brief is answered
+inline, with no dispatch, no quality gate and no audit trail.
 `);
     process.exit(EXIT.OK);
   }

--- a/skills/harness/tests/install-teaches-init.test.ts
+++ b/skills/harness/tests/install-teaches-init.test.ts
@@ -1,0 +1,61 @@
+// install-teaches-init.test.ts — the last screen of the install must teach the
+// one step that decides whether the product works as sold.
+//
+// `nrv init` writes the agent contract (AGENTS.md / CLAUDE.md / GEMINI.md) that
+// tells a runtime to orchestrate. Without it the skill must self-activate by
+// description match, and when it does not the brief is answered inline: no
+// dispatch, no gate, no audit. Users who skip init get a worse product and no
+// error telling them why.
+//
+// The pack installer used to end with "open any AI CLI and just talk to it",
+// which taught the inline path to the buyer on their very first run.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const engineInstall = fs.readFileSync(path.join(ROOT, "scripts/install.ts"), "utf8");
+
+/** Only the completion message, so a mention elsewhere in the file cannot pass this. */
+function summaryBlock(): string {
+  const start = engineInstall.indexOf("function summary(): void {");
+  const end = engineInstall.indexOf("async function main()");
+  expect(start).toBeGreaterThan(-1);
+  return engineInstall.slice(start, end);
+}
+
+describe("the engine installer's last screen", () => {
+  test("leads with nrv init, not with a command list", () => {
+    expect(summaryBlock()).toMatch(/Start every project with nrv init/);
+  });
+
+  test("shows both shapes: a new dir and an existing one", () => {
+    const s = summaryBlock();
+    expect(s).toMatch(/nrv init ~\/my-project/);
+    expect(s).toMatch(/nrv init \./);
+  });
+
+  test("states the consequence of skipping it, concretely", () => {
+    const s = summaryBlock();
+    expect(s).toMatch(/inline/i);
+    expect(s).toMatch(/no dispatch/i);
+    expect(s).toMatch(/no quality gate/i);
+    expect(s).toMatch(/no audit trail/i);
+  });
+
+  test("names all three contract files — no runtime is privileged", () => {
+    const s = summaryBlock();
+    for (const f of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) expect(s).toContain(f);
+  });
+
+  test("does not advertise the cockpit while it is unfinished", () => {
+    // A first screen should not point at the weakest surface.
+    expect(summaryBlock()).not.toMatch(/nrv glance/);
+  });
+
+  test("still tells the user how to verify the install", () => {
+    const s = summaryBlock();
+    expect(s).toMatch(/nrv install --check/);
+    expect(s).toMatch(/nrv validate/);
+  });
+});


### PR DESCRIPTION
## The problem

The engine installer ended with four commands in a flat list — `nrv init` **last**, `nrv glance` above it — and nothing saying what init was for. The natural read is "optional convenience".

The pack installer was worse:

> "Next: open any AI CLI you use (Claude, Codex, Gemini) and just talk to it."

That is precisely the inline path, taught to a **paying buyer on their first run**, in whatever directory they happened to be standing in.

## Why it matters

`nrv init` writes the contract (AGENTS.md / CLAUDE.md / GEMINI.md, one per runtime family) that tells an AI CLI to orchestrate through Nirvana-OS. Without it the skill must self-activate by description match, and when it does not, the brief is answered inline by a single agent: **no dispatch to the businesses and squads the user installed, no quality gate, no audit trail.**

Nothing errors. They get a worse product and no way to know why.

#10 added a doctor warning for this. This closes the same gap one step earlier — at the install, where every user passes exactly once.

## The change

Both installers lead with `nrv init`, show it for a new directory and for an existing one, and state the consequence in those words.

`nrv glance` is dropped from both: the cockpit is unfinished, and a first screen should not point at the weakest surface.

The pack's `setup.ts` lives in the base pack staging rather than this repo; it is fixed there and will ship with the next pack build (strip + `--check` = 0 before zipping, as always).

## Tests

6, scoped to the `summary()` function so a mention elsewhere in the file cannot satisfy them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)