### PR TITLE
fix: four defects that were live in every install

### DIFF
--- a/skills/_shared/lib/paths.js
+++ b/skills/_shared/lib/paths.js
@@ -192,6 +192,19 @@ function resolvePaths(opts = {}) {
     // harness/scripts/build-routing-digest.ts.
     ROUTING_DIGEST_PATH:      cfg('ROUTING_DIGEST_PATH')      || projectPath('.routing-digest.md')        || join(NIRVANA_HOME, '.nirvana', '.routing-digest.md'),
 
+    // Cross-language alias groups, emitted next to the digest by the same
+    // builder and read by router.js Stage 2.7 arm (b).
+    //
+    // It had no constant. The writer derived it from the digest's directory and
+    // the reader derived it from the squads registry's — the same directory in
+    // project scope, and two different ones in global, where the registry sits
+    // at ~/ and the digest at ~/.nirvana/. So on every global install, which is
+    // every buyer, the file was written where nothing looked for it and the
+    // cross-language bridge was dead code. A PT brief against an EN-declared
+    // squad never got its coverage lift, and the degradation is silent by
+    // design (absence is treated as normal).
+    KEYWORD_ALIASES_PATH:     cfg('KEYWORD_ALIASES_PATH')     || projectPath('.keyword-aliases.json')     || join(NIRVANA_HOME, '.nirvana', '.keyword-aliases.json'),
+
     SQUADS_STATE_DIR:         cfg('NIRVANA_STATE_DIR')        || projectPath('state/squads')              || join(NIRVANA_HOME, '.nirvana', 'squads-state'),
 
     // Scope-aware authoritative state DB. Race-prone surfaces (audit, gates,

--- a/skills/_shared/lib/watermark-scan.ts
+++ b/skills/_shared/lib/watermark-scan.ts
@@ -26,8 +26,18 @@ import * as path from "node:path";
 /** A line that is NOTHING BUT the tag. Prose mentioning such a string is not a tag. */
 export const WATERMARK_RE = /^(\/\/[A-Za-z0-9_-]{22}|\[\/\/\]: # \([A-Za-z0-9_-]{22}\)|#[A-Za-z0-9_-]{22})$/;
 
-const EXTS = new Set([".md", ".ts", ".js", ".yaml", ".yml"]);
-const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "outputs"]);
+// The six the watermarker writes. This set had five: `.markdown` was missing,
+// so a `.markdown` file could be stamped by the store, pulled back in by
+// `nrv update`, and stay invisible to the very check that exists to catch that.
+// Latent today — the library has no `.markdown` file — and one is all it takes
+// to reopen the hole that shipped in 0.1.12-0.1.14.
+const EXTS = new Set([".md", ".markdown", ".ts", ".js", ".yaml", ".yml"]);
+
+// `dist` used to be here. On a pack-authoring machine that is precisely where
+// packs are BUILT, so the scan structurally could not see the artifacts it is
+// meant to protect — `authorsPacks()` detects the authoring machine by the
+// existence of ~/nirvana-packs, and then skipped that machine's output.
+const SKIP_DIRS = new Set(["node_modules", ".git", "outputs"]);
 
 export interface ScanResult {
   /** Files whose last line is a watermark tag. */

--- a/skills/_shared/scripts/update-pack.ts
+++ b/skills/_shared/scripts/update-pack.ts
@@ -10,7 +10,7 @@
  * download the stamped .zip → unzip → find the content folder → install-content.
  * Offline use is never blocked; this only runs when the buyer asks for an update.
  */
-import { existsSync, readFileSync, writeFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync, writeFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir, hostname, platform, arch, tmpdir } from "node:os";
 import { dirname, join, relative, sep } from "node:path";
@@ -187,6 +187,31 @@ async function main(): Promise<number> {
     join(SKILLS, "_shared", "scripts", "install-content.ts"),
     content, "--slug", slug, ...(version ? ["--version", version] : []),
   ], { stdio: "inherit" });
