### PR TITLE
fix(install): three ways an install said done and left the buyer broken

### DIFF
--- a/packaging/pack/setup.ps1
+++ b/packaging/pack/setup.ps1
@@ -28,3 +28,8 @@ if (-not $bun) {
 
 $env:Path = (Split-Path -Parent $bun) + ";" + $env:Path
 & $bun (Join-Path $here "setup.ts")
+# Propagate the installer's exit code. Without this the script always returned 0,
+# so a Windows buyer whose setup failed saw a shell that said everything was fine
+# — on the exact platform the last two license reports came from. setup.sh gets
+# this for free via `exec`; PowerShell needs it spelled out.
+exit $LASTEXITCODE

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -751,18 +751,34 @@ async function offerStarterPack(): Promise<void> {
     try { writeFileSync(PACK_MANIFEST, JSON.stringify(newManifest, null, 2) + "\n"); } catch { /* ignore */ }
   }
 
+}
+
+/**
+ * Build the registries. Runs on EVERY install, which is the whole point of it
+ * living out here.
+ *
+ * It used to be the tail of offerStarterPack(), below the `--no-starter` early
+ * return — and `--no-starter` is exactly what both entry points pass
+ * (packaging/cli/bin/cli.mjs and packaging/pack/setup.ts). So a plain
+ * `npx @nirvana-os/cli` finished with no registry on disk at all and routing
+ * degraded from the first minute, with nothing saying so. Pack buyers escaped
+ * only by accident, because install-content.ts indexes on its own.
+ *
+ * CI never caught it because the smoke job runs `nrv index` by hand before the
+ * doctor, and the doctor passes a registry that exists over an empty library.
+ */
+function buildRegistries(): void {
   // Windows CreateProcess only auto-appends .exe, never .cmd — spawning the
   // extensionless bash `nrv` there fails, so the post-install index silently
   // never ran (registries stayed empty until a manual `nrv index`). Target the
   // .cmd launcher on Windows.
   const nrvBin = join(LOCAL_BIN, IS_WINDOWS ? "nrv.cmd" : "nrv");
-  if (FLAG_DRY) { /* no index on dry-run */ }
-  else if (FLAG_NO_INDEX) console.log("      Indexing deferred (--no-index).");
-  else if (existsSync(nrvBin)) {
-    console.log("      Re-indexing registries...");
-    const r = spawnSync(nrvBin, ["index"], { stdio: "inherit", shell: IS_WINDOWS });
-    if (r.status !== 0) console.log("      ⚠ nrv index reported issues. Run manually to verify.");
-  }
+  if (FLAG_DRY) return; // no index on dry-run
+  if (FLAG_NO_INDEX) { console.log("      Indexing deferred (--no-index)."); return; }
+  if (!existsSync(nrvBin)) return;
+  console.log("      Re-indexing registries...");
+  const r = spawnSync(nrvBin, ["index"], { stdio: "inherit", shell: IS_WINDOWS });
+  if (r.status !== 0) console.log("      ⚠ nrv index reported issues. Run manually to verify.");
 }
 
 // ── Hermes Agent integration (opt-in) ─────────────────────────────────────
@@ -1057,6 +1073,9 @@ async function main(): Promise<void> {
   // to exist all the same, and with a pack they are already ready to receive.
   ensureContentLibraries();
   await offerStarterPack();
+  // After the starter pack (so seeded content is in the index) and outside it
+  // (so an engine-only install gets registries too — see buildRegistries).
+  buildRegistries();
   await offerHermesBridge();
   summary();
 }

--- a/skills/_shared/scripts/install-content.ts
+++ b/skills/_shared/scripts/install-content.ts
@@ -124,8 +124,54 @@ function mirror(src: string, dst: string, ex: string[]): void {
 }
 
 import { contractBreaks, reportBreaks, type BreakingChange } from "../lib/contract-breaks.ts";
