### PR TITLE
fix(quota): a 5xx is transient, as the header always claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A 5xx killed runs the header promised to retry
+
+`quota-detector` has documented since day one that a 5xx classifies as
+`transient` — recoverable, retry the same runtime. No rule ever implemented it.
+Every 5xx fell through to `error`, which the cascade treats as fatal: it emits
+`runtime_error` and gives up, where `transient` sleeps and retries.
+
+Found by a real incident: an Anthropic **529 Overloaded** killed a dispatch that
+would have succeeded seconds later. The agentic orchestrator recovered by
+reasoning about the error in prose — it checked nothing had been written, closed
+the run `failed` with the reason, and redispatched from scratch. The scripted
+path had nothing to reason with.
+
+5xx now classifies as transient across every runtime, and conservatively: a bare
+"529" could be a line number, so a status code counts only next to
+status-shaped context, while the word "overloaded" is accepted alone because no
+provider uses it for anything else. The runtime tables keep first say — a 503
+that a provider uses to mean "your plan is spent" stays `quota_exhausted`,
+because that needs a cooldown and a handoff, not a retry against the same wall.
+
 ### A Hermes-only skill was offered to every runtime
 
 Installing OpenClaw and running `openclaw skills list` showed `nirvana-os-hermes`

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,27 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Um 5xx matava runs que o cabeçalho prometia retentar
+
+O `quota-detector` documenta desde sempre que um 5xx classifica como
+`transient` — recuperável, retenta o mesmo runtime. Nenhuma regra jamais
+implementou isso. Todo 5xx caía em `error`, que a cascata trata como fatal: emite
+`runtime_error` e desiste, enquanto `transient` dorme e retenta.
+
+Achado por um incidente real: um **529 Overloaded** da Anthropic matou um
+dispatch que teria funcionado segundos depois. O orquestrador agêntico se
+recuperou raciocinando sobre o erro em prosa — conferiu que nada tinha sido
+escrito, fechou o run como `failed` com o motivo, e redespachou do zero. O
+caminho scriptado não tinha com o que raciocinar.
+
+Agora 5xx classifica como transitório em todo runtime, e de forma conservadora:
+um "529" solto pode ser número de linha, então código de status só conta perto de
+contexto de status, enquanto a palavra "overloaded" é aceita sozinha porque
+nenhum provedor a usa para outra coisa. As tabelas por runtime mantêm a primeira
+palavra — um 503 que um provedor use para dizer "seu plano acabou" continua
+`quota_exhausted`, porque isso pede cooldown e handoff, não retentativa contra a
+mesma parede.
+
 ### Uma skill exclusiva do Hermes era oferecida a todo runtime
 
 Instalar o OpenClaw e rodar `openclaw skills list` mostrou o `nirvana-os-hermes`

--- a/skills/harness/lib/quota-detector.ts
+++ b/skills/harness/lib/quota-detector.ts
@@ -58,6 +58,37 @@ function findRetryAfterSec(text: string): number | undefined {
   return undefined;
 }
 
