### PR TITLE
feat(license): install a license without reinstalling the pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A license could only be installed by reinstalling the pack
+
+A buyer on Windows ran `nrv update genesis-circle` and got "Sem PROVENANCE com
+license_key". The message named both paths it had searched — that part worked —
+and then told them to re-run `bun setup.ts`, the entire pack installer, to copy
+one small file. That was the only route: the copy lives inside setup.ts and
+nowhere else.
+
+`nrv license install` is the missing command. With no argument it looks where a
+downloaded pack actually sits: the current directory, Downloads, Desktop, home,
+and one level into any subdirectory whose name mentions nirvana or pack. With an
+argument it takes a file or a folder, because a folder is what people paste.
+`LICENSE.txt` rides along when it sits beside it.
+
+Verification runs after the copy and never blocks it. A provenance that fails
+signature checking is still the file the buyer paid for, and telling them it is
+unsigned is more useful than refusing to move it.
+
 ## 0.3.9 — 2026-08-14
 
 ### The leak guard now follows the engine instead of remembering it

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,26 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Só dava para instalar a licença reinstalando o pack
+
+Um comprador no Windows rodou `nrv update genesis-circle` e recebeu "Sem
+PROVENANCE com license_key". A mensagem nomeou os dois caminhos consultados —
+essa parte funcionou — e então mandou rodar de novo o `bun setup.ts`, o
+instalador inteiro do pack, para copiar um arquivo pequeno. Era o único caminho:
+a cópia mora dentro do setup.ts e em nenhum outro lugar.
+
+O `nrv license install` é o comando que faltava. Sem argumento, ele procura onde
+um pack baixado de fato está: diretório atual, Downloads, Desktop, home, e um
+nível dentro de qualquer subpasta cujo nome mencione nirvana ou pack. Com
+argumento, aceita arquivo ou pasta, porque pasta é o que as pessoas colam. O
+`LICENSE.txt` vai junto quando está ao lado.
+
+A verificação roda depois da cópia e nunca a impede. Uma procedência que falha na
+assinatura ainda é o arquivo que o comprador pagou, e dizer que está sem
+assinatura é mais útil que recusar movê-la.
+
 ## 0.3.9 — 2026-08-14
 
 ### A guarda contra vazamento passou a seguir o engine em vez de lembrar dele

--- a/skills/_shared/scripts/license.ts
+++ b/skills/_shared/scripts/license.ts
@@ -255,10 +255,20 @@ async function install(explicit?: string): Promise<number> {
     return 1;
   }
 
-  // realpath, not resolve: on macOS /tmp is a symlink to /private/tmp, so two
-  // spellings of the same file compare unequal and the copy runs on itself.
+  // "Already installed" has two shapes, and only one of them is about paths.
+  //
+  //  - Same FILE: realpath, not resolve — on macOS /tmp is a symlink to
+  //    /private/tmp, so two spellings of one file compare unequal and the copy
+  //    would run on itself.
+  //  - Same CONTENT: the pack folder is still on disk after the first install,
+  //    so a second run finds the original again. Re-copying it is harmless, but
+  //    reporting "installed" for a no-op tells the buyer something happened
+  //    when nothing did.
   const same = (() => {
-    try { return realpathSync(src) === realpathSync(STORE_PROV); } catch { return false; }
+    try {
+      if (realpathSync(src) === realpathSync(STORE_PROV)) return true;
+      return existsSync(STORE_PROV) && readFileSync(src, "utf8") === readFileSync(STORE_PROV, "utf8");
+    } catch { return false; }
   })();
   if (same) {
     console.log(`${DIM}Já instalado em ${STORE_PROV}.${RST}`);

--- a/skills/_shared/scripts/license.ts
+++ b/skills/_shared/scripts/license.ts
@@ -15,9 +15,9 @@
  *   nrv license activate [--label "<nome>"]  → binds this machine (online)
  */
 import { createPublicKey, createHash, verify as edVerify } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, readdirSync, statSync, realpathSync } from "node:fs";
 import { homedir, hostname, platform, arch } from "node:os";
