### PR TITLE
protocol: cutting for cost is prohibited, and the gate can now tell

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,11 @@
     "check:dispatch": "bun scripts/check-dispatch-contract.ts",
     "check:purity": "bun scripts/check-engine-purity.ts",
     "check:english": "bun scripts/check-english-source.ts --strict",
+    "check:coverage": "bun skills/_shared/scripts/coverage-ratchet.ts --check --strict",
     "check:packs": "bun scripts/check-published-packs.ts --strict",
     "check:audit-parity": "bun scripts/check-audit-parity.ts --strict",
     "check:command-parity": "bun scripts/check-skillmd-command-parity.ts --strict",
     "check:changelog": "bun scripts/check-changelog-parity.ts --strict",
-    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
+    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
   }
 }

--- a/skills/_shared/ROUTING_METADATA_CONTRACT.md
+++ b/skills/_shared/ROUTING_METADATA_CONTRACT.md
@@ -159,6 +159,43 @@ flows enforce at minimum:
   `nrv find-clone` — the invariant of `MIND_CLONE_CREATION_PIPELINE.md` phase 5,
   measured continuously by `_shared/scripts/eval-clone-routing.ts`.
 
+## 8bis. Never cut for cost
+
+Two reasons lead people to remove routing metadata, and only one is legitimate.
+
+**Precision.** A redundant keyword, a fourth synonym of a concept already covered
+twice, a sentence that states nothing a router could match on. This is real: BM25
+normalizes by length, so redundancy inside one document costs that document
+precision. The test is measurable — run the self-retrieval gate before and after,
+and on the neighbours. If retrieval does not improve, the removal was loss, not
+precision.
+
+**Cost.** Shortening descriptions, dropping example briefs or deleting
+capabilities to reduce tokens. **This is prohibited.** It degrades the product to
+save money on the path that is already the cheap one:
+
+- The default router is agentic. It reads for meaning, and a more accurate,
+  more complete description is strictly better for it. There is no budget being
+  spent that a shorter description would save.
+- `fast` is BM25 and **indexes one document per capability** (`buildMatchDocs`).
+  A squad with 18 capabilities produces 19 documents. Declaring another one does
+  not dilute the others — they never shared a length budget.
+
+So neither matcher charges for size. What both punish is redundancy inside a
+single field, which is a precision problem with a precision fix.
+
+This is not hypothetical damage. The 500-character limit named in §1 was applied
+across this library and truncated descriptions mid-word; the correction there —
+"un-truncating is not enough, rewrite as complete text" — exists because someone
+optimized the wrong quantity.
+
+If a corpus does not fit a context budget, the budget is an engineering problem:
+tier the digest, escalate on demand, split the file. The answer is never to make
+the library know less.
+
+**For reviewers:** reject any change whose justification is token cost, and ask
+for the before/after retrieval numbers instead.
+
 ## 9. The SELF-RETRIEVAL GATE (blocking)
 
 **A newly created or edited entity's own `example_briefs` must route back to

