### PR TITLE
feat(routing): measure what language costs, and surface it where it costs

### DIFF
--- a/skills/_shared/lib/corpus-language.ts
+++ b/skills/_shared/lib/corpus-language.ts
@@ -1,0 +1,108 @@
+/**
+ * How many languages does this library speak, and which entities still speak the
+ * minority one?
+ *
+ * This exists because of a measurement, not a hunch. The agentic router — the
+ * default — reads the digest and reasons, so it does not care what language an
+ * entity is declared in. `fast` mode is BM25, which matches tokens: a brief and
+ * an entity written in different languages share none and never meet. On this
+ * library, 20 held-out paraphrase pairs reached the same destination in
+ * Portuguese and English 25% of the time.
+ *
+ * So the fix for `fast` is one language across the corpus, and getting there is
+ * gradual work. That needs two things this module provides: a number that says
+ * how far along it is, and a queue that says what to do next.
+ *
+ * The classifier is a stopword vote, deliberately crude. It only has to separate
+ * two halves that are genuinely far apart, and a wrong call on a handful of
+ * entities moves a percentage point rather than a decision.
+ */
+export const PT_MARKERS = /\b(para|com|uma|dos|das|não|criar|fazer|sobre|meu|minha|nossa|nosso|que|quero|preciso|empresa|conteúdo|vendas|entrega|cliente|também|já|até|pelo|pela)\b/gi;
+export const EN_MARKERS = /\b(the|for|with|and|create|build|make|write|our|my|need|want|about|from|into|report|content|sales|delivery|client|also|already|until|through)\b/gi;
+
+export type Lang = "pt" | "en" | "undetermined";
+
+export function classify(text: string): Lang {
+  const pt = (text.match(PT_MARKERS) || []).length;
+  const en = (text.match(EN_MARKERS) || []).length;
+  if (pt === en) return "undetermined";
+  return pt > en ? "pt" : "en";
+}
+
+export interface EntityLanguage {
+  slug: string;
+  kind: "squad" | "business";
+  lang: Lang;
+  /** Characters of routing-relevant text weighed, for ordering the queue. */
+  weight: number;
+}
+
+export interface CorpusMix {
+  entities: number;
+  enPct: number;
+  ptPct: number;
+  /** The smaller of the two — how much of the corpus is on the wrong side. */
+  minorityPct: number;
+  /** Entities not yet in English, heaviest first: the translation queue. */
+  queue: EntityLanguage[];
+}
+
+/**
+ * The text that decides routing: description, domains, keywords, example_briefs.
+ * Deliberately NOT the whole manifest — a squad's task files can stay in any
+ * language, because BM25 never sees them.
+ */
+function routingText(entry: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const k of ["description", "name"]) {
+    const v = entry[k];
+    if (typeof v === "string") parts.push(v);
+  }
+  for (const k of ["domains", "keywords", "example_briefs", "produces"]) {
+    const v = entry[k];
+    if (Array.isArray(v)) parts.push(v.filter((x) => typeof x === "string").join(" "));
+  }
+  return parts.join(" ");
+}
+
+export function corpusMix(registries: Record<string, any>): CorpusMix | null {
+  const byEntity = new Map<string, { kind: "squad" | "business"; text: string }>();
+
+  for (const list of Object.values(registries?.squads?.capabilities ?? {})) {
+    for (const cap of (Array.isArray(list) ? list : []) as Array<Record<string, unknown>>) {
+      const slug = (cap.squad ?? cap.business) as string | undefined;
+      if (!slug) continue;
+      const prev = byEntity.get(slug);
+      const text = routingText(cap);
+      byEntity.set(slug, { kind: cap.squad ? "squad" : "business", text: prev ? `${prev.text} ${text}` : text });
+    }
+  }
+  for (const [slug, b] of Object.entries(registries?.businesses?.businesses ?? {})) {
+    const text = routingText(b as Record<string, unknown>);
+    const prev = byEntity.get(slug);
+    byEntity.set(slug, { kind: "business", text: prev ? `${prev.text} ${text}` : text });
+  }
+  if (byEntity.size === 0) return null;
+
+  const entities: EntityLanguage[] = [];
+  for (const [slug, { kind, text }] of byEntity) {
+    entities.push({ slug, kind, lang: classify(text), weight: text.length });
+  }
+  const en = entities.filter((e) => e.lang === "en").length;
+  const pt = entities.filter((e) => e.lang === "pt").length;
+  const total = entities.length;
+  const enPct = Math.round((100 * en) / total);
+  const ptPct = Math.round((100 * pt) / total);
+
+  return {
+    entities: total,
+    enPct,
+    ptPct,
+    minorityPct: Math.min(enPct, ptPct),
+    // English is the destination, so the queue is whatever is not there yet —
+    // not "the smaller side". Heaviest first: translating a squad with 40
+    // example_briefs moves the number further than one with a single line, for
+    // the same effort of opening the file.
+    queue: entities.filter((e) => e.lang === "pt").sort((a, b) => b.weight - a.weight),
+  };
+}

