### PR TITLE
docs(protocol): what a notification means, learned by getting it wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Three things about notifications, learned by getting them wrong
+
+A live test dispatch notified with a garbled `<result>` and nothing on disk. Read
+as final, that is a failed delivery. Minutes later the same dispatch notified
+again — clean report, file written. The work had been arriving the whole time.
+
+So the protocol now says what a notification means. It fires each time a target
+stops with no live background child, which means **one dispatch can notify more
+than once**: a `<result>` that looks truncated, garbled or contradicts the disk
+reads as *not finished yet*, never as failed. **`<result>` is a report, not
+proof** — the harness can neutralise output that looks like instructions, and a
+report can simply be optimistic; what proves delivery is Phase 6 reading the
+disk. And **an honestly reported blocker is the system working**: record it,
+close the run failed with the reason, and do not re-dispatch the same brief
+hoping for a different wall.
+
 ### Blocking the session was the wrong price for getting results back
 
 Earlier today the protocol was changed to dispatch synchronously

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,23 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Três coisas sobre notificações, aprendidas errando
+
+Um dispatch de teste notificou com o `<result>` corrompido e nada no disco. Lido
+como definitivo, aquilo é entrega falhada. Minutos depois o mesmo dispatch
+notificou de novo — relatório limpo, arquivo escrito. O trabalho estava chegando
+o tempo todo.
+
+Então o protocolo passou a dizer o que uma notificação significa. Ela dispara
+toda vez que o alvo para sem filho em background vivo, ou seja, **um dispatch
+pode notificar mais de uma vez**: um `<result>` truncado, corrompido ou que
+contradiz o disco se lê como *ainda não terminou*, nunca como falhou. **O
+`<result>` é relatório, não prova** — o harness pode neutralizar saída que se
+pareça com instruções, e um relatório pode ser só otimista; o que prova entrega é
+a Phase 6 lendo o disco. E **um bloqueio relatado honestamente é o sistema
+funcionando**: registre, feche o run como falho com o motivo, e não redespache o
+mesmo brief esperando outra parede.
+
 ### Travar a sessão era o preço errado para receber os resultados
 
 Mais cedo hoje o protocolo passou a despachar de forma síncrona

--- a/scripts/check-dispatch-contract.ts
+++ b/scripts/check-dispatch-contract.ts
@@ -50,6 +50,13 @@ const REQUIRED: { file: string; label: string; test: RegExp }[] = [
   { file: "skills/businesses/SKILL.md", label: "the handoff arrives by notification", test: /task-notification/i },
   { file: "skills/squads/SKILL.md", label: "a phase reports by notification", test: /task-notification/i },
   { file: "skills/harness/references/04-multi-target.md", label: "a wave is one message", test: /A wave is one message/ },
+  // Learned by getting it wrong in a live test: the first notification of a
+  // dispatch carried a garbled result and no file on disk; minutes later the
+  // same dispatch notified again, clean and complete. Reading the first as
+  // final would have condemned a delivery that was still arriving.
+  { file: "skills/harness/SKILL.md", label: "a notification may not be the last one", test: /not always the last one/i },
+  { file: "skills/harness/SKILL.md", label: "<result> is a report, not proof", test: /is a report, not proof/i },
+  { file: "skills/harness/SKILL.md", label: "an honest failure is not retried blindly", test: /honest failure is the system working/i },
 ];
 
 const findings: string[] = [];

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -260,6 +260,14 @@ Treating the receipt as the result is the bug this paragraph exists to prevent. 
 
 **When a notification arrives, that is the work coming home.** Read the `<result>`, gate it (Phase 6), close its ledger run (Phase 7), and tell the user. A notification you noticed and did not act on is the same failure as a receipt you mistook for a result — the run is finished and nobody knows.
 