--- a/skills/_shared/scripts/coverage-ratchet.ts
+++ b/skills/_shared/scripts/coverage-ratchet.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+/**
+ * coverage-ratchet.ts — an entity may not quietly know less than it did.
+ *
+ * Every gate we have asks whether an entity can still be found. None of them
+ * asks whether it still covers what it used to. Delete five capabilities and
+ * their briefs and every gate stays green: the survivors self-retrieve fine,
+ * the neighbours are untouched, the YAML validates. The library got smaller and
+ * nothing said so.
+ *
+ * That is the exact shape of the damage the routing contract already carries a
+ * correction for — descriptions truncated mid-word at 500 characters, across the
+ * whole library, to save space. Losing coverage is invisible in a way that
+ * losing correctness is not, which is why it needs its own gate.
+ *
+ * So: record what each entity covers, and refuse a silent decrease. Removal
+ * stays possible — it just has to be said out loud.
+ *
+ *   bun coverage-ratchet.ts --check                  # every entity, warn on drops
+ *   bun coverage-ratchet.ts --check --strict         # exit 1 on any undeclared drop
+ *   bun coverage-ratchet.ts --check <slug>           # one entity
+ *   bun coverage-ratchet.ts --accept <slug> --reason "merged into X"
+ *   bun coverage-ratchet.ts --record                 # re-baseline everything
+ *
+ * The baseline lives beside the registries so it travels with the scope it
+ * describes, and it is meant to be committed.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { paths as nrvPaths, parseArgs } from "../lib/bun-helpers.ts";
+
+// parseArgs takes no options here and returns `positional`, not `positionals`.
+const { flags, positional } = parseArgs(process.argv.slice(2));
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+const BASELINE = join(
+  dirname((nrvPaths as Record<string, string>).SQUADS_REGISTRY_PATH ?? "."),
+  ".coverage-baseline.json",
+);
+
+interface Coverage {
+  capabilities: number;
+  example_briefs: number;
+  keywords: number;
+  /** Capability ids, so a swap of equal count is still visible. */
+  ids: string[];
+}
+interface Baseline {
+  recorded_at: string;
+  entities: Record<string, Coverage>;
+  /** Accepted decreases: slug → why. Cleared for an entity when it grows again. */
+  accepted: Record<string, { reason: string; at: string; from: Coverage }>;
+}
+
+function loadBaseline(): Baseline {
+  try {
+    return JSON.parse(readFileSync(BASELINE, "utf8"));
+  } catch {
+    return { recorded_at: "", entities: {}, accepted: {} };
+  }
+}
+
+/** What every entity in the live registries covers right now. */
+function measure(): Record<string, Coverage> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const registries = require("../../harness/lib/registry-loader.js").loadAll();
+  const out: Record<string, Coverage> = {};
+  const bump = (slug: string, cap: Record<string, unknown>, id: string) => {
+    const c = (out[slug] ??= { capabilities: 0, example_briefs: 0, keywords: 0, ids: [] });
+    c.capabilities++;
+    c.ids.push(id);
+    c.example_briefs += ((cap.example_briefs as unknown[]) ?? []).length;
+    c.keywords += ((cap.keywords as unknown[]) ?? []).length;
+  };
+  for (const [id, list] of Object.entries(registries?.squads?.capabilities ?? {})) {
+    for (const cap of (Array.isArray(list) ? list : []) as Array<Record<string, unknown>>) {
+      const slug = (cap.squad ?? cap.business) as string | undefined;
+      if (slug) bump(slug, cap, id);
+    }
+  }
+  for (const [slug, b] of Object.entries(registries?.businesses?.businesses ?? {})) {
+    const biz = b as Record<string, unknown>;
+    const c = (out[slug] ??= { capabilities: 0, example_briefs: 0, keywords: 0, ids: [] });
+    c.example_briefs += ((biz.example_briefs as unknown[]) ?? []).length;
+    c.keywords += ((biz.keywords as unknown[]) ?? []).length;
+  }
+  for (const c of Object.values(out)) c.ids.sort();
+  return out;
+}
+
+interface Drop { slug: string; field: string; from: number; to: number; lostIds?: string[]; }
+
+function compare(base: Baseline, now: Record<string, Coverage>, only?: string): Drop[] {
+  const drops: Drop[] = [];
+  for (const [slug, before] of Object.entries(base.entities)) {
+    if (only && slug !== only) continue;
+    const after = now[slug];
+    if (!after) {
+      drops.push({ slug, field: "entity", from: 1, to: 0 });
+      continue;
+    }
+    for (const f of ["capabilities", "example_briefs", "keywords"] as const) {
+      if (after[f] < before[f]) drops.push({ slug, field: f, from: before[f], to: after[f] });
+    }
+    // A swap keeps the count and still loses coverage, so compare the ids too.
+    const lost = before.ids.filter((id) => !after.ids.includes(id));
+    if (lost.length) drops.push({ slug, field: "capability ids", from: before.ids.length, to: after.ids.length, lostIds: lost });
+  }
+  return drops;
+}
+
+const baseline = loadBaseline();
+const now = measure();
+
+if (flags.record) {
+  mkdirSync(dirname(BASELINE), { recursive: true });
+  writeFileSync(BASELINE, JSON.stringify({ recorded_at: new Date().toISOString(), entities: now, accepted: baseline.accepted ?? {} }, null, 2) + "\n");
+  console.log(`${GRN}Baseline recorded${RST} — ${Object.keys(now).length} entities → ${BASELINE.replace(process.env.HOME ?? "~", "~")}`);
+  process.exit(0);
+}
+
+if (typeof flags.accept === "string") {
+  const slug = flags.accept;
+  const reason = typeof flags.reason === "string" ? flags.reason.trim() : "";
+  if (!reason) {
+    console.error(`${RED}--accept needs --reason "why this entity covers less now"${RST}`);
+    console.error(`${DIM}A decrease without a stated reason is exactly what this gate exists to catch.${RST}`);
+    process.exit(2);
+  }
+  baseline.accepted ??= {};
+  baseline.accepted[slug] = { reason, at: new Date().toISOString(), from: baseline.entities[slug] };
+  baseline.entities[slug] = now[slug] ?? { capabilities: 0, example_briefs: 0, keywords: 0, ids: [] };
+  writeFileSync(BASELINE, JSON.stringify(baseline, null, 2) + "\n");
+  console.log(`${GRN}Accepted${RST} ${slug}: ${reason}`);
+  process.exit(0);
+}
+
+// default: --check
+if (!baseline.recorded_at) {
+  console.log(`${YEL}No baseline yet.${RST} Run: bun coverage-ratchet.ts --record`);
+  process.exit(0);
+}
+
+const only = positional[0];
+const drops = compare(baseline, now, only).filter((d) => !baseline.accepted?.[d.slug]);
+
+if (flags.json) {
+  console.log(JSON.stringify({ baseline_at: baseline.recorded_at, drops }, null, 2));
+  process.exit(drops.length && flags.strict ? 1 : 0);
+}
+
+console.log(`\n${BOLD}COVERAGE RATCHET${RST}`);
+console.log(`${DIM}  baseline ${baseline.recorded_at.slice(0, 19)} · ${Object.keys(baseline.entities).length} entities${RST}\n`);
+
+if (drops.length === 0) {
+  console.log(`${GRN}  No entity knows less than it did.${RST}\n`);
+  process.exit(0);
+}
+
+for (const d of drops) {
+  console.log(`  ${RED}▼${RST} ${d.slug.padEnd(32)} ${d.field}: ${d.from} → ${d.to}`);
+  if (d.lostIds?.length) for (const id of d.lostIds.slice(0, 5)) console.log(`      ${DIM}lost ${id}${RST}`);
+}
+console.log(`\n${DIM}  Removal is allowed; silent removal is not. If the decrease is intended:${RST}`);
+console.log(`${DIM}    bun coverage-ratchet.ts --accept <slug> --reason "..."${RST}`);
+console.log(`${DIM}  If it is not, restore it. Cutting content to reduce tokens is prohibited —${RST}`);
+console.log(`${DIM}  see ROUTING_METADATA_CONTRACT §8bis.${RST}\n`);
+process.exit(flags.strict ? 1 : 0);