+import { InstallManifest } from "../lib/install-manifest.ts";
+import { randomUUID } from "node:crypto";
 
 interface Manifest { slug?: string; version?: string | null; updated_at?: string; squads?: Record<string, string>; businesses?: Record<string, string>; "mind-clones"?: Record<string, string>; }
+
+/**
+ * Record the install in ~/.nirvana-installed.jsonl, which is what `nrv installed`
+ * replays.
+ *
+ * This overlay wrote only ~/.nirvana/packs/<slug>.json, and list-installed.ts
+ * reads only the jsonl — two tracks that never spoke. A buyer finished a
+ * successful paid install and `nrv installed` answered "No installations
+ * recorded", which reads as "nothing was installed" and is the same shape as the
+ * license bug: written on one track, looked for on another.
+ *
+ * Best-effort on purpose: the content is already on disk and correct: failing
+ * the install over a bookkeeping line would trade a real problem for a
+ * cosmetic one. But it says so when it cannot, which is the part that was
+ * missing everywhere else.
+ */
+function recordInstall(m: Manifest): void {
+  try {
+    const items = ([["squad", m.squads], ["business", m.businesses], ["mind-clone", m["mind-clones"]]] as const)
+      .flatMap(([kind, hashes]) => Object.keys(hashes ?? {}).map((slug) => ({
+        kind, name: slug, slug,
+        path: join(kind === "squad" ? SQUADS_DIR : kind === "business" ? BUSINESSES_DIR : DNA_DIR, slug),
+      })));
+    new InstallManifest().append({
+      ts: new Date().toISOString(),
+      action: existsSync(manifestPath) && man.version ? "update" : "install",
+      install_id: randomUUID(),
+      kind: "pack",
+      name: SLUG,
+      version: m.version ?? "0.0.0",
+      // A pack has no single canonical directory — uninstall walks `items`.
+      source: `pack:${SLUG}`,
+      path: "",
+      checksum: createHash("sha256").update(JSON.stringify(items.map((i) => i.slug).sort())).digest("hex").slice(0, 16),
+      scope: "global",
+      items,
+      prev_version: man.version ?? undefined,
+    });
+  } catch (e) {
+    console.log(`  ⚠ could not record the install in ~/.nirvana-installed.jsonl: ${(e as Error).message}`);
+    console.log(`    The pack is installed and working; 'nrv installed' just will not list it.`);
+  }
+}
+
 const manifestPath = join(PACKS_DIR, `${SLUG}.json`);
 const man: Manifest = (() => { try { return JSON.parse(readFileSync(manifestPath, "utf8")); } catch { return {}; } })();
 