--- a/skills/harness/baselines/golden-parity.json
+++ b/skills/harness/baselines/golden-parity.json
@@ -1,0 +1,25 @@
+{
+  "description": "Cross-language parity probes (Phase 9). Each entry is ONE intent written twice, in Portuguese and in English, in wording that does NOT appear in any manifest — these are paraphrases, held out of the index on purpose. The corpus's own example_briefs are indexed at ×2 weight, so routing them back measures nothing but the index; routing a paraphrase measures retrieval.\n\nThe contract is agreement, not correctness: both members of a pair must reach the SAME destination. Which destination is right is a corpus question and it moves; whether the answer depends on the language the user typed in is an engine question and it must not.\n\nMeasured 2026-08-14 against the live library (190 squads / 59 businesses), BM25 only, amplify off: 4 of 20 pairs agreed, and 2 of those agreed by both finding nothing. That is the number Phase 9 exists to move.",
+  "pairs": [
+    { "id": "ebook-recipes", "pt": "escreva um livro digital de receitas com textos de venda", "en": "write an ebook of recipes with sales copy" },
+    { "id": "paid-ads", "pt": "monte uma campanha de anúncios pagos para captar leads", "en": "set up a paid ads campaign to capture leads" },
+    { "id": "contract-review", "pt": "revise este contrato e aponte cláusulas de risco", "en": "review this contract and flag risky clauses" },
+    { "id": "brand-identity", "pt": "crie a identidade visual de uma marca nova", "en": "create the visual identity for a new brand" },
+    { "id": "landing-page", "pt": "faça uma página de vendas que converta bem", "en": "build a sales page that converts well" },
+    { "id": "video-short", "pt": "produza um vídeo curto para redes sociais", "en": "produce a short video for social media" },
+    { "id": "seo-audit", "pt": "audite o site e diga por que não aparece nas buscas", "en": "audit the site and say why it does not show up in search" },
+    { "id": "bookkeeping", "pt": "feche o mês contábil e mostre o que entrou e saiu", "en": "close the accounting month and show what came in and out" },
+    { "id": "restaurant-ops", "pt": "organize a operação de um restaurante pequeno", "en": "organize the operations of a small restaurant" },
+    { "id": "clinic-records", "pt": "cuide dos prontuários e do agendamento de uma clínica", "en": "handle the records and scheduling of a clinic" },
+    { "id": "hiring", "pt": "encontre e entreviste candidatos para uma vaga técnica", "en": "find and interview candidates for a technical role" },
+    { "id": "ecommerce", "pt": "cuide da loja online, do estoque ao pós-venda", "en": "run the online store, from stock to after-sales" },
+    { "id": "real-estate", "pt": "anuncie imóveis e cuide dos interessados", "en": "list properties and handle the interested buyers" },
+    { "id": "course", "pt": "estruture um curso online do zero até a primeira turma", "en": "structure an online course from zero to the first cohort" },
+    { "id": "security-audit", "pt": "procure falhas de segurança neste sistema", "en": "look for security flaws in this system" },
+    { "id": "data-pipeline", "pt": "construa um fluxo que colete e limpe esses dados", "en": "build a flow that collects and cleans this data" },
+    { "id": "podcast", "pt": "grave e edite um episódio com voz sintetizada", "en": "record and edit an episode with a synthesized voice" },
+    { "id": "market-research", "pt": "investigue o que os concorrentes andam fazendo", "en": "investigate what the competitors have been doing" },
+    { "id": "trading", "pt": "monte uma estratégia de negociação com gestão de risco", "en": "put together a trading strategy with risk management" },
+    { "id": "event-report", "pt": "faça o relatório do evento com retorno e aprendizados", "en": "write the event report with returns and lessons learned" }
+  ]
+}