+Three things about notifications that cost a wrong conclusion to learn:
+
+**A notification is not always the last one.** It fires each time the target stops with no live background child of its own, so one dispatch can notify more than once — the note in the notification says so. An early one can carry a partial or garbled `<result>` while the work is still in flight. Measured: a test dispatch notified with mangled output and no file on disk, then notified again minutes later with the clean report and the file written. Had the first been read as final, a delivery in progress would have been declared a failure. So when a `<result>` looks truncated, garbled or contradicts the disk, the honest reading is *not finished yet* — check again before you conclude anything.
+
+**`<result>` is a report, not proof.** It can be garbled by the harness when the target's output happens to look like instructions, truncated, or simply optimistic. What proves delivery is Phase 6 reading the disk: `verify-deliverable` plus the gate on the artifact that is actually there. A `<result>` saying "done" with nothing on disk is a run that failed, whatever it claims — and the reverse happens too, so check before you believe either.
+
+**An honest failure is the system working.** A target that reports it was blocked — a sandbox policy, a missing credential, a hard dependency — has done its job by telling you. Record it, close the run `failed` with the reason, and surface it. Do not re-dispatch the same brief hoping for a different outcome; a blocker that is real stays real, and the retry burns budget to arrive at the same wall.
+
 On claude-code, codex, and antigravity you dispatch through the runtime's **native in-process subagent** (the claude `Agent` tool, codex `[agents]`, antigravity dynamic subagents) — **not** `nrv dispatch --exec`, **not** a child `claude -p`. The in-process path runs inside your session with no 20-min wall-clock kill, so long deliverables don't get truncated. Reserve `--exec` / `runHeadless` for standalone headless scripted runs and sub-process-only runtimes (legacy gemini-cli, hermes).
 
 **Mind-clones (mandatory when declared).** If the dispatch involves a business with `assigned_mind_clones`, or you inject inline, call `injectMindClones({trace_id, slugs, ...})` from `lib/dispatch.ts` BEFORE spawning — it emits one `mind_clone_injected` event per DNA file. Without it, the subagent reads as generic Claude. `buildEmployeePrompt({...include_dna: true})` handles this for business dispatches.

--- a/skills/harness/tests/dispatch-contract.test.ts
+++ b/skills/harness/tests/dispatch-contract.test.ts
@@ -73,6 +73,33 @@ describe("the result is collected from the notification", () => {
   });
 });
 
+describe("what a notification actually means", () => {
+  const h = () => read("skills/harness/SKILL.md");
+
+  test("one dispatch can notify more than once", () => {
+    // A live test dispatch notified with a garbled result and no file on disk,
+    // then notified again minutes later, clean and complete. Reading the first
+    // as final would have declared a delivery in flight a failure.
+    expect(h()).toMatch(/not always the last one/i);
+    expect(h()).toMatch(/notify more than once/i);
+  });
+
+  test("a garbled or contradicted result means 'not finished', not 'failed'", () => {
+    expect(h()).toMatch(/truncated, garbled or contradicts the disk/i);
+    expect(h()).toMatch(/not finished yet/i);
+  });
+
+  test("delivery is proven on disk, not by the report", () => {
+    expect(h()).toMatch(/is a report, not proof/i);
+    expect(h()).toMatch(/verify-deliverable/);
+  });
+
+  test("an honestly reported blocker is recorded, not retried blindly", () => {
+    expect(h()).toMatch(/honest failure is the system working/i);
+    expect(h()).toMatch(/Do not re-dispatch the same brief/i);
+  });
+});
+
 describe("the bans that survive from the first version", () => {
   test("filesystem polling is still forbidden", () => {
     expect(read("skills/harness/SKILL.md")).toMatch(/[Nn]ever poll the filesystem/);


### PR DESCRIPTION
Verifying #17 end to end produced a wrong conclusion I nearly reported as fact.

A test dispatch notified with a **garbled `<result>` and no file on disk**. Read as final, that is a failed delivery. **Minutes later the same dispatch notified again** — clean report, file written. The work had been arriving the whole time.

Three rules now say so in the file the orchestrator reads:

1. **A notification is not always the last one.** It fires each time the target stops with no live background child, so one dispatch can notify more than once — the notification's own note says this. A `<result>` that is truncated, garbled, or contradicts the disk reads as *not finished yet*, never as failed.
2. **`<result>` is a report, not proof.** The harness neutralises output that looks like instructions, and a report can simply be optimistic. Delivery is proven by Phase 6 reading the disk.
3. **An honestly reported blocker is the system working.** Record it, close the run `failed` with the reason, and do not re-dispatch the same brief — a real blocker stays real and the retry buys the same wall at full price.

`check-dispatch-contract` now carries 11 rules; 4 tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)