-import { join } from "node:path";
+import { join, dirname, resolve } from "node:path";
 
 // Nirvana's PUBLIC key (Ed25519 pair; the PRIVATE one lives only on the production VPS).
 // Safe to embed: it only serves to VERIFY signatures, never to sign.
@@ -201,8 +201,93 @@ async function check(): Promise<number> {
   return 0; // soft by design — never hard-fails
 }
 
+/**
+ * Install a PROVENANCE.json into the license store.
+ *
+ * Until now the ONLY way to get a license in place was `bun setup.ts` — the
+ * whole pack installer — because that is where the copy lives. A buyer whose
+ * license never landed (setup run from a folder without the file, or run as a
+ * different user, or never run at all) had to re-run an installer to copy one
+ * small file. Windows buyer on 2026-08-14 hit exactly that.
+ *
+ * Given no path, it looks where a downloaded pack actually sits. Verification
+ * comes after the copy and never blocks it: a file that fails signature checking
+ * is still the file the buyer paid for, and telling them it is unsigned is more
+ * useful than refusing to move it.
+ */
+async function install(explicit?: string): Promise<number> {
+  const searched: string[] = [];
+  const candidates: string[] = [];
+  if (explicit) {
+    // A folder is as good as a file — buyers paste the pack directory.
+    candidates.push(explicit, join(explicit, "PROVENANCE.json"));
+  } else {
+    const home = homedir();
+    for (const dir of [process.cwd(), join(home, "Downloads"), join(home, "Desktop"), home]) {
+      candidates.push(join(dir, "PROVENANCE.json"));
+      // One level down: ~/Downloads/nirvana-os-<pack>/PROVENANCE.json
+      try {
+        for (const e of readdirSync(dir, { withFileTypes: true })) {
+          // Skip the store itself: it matches /nirvana/ and would make the
+          // command "find" what it is trying to install, then copy it onto
+          // itself and report success on a no-op.
+          if (!e.isDirectory() || join(dir, e.name) === LICENSE_DIR) continue;
+          if (/nirvana|pack/i.test(e.name)) candidates.push(join(dir, e.name, "PROVENANCE.json"));
+        }
+      } catch { /* unreadable dir — skip */ }
+    }
+  }
+
+  let src: string | null = null;
+  for (const c of candidates) {
+    searched.push(c);
+    try { if (existsSync(c) && statSync(c).isFile()) { src = c; break; } } catch { /* keep looking */ }
+  }
+
+  if (!src) {
+    console.log(`\n${YEL}Não encontrei um PROVENANCE.json.${RST}`);
+    console.log(`${DIM}Procurei em:${RST}`);
+    for (const c of searched.slice(0, 8)) console.log(`${DIM}  ${c}${RST}`);
+    if (searched.length > 8) console.log(`${DIM}  … e mais ${searched.length - 8}${RST}`);
+    console.log(`\n${DIM}Ele vem dentro do zip da compra, ao lado do setup.ts. Aponte direto:${RST}`);
+    console.log(`${DIM}  nrv license install <caminho-do-PROVENANCE.json>${RST}`);
+    console.log(`${DIM}  nrv license install <pasta-do-pack>${RST}\n`);
+    return 1;
+  }
+
+  // realpath, not resolve: on macOS /tmp is a symlink to /private/tmp, so two
+  // spellings of the same file compare unequal and the copy runs on itself.
+  const same = (() => {
+    try { return realpathSync(src) === realpathSync(STORE_PROV); } catch { return false; }
+  })();
+  if (same) {
+    console.log(`${DIM}Já instalado em ${STORE_PROV}.${RST}`);
+    return 0;
+  }
+
+  try {
+    mkdirSync(LICENSE_DIR, { recursive: true });
+    copyFileSync(src, STORE_PROV);
+    const notice = join(dirname(src), "LICENSE.txt");
+    if (existsSync(notice)) copyFileSync(notice, join(LICENSE_DIR, "LICENSE.txt"));
+  } catch (e: any) {
+    console.error(`\n${RED}Não consegui escrever em ${STORE_PROV}: ${e?.message ?? e}${RST}`);
+    console.error(`${DIM}Rode com o mesmo usuário que vai usar o sistema (um terminal elevado tem outro perfil).${RST}\n`);
+    return 1;
+  }
+
+  console.log(`${GRN}✓${RST} licença instalada: ${src} → ${STORE_PROV}`);
+  // Report what it is, without gatekeeping: an unsigned copy is still theirs.
+  printStatus(verifyProvenance());
+  console.log(`${DIM}Agora "nrv update <pack>" encontra a licença.${RST}`);
+  return 0;
+}
+
 const sub = process.argv[2] || "status";
