### PR TITLE
fix(openclaw): only offer a runtime the skills it can actually use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A Hermes-only skill was offered to every runtime
+
+Installing OpenClaw and running `openclaw skills list` showed `nirvana-os-hermes`
+as ready. It is not in the skills root: OpenClaw scans six levels deep and found
+it under `_shared/adapters/hermes/`, which the installer links into every
+runtime. Its own description asks other runtimes to ignore it — prose enforces
+nothing. It is now gated on the `hermes` binary, so it disappears where Hermes is
+absent.
+
+The gate cannot express "which runtime am I" — OpenClaw offers binary, config and
+OS gates only — so on a machine that has Hermes installed and OpenClaw running,
+both variants still appear and the description is what remains.
+
+The `nirvana-os` skill also shipped with no gate at all, visible on machines that
+cannot run a line of it. It requires `bun` now, like the other three.
+
 ### OpenClaw
 
 Nirvana now installs into `~/.agents/skills`, the personal skills root OpenClaw

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,21 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Uma skill exclusiva do Hermes era oferecida a todo runtime
+
+Instalar o OpenClaw e rodar `openclaw skills list` mostrou o `nirvana-os-hermes`
+como pronto. Ele não está na raiz de skills: o OpenClaw varre seis níveis e o
+encontrou sob `_shared/adapters/hermes/`, que o instalador linka em todo runtime.
+A descrição dele pede que os outros runtimes o ignorem — prosa não impõe nada.
+Agora ele tem gate no binário `hermes`, então some onde o Hermes não existe.
+
+O gate não consegue expressar "qual runtime eu sou" — o OpenClaw só oferece gate
+por binário, config e SO — então numa máquina com Hermes instalado e OpenClaw
+rodando as duas variantes ainda aparecem, e o que resta é a descrição.
+
+A skill `nirvana-os` também vinha sem gate nenhum, visível em máquinas incapazes
+de rodar uma linha dela. Agora exige `bun`, como as outras três.
+
 ### OpenClaw
 
 O Nirvana passa a instalar em `~/.agents/skills`, a raiz de skills pessoais que o

--- a/skills/_shared/adapters/hermes/skills/nirvana/nirvana-os-hermes/SKILL.md
+++ b/skills/_shared/adapters/hermes/skills/nirvana/nirvana-os-hermes/SKILL.md
@@ -8,6 +8,14 @@ platforms: [macos, linux]
 metadata:
   hermes:
     tags: [nirvana, businesses, empresas, squads, mind-clones, harness, orchestration, orquestracao]
+  openclaw:
+    # This bridge asks, in its own description, to be ignored by every runtime
+    # but Hermes. OpenClaw scans six levels deep, found it under _shared/, and
+    # listed it as ready — offering a Hermes-only skill to someone who cannot
+    # use it. Prose cannot enforce that; this gate can: the skill appears only
+    # where the hermes binary exists.
+    requires:
+      bins: ["hermes"]
 prerequisites:
   commands: [nrv]
 ---

--- a/skills/harness/tests/openclaw-support.test.ts
+++ b/skills/harness/tests/openclaw-support.test.ts
@@ -79,6 +79,36 @@ describe("the dispatch path OpenClaw can actually run", () => {
   });
 });
 
+describe("only the skills a runtime can use are offered to it", () => {
+  // Found by installing OpenClaw and running `openclaw skills list`: it scans
+  // six levels deep, reached the Hermes bridge under _shared/, and listed it as
+  // ready — offering a Hermes-only skill to a runtime that cannot use it. The
+  // bridge's own description asks every other runtime to ignore it; prose does
+  // not enforce anything, a binary gate does.
+  const hermesBridge = "skills/_shared/adapters/hermes/skills/nirvana/nirvana-os-hermes/SKILL.md";
+
+  test("the Hermes bridge is gated on the hermes binary", () => {
+    const fm = frontmatter(hermesBridge);
+    expect(fm).toMatch(/openclaw:/);
+    expect(fm).toMatch(/bins:\s*\["hermes"\]/);
+  });
+
+  test("its description still says it out loud, as defence in depth", () => {
+    // The gate cannot express "which runtime am I" — OpenClaw offers binary,
+    // config and OS gates only. On a machine with hermes installed AND OpenClaw
+    // running, both variants appear, and the description is what remains.
+    expect(read(hermesBridge)).toMatch(/Hermes runtime ONLY/);
+  });
+
+  test("every Nirvana skill an OpenClaw user can see requires bun", () => {
+    // nirvana-os shipped without a gate and showed up on the list with no emoji
+    // — visible on a machine that cannot run one line of it.
+    for (const rel of [...SKILLS, "skills/nirvana-os/SKILL.md"]) {
+      expect(frontmatter(rel)).toMatch(/bins:\s*\["bun"\]/);
+    }
+  });
+});
+
 describe("the shared skills dir is treated with care", () => {
   test("the runtime-dirs comment warns against symlinking the whole directory", () => {
     // ~/.agents/skills is shared with other tooling. Symlinking the directory

--- a/skills/nirvana-os/SKILL.md
+++ b/skills/nirvana-os/SKILL.md
@@ -6,6 +6,12 @@ tools: [Bash, Read, Skill]
 version: 1.0.0
 author: nirvana-os
 license: SUL-1.0
+metadata:
+  openclaw:
+    emoji: "🌀"
+    requires:
+      # Bun-native como o resto do engine.
+      bins: ["bun"]
 ---
 
 # Nirvana-OS


### PR DESCRIPTION
Found by **installing OpenClaw and running `openclaw skills list`** — the test research alone could not do.

## The defect

`nirvana-os-hermes` listed as **ready**. It is not in the skills root: OpenClaw scans six levels deep and reached it under `_shared/adapters/hermes/`, which the installer links into every runtime dir.

Its own description says *"Hermes runtime ONLY — every other runtime must ignore this one"*. Prose enforces nothing. It is now gated on the `hermes` binary.

## Verified against the real CLI

`openclaw skills info nirvana-os-hermes` prints `Requirements: Binaries: ✓ hermes`. It still shows on this machine **because hermes is installed here** — the gate is working, not bypassed.

## The limit, stated rather than hidden

The gate cannot express *"which runtime am I"* — OpenClaw offers binary, config and OS gates only. On a machine with Hermes installed **and** OpenClaw running, both variants appear and the description is the remaining defence. A test pins that so it is not rediscovered as a surprise.

## Also

`nirvana-os` shipped with no `metadata.openclaw` at all — visible on a machine that cannot run a line of it, and the only one of the five listing without an emoji. It requires `bun` now, like the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)