--- a/skills/businesses/references/WEB3-ENGINEERING-DESIGN.md
+++ b/skills/businesses/references/WEB3-ENGINEERING-DESIGN.md
@@ -1,0 +1,262 @@
+# chain-atelier — design proposal
+
+**Status:** design · 2026-08-15
+**Ask:** a business that can build anything on-chain — banks, marketplaces,
+ecommerce, dApps — on Solana, EVM, or a chain named at brief time, usable by a
+weak local model with no internet, and aware of the regulation that applies where
+the system will run.
+
+---
+
+## 1. The boundary, and what it costs a neighbour
+
+`crypto-foundry` already exists and already declares `smart-contract-set`,
+`defi-protocol-spec` and `security-audit-report`. A new business that also claims
+those is born stealing, and the routing contract is explicit that taking a query
+from a better-grounded neighbour is worse than not being found.
+
+So the boundary has to be drawn, not avoided. It is sayable in one question:
+
+> **Are you launching a token, or building an application?**
+
+| | crypto-foundry | chain-atelier |
+|---|---|---|
+| unit of work | a project launch | a system that keeps running |
+| contracts it writes | token contracts — mint, vesting, staking, distribution | application contracts — escrow, custody, settlement, access control, registry |
+| horizon | 90 days to launch | the life of the system |
+| artifacts | tokenomics paper, launch package, vesting schedule | system spec, deployed contracts, dApp, indexer, runbook |
+| audit it runs | is this token safe to launch | do these invariants hold under adversarial use |
+
+**crypto-foundry gives up nothing it actually does.** Its engineering is token
+engineering, and it keeps that. What it should stop claiming is generic
+`smart-contract-set` and `security-audit-report` — those descriptions are broader
+than its material, which is precisely the shadowing failure measured across this
+library today. Narrowing them is part of this proposal, not a side effect of it.
+
+`fintech-forge` is untouched: it builds regulated fintech MVPs off-chain
+(KYC/AML, licensing, payment rails, BaaS). When a system is both — a bank whose
+ledger is on-chain — `fintech-forge` owns the regulatory perimeter and
+`chain-atelier` owns the chain. That is a two-business brief, and the handoff
+primitives exist for exactly that.
+
+## 2. What only a business can carry here
+
+Everything in this design that a squad could not do alone, per Business
+Protocol §1.4:
+
+- **An architecture decision that binds later phases.** Chain choice, custody
+  model and settlement model are decided once and constrain every squad
+  downstream. A squad is atomic and stateless; this is persistent state.
+- **Security with veto.** BP9 approval chains let the audit stage *block*
+  delivery. A squad can report a finding; only a business can refuse to ship.
+- **The antagonist.** Above 5 employees the protocol requires one, and here it is
+  load-bearing rather than ceremonial: the failure mode of on-chain work is
+  confident, well-tested, exploitable code.
+- **Memory across projects.** `memory/learned.md` is where a discovered attack
+  pattern survives the project that found it.
+- **Regulation as persistent institutional knowledge**, not a fact re-derived per
+  brief by a model that may be offline and weak.
+
+## 3. business.yaml — the declaration
+
+```yaml
+name: chain-atelier
+version: 0.1.0
+protocol: "1.0"
+description: >
+  Builds application systems that run on a blockchain and the software around
+  them: escrow and marketplace contracts, custody and key policy, on-chain
+  ledgers with off-chain reconciliation, token-gated commerce, and the dApp,
+  indexer and deployment runbook that make them usable. Takes the chain as an
+  input — Solana with Anchor and SPL, EVM with Solidity and the ERC standards,
+  or another named at brief time — and produces the same system spec against
+  either backend. Every contract ships with executable invariants, a property
+  test suite and an adversarial review that can block release.
+domains: [crypto, software_engineering, security, backend, frontend, fintech, compliance, infrastructure]
+operation_mode: zero_human
+authority_level: tier-2
+employee_count: 7
+runtime_requirements:
+  minimum:
+    - runtime: claude-code
+produces:
+  - onchain-system-spec
+  - smart-contract-application-set
+  - contract-invariant-suite
+  - adversarial-review-report
+  - custody-key-policy
+  - dapp-frontend
+  - chain-indexer
+  - deployment-runbook
+  - jurisdiction-obligation-matrix
+keywords:
+  - web3, web 3.0, blockchain, on-chain, onchain
+  - smart contract, contrato inteligente, contratos inteligentes
+  - solana, anchor, spl, program derived address, pda
+  - evm, solidity, erc-20, erc-721, erc-1155, foundry, hardhat
+  - escrow, custódia, custodia, custody, multisig, mpc
+  - marketplace on-chain, marketplace cripto, nft marketplace
+  - ecommerce cripto, pagamento em cripto, crypto payments
+  - carteira, wallet, assinatura de transação, transaction signing
+  - liquidação, liquidacao, settlement, ledger on-chain
+  - indexador, indexer, subgraph, rpc, nó, node
+  - auditoria de contrato, contract audit, invariante, invariant
+  - reentrância, reentrancia, reentrancy, overflow, oracle manipulation
+example_briefs:
+  - "Quero um marketplace onde o comprador só libera o pagamento quando recebe, e a taxa da plataforma sai automática"
+  - "Build a marketplace with escrow where funds release on delivery confirmation and the platform fee is taken on settlement"
+  - "Preciso de uma loja que aceite pagamento em cripto e entregue o produto digital na hora"
+  - "We need a system of accounts with balances on chain, where every movement reconciles against an off-chain ledger"
+  - "Quero tokenizar cotas de um fundo e controlar quem pode transferir para quem"
+  - "Same contract set, but deploy it on Solana instead of EVM"
+  - "Audit this contract before we put real money in it"
+```
+
+**Domain check:** every value is in `CAPABILITY_CATALOG_V1.yaml` v1.1.0. No
+`experimental_domains` needed.
+
+**Briefs check:** 7 briefs, EN and PT both present, symptom-phrased, no business
+slug inside any of them, conjugated and infinitive forms both covered.
+
+## 4. The org — 7 employees
+
+Seven crosses the antagonist threshold on purpose: the adversary is the point.
+
+| employee | type | role |
+|---|---|---|
+| `ca-intake` | orchestrator · `is_brief_intake: true` | the only entry. Extracts the three answers that shape everything: which chain, custody by whom, which jurisdiction. Refuses to route until it has them or a stated default. |
+| `ca-architect` | functional_specialist | writes the chain-agnostic system spec and its invariants. Owns the decision record. Reports to intake. |
+| `ca-solana` | functional_specialist | Anchor, SPL/Token-2022, PDAs, compute budget, account model. |
+| `ca-evm` | functional_specialist | Solidity, ERC standards, proxy and upgrade patterns, gas. |
+| `ca-adversary` | antagonist_gate · `is_antagonist: true` | tries to break what the other two built. Holds the release veto. |
+| `ca-regulatory` | functional_specialist | maps the jurisdiction to obligations and turns them into design constraints before code exists, not after. |
+| `ca-integration` | functional_specialist | dApp, wallet flows, indexer, RPC, deployment runbook, observability. |
+
+Org chart: `ca-intake` is the single root; the other six report to it.
+`ca-adversary` reports to intake and answers to nobody it reviews — an antagonist
+that reports to the person it audits is decoration.
+
+**Approval chain** (BP9), for anything touching value:
+
+```
+producer   ca-solana | ca-evm
+reviewer   ca-adversary        ← can reject, and rejection stops delivery
+approver   ca-architect        ← confirms the invariants still hold
+```
+
+## 5. Squads — what exists, what must be built
+
+Nothing in the library builds application-layer on-chain systems. What is
+adjacent and reusable:
+
+| exists | used for |
+|---|---|
+| `crypto-token-forge` | when the system needs a token minted (Solana, SPL/Token-2022) |
+| `nirvana-backend` | the off-chain half — API, database, reconciliation |
+| `nirvana-security-fullstack`, `security-audit` | conventional application security around the chain |
+| `landing-page-nirvana`, `awwwards-singularity-studio` | the marketing surface, when asked |
+| `nirvana-compliance-lgpd`, `nirvana-juridico-total` | Brazilian data and legal work |
+
+To create, four squads. Not seven — I proposed seven earlier by symmetry and the
+boundary test does not support it. Architecture and regulation decide together
+and produce one artifact set, so they are one squad. Frontend, indexer and
+deployment are one delivery surface, not three.
+
+| new squad | boundary, in one sentence |
+|---|---|
+| `onchain-architect` | Turns a system requirement into a chain-agnostic spec with executable invariants, a threat model, and the jurisdiction's obligations already folded in as constraints. |
+| `solana-engineering` | Implements an approved spec as Anchor programs with SPL/Token-2022, PDAs and an account model, plus its test suite. |
+| `evm-engineering` | Implements an approved spec as Solidity contracts with the right ERC standards and upgrade path, plus its test suite. |
+| `onchain-adversary` | Attacks a contract set against its declared invariants and known vulnerability classes, and reports whether it can be released. |
+
+`squads_authorized` stays **empty**, which means every squad is permitted. That
+is deliberate: the operational rule is now the top-5 agentic choice recorded in
+the audit, and a whitelist would only re-introduce a gate the harness already
+enforces better.
+
+## 6. Mind-clones
+
+Sparse and grounded, per the pipeline's own rule — a clone without material is an
+invented persona wearing a real name. Candidates worth building only if the
+sources sustain five layers:
+
+- a protocol designer, for the economic and mechanism reasoning the templates
+  cannot cover
+- a smart-contract security researcher, for the adversary's judgement
+- an applied cryptographer, for custody and key policy
+
+Anyone whose public material is thin ships as a declared **archetype**, not under
+a real name.
+
+## 7. The requirement that shapes everything: weak model, no internet
+
+The protocols already give: BM25 routing with zero LLM, deterministic gates,
+deterministic scaffolding by contract, local runtimes via Ollama and llama.cpp.
+What they do not give — stated plainly in the protocol audit — is offline
+*creation*. Creating this business needs a strong model. **Using** it must not.
+
+So the knowledge cannot live in the model. It lives in the artifacts:
+
+**Templates instead of advice.** Not "the agent knows how to write escrow" — the
+squad carries an audited escrow contract, parameterised. A weak model fills
+blanks; it does not design.
+
+**Gates instead of review.** `slither` and `mythril` for EVM, `anchor test` and
+`cargo-audit` for Solana, property tests over the declared invariants. The judge
+is the compiler and the fuzzer, which do not get worse when the model does.
+
+**A local chain instead of the internet.** `anvil` and `solana-test-validator`
+run offline; dependencies vendored, toolchains pinned. Nothing says "check the
+latest docs".
+
+**Regulation as a table, not as memory.** A weak model does not know MiCA from
+BACEN from the SEC. So the matrix is data: jurisdiction → obligation → what it
+forces in the design. `ca-regulatory` reads a table.
+
+## 8. What this business must refuse, in writing
+
+The refusal is a feature and belongs in `not_for`, short enough to fire
+(≤25 chars each):
+
+```
+not_for:
+  - novo mecanismo de consenso
+  - new consensus mechanism
+  - curva de amm inédita
+  - novel amm curve
+  - criptografia nova
+  - novel cryptography
+  - lançamento de token        # crypto-foundry
+  - token launch               # crypto-foundry
+  - tokenomics
+  - trading de cripto          # nirvana-crypto-trading
+  - crypto trading
+```
+
+The honest scope: **excellent at composing known, audited patterns; refuses
+novel design.** Escrow, vault, marketplace, registry, access control, vesting,
+multisig — patterns that exist, have been audited many times, and fit a template.
+A weak model composes those safely because it is not inventing.
+
+Novel economic design, new cryptography, a bespoke consensus — no gate catches a
+design error there. A business that accepts those with a weak model produces
+unsafe systems that look approved. For the bank in the original ask: a bank
+assembled from known patterns, this builds. Deposit tokenisation with bespoke
+settlement is novel design and needs people.
+
+## 9. Gates before this counts as created
+
+1. `validate-business.ts` — manifest, org chart, employee frontmatter (`.strict()`), integrity: one root, exactly one `is_brief_intake`, at least one antagonist above 5 employees.
+2. `validate-squad.ts` on each of the four new squads.
+3. **Self-retrieval** on the business and every capability — each `example_brief` returns its owner at rank 1.
+4. **Neighbours intact** — `crypto-foundry`, `fintech-forge`, `crypto-token-forge` and `nirvana-crypto-trading` keep winning their own briefs. This is the gate this design is most likely to fail, and the one worth failing on.
+5. `measure-language-parity.ts --safety` — the golden negatives keep abstaining.
+6. Isolation test, per BP §9.4.
+
+## 10. Build order
+
+Not four squads at once. `onchain-architect` and `onchain-adversary` first, and
+prove them on one real system: a marketplace with escrow, built on Solana and on
+EVM from the same spec. If a weak offline model produces both and both pass the
+gates, the design holds and the rest is replication. If it does not, we learn it
+with two squads instead of four.