-if (sub === "check") {
+if (sub === "install") {
+  const arg = process.argv[3];
+  process.exit(await install(arg && !arg.startsWith("-") ? arg : undefined));
+} else if (sub === "check") {
   process.exit(await check());
 } else if (sub === "activate") {
   const li = process.argv.indexOf("--label");
@@ -213,6 +298,6 @@ if (sub === "check") {
   printStatus(v);
   process.exit(v.status === "invalid" ? 3 : 0);
 } else {
-  console.log('uso: nrv license [status|verify|check|activate [--label "<nome>"]]');
+  console.log('uso: nrv license [status|verify|check|install [<caminho>]|activate [--label "<nome>"]]');
   process.exit(2);
 }

--- a/skills/_shared/scripts/update-pack.ts
+++ b/skills/_shared/scripts/update-pack.ts
@@ -103,8 +103,10 @@ async function main(): Promise<number> {
       console.log(`${DIM}Esse arquivo veio de uma cópia sem procedência. Use o zip que você recebeu na compra.${RST}\n`);
       return 1;
     }
-    console.log(`\n${DIM}Packs pagos vêm com PROVENANCE.json ao lado do setup.ts. Para instalar a licença:${RST}`);
-    console.log(`${DIM}  cd <pasta-do-pack> && bun setup.ts${RST}`);
+    console.log(`\n${DIM}Packs pagos vêm com PROVENANCE.json ao lado do setup.ts. Para instalar só a licença:${RST}`);
+    console.log(`${DIM}  nrv license install                      ${RST}${DIM}# procura em Downloads, Desktop e na pasta atual${RST}`);
+    console.log(`${DIM}  nrv license install <pasta-do-pack>      ${RST}${DIM}# ou aponte direto${RST}`);
+    console.log(`${DIM}Reinstalar o pack inteiro (bun setup.ts) também resolve, mas é bem mais caro.${RST}`);
     console.log(`${DIM}Se você já rodou o setup, confira que rodou com o MESMO usuário de agora`);
     console.log(`(um terminal "como administrador" tem outro perfil, e a licença fica no perfil de quem rodou).${RST}\n`);
     return 1;

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -95,7 +95,7 @@ export const COMMANDS: Command[] = [
   { name: "find-clone", aliases: ["clone-find", "find-mind-clone"], target: "_shared/scripts/find-clone.ts", category: "libraries", args: '"<query>"', summary: "Find a mind-clone by query", visibility: "user" },
 
   // license
-  { name: "license", aliases: ["verify-license", "whoami"], target: "_shared/scripts/license.ts", category: "license", args: "[status|check|activate]", summary: "Show your copy's provenance; activate or heartbeat-check (offline-safe)", visibility: "user" },
+  { name: "license", aliases: ["verify-license", "whoami"], target: "_shared/scripts/license.ts", category: "license", args: "[status|check|install [<path>]|activate]", summary: "Show your copy's provenance, install a PROVENANCE.json, activate (offline-safe)", visibility: "user" },
 
   // advanced / dev
   { name: "setup", target: "_shared/scripts/install.ts", category: "dev", summary: "Re-wire audit hooks (= install --bootstrap)", visibility: "dev" },

--- a/skills/harness/tests/license-install.test.ts
+++ b/skills/harness/tests/license-install.test.ts
@@ -1,0 +1,102 @@
+// license-install.test.ts — installing a license must not require reinstalling
+// the pack.
+//
+// A Windows buyer ran `nrv update genesis-circle` and got "Sem PROVENANCE com
+// license_key". The message named the two paths searched (good) and then told
+// them to re-run `bun setup.ts` — the whole pack installer — to copy one small
+// file. That is the only route that existed: the copy lives inside setup.ts.
+import { describe, expect, test, afterAll } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = path.resolve(import.meta.dir, "..", "..", "_shared", "scripts", "license.ts");
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-lic-"));
+
+const PROVENANCE = JSON.stringify({
+  license_key: "TEST-KEY-1234", edition: "genesis-circle",
+  buyer_email: "buyer@example.com", watermark_id: "wm-test",
+});
+
+function home(name: string): string {
+  const h = path.join(TMP, name);
+  fs.mkdirSync(h, { recursive: true });
+  return h;
+}
+
+function pack(h: string, dir = "Downloads/nirvana-os-genesis-circle-pack"): string {
+  const p = path.join(h, dir);
+  fs.mkdirSync(p, { recursive: true });
+  fs.writeFileSync(path.join(p, "PROVENANCE.json"), PROVENANCE);
+  fs.writeFileSync(path.join(p, "LICENSE.txt"), "licence notice\n");
+  return p;
+}
+
+const run = (h: string, args: string[], cwd = h) =>
+  spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8", cwd, env: { ...process.env, HOME: h, USERPROFILE: h } });
+
+const store = (h: string) => path.join(h, ".nirvana-license", "PROVENANCE.json");
+
+afterAll(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe("nrv license install", () => {
+  test("finds a downloaded pack without being told where", () => {
+    // The buyer's situation: the file is in the folder they unzipped, and they
+    // do not know the engine wants it somewhere else.
+    const h = home("auto"); pack(h);
+    const r = run(h, ["install"]);
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(store(h))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(store(h), "utf8")).license_key).toBe("TEST-KEY-1234");
+  }, 30_000);
+
+  test("takes a folder, not only a file — that is what people paste", () => {
+    const h = home("folder"); const p = pack(h, "packdir");
+    expect(run(h, ["install", p]).status).toBe(0);
+    expect(fs.existsSync(store(h))).toBe(true);
+  }, 30_000);
+
+  test("brings LICENSE.txt along when it sits next to it", () => {
+    const h = home("notice"); pack(h);
+    run(h, ["install"]);
+    expect(fs.existsSync(path.join(h, ".nirvana-license", "LICENSE.txt"))).toBe(true);
+  }, 30_000);
+
+  test("running it twice is a no-op, not a self-copy", () => {
+    // The store directory matches the /nirvana/ scan pattern, so an earlier
+    // version found the file it had just installed and copied it onto itself,
+    // reporting success on a no-op.
+    const h = home("twice"); pack(h);
+    run(h, ["install"]);
+    const second = run(h, ["install"]);
+    expect(second.status).toBe(0);
+    expect(second.stdout).toMatch(/Já instalado/);
+  }, 30_000);
+
+  test("with nothing to find, it says where it looked", () => {
+    // Never a bare failure: the buyer must be able to check the paths itself.
+    const h = home("empty");
+    const r = run(h, ["install"]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/Procurei em/);
+    expect(r.stdout).toMatch(/nrv license install <caminho/);
+  }, 30_000);
+
+  test("an unsigned provenance is still installed", () => {
+    // It is the file the buyer paid for. Telling them it is unsigned is more
+    // useful than refusing to move it.
+    const h = home("unsigned"); pack(h);
+    const r = run(h, ["install"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/não assinada|unsigned/i);
+  }, 30_000);
+});
+
+describe("the failure message points at the cheap fix", () => {
+  test("update-pack offers `nrv license install` before reinstalling the pack", () => {
+    const src = fs.readFileSync(path.resolve(import.meta.dir, "..", "..", "_shared", "scripts", "update-pack.ts"), "utf8");
+    expect(src).toMatch(/nrv license install/);
+    expect(src).toMatch(/bem mais caro/);
+  });
+});

--- a/skills/harness/tests/license-install.test.ts
+++ b/skills/harness/tests/license-install.test.ts
@@ -63,15 +63,27 @@ describe("nrv license install", () => {
     expect(fs.existsSync(path.join(h, ".nirvana-license", "LICENSE.txt"))).toBe(true);
   }, 30_000);
 
-  test("running it twice is a no-op, not a self-copy", () => {
-    // The store directory matches the /nirvana/ scan pattern, so an earlier
-    // version found the file it had just installed and copied it onto itself,
-    // reporting success on a no-op.
+  test("running it twice reports a no-op instead of a phantom install", () => {
+    // The pack folder is still on disk after the first run, so the second finds
+    // the same original. Re-copying is harmless; saying "installed" when
+    // nothing changed is what misleads. Content decides, not the path — an
+    // earlier version compared paths with resolve() and this test passed on
+    // macOS only by the accident of readdir order.
     const h = home("twice"); pack(h);
-    run(h, ["install"]);
+    expect(run(h, ["install"]).status).toBe(0);
     const second = run(h, ["install"]);
     expect(second.status).toBe(0);
     expect(second.stdout).toMatch(/Já instalado/);
+    expect(JSON.parse(fs.readFileSync(store(h), "utf8")).license_key).toBe("TEST-KEY-1234");
+  }, 30_000);
+
+  test("pointing it at the store itself never self-copies", () => {
+    const h = home("selfcopy"); pack(h);
+    run(h, ["install"]);
+    const r = run(h, ["install", store(h)]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Já instalado/);
+    expect(fs.readFileSync(store(h), "utf8")).toBe(PROVENANCE);
   }, 30_000);
 
   test("with nothing to find, it says where it looked", () => {


### PR DESCRIPTION
A buyer on Windows ran `nrv update genesis-circle`:

```
Sem PROVENANCE com license_key — nada a atualizar.
Procurei em:
  C:\Users\aalme\.nirvana-license\PROVENANCE.json
  C:\Users\aalme\PROVENANCE.json
```

The message naming both paths is the fix that shipped earlier, and it did its job. What it then offered was **re-running `bun setup.ts` — the entire pack installer — to copy one small file.** That was the only route: the copy lives inside setup.ts and nowhere else.

## The missing command

`nrv license install`

- **No argument:** looks where a downloaded pack actually sits — current directory, Downloads, Desktop, home, and one level into any subdirectory whose name mentions *nirvana* or *pack*.
- **With an argument:** takes a file **or a folder**, because a folder is what people paste.
- `LICENSE.txt` rides along when it sits beside it.
- Verification runs **after** the copy and never blocks it: a provenance that fails signature checking is still the file the buyer paid for.

## Two bugs found by testing, not by reading

- The store directory matches the `/nirvana/` scan pattern, so the command found the file it had just installed and copied it onto itself, reporting success on a no-op.
- The "already installed" check used `resolve()`, but on macOS `/tmp` and `/private/tmp` are the same file — it never matched. `realpath` plus an explicit skip of the store fixed both.

## Tests

7: auto-discovery, folder argument, LICENSE.txt, idempotency, the not-found message naming its paths, an unsigned copy still installing, and `update-pack` pointing at the cheap fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)