### PR TITLE
feat(harness): the orchestrator initialises the project it is standing in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Adopting Nirvana in a project you already had did not wire it
+
+`nrv init` writes the contract as AGENTS.md + CLAUDE.md + GEMINI.md so every
+runtime family finds one. For a file that already existed it kept the user's
+rules and appended only the *writing* contract — which left the most common case
+of all without the *invocation* contract, the part that tells a runtime to
+orchestrate. AGENTS.md received it, and Claude Code does not read AGENTS.md. A
+user with a pre-existing CLAUDE.md ran init, saw "ok", and went on getting inline
+answers: no dispatch, no gate, no audit.
+
+Both blocks are now appended under their own markers, with the user's rules
+untouched above them and a second run changing nothing.
+
+### The orchestrator repairs the project instead of reporting it
+
+Nobody drives this system by typing `nrv`. People talk to Claude Code, Codex,
+agy or Hermes, and that CLI runs the commands. So an uninitialised project is not
+a user error to report — it is a one-line repair the orchestrator performs,
+because the orchestrator is the one holding the shell. Phase 0 is now a
+preflight: no contract file present, run `nrv init .`, say so in a line, carry
+on. It asks first only when the directory is somebody else's repository, where
+three new files would land in their diff.
+
 ### The install taught the wrong first step
 
 The engine installer ended with a flat list of four commands, `nrv init` last and

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,29 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Adotar o Nirvana num projeto que já existia não ligava nada
+
+O `nrv init` escreve o contrato como AGENTS.md + CLAUDE.md + GEMINI.md para que
+toda família de runtime ache um. Para um arquivo que já existia, ele mantinha as
+regras do usuário e acrescentava só o contrato de *escrita* — o que deixava o
+caso mais comum de todos sem o contrato de *invocação*, a parte que manda o
+runtime orquestrar. O AGENTS.md recebia, e o Claude Code não lê AGENTS.md. Quem
+tinha um CLAUDE.md prévio rodava o init, via "ok", e seguia recebendo respostas
+inline: sem dispatch, sem gate, sem auditoria.
+
+Os dois blocos agora são acrescentados sob marcadores próprios, com as regras do
+usuário intactas acima e a segunda rodada não mudando nada.
+
+### O orquestrador conserta o projeto em vez de reportar
+
+Ninguém opera este sistema digitando `nrv`. As pessoas conversam com o Claude
+Code, Codex, agy ou Hermes, e é essa CLI que roda os comandos. Então projeto sem
+inicializar não é erro de usuário para reportar — é um conserto de uma linha que
+o orquestrador executa, porque é ele quem está com o shell na mão. A Phase 0
+virou preflight: sem arquivo de contrato, roda `nrv init .`, avisa numa linha,
+segue. Só pergunta antes quando o diretório é repositório de outra pessoa, onde
+três arquivos novos apareceriam no diff dela.
+
 ### A instalação ensinava o primeiro passo errado
 
 O instalador do engine terminava com uma lista de quatro comandos, o `nrv init`

