### PR TITLE
feat(openclaw): make the engine usable from OpenClaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### OpenClaw
+
+Nirvana now installs into `~/.agents/skills`, the personal skills root OpenClaw
+reads, and the three skills carry a `metadata.openclaw` gate requiring `bun` —
+without it the skill would appear on a machine that cannot run a single one of
+its scripts.
+
+Two facts about that runtime change how the system behaves there, and the
+adapter (`_shared/adapters/openclaw.md`) documents both. It has **no in-process
+subagent**: work is delegated with `bash background:true` to a child CLI, tracked
+with `process poll`, and the child announces its own completion. That is exactly
+what `nrv dispatch --exec` already does, so the scripted path is the dispatch
+there rather than a fallback. And it reads **no project instruction file** — no
+CLAUDE.md or AGENTS.md equivalent — so activation rests entirely on the skill's
+description, and the run-ledger supervisor is what covers a worker that dies
+before announcing anything.
+
+The skill's compatibility line used to claim that a runtime whose spawn is
+fire-and-forget "cannot run the cascade". That stopped being true when dispatch
+became notification-collected, and it was never true for a runtime that offers a
+pollable handle instead.
+
 ### Three things about notifications, learned by getting them wrong
 
 A live test dispatch notified with a garbled `<result>` and nothing on disk. Read

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,28 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### OpenClaw
+
+O Nirvana passa a instalar em `~/.agents/skills`, a raiz de skills pessoais que o
+OpenClaw lê, e as três skills carregam um gate `metadata.openclaw` exigindo
+`bun` — sem ele, a skill apareceria numa máquina incapaz de rodar um único de
+seus scripts.
+
+Dois fatos daquele runtime mudam como o sistema se comporta lá, e o adapter
+(`_shared/adapters/openclaw.md`) documenta os dois. Ele **não tem subagente
+in-process**: o trabalho é delegado com `bash background:true` para um CLI filho,
+acompanhado por `process poll`, e o filho anuncia a própria conclusão. É
+exatamente o que o `nrv dispatch --exec` já faz, então ali o caminho scriptado é
+o dispatch, não um fallback. E ele **não lê arquivo de instrução de projeto** —
+não há equivalente a CLAUDE.md ou AGENTS.md — então a ativação depende
+inteiramente da descrição da skill, e quem cobre um worker que morre antes de
+anunciar é o supervisor do run-ledger.
+
+A linha de compatibilidade da skill afirmava que um runtime cujo spawn é
+fire-and-forget "não consegue rodar a cascata". Isso deixou de ser verdade quando
+o dispatch passou a ser coletado por notificação, e nunca foi verdade para um
+runtime que oferece um handle consultável no lugar.
+
 ### Três coisas sobre notificações, aprendidas errando
 
 Um dispatch de teste notificou com o `<result>` corrompido e nada no disco. Lido