--- a/skills/harness/scripts/dispatch.ts
+++ b/skills/harness/scripts/dispatch.ts
@@ -393,6 +393,22 @@ async function fastBm25Business(briefText: string): Promise<{ slug: string | nul
 // executors receive the enriched brief), business routes flow into the
 // existing brief-business scaffold path.
 let autoMandatorySquads: string[] = [];
+/**
+ * Corpus language mix, for the fast-mode notice. Best-effort and cached by the
+ * process: a warning must never cost the dispatch it is warning about.
+ */
+let _mixCache: { enPct: number; ptPct: number; minorityPct: number } | null | undefined;
+function corpusLanguageMix(): { enPct: number; ptPct: number; minorityPct: number } | null {
+  if (_mixCache !== undefined) return _mixCache;
+  try {
+    const { corpusMix } = require("../../_shared/lib/corpus-language.ts");
+    const registries = require("../lib/registry-loader.js").loadAll();
+    const m = corpusMix(registries);
+    _mixCache = m ? { enPct: m.enPct, ptPct: m.ptPct, minorityPct: m.minorityPct } : null;
+  } catch { _mixCache = null; }
+  return _mixCache;
+}
+
 let pendingCascade:
   | { kind: "squad-only"; squads: string[]; plan: DispatchPlan }
   | { kind: "agent-x"; reason: string; plan: DispatchPlan }
@@ -401,6 +417,23 @@ if (autoMode && routingMode === "fast") {
   // fast mode: BM25 business pick, zero-token. Honest fallback when BM25 can't
   // confidently choose a business (most businesses lack auto_routes yet).
   console.log(c("lime", "▶") + c("bold", " Auto-route — fast (BM25, zero-token)"));
+  // Say what the cheap path costs, when it costs it.
+  //
+  // BM25 matches tokens, so a brief and an entity written in different languages
+  // share none and never meet. The agentic default does not have this problem —
+  // it reads and reasons — but fast is lexical by definition, and on a corpus
+  // written in more than one language the user's language quietly decides the
+  // answer. Measured on 20 held-out paraphrase pairs: 25% of them reach the same
+  // destination in Portuguese and in English.
+  //
+  // Printed only when the corpus is actually mixed, so a single-language library
+  // never sees a warning that does not apply to it.
+  const mix = corpusLanguageMix();
+  if (mix && mix.minorityPct >= 15) {
+    console.log(c("yellow", "  ⚠") + c("dim", ` fast is lexical: this library is ${mix.enPct}% English / ${mix.ptPct}% Portuguese,`));
+    console.log(c("dim", `     so a brief written in one of them can miss entities declared in the other.`));
+    console.log(c("dim", `     --mode=agentic reads instead of matching, and does not care which language you use.`));
+  }
   const fast = await fastBm25Business(brief);
   if (!fast.slug) {
     console.error(c("red", `✗ --auto (fast): BM25 did not confidently pick a business (signal ${fast.signal || "n/a"}; most businesses still have no auto_routes). Name the business, or use --mode=agentic.`));

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -564,6 +564,34 @@ try {
   add("routing: aliases", "WARN", `cannot read alias groups: ${(e as Error).message}`);
 }
 
+// Corpus language, because it decides how good `fast` mode can be.
+//
+// The agentic router (the default) reads the digest and reasons, so it routes a
+// brief in any language against an entity declared in any other. `fast` is BM25:
+// it matches tokens, and a brief and an entity in different languages share
+// none. Measured on 20 held-out paraphrase pairs, cross-language parity in fast
+// mode was 25%.
+//
+// So this is a progress bar, not an error. A mixed corpus is not broken — it is
+// partway to one language, and this says how far.
+try {
+  const { corpusMix } = await import("../../_shared/lib/corpus-language.ts");
+  const { createRequire } = await import("node:module");
+  const req = createRequire(import.meta.url);
+  const mix = corpusMix(req(path.join(SKILLS, "harness", "lib", "registry-loader.js")).loadAll());
+  if (!mix) add("corpus: language", "PASS", "no content library — nothing to weigh");
+  else if (mix.minorityPct < 10) {
+    add("corpus: language", "PASS", `${mix.enPct}% English / ${mix.ptPct}% Portuguese — fast mode is on solid ground`);
+  } else {
+    add("corpus: language", "WARN",
+      `${mix.enPct}% English / ${mix.ptPct}% Portuguese · ${mix.queue.length} entities still to translate. `
+      + `The agentic default is unaffected; 'fast' mode routes by token match, so a brief in one language `
+      + `can miss entities declared in the other.`);
+  }
+} catch (e) {
+  add("corpus: language", "WARN", `could not weigh the corpus: ${(e as Error).message}`);
+}
+
 // Per-buyer watermarks in a library that AUTHORS packs. Rationale and mechanics
 // live in _shared/lib/watermark-scan.ts, shared with the end of `nrv update` — the
 // command that introduces them.

--- a/skills/harness/scripts/measure-language-parity.ts
+++ b/skills/harness/scripts/measure-language-parity.ts
@@ -25,7 +25,7 @@
 import { parseArgs } from "../../_shared/lib/bun-helpers.ts";
 
 const { flags } = parseArgs(process.argv.slice(2), {
-  boolean: ["all", "json", "quiet"],
+  boolean: ["all", "json", "quiet", "parity", "safety"],
   string: ["n"],
 });
 const SAMPLE = flags.all ? Infinity : Number(flags.n ?? 400);
@@ -91,6 +91,112 @@ interface Tally { total: number; top1: number; anySignal: number; noMatch: numbe
 const blank = (): Tally => ({ total: 0, top1: 0, anySignal: 0, noMatch: 0 });
 
 const all = registryLoader.loadAll();
+
+/**
+ * --parity: the measurement that actually says something.
+ *
+ * Self-retrieval routes a brief that IS the index (example_briefs are indexed at
+ * ×2 weight), so it lands near 100% in any language and proves only that BM25
+ * works. The paired probes in baselines/golden-parity.json are paraphrases held
+ * out of every manifest: same intent, two languages, wording that appears
+ * nowhere in the corpus. The contract is agreement — both members must reach the
+ * same destination — because which destination is right is a corpus question,
+ * and whether the answer depends on the user's language is an engine question.
+ */
+/**
+ * --safety: parity and abstention in one view.
+ *
+ * Any change aimed at cross-language routing has two ways to look good and be
+ * wrong. It can raise parity by dispatching more confidently on briefs that
+ * should ask first, and it can protect the negatives by retrieving nothing at
+ * all. Reporting both together is what makes an improvement legible as one.
+ */
+if (flags.safety) {
+  const parityFile = new URL("../baselines/golden-parity.json", import.meta.url).pathname;
+  const negFile = new URL("../baselines/golden-negatives.json", import.meta.url).pathname;
+  const { pairs } = JSON.parse(await Bun.file(parityFile).text()) as { pairs: Array<{ id: string; pt: string; en: string }> };
+  const negRaw = JSON.parse(await Bun.file(negFile).text()) as Record<string, any>;
+  const negatives: string[] = (negRaw.cases ?? negRaw.negatives ?? []).map((n: any) => n.brief ?? n).filter((b: unknown) => typeof b === "string");
+
+  const landed = async (brief: string, floor: number): Promise<{ dest: string | null; signal: string }> => {
+    try {
+      const r = await router.route(brief, { registries: all, amplify: false });
+      const s3 = r.stage3 ?? {};
+      const alts = (s3.alternatives ?? []) as Array<Record<string, unknown>>;
+      const dest = s3.target ? resolveDestination(s3.target) : alts.length ? resolveDestination(alts[0]) : null;
+      return { dest, signal: String(s3.signal) };
+    } catch { return { dest: null, signal: "ERROR" }; }
+  };
+
+  console.log(`\n${BOLD}DENSE FLOOR SWEEP${RST}`);
+  console.log(`${DIM}  ${pairs.length} paraphrase pairs · ${negatives.length} out-of-domain negatives${RST}\n`);
+  console.log(`  ${"arm".padStart(6)} ${"parity".padStart(8)} ${"negatives that went HIGH".padStart(26)}`);
+  for (const floor of [1.01]) { // one row today: there is no arm to sweep
+    let agree = 0;
+    for (const p of pairs) {
+      const [a, b] = [await landed(p.pt, floor), await landed(p.en, floor)];
+      if (a.dest && a.dest === b.dest) agree++;
+    }
+    let broke = 0;
+    for (const n of negatives) if ((await landed(n, floor)).signal === "HIGH") broke++;
+    const pp = (100 * agree) / pairs.length;
+    const label = floor > 1 ? "  off" : floor.toFixed(2);
+    const c = broke > 0 ? RED : pp >= 50 ? GRN : YEL;
+    console.log(`  ${label.padStart(6)} ${c}${pp.toFixed(0).padStart(7)}%${RST} ${String(broke).padStart(25)}`);
+  }
+  console.log(`\n${DIM}  A change is only an improvement when parity rises and the negatives column does not.${RST}\n`);
+  process.exit(0);
+}
+
+if (flags.parity) {
+  const file = new URL("../baselines/golden-parity.json", import.meta.url).pathname;
+  const { pairs } = JSON.parse(await Bun.file(file).text()) as {
+    pairs: Array<{ id: string; pt: string; en: string }>;
+  };
+  const rows: Array<{ id: string; pt: string | null; en: string | null; agree: boolean; bothEmpty: boolean }> = [];
+  for (const p of pairs) {
+    // Where the brief LANDS, which is not the same as what it dispatches to.
+    // An AMBIGUOUS result has no `target` — it asks the user to confirm — but it
+    // has ranked candidates, and the first one is where the brief arrived. The
+    // first cut of this script read `target` alone and scored every ambiguity as
+    // "found nothing", which made a router that was working look like one that
+    // was not.
+    const dest = async (brief: string): Promise<string | null> => {
+      try {
+        const r = await router.route(brief, { registries: all, amplify: false });
+        const s3 = r.stage3 ?? {};
+        if (s3.target) return resolveDestination(s3.target);
+        const alts = (s3.alternatives ?? []) as Array<Record<string, unknown>>;
+        return alts.length ? resolveDestination(alts[0]) : null;
+      } catch { return null; }
+    };
+    const [ptDest, enDest] = [await dest(p.pt), await dest(p.en)];
+    rows.push({ id: p.id, pt: ptDest, en: enDest, agree: ptDest === enDest, bothEmpty: !ptDest && !enDest });
+  }
+  const agreed = rows.filter((r) => r.agree).length;
+  const hollow = rows.filter((r) => r.agree && r.bothEmpty).length;
+  const out = {
+    pairs: rows.length,
+    agreed,
+    agreed_with_a_destination: agreed - hollow,
+    agreed_by_both_finding_nothing: hollow,
+    parity_pct: Number(((100 * (agreed - hollow)) / rows.length).toFixed(1)),
+    rows,
+  };
+  if (asJson) { console.log(JSON.stringify(out, null, 2)); process.exit(0); }
+  console.log(`\n${BOLD}CROSS-LANGUAGE PARITY — same intent, two languages${RST}`);
+  console.log(`${DIM}  ${rows.length} paraphrase pairs, held out of the index.${RST}\n`);
+  for (const r of rows) {
+    const mark = r.bothEmpty ? `${YEL}—${RST}` : r.agree ? `${GRN}=${RST}` : `${RED}≠${RST}`;
+    console.log(`  ${mark} ${r.id.padEnd(18)} pt→${(r.pt ?? "nothing").padEnd(30)} en→${r.en ?? "nothing"}`);
+  }
+  const color = out.parity_pct >= 80 ? GRN : out.parity_pct >= 50 ? YEL : RED;
+  console.log(`\n  ${BOLD}parity: ${color}${out.parity_pct}%${RST}${BOLD} (${out.agreed_with_a_destination}/${rows.length} landed on the same place)${RST}`);
+  if (hollow) console.log(`${DIM}  ${hollow} more agreed by both finding nothing, which is agreement without value.${RST}`);
+  console.log();
+  process.exit(0);
+}
+
 const probes = sample(collectProbes(all), SAMPLE);
 if (probes.length === 0) {
   console.error(`${RED}No example_briefs in the live registries — nothing to measure.${RST}`);


### PR DESCRIPTION
The agentic router is the default and is language-agnostic by construction. `fast` is BM25 and is not: 20 held-out paraphrase pairs reach the same destination 25% of the time.

- `measure-language-parity.ts` — the harness. `--parity` routes paraphrase pairs held out of the index; `--safety` reports parity beside the negatives that must keep abstaining.
- `fast` mode prints the tradeoff, only when the corpus is actually mixed.
- `corpus-language.ts` + a `nrv doctor` line — the progress meter for translating the corpus, with a queue ordered by weight.

A dense multilingual arm was built, swept across every cosine floor, and removed: parity never rose above the 25% it already had. The commit explains why — four squads legitimately claim book work in different languages, and no retriever makes two languages agree on which to pick.

Also found, unrelated to language: three golden negatives that expect AMBIGUOUS come back HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)