### PR TITLE
fix(install): drop the last nrv glance the user actually sees

### DIFF
--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -541,7 +541,9 @@ inline, with no dispatch, no quality gate and no audit trail.
       console.log("Done. No agent runtime detected — the engine is installed anyway; install a runtime and re-run to wire its hooks.");
     } else {
       console.log(`Done. ${installedCount} agent(s) configured. New sessions will emit audit events automatically.`);
-      console.log(`Watch with: ${anyChange ? "(may need to restart your agent for hooks to load) " : ""}nrv watch  or  nrv glance --allow-actions`);
+      // No `nrv glance` here: the cockpit is unfinished, and an install should
+      // not send a new user to the weakest surface as their first stop.
+      console.log(`Watch with: ${anyChange ? "(may need to restart your agent for hooks to load) " : ""}nrv watch`);
     }
   } else {
     console.log("Done. Hooks removed. Other settings preserved.");

--- a/skills/harness/tests/install-teaches-init.test.ts
+++ b/skills/harness/tests/install-teaches-init.test.ts
@@ -53,6 +53,15 @@ describe("the engine installer's last screen", () => {
     expect(summaryBlock()).not.toMatch(/nrv glance/);
   });
 
+  test("no installer prints nrv glance to the user", () => {
+    // Scoped to what the user SEES: the engine installer's summary and the
+    // hooks installer's closing line. A comment explaining the absence is fine.
+    const hooks = fs.readFileSync(path.join(ROOT, "skills/_shared/scripts/install.ts"), "utf8");
+    const printed = hooks.split("\n").filter((l) => l.includes("console.log") && l.includes("nrv glance"));
+    expect(printed).toEqual([]);
+    expect(summaryBlock()).not.toMatch(/console\.log\(.*nrv glance/);
+  });
+
   test("still tells the user how to verify the install", () => {
     const s = summaryBlock();
     expect(s).toMatch(/nrv install --check/);


### PR DESCRIPTION
#12 removed `nrv glance` from the engine installer's summary. The hooks installer closes from a **different file** with:

> Watch with: nrv watch  or  nrv glance --allow-actions

My test in #12 was scoped to `summary()`, so it did not catch it — a scoping choice that was right for that test and wrong as the whole guard.

The cockpit is unfinished; an install should not send a new user to the weakest surface. The test now checks every `console.log` across both installers, so a mention in a comment stays allowed and one in printed output does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)