--- a/skills/harness/references/BODY_INDEXING_PROPOSAL.md
+++ b/skills/harness/references/BODY_INDEXING_PROPOSAL.md
@@ -1,0 +1,142 @@
+# Indexing what a capability does, not only what it says it does
+
+**Status:** proposal · 2026-08-15
+**Decides:** whether BM25 keeps matching against routing metadata alone, or also
+against the body each capability actually executes.
+
+---
+
+## The finding
+
+Measured on a catalogue of ~80,000 skills with heavy overlap
+(arXiv:2603.22455, *SkillRouter*): routing that sees only names and descriptions
+loses **37–44 percentage points** of accuracy against routing that sees the
+body. The comparison, Hit@1:
+
+| retrieval over | Hit@1 |
+|---|---|
+| trained reranker (full body) | 74.0% |
+| LLM as judge | 67.3% |
+| dense embeddings (full body) | 64.0% |
+| **BM25 (description only)** | **31.4%** |
+
+And the part that closes the argument for us: description-only trailed by
+**≥27pp in every description-length quartile, including the longest**. Writing a
+longer description does not substitute for indexing the body.
+
+A second result, on a production catalogue of 110 agents and 584 tools
+(arXiv:2606.17519): **tool-level retrieval beats pack-level and hierarchical
+routing by 2–4pp**, and the first hop of a hierarchy is an unrecoverable error
+source — the LLM picks only 1.2 packs on average with an 83% hit rate.
+
+## Why this lands squarely on us
+
+Nirvana-OS is a pure retrieval system for its content. Squads and businesses are
+**not** loaded into context — they are searched. 4 skills load by description;
+249 entities are retrieved. So the context-overhead half of the skill-degradation
+literature does not apply to us at all (and its confidence interval already
+included zero), while the discrimination half applies completely.
+
+What the index sees today (`router.js buildMatchDocs`):
+
+```
+description + keywords ×3 + example_briefs ×2 + produces + domains
+```
+
+What it does not see: `agents/*.md`, `tasks/*.md`, `workflows/*.yaml` — 5,767
+files, ~16 MB, which is where the capability's actual method lives. A squad can
+have a task doc that names the exact tool, format, standard and failure mode a
+user is asking about, and none of it is retrievable.
+
+This also explains a negative result from 2026-08-14. A dense multilingual arm
+was added to the router and swept across every cosine floor; cross-language
+parity never rose above the 25% it already had. The arm embedded **the same
+routing metadata BM25 already saw**. Swapping the matcher over identical text
+buys nothing; the measured gain comes from widening what is matched.
+
+## What is proposed
+
+Index a **body document per capability**, alongside the metadata document that
+exists now. Not per squad — per capability, because that is the granularity the
+evidence favours and because `invoke.ref` already makes it resolvable: all 678
+capabilities declare one (587 workflow, 80 task, 11 agent).
+
+Resolution, per capability:
+
+```
+invoke.type=task      → the task doc
+invoke.type=agent     → the agent body
+invoke.type=workflow  → the workflow's steps, each step's task doc and agent body
+```
+
+A workflow expands to the union of what it runs, which is exactly the set of
+material that decides whether that capability fits a brief.
+
+### Keeping the body from swamping the metadata
+
+Two documents per capability, not one merged blob:
+
+- `squad_capability:<squad>:<cap>` — the metadata doc, unchanged, unchanged
+  weights (keywords ×3, briefs ×2). This is the precise, hand-curated signal.
+- `squad_capability_body:<squad>:<cap>` — the body doc, weight ×1, and its score
+  **capped below the metadata doc's** so a long body can surface a capability
+  that metadata missed, but cannot outrank a capability whose metadata actually
+  matched.
+
+That ordering matters. The body is for **recall** — finding the capability whose
+declared vocabulary happened to miss the user's words. Precision stays where it
+is calibrated, on curated metadata. It is the same division that made dense
+recall the right idea in the wrong place: widen what can be found, do not move
+where the confidence comes from.
+
+### What gets stripped before indexing
+
+Bodies are prose written for an executing agent, not for a matcher. Before
+indexing: drop fenced code blocks, YAML front matter, file paths, URLs, and the
+scaffold headings every task doc repeats (`## Objetivo`, `## Output`,
+`## Anti-patterns`). What remains is the domain vocabulary — tool names, format
+names, standards, failure modes — which is the part that discriminates.
+
+Cap each body doc at a fixed budget (proposed: 4,000 characters of retained
+text, longest-section-first). The largest agent body in the library is 36 KB;
+indexing it whole would give one capability more length budget than a hundred
+others put together, and BM25 normalizes by length precisely to stop that.
+
+### Cost
+
+Index build only, never context. The body index adds an estimated 3–5 MB to the
+squads registry against the current 2.4 MB, and a few seconds to `nrv index`.
+Nothing about a dispatch gets more expensive: `fast` stays zero-token, and the
+agentic router keeps reading the digest, which does **not** carry bodies.
+
+## How it will be judged
+
+The same instrument the corpus already has, before and after, on the same corpus:
+
+1. `measure-language-parity.ts --parity` — 20 held-out paraphrase pairs.
+   Baseline 25%. This is the headline number.
+2. `measure-language-parity.ts --safety` — the 40 golden negatives must not
+   start dispatching HIGH. A recall widening that also rescues out-of-domain
+   briefs is a loss, not a win.
+3. `self-retrieval-gate.ts` across the library — no entity may lose its own
+   briefs to a neighbour whose body now matches.
+4. `routing-eval.test.ts` watermarks — no regression on same-language top-1,
+   which currently sits near 100%.
+
+**Pre-committed decision rule:** ship only if parity rises with zero negatives
+lost and zero same-language regression. If parity does not move, the body index
+is removed the same way the dense arm was — the measurement decides, not the
+theory. That is the second time this rule applies today, and the first time it
+said no.
+
+## What this is not
+
+Not a replacement for curated metadata. The shadowing result (arXiv:2605.24050)
+puts **68% of degradation at 202 skills on description overlap**, and bodies
+overlap more than descriptions do, not less. Body indexing widens recall; it can
+also widen collisions. That is why the score cap and the negatives gate are part
+of the proposal and not an afterthought.
+
+Not a change to what loads in context. The body stays out of the prompt. Index
+and context are different systems, and treating them as one is the confusion
+this proposal exists to remove.