@@ -191,6 +237,7 @@ if (!DRY) {
   mkdirSync(PACKS_DIR, { recursive: true });
   const out: Manifest = { slug: SLUG, version: VERSION, updated_at: new Date().toISOString(), squads: sq.hashes, businesses: bz.hashes, "mind-clones": cl.hashes };
   writeFileSync(manifestPath, JSON.stringify(out, null, 2) + "\n");
+  recordInstall(out);
   // Reindex: without this the content stays on disk and the orchestrator cannot
   // see it — the most expensive failure possible, because everything LOOKS installed.
   //

--- a/skills/harness/baselines/golden-bridge-cases.json
+++ b/skills/harness/baselines/golden-bridge-cases.json
@@ -22,8 +22,18 @@
       "brief": "escreva um livro digital de receitas fitness com textos de venda",
       "language": "pt",
       "requires_alias_file": true,
-      "expect_top1": "ebook-maestro-nirvana",
-      "note": "PT vocabulary (livro digital, textos de venda) against the EN-declared squad: pre-bridge coverage 2/7 (confirm band); the alias groups lift it to 3/7 and ebook-maestro-nirvana leads the candidate list."
+      "accepted_top1": [
+        "ebook-maestro-nirvana",
+        "nirvana-editora",
+        "ars-libri",
+        "polymath-press"
+      ],
+      "expect_signal_in": [
+        "HIGH",
+        "AMBIGUOUS"
+      ],
+      "expect_alias_adopted": true,
+      "note": "PT vocabulary (livro digital, textos de venda) against the EN-declared squad: pre-bridge coverage 2/7 (confirm band); the alias groups lift it to 3/7. What this case proves is the lift, which is what the bridge owns. It used to pin expect_top1 to ebook-maestro-nirvana, and that broke on 2026-08-14 when nirvana-editora edged ahead by 0.079 BM25 points (13.511 vs 13.432, a 0.58% gap between two legitimate publishing claimants). Arm (b) rewrites coverage and never re-sorts (router.js:1815-1831), so rank-1 identity was never something this case could test — it was a corpus property wearing a bridge test's name. Siblings bridge-pt-live-miss-ebook and bridge-en-publish-kdp were relaxed for the same reason on 2026-08-07; this one was missed."
     },
     {
       "id": "bridge-en-ebook-compound",

--- a/skills/harness/tests/bridge-cases.test.ts
+++ b/skills/harness/tests/bridge-cases.test.ts
@@ -65,6 +65,16 @@ d("amplification bridge — golden bridge cases (live corpus, amplify OFF)", () 
       if (kase.expect_signal_not) expect(s3.signal).not.toBe(kase.expect_signal_not);
       if (kase.expect_top1) expect(top1).toBe(kase.expect_top1);
       if (Array.isArray(kase.accepted_top1)) expect(kase.accepted_top1).toContain(top1);
+      // What the bridge actually owns: it re-scores coverage through the alias
+      // groups, and never touches rank order (router.js:1815-1831). So assert
+      // the lift, not the winner — pinning rank-1 tests the corpus, and the
+      // corpus moves.
+      //
+      // `alias_adopted` IS the lift: it is set only when the alias-recomputed
+      // coverage clears the gate the direct coverage did not (router.js:1826).
+      // The two coverage numbers stay on the match objects and never reach
+      // stage3, so this flag is the whole observable signal.
+      if (kase.expect_alias_adopted) expect(r.stage_bridge?.alias_adopted).toBe(true);
     });
   }
 

