### PR TITLE
test(driver): drop the heartbeat assertion that raced the design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@ preflight: no contract file present, run `nrv init .`, say so in a line, carry
 on. It asks first only when the directory is somebody else's repository, where
 three new files would land in their diff.
 
+### The heartbeat test flaked because it asserted the opposite of the design
+
+`driver — heartbeat sidecar` failed roughly one CI run in three, on macOS and
+Windows both, and blocked three pull requests in a row. It checked that the last
+heartbeat looked stale at the moment the test read it — but the sidecar renews
+the lease on ANY new output, and the child's final result JSON is new output.
+Whether the heartbeat looked stale depended on where a 250ms poll happened to
+land relative to that write.
+
+Renewing on the final write is correct behaviour, so the assertion was wrong,
+not the timing. An earlier attempt to fix it by exiting the fake child sooner
+only narrowed the window: the bytes are already in the capture file by then.
+
+The property it wanted — the sidecar stopped renewing during the stall — is
+proven outright by the `x_ledger_stall_observed` event, emitted once with the
+measured gap. Against 2.2s of silence and a 1.2s budget the sidecar gets about
+eight polls to notice it. Nothing left to race.
+
 ### The install taught the wrong first step
 
 The engine installer ended with a flat list of four commands, `nrv init` last and

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -31,6 +31,25 @@ virou preflight: sem arquivo de contrato, roda `nrv init .`, avisa numa linha,
 segue. Só pergunta antes quando o diretório é repositório de outra pessoa, onde
 três arquivos novos apareceriam no diff dela.
 
+### O teste de heartbeat falhava por afirmar o contrário do desenho
+
+O `driver — heartbeat sidecar` reprovava cerca de uma rodada de CI em três, no
+macOS e no Windows, e travou três pull requests seguidas. Ele conferia se o
+último heartbeat parecia velho no instante em que o teste olhava — mas o sidecar
+renova o lease a QUALQUER saída nova, e o JSON de resultado do filho é saída
+nova. Se o heartbeat parecia velho dependia de onde um poll de 250ms caía em
+relação a essa escrita.
+
+Renovar na escrita final é comportamento correto, então a asserção é que estava
+errada, não o tempo. Uma tentativa anterior de consertar fazendo o filho falso
+sair mais cedo só estreitou a janela: os bytes já estão no arquivo de captura
+nesse ponto.
+
+A propriedade que ela queria — o sidecar parou de renovar durante a parada — é
+provada direto pelo evento `x_ledger_stall_observed`, emitido uma vez com o gap
+medido. Contra 2,2s de silêncio e um teto de 1,2s, o sidecar tem cerca de oito
+polls para notar. Não sobra corrida.
+
 ### A instalação ensinava o primeiro passo errado
 
 O instalador do engine terminava com uma lista de quatro comandos, o `nrv init`

--- a/skills/harness/tests/driver-ledger-heartbeat.test.ts
+++ b/skills/harness/tests/driver-ledger-heartbeat.test.ts
@@ -32,11 +32,11 @@ writeFakeCli(FAKE_BIN, "claude", `
   console.error("tick 3");
   await Bun.sleep(2200);
   console.log(JSON.stringify({ type: "result", result: "done", session_id: "fake-session-123", total_cost_usd: 0.01 }));
-  // Exit in the same breath as the write. The final result IS activity, so any
-  // sidecar tick landing between the write and process teardown renews the lease
-  // and the "stopped renewing during the stall" assertion sees a fresh heartbeat.
-  // The bash original exited immediately after printf; Bun's teardown widened
-  // that window enough to make the race show up roughly one run in three.
+  // Exit immediately after the write, as the bash original did — it keeps the
+  // fake's shape tight. It is no longer load-bearing: the assertion that used to
+  // race against this teardown was measuring the wrong thing and is gone (see
+  // the stall check below). Renewing on the final write is correct behaviour, so
+  // no amount of exiting sooner would have fixed it.
   process.exit(0);
 `);
 const ORIGINAL_PATH = process.env.PATH;
@@ -100,13 +100,27 @@ describe("driver — heartbeat sidecar", () => {
     // Renewed at least once during the active phase (stderr ticks).
     expect(Date.parse(after.heartbeat_at!)).toBeGreaterThan(t0);
     expect(Date.parse(after.lease_expires_at!)).toBeGreaterThan(leaseBefore);
-    // Stopped renewing during the stall: the last heartbeat is old relative to
-    // run end (the quiet stretch was 2.2s with a 1.2s stall budget).
-    expect(Date.now() - Date.parse(after.heartbeat_at!)).toBeGreaterThanOrEqual(1200);
-    // The stall itself was observed and recorded.
+    // "Stopped renewing during the stall" is asserted through the audit event,
+    // not through the freshness of heartbeat_at at the moment the test looks.
+    //
+    // A previous version checked `Date.now() - heartbeat_at >= 1200` and flaked
+    // on CI roughly one run in three (macOS and Windows both). It was asserting
+    // something the design contradicts: the sidecar renews on ANY new output,
+    // and the child's final result JSON is new output. Whether the heartbeat
+    // looks stale depends on where the 250ms poll happens to land relative to
+    // that last write — and killing the child sooner does not help, because the
+    // bytes are already in the capture file by then. Renewing on the final write
+    // is correct behaviour, so the assertion was wrong, not the timing.
+    //
+    // The event proves the property outright: the sidecar emits it once
+    // (`stallRecorded` guard) with the measured gap, and 2.2s of silence against
+    // a 1.2s budget gives it ~8 polls to notice. Nothing to race.
     const stallEvents = readAuditEvents().filter(e => e.event === "x_ledger_stall_observed" && e.run_id === row.run_id);
     expect(stallEvents.length).toBeGreaterThanOrEqual(1);
     expect(Number(stallEvents[0].gap_ms)).toBeGreaterThanOrEqual(1200);
+    // And it recorded WHICH heartbeat went stale, so the link between the stall
+    // and the lease is still covered.
+    expect(typeof stallEvents[0].heartbeat_at).toBe("string");
 
     // No dangling sidecar (the managed equivalent of "all timers cleared"):
     // give the SIGTERM/sentinel a moment, then look for the run id in ps.


### PR DESCRIPTION
## The flake

`driver — heartbeat sidecar` failed roughly **one CI run in three**, on macOS and Windows both, and blocked three PRs in a row (#4, #5, #13). Each time a manual re-run made it pass — exactly the friction an external contributor would hit and not know to ignore.

## The cause

```ts
expect(Date.now() - Date.parse(after.heartbeat_at!)).toBeGreaterThanOrEqual(1200)
```

The sidecar renews the lease on **any new output**. The child's final result JSON *is* new output. So whether `heartbeat_at` looked stale depended on where a 250ms poll landed relative to that last write.

Renewing on the final write is correct behaviour. **The assertion was wrong, not the timing.**

My earlier attempt (0.3.2 — make the fake child exit sooner) only narrowed the window: the bytes are already in the fd-redirected capture file by the time the child dies, so the next poll sees them regardless. That is why it came back.

## The fix

The property the test wanted — *the sidecar stopped renewing during the stall* — is proven outright by `x_ledger_stall_observed`: emitted once (guarded by `stallRecorded`), carrying the measured gap. Against 2.2s of silence with a 1.2s budget the sidecar gets ~8 polls to notice it. Nothing to race.

Not merely deleted: an added assertion checks the event carries the `heartbeat_at` it saw go stale, so the stall/lease link stays covered.

6 consecutive local runs clean. The comment in the fake CLI that justified the old exit timing now records that it is no longer load-bearing, so nobody reinstates a fix for a race that is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)