--- a/skills/_shared/scripts/init-project.ts
+++ b/skills/_shared/scripts/init-project.ts
@@ -311,6 +311,7 @@ function main() {
     const agentsTemplate = path.join(SKILLS_ROOT, "_shared", "templates", "AGENTS.md");
     const writingContractSnippet = path.join(SKILLS_ROOT, "_shared", "templates", "writing-contract-snippet.md");
     const WRITING_CONTRACT_MARKER = "<!-- nirvana-os:writing-contract:v1 -->";
+    const INVOCATION_CONTRACT_MARKER = "<!-- nirvana-os:invocation-contract:v1 -->";
     if (fs.existsSync(agentsTemplate)) {
       for (const name of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) {
         const dst = path.join(target, name);
@@ -319,7 +320,18 @@ function main() {
         if (!fs.existsSync(dst)) {
           copyFile(agentsTemplate, dst, false);
         } else {
+          // A pre-existing CLAUDE.md is the COMMON case, not the edge: people
+          // adopt Nirvana in projects they already have. Keeping the file and
+          // appending only the writing contract left exactly those users without
+          // the invocation contract — the part that tells the runtime to
+          // orchestrate at all. AGENTS.md got it, and Claude Code does not read
+          // AGENTS.md. The user ran init, saw "ok", and kept getting inline
+          // answers with no dispatch, no gate, no audit.
+          //
+          // So the invocation contract is appended too, under its own marker,
+          // with the user's rules untouched above it.
           log.warn(`exists, kept: ${dst}`);
+          appendWithMarker(agentsTemplate, dst, INVOCATION_CONTRACT_MARKER);
         }
         // Phase 2: append the writing contract (idempotent via marker).
         appendWithMarker(writingContractSnippet, dst, WRITING_CONTRACT_MARKER);

--- a/skills/_shared/templates/AGENTS.md
+++ b/skills/_shared/templates/AGENTS.md
@@ -1,3 +1,4 @@
+<!-- nirvana-os:invocation-contract:v1 -->
 # Project guidelines (universal — Claude Code · Gemini-CLI · Codex · Cursor · Antigravity · any agent runtime)
 
 This file is the contract every agent must read **before doing anything**.

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -126,7 +126,39 @@ The point of rule 4 is the difference between degrading and lying. Working witho
 
 When a production brief arrives, run this loop. Each step has a deliverable and an audit event.
 
-### Phase 0 — Declare your operating window
+### Phase 0 — Preflight: make the project a Nirvana project
+
+Almost nobody drives this system by typing `nrv`. People talk to their AI CLI —
+Claude Code, Codex, agy, Hermes — and that CLI is what runs the commands. You are
+that CLI. So a project missing its contract is not a user error to report; it is
+a one-line repair you perform, because you are the one holding the shell.
+
+Before anything else, check whether this directory is a Nirvana project:
+
+```bash
+ls AGENTS.md CLAUDE.md GEMINI.md 2>/dev/null | head -1
+```
+
+Nothing came back? Run `nrv init .` and continue. It writes the contract
+(`AGENTS.md` + `CLAUDE.md` + `GEMINI.md`, one per runtime family) plus the
+`.nirvana/` scaffold. It never touches code, and it never overwrites: a contract
+file that already exists keeps the user's rules at the top and gets the Nirvana
+blocks appended under their own markers, so running it twice changes nothing.
+Say in one line that you did it and why — the user's `CLAUDE.md` did grow, and
+they should hear it from you rather than from a diff — then get on with the
+brief. Do not stop to ask permission for a repair this cheap.
+
+What it buys is not this run, which you are already orchestrating. It is the
+NEXT session in this directory, and the one after: without the contract, the
+runtime has nothing telling it to reach for this skill, and a brief gets answered
+inline by a single agent — no dispatch, no gate, no audit trail. That failure is
+silent, which is why it is worth one command now.
+
+The one case to ask first: the directory is somebody else's repository and
+writing three files at its root would show up in their diff. Then say so and let
+the user decide.
+
+### Phase 0.1 — Declare your operating window
 Before reading the brief, declare your context window and budget. Inspect via `/context` (Claude Code), `/memory` (Gemini-CLI), `/usage` (Codex), or read it from your system prompt. Write a header at the top of `${HARNESS_LOGS_DIR}/$(date +%Y-%m-%d)/briefs/<trace_id>.txt`:
 
 ```
@@ -230,7 +262,7 @@ On claude-code, codex, and antigravity you dispatch through the runtime's **nati
 
 Writing the DAG down is what makes the order auditable. A wave you can point at is a decision; a wave you kept in your head is a guess the user can't check.
 
-**Checkpoint between waves.** A wave boundary is the one moment in a multi-target run where nothing is in flight: every target of the wave has returned and the next has not started. That is the cheapest possible place to shed context, and the only place where a rollover costs nothing in lost state — the `manifest.json` DAG and each `_SUMMARY.md` already hold everything the next session needs. Run `nrv guard context` there (Phase 0), and when it exits `8`, roll before dispatching the next wave rather than after.
+**Checkpoint between waves.** A wave boundary is the one moment in a multi-target run where nothing is in flight: every target of the wave has returned and the next has not started. That is the cheapest possible place to shed context, and the only place where a rollover costs nothing in lost state — the `manifest.json` DAG and each `_SUMMARY.md` already hold everything the next session needs. Run `nrv guard context` there (Phase 0.1), and when it exits `8`, roll before dispatching the next wave rather than after.
 
 Audit events: `target_plan_committed`, `x_enriched_brief_written`, `dispatch_business`/`dispatch_squad`/`dispatch_agent_x`, `mind_clone_injected`, `human_notification_required` (only if truly blocked).
 

--- a/skills/harness/tests/init-existing-project.test.ts
+++ b/skills/harness/tests/init-existing-project.test.ts
@@ -17,6 +17,11 @@ const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
 const INIT = path.join(ROOT, "skills/_shared/scripts/init-project.ts");
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-init-existing-"));
 
+/** A cold CI runner spawns Bun and does registry work per call: the five tests
+ *  take 684ms together locally and blew the 5s default on Windows. The budget
+ *  below is wall-clock reality, not slack for a hang. */
+const INIT_TIMEOUT_MS = 60_000;
+
 /** NIRVANA_SKILLS_DIR pinned to the repo: without it the script reads the
  *  INSTALLED templates, and the test would silently grade a different tree. */
 function runInit(dir: string) {
@@ -43,14 +48,14 @@ describe("a project that already has a contract file", () => {
     expect(claude).toContain("never delete this line");        // user content survives
     expect(claude).toMatch(/invoke the .?harness.? skill/i);   // and orchestration is wired
     expect(claude).toMatch(/Writing contract/);
-  });
+  }, INIT_TIMEOUT_MS);
 
   test("the user's rules stay at the top, above what we appended", () => {
     const dir = project("order", { "CLAUDE.md": "# My rules\nMY MARKER LINE\n" });
     runInit(dir);
     const c = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
     expect(c.indexOf("MY MARKER LINE")).toBeLessThan(c.indexOf("Writing contract"));
-  });
+  }, INIT_TIMEOUT_MS);
 
   test("running it twice changes nothing — markers make it idempotent", () => {
     const dir = project("twice", { "CLAUDE.md": "# Mine\n" });
@@ -58,7 +63,7 @@ describe("a project that already has a contract file", () => {
     const first = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
     runInit(dir);
     expect(fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8")).toBe(first);
-  });
+  }, INIT_TIMEOUT_MS);
 
   test("code and other files are never touched", () => {
     const dir = project("code", { "app.ts": "console.log('mine')\n", "README.md": "# mine\n" });
@@ -68,7 +73,7 @@ describe("a project that already has a contract file", () => {
     expect(fs.readFileSync(path.join(dir, "app.ts"), "utf8")).toBe("console.log('mine')\n");
     expect(fs.readFileSync(path.join(dir, "README.md"), "utf8")).toBe("# mine\n");
     expect(fs.readFileSync(path.join(dir, "src/lib.ts"), "utf8")).toBe("export const x = 1\n");
-  });
+  }, INIT_TIMEOUT_MS);
 
   test("every runtime family ends up with the invocation contract", () => {
     // A project with only CLAUDE.md must still serve codex (AGENTS.md) and
@@ -78,5 +83,5 @@ describe("a project that already has a contract file", () => {
     for (const f of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) {
       expect(fs.readFileSync(path.join(dir, f), "utf8")).toMatch(/invoke the .?harness.? skill/i);
     }
-  });
+  }, INIT_TIMEOUT_MS);
 });

--- a/skills/harness/tests/init-existing-project.test.ts
+++ b/skills/harness/tests/init-existing-project.test.ts
@@ -1,0 +1,82 @@
+// init-existing-project.test.ts — adopting Nirvana in a project you already have.
+//
+// `nrv init` materialises the contract as AGENTS.md + CLAUDE.md + GEMINI.md so
+// every runtime family finds one. For a file that already exists it kept the
+// user's rules and appended only the WRITING contract — which left the most
+// common case of all without the INVOCATION contract, the part that tells the
+// runtime to orchestrate. AGENTS.md got it, and Claude Code does not read
+// AGENTS.md. So a Claude Code user with a pre-existing CLAUDE.md ran init, saw
+// "ok", and went on getting inline answers: no dispatch, no gate, no audit.
+import { describe, expect, test, afterAll } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const INIT = path.join(ROOT, "skills/_shared/scripts/init-project.ts");
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-init-existing-"));
+
+/** NIRVANA_SKILLS_DIR pinned to the repo: without it the script reads the
+ *  INSTALLED templates, and the test would silently grade a different tree. */
+function runInit(dir: string) {
+  return spawnSync(process.execPath, [INIT, "."], {
+    cwd: dir, encoding: "utf8",
+    env: { ...process.env, NIRVANA_SKILLS_DIR: path.join(ROOT, "skills") },
+  });
+}
+
+function project(name: string, files: Record<string, string> = {}): string {
+  const dir = path.join(TMP, name);
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+  for (const [f, body] of Object.entries(files)) fs.writeFileSync(path.join(dir, f), body);
+  return dir;
+}
+
+afterAll(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe("a project that already has a contract file", () => {
+  test("keeps the user's rules AND gains the invocation contract", () => {
+    const dir = project("existing", { "CLAUDE.md": "# My rules\nnever delete this line\n" });
+    runInit(dir);
+    const claude = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
+    expect(claude).toContain("never delete this line");        // user content survives
+    expect(claude).toMatch(/invoke the .?harness.? skill/i);   // and orchestration is wired
+    expect(claude).toMatch(/Writing contract/);
+  });
+
+  test("the user's rules stay at the top, above what we appended", () => {
+    const dir = project("order", { "CLAUDE.md": "# My rules\nMY MARKER LINE\n" });
+    runInit(dir);
+    const c = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
+    expect(c.indexOf("MY MARKER LINE")).toBeLessThan(c.indexOf("Writing contract"));
+  });
+
+  test("running it twice changes nothing — markers make it idempotent", () => {
+    const dir = project("twice", { "CLAUDE.md": "# Mine\n" });
+    runInit(dir);
+    const first = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
+    runInit(dir);
+    expect(fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8")).toBe(first);
+  });
+
+  test("code and other files are never touched", () => {
+    const dir = project("code", { "app.ts": "console.log('mine')\n", "README.md": "# mine\n" });
+    fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "src/lib.ts"), "export const x = 1\n");
+    runInit(dir);
+    expect(fs.readFileSync(path.join(dir, "app.ts"), "utf8")).toBe("console.log('mine')\n");
+    expect(fs.readFileSync(path.join(dir, "README.md"), "utf8")).toBe("# mine\n");
+    expect(fs.readFileSync(path.join(dir, "src/lib.ts"), "utf8")).toBe("export const x = 1\n");
+  });
+
+  test("every runtime family ends up with the invocation contract", () => {
+    // A project with only CLAUDE.md must still serve codex (AGENTS.md) and
+    // gemini-cli (GEMINI.md) after init.
+    const dir = project("all-runtimes", { "CLAUDE.md": "# Mine\n" });
+    runInit(dir);
+    for (const f of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) {
+      expect(fs.readFileSync(path.join(dir, f), "utf8")).toMatch(/invoke the .?harness.? skill/i);
+    }
+  });
+});


### PR DESCRIPTION
## The premise I had wrong

Nobody drives this system by typing `nrv`. People talk to Claude Code, Codex, agy or Hermes, and **that CLI runs the commands**. So telling a human "remember to run `nrv init`" fixes little — the agent is the operator.

An uninitialised project is therefore not a user error to report. It is a one-line repair the orchestrator performs, because the orchestrator is holding the shell. **Phase 0 is now a preflight**: no contract file present → `nrv init .` → say so in a line → carry on. It asks first only when the directory is somebody else's repository, where three new files would land in their diff.

## The worse bug found while verifying that was safe

`nrv init` writes AGENTS.md + CLAUDE.md + GEMINI.md, one per runtime family. For a file that **already existed** it kept the user's rules and appended only the *writing* contract.

That left the most common case of all — adopting Nirvana in a project you already have — without the *invocation* contract, the part that tells a runtime to orchestrate. AGENTS.md received it. **Claude Code does not read AGENTS.md.**

Measured on a scratch project with a pre-existing CLAUDE.md:

| | before | after |
|---|---|---|
| invocation contract in CLAUDE.md | **0** | 3 |
| writing contract | 1 | 1 |
| size | 2 KB | 17.5 KB |

The user ran init, saw "ok", and went on getting inline answers with no dispatch, no gate, no audit.

Both blocks now append under their own markers, user rules untouched above, second run a no-op.

## Two corrections to my own work

- SKILL.md first claimed init "neither overwrites an existing file nor touches the user's code". The second half is true; the first is imprecise — it *appends*. A user should hear their CLAUDE.md grew from the agent, not from a diff.
- A test that appeared to prove idempotency was reading the **installed** templates rather than the repo's, so it graded a different tree. Pinning `NIRVANA_SKILLS_DIR` is what made it honest.

## Tests

5: user rules survive and orchestration is wired, their rules stay on top, idempotency, code untouched, and every runtime family ends up with the invocation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)