--- a/skills/harness/tests/install-silent-failures.test.ts
+++ b/skills/harness/tests/install-silent-failures.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Three ways an install said "done" while leaving the buyer broken.
+ *
+ * Each of these shipped for months. None of them threw, none of them printed
+ * anything, and `nrv doctor` said "All systems nominal" on top of all three.
+ * They share one shape with the license bug: something is written on one track
+ * and looked for on another, or a step is skipped by a flag nobody connected to
+ * it.
+ *
+ * Source-level assertions, deliberately. Executing the real installer needs a
+ * network fetch and a writable HOME; what is cheap and honest to guard here is
+ * the wiring, and the behavioural coverage lives in buyer-path.test.ts.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const read = (...p: string[]) => readFileSync(join(REPO, ...p), "utf8");
+
+const INSTALL = read("scripts", "install.ts");
+const SETUP_PS1 = read("packaging", "pack", "setup.ps1");
+const SETUP_SH = read("packaging", "pack", "setup.sh");
+const CONTENT = read("skills", "_shared", "scripts", "install-content.ts");
+
+describe("the registries are built on every install, not only with a starter pack", () => {
+  // The index call used to sit at the tail of offerStarterPack(), below its
+  // `--no-starter` early return — and --no-starter is what both entry points
+  // pass. A plain `npx @nirvana-os/cli` finished with no registry on disk.
+  test("indexing lives in its own function", () => {
+    expect(INSTALL).toMatch(/function buildRegistries\(\)/);
+  });
+
+  test("main() calls it outside offerStarterPack", () => {
+    const main = INSTALL.slice(INSTALL.indexOf("async function main("));
+    expect(main).toMatch(/buildRegistries\(\)/);
+  });
+
+  test("offerStarterPack no longer owns the index", () => {
+    const start = INSTALL.indexOf("async function offerStarterPack(");
+    const body = INSTALL.slice(start, INSTALL.indexOf("function buildRegistries("));
+    expect(body).not.toMatch(/"index"/);
+  });
+
+  test("--no-index and --dry still suppress it", () => {
+    const fn = INSTALL.slice(INSTALL.indexOf("function buildRegistries("));
+    expect(fn.slice(0, 600)).toMatch(/FLAG_DRY/);
+    expect(fn.slice(0, 600)).toMatch(/FLAG_NO_INDEX/);
+  });
+});
+
+describe("the Windows bootstrap reports the installer's exit code", () => {
+  // Without this the script always returned 0, so a Windows buyer whose setup
+  // failed saw a shell that said everything was fine — on the platform both
+  // license reports came from.
+  test("setup.ps1 propagates LASTEXITCODE", () => {
+    expect(SETUP_PS1).toMatch(/exit \$LASTEXITCODE/);
+  });
+
+  test("it is the last thing the script does", () => {
+    const lines = SETUP_PS1.trimEnd().split("\n");
+    expect(lines[lines.length - 1].trim()).toBe("exit $LASTEXITCODE");
+  });
+
+  test("setup.sh gets the same guarantee from exec", () => {
+    expect(SETUP_SH).toMatch(/\bexec\b/);
+  });
+});
+
+describe("a paid pack is visible to `nrv installed`", () => {
+  // install-content wrote only ~/.nirvana/packs/<slug>.json; list-installed
+  // replays only ~/.nirvana-installed.jsonl. A successful paid install answered
+  // "No installations recorded".
+  test("install-content records the install in the manifest", () => {
+    expect(CONTENT).toMatch(/import \{ InstallManifest \}/);
+    expect(CONTENT).toMatch(/function recordInstall\(/);
+    expect(CONTENT).toMatch(/recordInstall\(out\)/);
+  });
+
+  test("it records kind 'pack' with its items", () => {
+    const fn = CONTENT.slice(CONTENT.indexOf("function recordInstall("));
+    expect(fn.slice(0, 1800)).toMatch(/kind: "pack"/);
+    expect(fn.slice(0, 1800)).toMatch(/items,/);
+  });
+
+  test("a bookkeeping failure is reported, not swallowed", () => {
+    const fn = CONTENT.slice(CONTENT.indexOf("function recordInstall("));
+    const cat = fn.slice(fn.indexOf("} catch"), fn.indexOf("} catch") + 400);
+    expect(cat).toMatch(/console\.log/);
+    expect(cat).not.toMatch(/catch\s*(\([^)]*\))?\s*\{\s*\}/);
+  });
+
+  test("it does not abort the install — the content is already on disk", () => {
+    const fn = CONTENT.slice(CONTENT.indexOf("function recordInstall("));
+    expect(fn.slice(0, 2200)).not.toMatch(/process\.exit/);
+  });
+});


### PR DESCRIPTION
Found while auditing why one buyer's `nrv update` failed. None of these threw, none printed anything, and `nrv doctor` reported "All systems nominal" on top of all three.

**Registries never built on the buyer's path.** The engine installer's only `nrv index` call lived below `offerStarterPack()`'s `--no-starter` early return — and `--no-starter` is what both entry points pass. A plain `npx @nirvana-os/cli` finished with no registry on disk.

**`setup.ps1` swallowed the exit code.** A Windows buyer whose setup failed saw exit 0.

**A paid pack was invisible to `nrv installed`.** Written to one track, read from another — the same shape as the license bug.

Verified in a clean HOME: engine-only install now produces all four registries; a pack install lists as `active pack demo-pack 1.2.3` with its items.

Also relaxes `bridge-pt-livro-digital` to assert what the bridge owns instead of a rank-1 pin the bridge cannot influence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)