--- a/skills/_shared/adapters/openclaw.md
+++ b/skills/_shared/adapters/openclaw.md
@@ -1,0 +1,133 @@
+# Adapter · OpenClaw
+
+> Runtime adapter para Squad Protocol v5 + Business Protocol v1 + Harness Protocol v2.
+> Identidade + capabilities do sistema: ver `../NIRVANA-OS.md` (fonte única).
+> Pesquisado em 2026-08-13 contra `docs.openclaw.ai` e `openclaw/openclaw` no GitHub.
+
+---
+
+## 1. Adapter Metadata
+
+| Campo | Valor |
+|---|---|
+| Runtime | OpenClaw (`openclaw`) |
+| Skills spec | [AgentSkills](https://agentskills.io) — `SKILL.md` com frontmatter YAML |
+| Skills roots (precedência) | `<workspace>/skills` → `<workspace>/.agents/skills` → `~/.agents/skills` → `<state-dir>/skills` → bundled |
+| Onde o engine instala | `~/.agents/skills` (personal), via `RUNTIME_SKILL_DIRS` |
+| Descoberta | varre até 6 níveis, casa pelo campo `name` do frontmatter — **não** pelo nome da pasta |
+| Invocação | `/harness` (slash), `$harness` (referência no prompt), ou dispatch direto por tool |
+| Contrato de projeto | **não existe** equivalente a `CLAUDE.md` / `AGENTS.md` lido pelo runtime |
+| Subagente in-process | **não existe** |
+| Delegação | `bash background:true` → CLI filho; acompanhamento por `process poll` / `process log` |
+
+---
+
+## 2. A diferença que decide tudo
+
+Claude Code, Codex e Antigravity têm um primitivo de subagente que roda dentro
+da sessão e devolve o resultado. O OpenClaw **não tem**. O que ele tem é o mesmo
+padrão que a própria skill `coding-agent` dele usa:
+
+```
+bash background:true workdir:<dir> command:"claude --permission-mode bypassPermissions --print < $PROMPT"
+```
+
+Isso devolve um **session id** na hora. O acompanhamento é por `process poll`
+(status) e `process log` (saída). E a conclusão **não chega sozinha**: o worker é
+instruído a anunciar o próprio fim com
+
+```
+openclaw message send --channel <channel> --target '<target>' --message '<resultado breve>'
+```
+
+Três consequências para o Nirvana, e nenhuma é opcional:
+
+1. **O caminho de dispatch aqui é o SCRIPTADO**, não o agêntico in-process.
+   `nrv dispatch --exec` (que é `runHeadless` disparando um CLI filho) é
+   exatamente a forma que o OpenClaw já usa. O `Agent(...)` do harness §Phase 4
+   não existe neste runtime.
+2. **A garantia de "nunca esquecido" passa a depender do ledger**, não de uma
+   notificação do runtime. É precisamente o cenário para o qual o run-ledger e o
+   supervisor foram construídos: sem callback automático, a prova de vida é a
+   atividade em disco sob `--outputs`, o lease vence, e o supervisor escala e
+   avisa. Ver `harness/SKILL.md` §Run ledger & supervisor.
+3. **O contrato de invocação não pode morar num arquivo de projeto**, porque o
+   OpenClaw não lê nenhum. Ele mora na skill — que é justamente onde o Nirvana
+   já o coloca desde 2026-08-13. Um projeto sem `nrv init` aqui não é degradação
+   parcial: é o único modo que existe.
+
+---
+
+## 3. Concept Mapping
+
+| Conceito Nirvana | OpenClaw |
+|---|---|
+| Skill (harness/squads/businesses) | `SKILL.md` em `~/.agents/skills/<nome>/` |
+| Invocar o maestro | `/harness` ou `$harness` no prompt |
+| Dispatch para business/squad | `bash background:true` → `nrv dispatch --exec --target <slug>` |
+| Retorno do alvo | `process poll` até terminar + `_SUMMARY.md` em disco |
+| Notificação de fim | worker anuncia via `openclaw message send`, ou o supervisor do Nirvana avisa |
+| Quality gate | idêntico — `quality-gate.ts`, roda no shell |
+| Auditoria | idêntica — `~/.harness-logs/<data>/audit.jsonl` |
+| Mind-clone | idêntico — DNA injetado no prompt do CLI filho |
+
+---
+
+## 4. Frontmatter
+
+O OpenClaw exige `name` + `description` e aceita `metadata.openclaw` para
+gating. O bloco abaixo é o que faz a skill aparecer só onde ela funciona — sem
+ele, um usuário sem Bun vê a skill, invoca e recebe erro:
+
+```yaml
+metadata:
+  openclaw:
+    emoji: "🎼"
+    requires:
+      bins: ["bun"]        # todo script do Nirvana é Bun-nativo; sem bun nada roda
+      anyBins: ["claude", "codex", "opencode"]   # algum CLI para receber o dispatch
+```
+
+`user-invocable` fica no default (`true`), então `/harness` funciona.
+Não usar `disable-model-invocation`: o harness precisa ativar por descrição
+quando o usuário pede um artefato sem citar o sistema pelo nome.
+
+---
+
+## 5. Dispatch — a forma correta neste runtime
+
+```bash
+# 1. prep (idêntico a todo runtime): abre o run no ledger, emite auditoria
+bun ~/.nirvana/skills/squads/scripts/brief-squad.ts <slug> "<brief>" --project <trace_id>
+
+# 2. dispatch em background, com o CLI filho que o OpenClaw tiver
+bash background:true workdir:<project_dir> \
+  command:"nrv dispatch '<brief>' --target squad:<slug> --project <trace_id> --exec"
+
+# 3. acompanhar SEM varrer o disco
+process poll <session_id>
+
+# 4. quando terminar: gate, fechar o run, avisar
+bun ~/.nirvana/skills/harness/scripts/quality-gate.ts <artefato> --auto
+nrv run-track close <run-id> --state delivered|withheld|failed
+```
+
+As regras do harness que **valem igual aqui**: recibo não é resultado (aqui o
+recibo é o session id); nunca inferir conclusão varrendo arquivo — use
+`process poll`, que é a resposta autoritativa; dispatch não leva timeout; e uma
+onda de alvos independentes dispara todos os `bash background:true` antes de
+esperar qualquer um.
+
+---
+
+## 6. Limites conhecidos
+
+- **Sem contrato de projeto.** Não há `CLAUDE.md`/`AGENTS.md` que o OpenClaw
+  leia, então a ativação depende inteiramente da descrição da skill. Escrever a
+  descrição bem é aqui uma questão de funcionamento, não de estilo.
+- **Conclusão é anunciada, não entregue.** Se o worker morrer antes de anunciar,
+  quem percebe é o supervisor do Nirvana pelo lease vencido — não o OpenClaw.
+- **`~/.agents/skills` é compartilhado.** Outras ferramentas escrevem ali (o CLI
+  do `agentskills`, por exemplo). O engine linka por-skill, nunca o diretório
+  inteiro: um symlink do diretório para a árvore de outro runtime faz cada skill
+  ser alcançável duas vezes e gera "Skill conflict detected".

--- a/skills/_shared/lib/runtime-dirs.ts
+++ b/skills/_shared/lib/runtime-dirs.ts
@@ -27,6 +27,15 @@ export const RUNTIME_SKILL_DIRS = [
   join(homedir(), ".gemini/skills"),
   join(homedir(), ".antigravity/skills"),
   join(homedir(), ".pi/agent/skills"),   // Pi Coding Agent (Agent Skills standard)
+  // OpenClaw reads ~/.agents/skills as its "personal agent skills" source. It
+  // is a real runtime dir, not a stray: linking the engine there is the only
+  // way an OpenClaw session ever sees the harness. Note that a SYMLINK of this
+  // whole directory to another runtime's tree is a different thing and a bad
+  // one — it makes every skill reachable twice and runtimes that honour both
+  // paths log "Skill conflict detected" (see doctor: duplicate exposure).
+  // Per-skill links into ~/.nirvana/skills, like every other entry here, do not
+  // have that problem.
+  join(homedir(), ".agents/skills"),     // OpenClaw (personal agent skills)
 ];
 
 /**

--- a/skills/businesses/SKILL.md
+++ b/skills/businesses/SKILL.md
@@ -4,6 +4,12 @@ description: "Business lifecycle skill (DOMAIN-AGNOSTIC). Creates, lists, inspec
 compatibility: "Requires the Nirvana-OS engine: the `nrv` CLI and Bun on PATH. Install: npx @nirvana-os/cli. Runtime-agnostic — no dependency on any specific agent CLI. Creation flows need an interactive question primitive; without one, use the non-interactive list/inspect/validate paths."
 tools: [Read, Write, Edit, Glob, Grep, Bash, AgentTool, TaskCreate, AskUserQuestion]
 maxTurns: 100
+metadata:
+  openclaw:
+    emoji: "🏢"
+    requires:
+      # Todo script do Nirvana é Bun-nativo: sem bun a skill aparece e falha.
+      bins: ["bun"]
 ---
 
 # Business Protocol Engine v1.0

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: harness
 description: "Nirvana-OS orchestrator: routes a brief across the user's own library of businesses, squads and mind-clones, dispatches the best combination, and gates the result before delivery. Use when the user asks for a concrete artifact (book, video, report, design, code, campaign, any deliverable) in a machine where Nirvana-OS is installed, or whenever they invoke the system by name: 'use o nirvana-os', 'via nirvana', 'pelo nirvana', 'orquestre via nirvana', 'manda o nirvana', 'use minhas empresas/squads', 'o que o nirvana pode fazer'. Agentic by default; a `fast` BM25 mode gives zero-token deterministic routing."
-compatibility: "Requires the Nirvana-OS engine: the `nrv` CLI and Bun on PATH, plus a content library under ~/businesses and ~/squads. Install: npx @nirvana-os/cli. Runtime-agnostic — no dependency on any specific agent CLI. Dispatch needs a subagent primitive that RETURNS its result; runtimes whose spawn is fire-and-forget cannot run the cascade."
+compatibility: "Requires the Nirvana-OS engine: the `nrv` CLI and Bun on PATH, plus a content library under ~/businesses and ~/squads. Install: npx @nirvana-os/cli. Runtime-agnostic — no dependency on any specific agent CLI. Dispatch needs a way to learn that a target finished: a completion notification (claude-code, codex, antigravity), a pollable process handle (openclaw), or the run-ledger supervisor when the runtime offers neither."
 tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, TaskCreate, AskUserQuestion, WebSearch, WebFetch]
 maxTurns: 200
+metadata:
+  openclaw:
+    emoji: "🎼"
+    requires:
+      # Todo script do Nirvana é Bun-nativo: sem bun a skill aparece e falha.
+      bins: ["bun"]
 ---
 
 # Harness Protocol Engine v2.0 — Agentic Mode
@@ -267,6 +273,8 @@ Three things about notifications that cost a wrong conclusion to learn:
 **`<result>` is a report, not proof.** It can be garbled by the harness when the target's output happens to look like instructions, truncated, or simply optimistic. What proves delivery is Phase 6 reading the disk: `verify-deliverable` plus the gate on the artifact that is actually there. A `<result>` saying "done" with nothing on disk is a run that failed, whatever it claims — and the reverse happens too, so check before you believe either.
 
 **An honest failure is the system working.** A target that reports it was blocked — a sandbox policy, a missing credential, a hard dependency — has done its job by telling you. Record it, close the run `failed` with the reason, and surface it. Do not re-dispatch the same brief hoping for a different outcome; a blocker that is real stays real, and the retry burns budget to arrive at the same wall.
+
+**On OpenClaw there is no in-process subagent, so the scripted path IS the dispatch.** It has no `Agent(...)`: work is delegated with `bash background:true` to a child CLI, tracked with `process poll`, and the child announces its own completion. That is exactly what `nrv dispatch --exec` does, so use it — the prep step, the ledger, the gate and the audit are unchanged. Details and the exact command shapes: `../_shared/adapters/openclaw.md`. The same holds for any runtime whose only delegation primitive is a shell.
 
 On claude-code, codex, and antigravity you dispatch through the runtime's **native in-process subagent** (the claude `Agent` tool, codex `[agents]`, antigravity dynamic subagents) — **not** `nrv dispatch --exec`, **not** a child `claude -p`. The in-process path runs inside your session with no 20-min wall-clock kill, so long deliverables don't get truncated. Reserve `--exec` / `runHeadless` for standalone headless scripted runs and sub-process-only runtimes (legacy gemini-cli, hermes).
 

--- a/skills/harness/tests/openclaw-support.test.ts
+++ b/skills/harness/tests/openclaw-support.test.ts
@@ -1,0 +1,92 @@
+// openclaw-support.test.ts — Nirvana must be usable from OpenClaw.
+//
+// Researched 2026-08-13 against docs.openclaw.ai and openclaw/openclaw. Three
+// facts drive everything here:
+//
+//   1. OpenClaw discovers skills under ~/.agents/skills (personal), matching on
+//      the frontmatter `name`, not the folder. If the engine does not link
+//      there, an OpenClaw session never sees the harness at all.
+//   2. It has NO in-process subagent. Delegation is `bash background:true` to a
+//      child CLI, tracked with `process poll`, and the child announces its own
+//      completion. So the scripted path (`nrv dispatch --exec`) is the dispatch
+//      on that runtime, not a fallback.
+//   3. It reads NO project instruction file — no CLAUDE.md/AGENTS.md
+//      equivalent. Activation rests entirely on the skill's own description.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { RUNTIME_SKILL_DIRS } from "../../_shared/lib/runtime-dirs.ts";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const SKILLS = ["skills/harness/SKILL.md", "skills/squads/SKILL.md", "skills/businesses/SKILL.md"];
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+const frontmatter = (rel: string) => read(rel).split("---")[1];
+
+describe("OpenClaw can find the skills", () => {
+  test("~/.agents/skills is a wired runtime dir", () => {
+    expect(RUNTIME_SKILL_DIRS).toContain(path.join(os.homedir(), ".agents/skills"));
+  });
+
+  test("every skill declares a name — OpenClaw matches on it, not the folder", () => {
+    for (const rel of SKILLS) expect(frontmatter(rel)).toMatch(/^name:\s*\S+/m);
+  });
+});
+
+describe("OpenClaw gating", () => {
+  test("each skill requires bun, because every script is Bun-native", () => {
+    // Without the gate the skill shows up on a machine with no bun, gets
+    // invoked, and fails at the first command.
+    for (const rel of SKILLS) {
+      const fm = frontmatter(rel);
+      expect(fm).toMatch(/openclaw:/);
+      expect(fm).toMatch(/bins:\s*\["bun"\]/);
+    }
+  });
+
+  test("model invocation stays enabled", () => {
+    // The harness must be able to activate from a plain production brief, not
+    // only from an explicit /harness. `disable-model-invocation` would kill that.
+    for (const rel of SKILLS) expect(frontmatter(rel)).not.toMatch(/disable-model-invocation:\s*true/);
+  });
+});
+
+describe("the dispatch path OpenClaw can actually run", () => {
+  test("the protocol names the scripted path for runtimes with no subagent", () => {
+    const h = read("skills/harness/SKILL.md");
+    expect(h).toMatch(/no in-process subagent/i);
+    expect(h).toMatch(/bash background:true/);
+    expect(h).toMatch(/process poll/);
+  });
+
+  test("the stale compatibility claim is gone", () => {
+    // It used to say a fire-and-forget runtime "cannot run the cascade". Untrue
+    // since dispatch became notification-collected, and untrue for OpenClaw,
+    // which offers a pollable handle instead.
+    expect(read("skills/harness/SKILL.md")).not.toMatch(/cannot run the cascade/);
+  });
+
+  test("the adapter documents the mechanism, not just the name", () => {
+    const a = read("skills/_shared/adapters/openclaw.md");
+    expect(a).toMatch(/openclaw message send/);      // how completion is announced
+    expect(a).toMatch(/process poll/);               // how it is tracked
+    expect(a).toMatch(/nrv dispatch .*--exec/);      // what Nirvana runs
+    expect(a).toMatch(/run-ledger|supervisor/i);     // what covers a worker that dies silent
+  });
+
+  test("the adapter is honest that no project contract file exists there", () => {
+    expect(read("skills/_shared/adapters/openclaw.md")).toMatch(/não existe.*equivalente a `CLAUDE\.md`|reads NO project|não lê nenhum/i);
+  });
+});
+
+describe("the shared skills dir is treated with care", () => {
+  test("the runtime-dirs comment warns against symlinking the whole directory", () => {
+    // ~/.agents/skills is shared with other tooling. Symlinking the directory
+    // to another runtime's tree makes every skill reachable twice and produces
+    // "Skill conflict detected" — that exact defect was found and removed on
+    // this machine on 2026-08-13.
+    const rd = read("skills/_shared/lib/runtime-dirs.ts");
+    expect(rd).toMatch(/Skill conflict detected/);
+    expect(rd).toMatch(/OpenClaw/);
+  });
+});

--- a/skills/squads/SKILL.md
+++ b/skills/squads/SKILL.md
@@ -4,6 +4,12 @@ description: "Squad lifecycle skill. Use when asked to create, validate, inspect
 compatibility: "Requires the Nirvana-OS engine: the `nrv` CLI and Bun on PATH. Install: npx @nirvana-os/cli. Runtime-agnostic — no dependency on any specific agent CLI. Squad activation may install large dependencies and needs an interactive consent primitive."
 tools: [Read, Write, Edit, Glob, Grep, Bash]
 maxTurns: 50
+metadata:
+  openclaw:
+    emoji: "🛠️"
+    requires:
+      # Todo script do Nirvana é Bun-nativo: sem bun a skill aparece e falha.
+      bins: ["bun"]
 ---
 
 # Squad Protocol Engine v5.0.0


### PR DESCRIPTION
Researched against [docs.openclaw.ai](https://docs.openclaw.ai/tools/skills) and [openclaw/openclaw](https://github.com/openclaw/openclaw) on 2026-08-13. Three facts about that runtime drove the whole change.

## 1. It never saw the skills

OpenClaw discovers skills under `~/.agents/skills` (personal root), matching on the frontmatter `name` rather than the folder. The engine did not link there, so an OpenClaw session never saw the harness at all.

`~/.agents/skills` joins `RUNTIME_SKILL_DIRS` — **per-skill links, never a symlink of the whole directory.** That distinction is not theoretical: a directory symlink is exactly what produced "Skill conflict detected" on this machine earlier today, because it makes every skill reachable twice.

## 2. It has no in-process subagent

Delegation is `bash background:true` to a child CLI, tracked with `process poll` / `process log`, and the child announces its own completion:

```
openclaw message send --channel <channel> --target '<target>' --message '<result>'
```

That is precisely what `nrv dispatch --exec` already does. **So the scripted path IS the dispatch there** — not a fallback. Documented in `SKILL.md` and in the new adapter with the exact command shapes.

A worker that dies before announcing is covered by the run-ledger supervisor: no callback, so file activity under `--outputs` is the proof of life, the lease expires, and the human is told. That is the case the ledger was built for.

## 3. It reads no project instruction file

No `CLAUDE.md`/`AGENTS.md` equivalent exists. Activation rests entirely on the skill's description, and the invocation contract has to live in the skill — which is where it already is.

## Gating

The three skills gain `metadata.openclaw` requiring `bun`. Without it the skill appears on a machine that cannot run a single one of its scripts. `disable-model-invocation` is deliberately not set: the harness must activate from a plain production brief, not only from `/harness`.

## A stale claim corrected

The compatibility line said a runtime whose spawn is fire-and-forget *"cannot run the cascade"*. That stopped being true when dispatch became notification-collected (#17), and was never true for a runtime offering a pollable handle instead.

## Tests

9 in `openclaw-support.test.ts`: discovery path, the `name` field, the bun gate, model invocation left enabled, the scripted path named in the protocol, the stale claim gone, the adapter documenting the real mechanism rather than the name, its honesty about the missing project contract, and the warning against directory symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)