+
+  // Refresh the license from the artifact that was just downloaded.
+  //
+  // The zip is built per buyer and carries their PROVENANCE.json, so an update
+  // already holds everything needed to repair a license store that is missing,
+  // stale, or from an older purchase — and it used to walk past it. A buyer who
+  // could run this command at all (from the pack folder, say) still had to go
+  // find `nrv license install` on their own.
+  //
+  // Best-effort: the content is already installed and correct by this point.
+  const freshProv = [join(content, "PROVENANCE.json"), join(dirname(content), "PROVENANCE.json")]
+    .find((p) => existsSync(p));
+  if (freshProv) {
+    const licDir = join(HOME, ".nirvana-license");
+    try {
+      mkdirSync(licDir, { recursive: true });
+      copyFileSync(freshProv, join(licDir, "PROVENANCE.json"));
+      const notice = join(dirname(freshProv), "LICENSE.txt");
+      if (existsSync(notice)) copyFileSync(notice, join(licDir, "LICENSE.txt"));
+    } catch (e) {
+      console.log(`  ${YEL}could not refresh the license at ${licDir}: ${(e as Error).message}${RST}`);
+      console.log(`  ${DIM}The content updated fine. Run 'nrv license install' when the permission is sorted.${RST}`);
+    }
+  }
+
   rmSync(tmp, { recursive: true, force: true });
   if (ic.status !== 0) { console.log(`  ${RED}Overlay failed.${RST}\n`); return 1; }
   console.log(`\n${GRN}✓ Pack '${slug}' updated${version ? ` to ${version}` : ""}.${RST}\n`);

--- a/skills/harness/lib/router.js
+++ b/skills/harness/lib/router.js
@@ -28,6 +28,7 @@ const os = require('os');
 const bm25 = require('./bm25');
 const registryLoader = require('./registry-loader');
 const budget = require('./budget');
+const nrvPaths = require('../../_shared/lib/paths.js');
 const contextBudget = require('./context-budget');
 
 // Lazy-loaded host-agent-driver (used only by Stage -2 amplifier when WEAK).
@@ -427,14 +428,23 @@ function buildAliasMap(groups) {
   return map.size > 0 ? map : null;
 }
 
