### PR TITLE
fix(purity): derive the guarded paths from the engine, not from memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The leak guard now follows the engine instead of remembering it
+
+Removing the committed run artifacts left a gate that named three paths from
+memory — `outputs/`, `.nirvana/`, `.harness-logs/`. A list like that goes stale
+the day someone changes where a run writes, and the leak it would miss looks
+exactly like the one it caught.
+
+The guarded set is now asked of the engine's own resolvers (`outputsDir`,
+`harnessLogsDir`), with those three as a floor if resolution ever fails. Moving
+an output directory cannot silently unguard it: a test derives the same paths
+and fails until `.gitignore` follows. Another checks that plain `git add` is
+refused without `--force`, because the cheapest guard is the one that stops the
+mistake being made at all.
+
 ### Run artifacts were committed into the engine
 
 `outputs/` was never gitignored, so nine files from a dispatch run reached the

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,20 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A guarda contra vazamento passou a seguir o engine em vez de lembrar dele
+
+Remover os artefatos de run commitados deixou um gate que citava três caminhos de
+memória — `outputs/`, `.nirvana/`, `.harness-logs/`. Uma lista dessas envelhece no
+dia em que alguém muda onde um run escreve, e o vazamento que ela deixaria passar
+é idêntico ao que ela pegou.
+
+O conjunto protegido agora é perguntado aos próprios resolvedores do engine
+(`outputsDir`, `harnessLogsDir`), com aqueles três como piso caso a resolução
+falhe. Mover um diretório de saída não o desprotege em silêncio: um teste deriva
+os mesmos caminhos e reprova até o `.gitignore` acompanhar. Outro confere que o
+`git add` simples é recusado sem `--force`, porque a guarda mais barata é a que
+impede o erro de ser cometido.
+
 ### Artefatos de run foram commitados dentro do engine
 
 O `outputs/` nunca esteve no gitignore, então nove arquivos de um run de dispatch

--- a/scripts/check-engine-purity.ts
+++ b/scripts/check-engine-purity.ts
@@ -23,8 +23,10 @@
  *
  * Usage: bun scripts/check-engine-purity.ts
  */
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -91,12 +93,50 @@ walk(REPO, "");
 // different clothes: the trace of USING the engine, committed into the engine.
 // Nine of them reached the public repo — a brief, a HANDOFF, a business's
 // outputs, a generated report — because `outputs/` was never gitignored and