+/**
+ * A 5xx from any provider means "the server could not, try again", never "your
+ * request was wrong". The header of this file has promised since day one that
+ * 5xx classifies as transient — and no rule ever implemented it, so every 5xx
+ * fell through to `error`, which the cascade treats as fatal: it emits
+ * runtime_error and gives up instead of retrying.
+ *
+ * Found by a real incident: an Anthropic 529 Overloaded killed a dispatch that
+ * would have succeeded seconds later. The orchestrator recovered by reasoning
+ * about it in prose; the scripted path had nothing to reason with.
+ *
+ * Conservative on purpose. A bare "529" in output could be a line number or a
+ * token count, so a status code only counts next to status-shaped context, and
+ * the word "overloaded" is accepted on its own because no provider uses it for
+ * anything else.
+ */
+function serverSideFailure(text: string): QuotaClass | undefined {
+  const overloaded = /\boverloaded\b/i.test(text);
+  const status5xx = /\b(?:status|http|code|error)\b[^0-9]{0,12}\b5(?:00|02|03|04|29)\b/i.test(text)
+    || /\b5(?:00|02|03|04|29)\b\s*(?:overloaded|internal server error|bad gateway|service unavailable|gateway timeout)/i.test(text);
+  if (!overloaded && !status5xx) return undefined;
+  return {
+    kind: "transient",
+    // Honour an explicit retry-after; otherwise let the caller pick its default.
+    // An overloaded server rarely says how long, and guessing long here would
+    // stall a run that a few seconds would have fixed.
+    retryAfterSec: findRetryAfterSec(text),
+    hint: overloaded ? "provider overloaded (5xx) — transient" : "provider server error (5xx) — transient",
+  };
+}
+
 function classifyClaudeCode(text: string): QuotaClass {
   const t = text.toLowerCase();
   // Subscription windows surface as text — not status codes. The live message
@@ -225,10 +256,21 @@ export function classify(runtime: Runtime, r: RunResultLike): QuotaClass {
   if (r.ok && r.exitCode === 0) return { kind: "ok" };
   const text = [r.stderr, r.error, r.result].filter(Boolean).join("\n");
   if (!text) return { kind: "error", hint: `runtime ${runtime} exit ${r.exitCode} with no output` };
-  if (runtime === "claude-code") return classifyClaudeCode(text);
-  if (runtime === "codex") return classifyCodex(text);
-  if (runtime === "gemini-cli") return classifyGemini(text);
-  if (runtime === "antigravity-cli") return classifyAntigravity(text);
-  if (runtime === "pi") return classifyPi(text);
+  if (runtime === "claude-code") return refineServerFailure(classifyClaudeCode(text), text);
+  if (runtime === "codex") return refineServerFailure(classifyCodex(text), text);
+  if (runtime === "gemini-cli") return refineServerFailure(classifyGemini(text), text);
+  if (runtime === "antigravity-cli") return refineServerFailure(classifyAntigravity(text), text);
+  if (runtime === "pi") return refineServerFailure(classifyPi(text), text);
   return { kind: "error", hint: `unknown runtime ${runtime}` };
+}
+
+/**
+ * The runtime tables get first say: a 503 that a provider uses to mean "your
+ * plan is spent" must stay quota_exhausted, because that needs a cooldown and a
+ * handoff, not a retry against the same wall. Only a verdict of `error` — the
+ * bucket that means "we do not recognise this" — is re-examined for a 5xx.
+ */
+function refineServerFailure(v: QuotaClass, text: string): QuotaClass {
+  if (v.kind !== "error") return v;
+  return serverSideFailure(text) ?? v;
 }

--- a/skills/harness/tests/quota-5xx.test.ts
+++ b/skills/harness/tests/quota-5xx.test.ts
@@ -1,0 +1,71 @@
+// quota-5xx.test.ts — a 5xx is transient, which the header always claimed and
+// no rule ever implemented.
+//
+// Found by a real incident (galinha-dos-ovos-de-ouro, 2026-08-13 23:04): an
+// Anthropic 529 Overloaded killed a dispatch that would have succeeded seconds
+// later. Every 5xx fell through to `error`, and the cascade treats `error` as
+// fatal — it emits runtime_error and gives up, where `transient` sleeps and
+// retries the same runtime. The agentic orchestrator recovered by reasoning
+// about the error in prose; the scripted path had nothing to reason with.
+import { describe, expect, test } from "bun:test";
+import { classify } from "../lib/quota-detector.ts";
+
+const fail = (stderr: string) => ({ ok: false, exitCode: 1, stderr });
+
+describe("5xx classifies as transient", () => {
+  test("the exact 529 payload from the incident", () => {
+    const v = classify("claude-code", fail(
+      'API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+    ));
+    expect(v.kind).toBe("transient");
+  });
+
+  test("the gateway family, on every runtime", () => {
+    for (const rt of ["claude-code", "codex", "gemini-cli", "antigravity-cli", "pi"] as const) {
+      for (const body of ["HTTP 503 Service Unavailable", "status 500 internal server error", "error 502 bad gateway"]) {
+        expect(classify(rt, fail(body)).kind).toBe("transient");
+      }
+    }
+  });
+
+  test('the bare word "overloaded" is enough', () => {
+    // No provider uses it for anything else, and a 529 does not always print
+    // its status code.
+    expect(classify("claude-code", fail("Server overloaded, please retry")).kind).toBe("transient");
+  });
+
+  test("an explicit retry-after is carried through", () => {
+    const v = classify("claude-code", fail("503 service unavailable, retry-after: 30"));
+    expect(v.kind).toBe("transient");
+    if (v.kind === "transient") expect(v.retryAfterSec).toBe(30);
+  });
+});
+
+describe("what must NOT become transient", () => {
+  test("a loose number that happens to be 5xx-shaped", () => {
+    // "529" can be a line number or a token count. Without status-shaped
+    // context around it, a retry would be guessing.
+    expect(classify("claude-code", fail("parsed 529 tokens from the file")).kind).toBe("error");
+    expect(classify("codex", fail("line 500: unexpected token")).kind).toBe("error");
+  });
+
+  test("quota keeps its verdict — it needs a cooldown, not a retry", () => {
+    // Retrying the same runtime against a spent plan buys the same wall at full
+    // price. The runtime tables get first say for exactly this reason.
+    const v = classify("claude-code", fail("Rate limit reached. Your limit will reset at 3pm."));
+    expect(v.kind).toBe("quota_exhausted");
+  });
+
+  test("auth failure keeps its verdict", () => {
+    const v = classify("pi", fail("401 unauthorized: invalid api key"));
+    expect(v.kind).toBe("auth_failed");
+  });
+
+  test("a genuine bug stays an error", () => {
+    expect(classify("claude-code", fail("TypeError: cannot read property 'x' of undefined")).kind).toBe("error");
+  });
+
+  test("success is still ok", () => {
+    expect(classify("claude-code", { ok: true, exitCode: 0 }).kind).toBe("ok");
+  });
+});


### PR DESCRIPTION
## The gap between the comment and the code

`quota-detector.ts` line 3, since day one:

> `transient : recoverable error (5xx, brief 429 with short retry-after) — caller may retry same runtime`

**No rule implemented it.** `529` appears nowhere in the file, and there is no 5xx status check anywhere — only text patterns and retry-after parsing. Every 5xx fell through to `error`.

And `cascade-runner` treats the two very differently:

| verdict | what happens |
|---|---|
| `transient` | sleeps, **retries the same runtime** |
| `error` | emits `runtime_error`, **gives up** |

So a provider hiccup that resolves in seconds ended the run.

## Found by a real incident

`galinha-dos-ovos-de-ouro`, 23:04 — an Anthropic **529 Overloaded** killed a dispatch that would have succeeded moments later.

The agentic orchestrator recovered *by reasoning about it in prose*: it verified nothing had been written (HEAD unchanged, outputs empty), closed the run `failed` with the reason, and redispatched from scratch. Correct — and entirely by judgement. The scripted path had nothing to reason with.

## Conservative by construction

- A bare `529` can be a line number or a token count, so a status code counts **only adjacent to status-shaped context** (`status`/`http`/`code`/`error`, or a known 5xx phrase).
- The word `overloaded` is accepted alone — no provider uses it for anything else.
- **The runtime tables keep first say.** Only a verdict of `error` — the bucket meaning "unrecognised" — is re-examined. A 503 that a provider uses for "your plan is spent" stays `quota_exhausted`, which needs a cooldown and a handoff, not a retry against the same wall.
- The transient retry consumes a loop attempt (`attempt++` at the top of the `while`), so a persistent 5xx stays bounded by `maxHandoffs`.

## Tests

9: the exact incident payload, the gateway family across all five runtimes, bare "overloaded", retry-after carried through, and the four things that must **not** become transient — loose numbers, quota, auth, real bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)