--- a/skills/harness/tests/coverage-ratchet.test.ts
+++ b/skills/harness/tests/coverage-ratchet.test.ts
@@ -1,0 +1,130 @@
+/**
+ * An entity may not quietly know less than it did.
+ *
+ * The gates this library already had all ask whether an entity can still be
+ * FOUND. None asked whether it still COVERS what it used to. Measured on a real
+ * squad: deleting 3 of 8 capabilities and trimming 56 briefs to 10 left the
+ * self-retrieval gate reporting a clean PASS — the survivors retrieved
+ * perfectly, the neighbours were untouched. The library got smaller and every
+ * signal stayed green.
+ *
+ * That is the shape of the damage the routing contract already carries a
+ * correction for: descriptions truncated mid-word at 500 characters across the
+ * whole library, to save space. Losing coverage is invisible in a way losing
+ * correctness is not.
+ *
+ * These tests run against a fixture baseline rather than the live one, so they
+ * are deterministic and say nothing about whatever the developer's library
+ * happens to hold today.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const SCRIPT = path.resolve(import.meta.dir, "..", "..", "_shared", "scripts", "coverage-ratchet.ts");
+
+let tmp: string;
+let env: NodeJS.ProcessEnv;
+
+/**
+ * Point the script at a throwaway registry. The baseline lands beside it, so a
+ * run here never reads or writes the developer's real one.
+ */
+function writeRegistry(caps: Record<string, Array<Record<string, unknown>>>): void {
+  fs.writeFileSync(path.join(tmp, ".squads-registry.json"), JSON.stringify({ capabilities: caps }));
+  fs.writeFileSync(path.join(tmp, ".businesses-registry.json"), JSON.stringify({ businesses: {} }));
+}
+
+/** Two capabilities on one squad, each with briefs and keywords. */
+const FULL = {
+  "demo.alpha.execute": [{ squad: "demo-squad", example_briefs: ["a", "b", "c"], keywords: ["k1", "k2"] }],
+  "demo.beta.execute": [{ squad: "demo-squad", example_briefs: ["d", "e"], keywords: ["k3"] }],
+};
+
+function run(args: string[]): { code: number; out: string } {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], { cwd: tmp, env, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-ratchet-"));
+  env = {
+    ...process.env,
+    SQUADS_REGISTRY_PATH: path.join(tmp, ".squads-registry.json"),
+    BUSINESSES_REGISTRY_PATH: path.join(tmp, ".businesses-registry.json"),
+  };
+  writeRegistry(FULL);
+});
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe("coverage ratchet", () => {
+  test("records a baseline and passes against itself", () => {
+    expect(run(["--record"]).code).toBe(0);
+    const r = run(["--check", "--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("No entity knows less");
+  });
+
+  test("a deleted capability fails, and names what was lost", () => {
+    run(["--record"]);
+    writeRegistry({ "demo.alpha.execute": FULL["demo.alpha.execute"] }); // beta amputated
+    const r = run(["--check", "--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("capabilities: 2 → 1");
+    expect(r.out).toContain("demo.beta.execute");
+  });
+
+  test("deleted briefs fail even when the capability survives", () => {
+    run(["--record"]);
+    writeRegistry({
+      ...FULL,
+      "demo.alpha.execute": [{ squad: "demo-squad", example_briefs: ["a"], keywords: ["k1", "k2"] }],
+    });
+    const r = run(["--check", "--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("example_briefs: 5 → 3");
+  });
+
+  test("a swap that keeps the count is still caught", () => {
+    // Same number of capabilities, different ids. Counting alone would miss it.
+    run(["--record"]);
+    writeRegistry({
+      "demo.alpha.execute": FULL["demo.alpha.execute"],
+      "demo.gamma.execute": [{ squad: "demo-squad", example_briefs: ["x", "y"], keywords: ["k9"] }],
+    });
+    const r = run(["--check", "--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("demo.beta.execute");
+  });
+
+  test("growth is never a failure", () => {
+    run(["--record"]);
+    writeRegistry({
+      ...FULL,
+      "demo.delta.execute": [{ squad: "demo-squad", example_briefs: ["f", "g", "h"], keywords: ["k4"] }],
+    });
+    expect(run(["--check", "--strict"]).code).toBe(0);
+  });
+
+  test("an intended removal can be accepted, and needs a reason to be", () => {
+    run(["--record"]);
+    writeRegistry({ "demo.alpha.execute": FULL["demo.alpha.execute"] });
+
+    // A decrease without a stated reason is exactly what this gate is for.
+    const bare = run(["--accept", "demo-squad"]);
+    expect(bare.code).toBe(2);
+    expect(bare.out).toContain("--reason");
+
+    expect(run(["--accept", "demo-squad", "--reason", "merged into demo.alpha"]).code).toBe(0);
+    expect(run(["--check", "--strict"]).code).toBe(0);
+  });
+
+  test("with no baseline it says so instead of failing", () => {
+    // A fresh checkout must not fail the contract gates for lack of a baseline.
+    const r = run(["--check", "--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("No baseline");
+  });
+});

--- a/skills/squads/SQUAD_PROTOCOL_V5.md
+++ b/skills/squads/SQUAD_PROTOCOL_V5.md
@@ -241,6 +241,49 @@ A v5 squad with `capabilities:` MUST satisfy:
 
 Validators are runtime-neutral and live in `~/.nirvana/skills/squads/lib/validators/`.
 
+### 22.10 The index is per capability, not per squad
+
+`buildMatchDocs` emits **one document per capability**, plus one for the squad
+itself. A squad with 18 capabilities produces 19 documents, each with its own
+length normalization.
+
+The consequence is the one people get wrong: **declaring another capability does
+not dilute the ones already there.** They are separate documents and they do not
+compete for each other's length budget. What dilutes is padding a single
+description or stacking a fourth synonym of a concept already covered twice —
+that is redundancy inside one document, and it costs precision in that document
+alone.
+
+So there is no retrieval-quality argument for keeping a squad small. There is one
+for keeping each capability sharp.
+
+### 22.11 Never cut for cost
+
+Two different reasons can lead someone to remove content. Only one of them is
+legitimate, and the protocol distinguishes them because the wrong one has already
+done damage here: descriptions in this library were once truncated mid-word at
+500 characters, and the routing contract still carries the correction that
+"un-truncating is not enough — rewrite them as complete text".
+
+**Cutting for precision is legitimate.** A redundant keyword, a fourth synonym, a
+sentence that says nothing a router could match on. The test is measurable: run
+the self-retrieval gate before and after, and on the neighbours too. If removal
+does not improve retrieval, it was not precision — it was loss.
+
+**Cutting for cost is prohibited.** Removing capabilities, shortening
+descriptions, or dropping example briefs to reduce tokens degrades the product to
+save money on the path that was already the cheap one. The default router is
+agentic and reads for meaning: more accurate description is strictly better for
+it. `fast` is BM25, opt-in, and indexed per capability — so it does not pay for
+squad size either.
+
+If a corpus genuinely does not fit a context budget, the budget is an engineering
+problem: tier the digest, escalate on demand, split the file. The answer is never
+to make the library know less.
+
+A reviewer should reject any change whose justification is token cost, and ask
+for the retrieval measurement instead.
+
 ---
 
 ## §23 Global Registry and Indexing
@@ -919,8 +962,21 @@ Two squads cannot declare the same capability id. The registry rejects on indexi
 **3. Examples that overlap with not_for.**
 If `examples: ["analyze video"]` and `not_for: ["analyze video for education"]`, BM25 gets confused. Examples MUST be distinct from anti-patterns.
 
-**4. Capability id inflation.**
-Don't declare 50 capabilities per squad. Most squads should have 3-10. If you have more, the squad is doing too much; consider splitting.
+**4. A squad without a sayable boundary.**
+The test is not how many capabilities a squad declares — it is whether you can
+say what the squad is for in one sentence, and have every capability fit inside
+it. A squad of 40 coherent capabilities is healthy; a squad of 6 that do
+unrelated things is not.
+
+The sharp version: **if the capabilities of a squad need `not_for` against each
+other, they are two squads.** That is a boundary problem, and splitting fixes it.
+Count never was the diagnosis — it was a symptom that used to correlate.
+
+This entry used to read "most squads should have 3-10; if you have more, the
+squad is doing too much". The argument underneath was coherence, but written as
+a number it became a target, and a number that looks like a budget invites
+cutting for the wrong reason. See §22.11 for why cutting for cost is prohibited
+and why capability count costs nothing in retrieval.
 
 **5. Fidelity theater.**
 Don't declare `status: validated` without actual ground-truth + eval-results.json. Validator checks file existence. The harness will refuse capabilities whose claimed status doesn't match disk reality.


### PR DESCRIPTION
The library already suffered this once: descriptions truncated mid-word at 500 characters to save space.

**The fact that removes the excuse:** `buildMatchDocs` emits one document per capability. 18 capabilities → 19 documents, each normalized on its own. Adding one does not dilute the others. And squads are retrieved, never loaded — so the context-overhead arm of the skill-degradation literature (whose CI already included zero at 202 skills) is absent here entirely.

- `SQUAD_PROTOCOL_V5.md` §22.10 and §22.11, `ROUTING_METADATA_CONTRACT.md` §8bis — cut for precision, measurably; never for cost.
- The "most squads should have 3-10 capabilities" anti-pattern is replaced by the test it meant: if the capabilities need `not_for` against each other, they are two squads.
- `coverage-ratchet.ts` — every existing gate asks whether an entity can still be *found*. Deleting 3 of 8 capabilities and trimming 56 briefs to 10 left the self-retrieval gate at a clean PASS. The ratchet catches that, and catches a swap that keeps the count.

788 tests pass; `check:all` green with the ratchet wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)