-// this gate only looked for squad.yaml-shaped things. Checking the git index
-// rather than the disk, so a developer's local run is left alone and only a
-// tracked one fails.
+// this gate only looked for squad.yaml-shaped things.
+//
+// The guarded paths are ASKED OF THE ENGINE, not remembered here. A hardcoded
+// list is a list that goes stale the day someone changes where a run writes,
+// and the leak it misses looks exactly like the one it caught. So the same
+// resolvers the runtime uses answer the question, with a static floor in case
+// resolution ever fails.
+function runArtifactRoots(): string[] {
+  const roots = new Set<string>(["outputs", ".nirvana", ".harness-logs"]);   // floor
+  try {
+    // The resolvers honour env overrides; neutralise them so we ask about the
+    // DEFAULT layout, which is the one a contributor's repo will have.
+    const saved = { out: process.env.NIRVANA_OUTPUTS_DIR, logs: process.env.HARNESS_LOGS_DIR };
+    delete process.env.NIRVANA_OUTPUTS_DIR;
+    delete process.env.HARNESS_LOGS_DIR;
+    try {
+      const scope = require(join(REPO, "skills/_shared/lib/scope.ts"));
+      const logs = require(join(REPO, "skills/_shared/lib/log-paths.ts"));
+      for (const abs of [
+        scope.outputsDir({ projectRoot: REPO }),
+        logs.harnessLogsDir({ projectRoot: REPO }),
+        logs.maestroLogsDir?.({ projectRoot: REPO }),
+      ]) {
+        if (typeof abs !== "string") continue;
+        const rel = relative(REPO, abs);
+        // Only paths INSIDE the repo matter; a run writing to $HOME is not our problem.
+        if (rel && !rel.startsWith("..") && !isAbsolute(rel)) roots.add(rel.split("/")[0]);
+      }
+    } finally {
+      if (saved.out !== undefined) process.env.NIRVANA_OUTPUTS_DIR = saved.out;
+      if (saved.logs !== undefined) process.env.HARNESS_LOGS_DIR = saved.logs;
+    }
+  } catch {
+    // Resolver moved or failed to load — the floor above still guards the
+    // three paths that leaked once, and the drift test will say so out loud.
+  }
+  return [...roots];
+}
+
+// Checking the git INDEX rather than the disk: a developer running a dispatch
+// inside their clone is normal and must stay silent; committing one is the fault.
 const trackedRunArtifacts = (() => {
   try {
-    const out = Bun.spawnSync(["git", "ls-files", "outputs", ".nirvana", ".harness-logs"], { cwd: REPO }).stdout.toString().trim();
+    const out = Bun.spawnSync(["git", "ls-files", ...runArtifactRoots()], { cwd: REPO }).stdout.toString().trim();
     return out ? out.split("\n") : [];
   } catch {
     return [];   // no git (a tarball checkout) — nothing to judge

--- a/skills/harness/tests/engine-purity-run-artifacts.test.ts
+++ b/skills/harness/tests/engine-purity-run-artifacts.test.ts
@@ -23,9 +23,31 @@ const GATE = path.join(ROOT, "scripts", "check-engine-purity.ts");
 const gitignore = () => fs.readFileSync(path.join(ROOT, ".gitignore"), "utf8");
 const runGate = () => spawnSync(process.execPath, [GATE], { encoding: "utf8", cwd: ROOT });
 
-/** First path segment of where the engine writes, relative to a project root. */
-function writeRoot(abs: string): string {
-  return path.relative(ROOT, abs).split(path.sep)[0];
+/** First path segment of where the engine writes, relative to a project root.
+ *  Returns null when the engine writes outside the repo — not our problem. */
+function writeRoot(abs: string): string | null {
+  const rel = path.relative(ROOT, abs);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return rel.split(path.sep)[0];
+}
+
+/** Ask the resolvers about the DEFAULT layout.
+ *
+ *  Both honour env overrides, and several test files in this suite set
+ *  HARNESS_LOGS_DIR at module scope — under `bun test` those share a process,
+ *  so the value leaks across files. Run this file alone and it passes; run the
+ *  suite and the resolver answers with somebody else's temp dir. That is
+ *  exactly how this test failed on CI while passing locally. */
+function defaultLayout<T>(fn: () => T): T {
+  const saved = { out: process.env.NIRVANA_OUTPUTS_DIR, logs: process.env.HARNESS_LOGS_DIR };
+  delete process.env.NIRVANA_OUTPUTS_DIR;
+  delete process.env.HARNESS_LOGS_DIR;
+  try {
+    return fn();
+  } finally {
+    if (saved.out !== undefined) process.env.NIRVANA_OUTPUTS_DIR = saved.out;
+    if (saved.logs !== undefined) process.env.HARNESS_LOGS_DIR = saved.logs;
+  }
 }
 
 describe("run artifacts cannot be committed", () => {
@@ -44,9 +66,11 @@ describe("run artifacts cannot be committed", () => {
     // Derived, not listed: if outputsDir() moves, this test follows it there and
     // fails until .gitignore follows too.
     const ig = gitignore();
-    for (const abs of [outputsDir({ projectRoot: ROOT } as any), harnessLogsDir({ projectRoot: ROOT })]) {
-      const root = writeRoot(abs);
-      expect(root).toBeTruthy();
+    const roots = defaultLayout(() =>
+      [outputsDir({ projectRoot: ROOT } as any), harnessLogsDir({ projectRoot: ROOT })].map(writeRoot),
+    ).filter((r): r is string => r !== null);
+    expect(roots.length).toBeGreaterThan(0);   // resolution must have produced something
+    for (const root of roots) {
       expect(ig).toMatch(new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/?$`, "m"));
     }
   });

--- a/skills/harness/tests/engine-purity-run-artifacts.test.ts
+++ b/skills/harness/tests/engine-purity-run-artifacts.test.ts
@@ -1,0 +1,85 @@
+// engine-purity-run-artifacts.test.ts — the trace of using the engine must never
+// be committed into the engine.
+//
+// Nine files from a real dispatch run (a brief, a HANDOFF, a business's
+// deliverables, a generated report) were committed and pushed to the public repo
+// because `outputs/` was never gitignored and the purity gate only looked for
+// squad.yaml-shaped content. The history had to be rewritten to remove them.
+//
+// Two things stop it now, and this file pins both: `outputs/` is ignored, and
+// the gate fails on anything TRACKED under a path the engine writes to. The
+// guarded paths are derived from the engine's own resolvers rather than
+// hardcoded, so moving an output directory cannot silently unguard it.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { outputsDir } from "../../_shared/lib/scope.ts";
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const GATE = path.join(ROOT, "scripts", "check-engine-purity.ts");
+
+const gitignore = () => fs.readFileSync(path.join(ROOT, ".gitignore"), "utf8");
+const runGate = () => spawnSync(process.execPath, [GATE], { encoding: "utf8", cwd: ROOT });
+
+/** First path segment of where the engine writes, relative to a project root. */
+function writeRoot(abs: string): string {
+  return path.relative(ROOT, abs).split(path.sep)[0];
+}
+
+describe("run artifacts cannot be committed", () => {
+  test("nothing under a write path is tracked right now", () => {
+    const tracked = spawnSync("git", ["ls-files", "outputs", ".nirvana", ".harness-logs"], { cwd: ROOT, encoding: "utf8" });
+    expect((tracked.stdout || "").trim()).toBe("");
+  });
+
+  test("the gate passes on the shipped tree", () => {
+    const r = runGate();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("OK");
+  });
+
+  test("every path the engine writes to is gitignored", () => {
+    // Derived, not listed: if outputsDir() moves, this test follows it there and
+    // fails until .gitignore follows too.
+    const ig = gitignore();
+    for (const abs of [outputsDir({ projectRoot: ROOT } as any), harnessLogsDir({ projectRoot: ROOT })]) {
+      const root = writeRoot(abs);
+      expect(root).toBeTruthy();
+      expect(ig).toMatch(new RegExp(`^${root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/?$`, "m"));
+    }
+  });
+
+  test("git itself refuses to add one without --force", () => {
+    // The gate is the backstop; this is the first line, and it is the one that
+    // stops the mistake being made at all.
+    const p = path.join(ROOT, "outputs", "__purity_probe__.md");
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, "probe\n");
+    try {
+      const r = spawnSync("git", ["add", p], { cwd: ROOT, encoding: "utf8" });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/ignored/i);
+    } finally {
+      fs.rmSync(p, { force: true });
+    }
+  });
+});
+
+describe("the guarded set follows the engine, not a memory of it", () => {
+  test("the gate names the derivation rather than a fixed list", () => {
+    const src = fs.readFileSync(GATE, "utf8");
+    expect(src).toMatch(/ASKED OF THE ENGINE/);
+    expect(src).toContain("outputsDir");
+    expect(src).toContain("harnessLogsDir");
+  });
+
+  test("a static floor survives if the resolvers cannot be loaded", () => {
+    // Resolution failing must degrade to guarding the three paths that leaked
+    // once — never to guarding nothing.
+    const src = fs.readFileSync(GATE, "utf8");
+    expect(src).toMatch(/floor/);
+    for (const p of ["outputs", ".nirvana", ".harness-logs"]) expect(src).toContain(`"${p}"`);
+  });
+});


### PR DESCRIPTION
Follow-up to #24. Removing the committed run artifacts left a gate naming three paths as string literals — `outputs/`, `.nirvana/`, `.harness-logs/`.

That is a denylist, and **a denylist goes stale the day someone changes where a run writes.** The leak it would then miss looks exactly like the one it just caught.

## The change

The guarded set is asked of the engine's own resolvers — `scope.outputsDir`, `log-paths.harnessLogsDir`, `maestroLogsDir` — with the three literals kept as a **floor** if resolution ever fails. Degrading to "guard less" is acceptable; degrading to "guard nothing" is not.

Env overrides are neutralised during the query so the answer describes the *default* layout a contributor's clone has, then restored.

## Verified

| | |
|---|---|
| run output committed | exit 1 |
| audit log committed | exit 1 |
| clean tree | exit 0 |

It reads the git **index**, so a developer running a dispatch inside their clone stays silent.

## Tests

6, including two that would have caught the original leak:

- **every path the engine writes to must be gitignored** — derived, so moving an output directory fails the test until `.gitignore` follows;
- **plain `git add` must be refused without `--force`** — the cheapest guard is the one that stops the mistake being made at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)