-/** Load `.keyword-aliases.json` from the squads registry's directory.
+/** Load `.keyword-aliases.json` from the one path the writer also uses.
+ *
+ *  It used to derive the location from the squads registry's directory while
+ *  build-routing-digest derived it from the digest's. Those agree in project
+ *  scope and diverge in global — registry at ~/, digest at ~/.nirvana/ — so on
+ *  every buyer's install the file was written where this function never looked,
+ *  and arm (b) of the bridge silently did nothing. Both sides read
+ *  KEYWORD_ALIASES_PATH now; `resolvePaths()` re-resolves for the current cwd
+ *  rather than trusting values captured at require time.
+ *
  *  Tolerates absence and malformed content (returns null). Cached by
  *  path+mtime — route() may run thousands of times per eval. */
 function loadKeywordAliases(registries) {
   try {
     const src = registries && registries.squads && registries.squads.source_path;
     if (!src) return null;
-    const p = path.join(path.dirname(src), '.keyword-aliases.json');
+    const p = nrvPaths.resolvePaths().KEYWORD_ALIASES_PATH;
     const st = fs.statSync(p); // throws when absent → null below
     if (_aliasCache && _aliasCache.path === p && _aliasCache.mtimeMs === st.mtimeMs) {
       return _aliasCache.map;

--- a/skills/harness/scripts/build-routing-digest.ts
+++ b/skills/harness/scripts/build-routing-digest.ts
@@ -76,7 +76,11 @@ export function resolveRoutingArtifactPaths(): RoutingArtifactPaths {
     squadsRegistry: nrvPaths.SQUADS_REGISTRY_PATH,
     mindClonesRegistry: path.join(cloneDir, ".mind-clones-registry.json"),
     digest,
-    aliases: path.join(path.dirname(digest), ".keyword-aliases.json"),
+    // The same constant the router reads. Deriving it from the digest's
+    // directory here and from the registry's there put the file, in global
+    // scope, somewhere nothing looked.
+    aliases: nrvPaths.KEYWORD_ALIASES_PATH
+      || path.join(path.dirname(digest), ".keyword-aliases.json"),
   };
 }
 
@@ -484,7 +488,14 @@ if (import.meta.main) {
     mindClonesRegistry: typeof flags.clones === "string" ? flags.clones : resolved.mindClonesRegistry,
   };
   const digestPath = typeof flags.out === "string" ? flags.out : resolved.digest;
-  const aliasesPath = typeof flags["aliases-out"] === "string" ? flags["aliases-out"] : path.join(path.dirname(digestPath), ".keyword-aliases.json");
+  // Explicit flags win, and `--out` carries the aliases with it: a caller that
+  // relocates the digest means to relocate the pair. Only the DEFAULT comes from
+  // the shared constant — that default is what diverged from the reader.
+  const aliasesPath = typeof flags["aliases-out"] === "string"
+    ? flags["aliases-out"]
+    : typeof flags.out === "string"
+      ? path.join(path.dirname(digestPath), ".keyword-aliases.json")
+      : resolved.aliases;
 
   const input = loadDigestInput(registryPaths);
   const readable = input.readable ?? { businesses: true, squads: true, mindClones: true };

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -477,6 +477,93 @@ if (fs.existsSync(dnaLib)) {
   add("library: mind-clones", "WARN", "no mind-clone library — run with --starter");
 }
 
+// SECTION 6.5: PAID INSTALL
+//
+// The doctor had nothing here. On a machine where a paid pack installed its
+// content but never installed its license, every check above passed and the
+// last line read "All systems nominal" — while `nrv update <slug>` was already
+// broken and would stay broken until the buyer wrote to support days later.
+// These are the things a buyer would notice were missing, if anything told them.
+const licStore = path.join(HOME, ".nirvana-license", "PROVENANCE.json");
+const packsDir = path.join(HOME, ".nirvana", "packs");
+const installedPacks = fs.existsSync(packsDir)
+  ? fs.readdirSync(packsDir).filter((f) => f.endsWith(".json"))
+  : [];
+
+if (installedPacks.length === 0) {
+  add("paid: pack", "PASS", "no paid pack installed (free engine)");
+} else {
+  const names = installedPacks.map((f) => f.replace(/\.json$/, ""));
+  add("paid: pack", "PASS", `${names.join(", ")}`);
+
+  if (!fs.existsSync(licStore)) {
+    add("paid: license", "FAIL",
+      `pack installed but no license at ${licStore.replace(HOME, "~")} — ` +
+      `"nrv update ${names[0]}" cannot work. Fix: nrv license install`);
+  } else {
+    try {
+      const prov = JSON.parse(fs.readFileSync(licStore, "utf8"));
+      if (!prov.license_key) {
+        add("paid: license", "FAIL", "PROVENANCE.json has no license_key — that copy has no provenance");
+      } else if (!prov.signature) {
+        add("paid: license", "WARN", `${prov.license_key} — unsigned (offline use is fine; support cannot verify it)`);
+      } else {
+        add("paid: license", "PASS", `${prov.license_key}${prov.edition ? ` (${prov.edition})` : ""}`);
+      }
+    } catch (e) {
+      add("paid: license", "FAIL", `cannot read ${licStore.replace(HOME, "~")}: ${(e as Error).message}`);
+    }
+  }
+
+  // The overlay is only real if the components it recorded are on disk. A
+  // manifest that lists content nobody can find is the expensive failure: the
+  // install LOOKS complete.
+  for (const f of installedPacks) {
+    const slug = f.replace(/\.json$/, "");
+    try {
+      const man = JSON.parse(fs.readFileSync(path.join(packsDir, f), "utf8"));
+      const kinds: Array<[string, string]> = [
+        ["squads", homeSquads], ["businesses", homeBiz], ["mind-clones", dnaLib],
+      ];
+      const missing: string[] = [];
+      let total = 0;
+      for (const [kind, dir] of kinds) {
+        for (const slugName of Object.keys(man[kind] ?? {})) {
+          total++;
+          if (!fs.existsSync(path.join(dir, slugName))) missing.push(`${kind}/${slugName}`);
+        }
+      }
+      if (total === 0) add(`paid: content ${slug}`, "WARN", "manifest records no components");
+      else if (missing.length) {
+        add(`paid: content ${slug}`, "FAIL",
+          `${missing.length} of ${total} missing from the library (${missing.slice(0, 3).join(", ")}${missing.length > 3 ? ", …" : ""}) — re-run: nrv update ${slug}`);
+      } else add(`paid: content ${slug}`, "PASS", `${total} components present`);
+    } catch (e) {
+      add(`paid: content ${slug}`, "FAIL", `unreadable manifest: ${(e as Error).message}`);
+    }
+  }
+}
+
+// The cross-language alias groups, at the path the router actually reads. Its
+// absence is a silent routing downgrade: a brief in one language against an
+// entity declared in another stops getting its coverage lift, and nothing says
+// so at dispatch time.
+try {
+  const aliasPath = (nrvPaths as Record<string, string>).KEYWORD_ALIASES_PATH;
+  if (!aliasPath) add("routing: aliases", "WARN", "this engine predates KEYWORD_ALIASES_PATH");
+  else if (!fs.existsSync(aliasPath)) {
+    add("routing: aliases", "WARN",
+      `${aliasPath.replace(HOME, "~")} missing — cross-language routing runs without alias lift. Fix: nrv index`);
+  } else {
+    const groups = JSON.parse(fs.readFileSync(aliasPath, "utf8"));
+    const n = Array.isArray(groups) ? groups.length : 0;
+    if (n === 0) add("routing: aliases", "WARN", "no alias groups — a corpus in one language emits none");
+    else add("routing: aliases", "PASS", `${n} cross-language group(s)`);
+  }
+} catch (e) {
+  add("routing: aliases", "WARN", `cannot read alias groups: ${(e as Error).message}`);
+}
+
 // Per-buyer watermarks in a library that AUTHORS packs. Rationale and mechanics
 // live in _shared/lib/watermark-scan.ts, shared with the end of `nrv update` — the
 // command that introduces them.

--- a/skills/harness/tests/alias-path-agreement.test.ts
+++ b/skills/harness/tests/alias-path-agreement.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The writer and the reader of `.keyword-aliases.json` must name the same file.
+ *
+ * They did not. build-routing-digest derived the path from the digest's
+ * directory; router.js derived it from the squads registry's. Those are the same
+ * directory in project scope and two different ones in global — the registry
+ * sits at `~/`, the digest at `~/.nirvana/`. Global scope is what every buyer
+ * runs, so the file was written where nothing ever looked, and arm (b) of the
+ * amplification bridge — the part that lifts a Portuguese brief onto an
+ * English-declared squad — was dead code on every install.
+ *
+ * Nothing caught it because absence is normal by design: a partial install has
+ * no alias file, so the bridge degrades quietly. A silent degradation that is
+ * correct in one case and a bug in another needs a test that pins the path, not
+ * the behaviour.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const PATHS = join(import.meta.dir, "..", "..", "_shared", "lib", "paths.js");
+
+/** Resolve the paths module against a given cwd, the way a real run does. */
+function resolveIn(cwd: string): Record<string, string> {
+  const prev = process.cwd();
+  try {
+    process.chdir(cwd);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require(PATHS);
+    delete require.cache[require.resolve(PATHS)];
+    return mod.resolvePaths();
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+describe("`.keyword-aliases.json` has one location", () => {
+  test("paths.js names it", () => {
+    const p = resolveIn(process.cwd());
+    expect(typeof p.KEYWORD_ALIASES_PATH).toBe("string");
+    expect(p.KEYWORD_ALIASES_PATH.endsWith(".keyword-aliases.json")).toBe(true);
+  });
+
+  test("in project scope it sits beside the digest", () => {
+    const root = mkdtempSync(join(tmpdir(), "nrv-alias-proj-"));
+    try {
+      // A project is a directory with .nirvana/ in it.
+      mkdirSync(join(root, ".nirvana"), { recursive: true });
+      writeFileSync(join(root, "CLAUDE.md"), "# project\n");
+      const p = resolveIn(root);
+      expect(dirname(p.KEYWORD_ALIASES_PATH)).toBe(dirname(p.ROUTING_DIGEST_PATH));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("in global scope it sits beside the digest too — the divergence that broke it", () => {
+    const root = mkdtempSync(join(tmpdir(), "nrv-alias-global-"));
+    try {
+      const p = resolveIn(root); // no .nirvana/ here → global scope
+      expect(dirname(p.KEYWORD_ALIASES_PATH)).toBe(dirname(p.ROUTING_DIGEST_PATH));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("neither side invents the default on its own any more", async () => {
+    const router = await Bun.file(join(import.meta.dir, "..", "lib", "router.js")).text();
+    const builder = await Bun.file(join(import.meta.dir, "..", "scripts", "build-routing-digest.ts")).text();
+    // The reader has no derivation left at all — it only ever reads the default.
+    expect(router).toMatch(/KEYWORD_ALIASES_PATH/);
+    expect(router).not.toMatch(/path\.join\(path\.dirname\(src\), '\.keyword-aliases\.json'\)/);
+    // The writer reaches for the constant. It may still place the pair beside an
+    // explicitly relocated --out, which is a caller's choice, not a default.
+    expect(builder).toMatch(/KEYWORD_ALIASES_PATH/);
+    expect(builder).toMatch(/resolved\.aliases/);
+  });
+
+  test("the default the builder resolves is the one the router reads", () => {
+    // The regression in prose: writer said `dirname(digest)`, reader said
+    // `dirname(squads registry)`. Same directory in a project, two in global.
+    const p = resolveIn(process.cwd());
+    expect(p.KEYWORD_ALIASES_PATH).toBe(p.KEYWORD_ALIASES_PATH); // resolved once
+    expect(dirname(p.KEYWORD_ALIASES_PATH)).toBe(dirname(p.ROUTING_DIGEST_PATH));
+  });
+});


### PR DESCRIPTION
**The cross-language bridge was dead code for every buyer.** `.keyword-aliases.json` was written next to the digest and read next to the squads registry — the same directory in a project, two different ones in global scope. One constant now.

**`nrv doctor` did not know licenses exist.** It printed "All systems nominal" on the machine that started this whole investigation. It reports the license, the pack's components against the disk, and the alias groups now.

**`nrv update` walked past the license in the zip it had just downloaded.**

**The watermark detector knew five extensions; the watermarker knows six** — and it skipped `dist/`, the one directory where packs are built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)