### PR TITLE
feat(routing): index what a capability does, not only what it says it does

### DIFF
--- a/skills/_shared/lib/body-index.js
+++ b/skills/_shared/lib/body-index.js
@@ -1,0 +1,124 @@
+'use strict';
+/**
+ * body-index.js — the text a capability actually executes, made retrievable.
+ *
+ * What the index sees today is what a capability *says about itself*:
+ * description, keywords, example_briefs, produces. What it never sees is the
+ * task doc, the agent body, the workflow — 5,767 files and ~16 MB where the
+ * method actually lives. A squad can name the exact tool, format, standard and
+ * failure mode a user is asking about, and none of it is retrievable.
+ *
+ * Measured on a catalogue of ~80,000 skills (arXiv:2603.22455): routing that
+ * sees only names and descriptions loses 37-44 percentage points against
+ * routing that sees the body, and the gap holds "in every description-length
+ * quartile, including the longest". Writing a longer description does not
+ * substitute for indexing the body.
+ *
+ * Two constraints shape everything here:
+ *
+ * 1. **Index time, never route time.** route() runs thousands of times in an
+ *    eval; reading files there would be ruinous. The extraction happens once,
+ *    during `nrv index`, and the result is stored in the registry.
+ * 2. **Recall, not precision.** The body is prose written for an executing
+ *    agent, not for a matcher. It widens what can be *found*; the curated
+ *    metadata keeps deciding what *wins*. See the score cap in router.js.
+ */
+const fs = require('fs');
+const path = require('path');
+
+/** Characters of retained text per capability. Measured on 106 task docs: median
+ *  1,349, p90 3,022, and only 2% above this. The cap exists for the outlier —
+ *  the largest agent body in the library is 36 KB, and indexing it whole would
+ *  hand one capability more length budget than a hundred others together. */
+const BODY_BUDGET = 4000;
+
+/** Scaffold headings every task doc repeats. They are structure, not vocabulary. */
+const SCAFFOLD = /^#{1,6}\s*(objetivo|objective|output|outputs?|input|inputs?|processo|process|anti-?patterns?|antipadr[õo]es|crit[ée]rios?|acceptance|checklist|passos?|steps?|formato|format|exemplo|example)s?\b.*$/gim;
+
+/**
+ * Strip everything a matcher cannot use.
+ *
+ * Code blocks, front matter, URLs and paths are noise with high token mass:
+ * they would dominate a BM25 document without discriminating between
+ * capabilities, since every squad's task docs contain the same shapes.
+ */
+function clean(raw) {
+  if (typeof raw !== 'string' || !raw) return '';
+  return raw
+    .replace(/^---[\s\S]*?^---/m, ' ')          // YAML front matter
+    .replace(/```[\s\S]*?```/g, ' ')            // fenced code
+    .replace(/`[^`\n]{1,120}`/g, ' ')           // inline code
+    .replace(/https?:\/\/\S+/g, ' ')            // urls
+    .replace(/[\w./-]*\/[\w./-]+\.\w{1,5}\b/g, ' ') // file paths
+    .replace(SCAFFOLD, ' ')
+    .replace(/[|>#*_`~\[\]()-]{2,}/g, ' ')      // table pipes, rules, markdown noise
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function readIfFile(p) {
+  try {
+    if (!p || !fs.existsSync(p) || !fs.statSync(p).isFile()) return '';
+    return fs.readFileSync(p, 'utf8');
+  } catch { return ''; }
+}
+
+/** `ref` may carry an extension or not, and may name a dir-relative file. */
+function resolveRef(squadDir, ref, kind) {
+  if (typeof ref !== 'string' || !ref) return '';
+  const exts = kind === 'workflow' ? ['', '.yaml', '.yml'] : ['', '.md'];
+  const bases = [ref, path.join(kind === 'agent' ? 'agents' : kind === 'workflow' ? 'workflows' : 'tasks', ref)];
+  for (const b of bases) {
+    for (const e of exts) {
+      const p = path.join(squadDir, b + e);
+      const t = readIfFile(p);
+      if (t) return t;
+    }
+  }
+  return '';
+}
+
+/** A workflow expands to the union of what it runs — that is the material that
+ *  decides whether the capability fits a brief, not the DAG itself. */
+function expandWorkflow(squadDir, raw) {
+  const parts = [raw];
+  // Deliberately regex, not a YAML parse: a malformed workflow must degrade to
+  // "less body text", never to a failed index.
+  for (const m of raw.matchAll(/^\s*-?\s*(?:agent|task):\s*["']?([\w./-]+)["']?\s*$/gim)) {
+    const name = m[1];
+    parts.push(resolveRef(squadDir, name, 'task'));
+    parts.push(resolveRef(squadDir, name, 'agent'));
+  }
+  return parts.filter(Boolean).join(' ');
+}
+
+/**
+ * The body text for one capability, cleaned and capped.
+ *
+ * Never throws: a capability whose ref does not resolve simply has no body
+ * document, and keeps the metadata document it always had. Body indexing is
+ * additive — it cannot take a capability out of the index.
+ */
+function bodyTextFor(manifestPath, invoke) {
+  try {
+    if (!invoke || typeof invoke !== 'object') return '';
+    const squadDir = path.dirname(manifestPath);
+    const type = invoke.type;
+    const ref = invoke.ref;
+    let raw = '';
+    if (type === 'workflow') {
+      const wf = resolveRef(squadDir, ref, 'workflow');
+      raw = wf ? expandWorkflow(squadDir, wf) : '';
+    } else if (type === 'agent') {
+      raw = resolveRef(squadDir, ref, 'agent');
+    } else {
+      // task, and anything unrecognised: a task doc plus its bound agent.
+      raw = [resolveRef(squadDir, ref, 'task'), resolveRef(squadDir, invoke.agent, 'agent')]
+        .filter(Boolean).join(' ');
+    }
+    const t = clean(raw);
+    return t.length > BODY_BUDGET ? t.slice(0, BODY_BUDGET) : t;
+  } catch { return ''; }
+}
+
+module.exports = { bodyTextFor, clean, BODY_BUDGET };

--- a/skills/harness/lib/router.js
+++ b/skills/harness/lib/router.js
@@ -185,6 +185,39 @@ function buildMatchDocs(squadsRegistry, businessesRegistry) {
             examples: p.examples || [],
           },
         });
+
+        // Body document — recall, not precision.
+        //
+        // The metadata doc above is hand-curated and is what decides a match.
+        // This one carries the task/agent/workflow text the capability actually
+        // executes (extracted at index time by _shared/lib/body-index.js), so a
+        // capability whose declared vocabulary missed the user's words can still
+        // be FOUND. It is capped below the metadata doc at scoring time
+        // (BODY_DOC_MAX_NORMALIZED) so it can surface a candidate but never
+        // outrank one whose curated metadata genuinely matched.
+        //
+        // Weight ×1 deliberately: the body is prose for an executing agent, not
+        // a signal someone tuned. Measured before this existed: description-only
+        // routing trails body-aware routing by 37-44pp (arXiv:2603.22455).
+        if (typeof p.body_text === 'string' && p.body_text.length > 0) {
+          docs.push({
+            id: `squad_capability_body:${p.squad}:${capId}`,
+            text: p.body_text,
+            meta: {
+              type: 'squad_capability',
+              via_body: true,
+              capability_id: capId,
+              squad: p.squad,
+              description: p.description || '',
+              domains: p.domains || [],
+              not_for: p.not_for || [],
+              fidelity_status: p.fidelity_status || null,
+              score_boost: typeof p.score_boost === 'number' ? p.score_boost : 1.0,
+              invoke: p.invoke || null,
+              examples: p.examples || [],
+            },
+          });
+        }
       }
     }
   }
@@ -533,6 +566,39 @@ function applyAdjustments(results, intent, briefText) {
         }
       }
     }
+
+    // A body document needs more evidence to count than a curated one does.
+    //
+    // Metadata is chosen for retrieval: every token in it was put there by
+    // someone deciding this capability should answer that word. A body is prose
+    // written for an executing agent, and it contains whatever prose contains —
+    // greetings, example dialogue, connective tissue. A brief with one content
+    // token ("bom dia, tudo bem com você?") found a course squad's task doc that
+    // happened to open with a greeting, and turned an abstention into an
+    // ambiguity.
+    //
+    // So a body document only counts when the brief shares real vocabulary with
+    // it. Not a stoplist of the words that failed — that is overfitting, and the
+    // routing contract forbids it — but a floor on how much evidence uncurated
+    // text must show before it is allowed to compete at all.
+    if (meta.via_body) {
+      const cov = countMatchedContentTokens(lc, r.doc.text);
+      if ((cov && cov.matched != null ? cov.matched : 0) < BODY_DOC_MIN_OVERLAP) continue;
+    }
+
+    // A body document may surface a capability, never win over a curated one.
+    //
+    // The body is prose written for an executing agent: long, unweighted, and
+    // full of vocabulary nobody chose for retrieval. Letting it compete on equal
+    // terms would hand the ranking to whoever wrote the most words. Capping it
+    // keeps the division the whole design rests on — the body widens recall, the
+    // curated metadata keeps deciding precision.
+    //
+    // The cap is a ceiling on the normalized score, not a multiplier: a body
+    // match lands just below a perfect metadata match and above a weak one,
+    // which is exactly where a recall arm belongs.
+    if (meta.via_body) score = Math.min(score, BODY_DOC_MAX_NORMALIZED);
+
     adjusted.push({ ...r, score_adjusted: score });
   }
   // Re-rank by adjusted score
@@ -710,6 +776,23 @@ function stage3Decide(matches, opts) {
   const thr = Object.assign({}, DEFAULT_THRESHOLDS, (opts && opts.thresholds) || {});
   if (!matches || matches.length === 0) {
     return { signal: 'NO_MATCH', reason: 'no_candidates', thresholds: thr };
+  }
+
+  // Abstention is a decision, and decisions belong to curated metadata.
+  //
+  // A body document carries prose written for an executing agent, and prose
+  // contains prose: "bom dia, tudo bem com você?" shares four of its five tokens
+  // with an online-course task doc that opens with a greeting. No overlap floor
+  // separates that from a real match — the overlap is high, the tokens are
+  // empty — and a stoplist of the words that failed would be overfitting, which
+  // the routing contract forbids by name.
+  //
+  // So the body arm may add candidates, never remove an abstention. If every
+  // candidate reached the list through a body document, nothing curated
+  // recognised this brief, and the honest answer is still "I don't know". The
+  // body widens what can be found; it does not get to decide that something was.
+  if (matches.every((m) => m && m.meta && m.meta.via_body)) {
+    return { signal: 'NO_MATCH', reason: 'body_only_candidates', thresholds: thr };
   }
 
   // A `business_route` declares an activation regex. When that regex does NOT
@@ -897,6 +980,17 @@ function stage3Decide(matches, opts) {
 // enable` after verifying the neural backend loads) or env override
 // NIRVANA_ROUTER_DENSE=1; NIRVANA_ROUTER_DENSE=0 forces off. With the neural
 // backend absent, denseRank returns null and the slot is a clean no-op.
+
+/** Ceiling on a body document's normalized score. Below a strong metadata match
+ *  (1.0) and above a weak one, so the body arm surfaces candidates without
+ *  taking the decision away from curated metadata. Tunable via
+ *  NIRVANA_BODY_DOC_MAX for the eval sweep. */
+/** Minimum content-token overlap before an uncurated body document competes.
+ *  Two, because one is the regime where a greeting matches example dialogue.
+ *  Tunable via NIRVANA_BODY_DOC_MIN_OVERLAP for the sweep. */
+const BODY_DOC_MIN_OVERLAP = Number(process.env.NIRVANA_BODY_DOC_MIN_OVERLAP) || 2;
+
+const BODY_DOC_MAX_NORMALIZED = Number(process.env.NIRVANA_BODY_DOC_MAX) || 0.85;
 
 const DENSE_FALLBACK_MIN_COSINE = 0.55;
 

--- a/skills/harness/tests/body-indexing.test.ts
+++ b/skills/harness/tests/body-indexing.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The body arm widens what can be found. It does not decide that something was.
+ *
+ * Indexing the task/agent/workflow text behind each capability moved
+ * cross-language parity from 25% to 35% on the held-out paraphrase pairs, and
+ * closed the self-retrieval gap between Portuguese and English to zero. That is
+ * the largest routing gain measured in this library.
+ *
+ * It also broke an abstention on the first attempt, and the way it broke is the
+ * reason for the second rule here. "bom dia, tudo bem com você?" shares four of
+ * its five tokens with an online-course task doc that opens with a greeting. A
+ * score cap did nothing. An overlap floor did nothing — the overlap was high,
+ * the tokens were empty. A stoplist of the words that failed would have been
+ * overfitting, which the routing contract forbids by name.
+ *
+ * What worked was saying out loud what the design already implied: abstention is
+ * a decision, and decisions belong to curated metadata. These tests pin both
+ * halves.
+ */
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require_ = createRequire(import.meta.url);
+const router = require_(join(import.meta.dir, "..", "lib", "router.js"));
+const bodyIndex = require_(join(import.meta.dir, "..", "..", "_shared", "lib", "body-index.js"));
+
+/** A registry shaped like the real one, with one capability carrying a body. */
+function registries(bodyText: string | null, metaDescription = "Generates a quarterly revenue report from ledger exports") {
+  return {
+    squads: {
+      capabilities: {
+        "finance.revenue_report.execute": [{
+          squad: "fixture-finance",
+          description: metaDescription,
+          domains: ["finance"],
+          examples: ["quarterly revenue report"],
+          keywords: ["revenue report", "relatório de receita"],
+          example_briefs: ["Preciso do relatório de receita do trimestre"],
+          invoke: { type: "task", ref: "tasks/report.md" },
+          ...(bodyText ? { body_text: bodyText } : {}),
+        }],
+      },
+    },
+    businesses: { businesses: {} },
+  };
+}
+
+describe("the body document is emitted, and marked", () => {
+  test("a capability with body_text gets a second document", () => {
+    const docs = router.buildMatchDocs(registries("depreciation amortization accrual").squads, {});
+    const ids = docs.map((d: { id: string }) => d.id);
+    expect(ids).toContain("squad_capability:fixture-finance:finance.revenue_report.execute");
+    expect(ids).toContain("squad_capability_body:fixture-finance:finance.revenue_report.execute");
+  });
+
+  test("without body_text there is only the metadata document", () => {
+    const docs = router.buildMatchDocs(registries(null).squads, {});
+    expect(docs.filter((d: { meta?: { via_body?: boolean } }) => d.meta?.via_body)).toHaveLength(0);
+  });
+
+  test("the body document is flagged, so scoring can treat it differently", () => {
+    const docs = router.buildMatchDocs(registries("depreciation amortization").squads, {});
+    const body = docs.find((d: { id: string }) => d.id.startsWith("squad_capability_body:"));
+    expect(body.meta.via_body).toBe(true);
+    // It still resolves to the same destination — recall, not a new entity.
+    expect(body.meta.squad).toBe("fixture-finance");
+    expect(body.meta.capability_id).toBe("finance.revenue_report.execute");
+  });
+});
+
+describe("the body finds what the metadata missed", () => {
+  test("a brief using body vocabulary reaches the capability", async () => {
+    // "depreciation" appears nowhere in the description or keywords.
+    const withBody = await router.route(
+      "preciso calcular depreciation e amortization do trimestre",
+      { registries: registries("depreciation amortization accrual ledger reconciliation"), amplify: false },
+    );
+    expect(withBody.stage3.signal).not.toBe("NO_MATCH");
+  });
+});
+
+describe("abstention belongs to curated metadata", () => {
+  test("candidates found only through a body do not lift a NO_MATCH", async () => {
+    // The greeting case, generalized: a body full of conversational prose, and a
+    // brief that shares its words without sharing its domain.
+    const r = await router.route(
+      "bom dia, tudo bem com você?",
+      { registries: registries("bom dia tudo bem pessoal vamos começar a aula de hoje"), amplify: false },
+    );
+    expect(r.stage3.signal).toBe("NO_MATCH");
+    expect(r.stage3.reason).toBe("body_only_candidates");
+  });
+
+  test("a metadata match still decides, with the body alongside it", async () => {
+    const r = await router.route(
+      "Preciso do relatório de receita do trimestre",
+      { registries: registries("depreciation amortization accrual"), amplify: false },
+    );
+    expect(r.stage3.signal).not.toBe("NO_MATCH");
+    expect(r.stage3.reason).not.toBe("body_only_candidates");
+  });
+});
+
+describe("extraction is bounded and never throws", () => {
+  test("an unresolvable ref yields no body rather than an error", () => {
+    expect(bodyIndex.bodyTextFor("/nonexistent/squad.yaml", { type: "task", ref: "tasks/nope.md" })).toBe("");
+    expect(bodyIndex.bodyTextFor("/nonexistent/squad.yaml", null)).toBe("");
+    expect(bodyIndex.bodyTextFor("", { type: "workflow", ref: "" })).toBe("");
+  });
+
+  test("cleaning removes what a matcher cannot use", () => {
+    const cleaned = bodyIndex.clean([
+      "---", "name: x", "---",
+      "## Objetivo",
+      "Reconcile the ledger against depreciation schedules.",
+      "```ts", "const x = 1;", "```",
+      "See https://example.com/docs and src/lib/thing.ts",
+    ].join("\n"));
+    expect(cleaned).toContain("depreciation");
+    expect(cleaned).not.toContain("const x");
+    expect(cleaned).not.toContain("example.com");
+    expect(cleaned).not.toContain("Objetivo");
+  });
+
+  test("the budget caps a body that would swamp the index", () => {
+    const huge = "reconciliation ".repeat(2000);
+    expect(bodyIndex.clean(huge).length).toBeGreaterThan(bodyIndex.BODY_BUDGET);
+    // bodyTextFor applies the cap; clean() alone does not, by design — the cap
+    // belongs to indexing, not to cleaning.
+    expect(bodyIndex.BODY_BUDGET).toBe(4000);
+  });
+});

--- a/skills/squads/lib/registry.js
+++ b/skills/squads/lib/registry.js
@@ -36,6 +36,7 @@ const YAML = require('yaml');
 
 // v4 capability inferrer (no external deps).
 const v4Inferrer = require(path.join(__dirname, 'v4-capability-inferrer'));
+const bodyIndex = require('../../_shared/lib/body-index.js');
 
 // Centralized path resolver — single source of truth for all path defaults.
 const PATHS = require(path.join(__dirname, '..', '..', '_shared', 'lib', 'paths.js'));
@@ -266,6 +267,12 @@ function build(roots) {
         if (Array.isArray(cap.produces) && cap.produces.length > 0) capEntry.produces = cap.produces;
         if (Array.isArray(cap.example_briefs) && cap.example_briefs.length > 0) capEntry.example_briefs = cap.example_briefs;
         if (Array.isArray(cap.keywords) && cap.keywords.length > 0) capEntry.keywords = cap.keywords;
+        // The body this capability actually executes, resolved through
+        // invoke.ref and cleaned. Extracted here, once, because route() runs
+        // thousands of times per eval and must never touch the filesystem.
+        // Additive: a ref that does not resolve simply yields no body.
+        const bodyText = bodyIndex.bodyTextFor(entry.manifest_path, cap.invoke);
+        if (bodyText) capEntry.body_text = bodyText;
         if (!capabilities[cap.id]) capabilities[cap.id] = [];
         capabilities[cap.id].push(capEntry);
       }


### PR DESCRIPTION
Cross-language parity **25% → 35%** on the held-out paraphrase pairs. The self-retrieval gap between Portuguese and English closes to **zero**. Four golden negatives that were already dispatching HIGH before this change **stopped dispatching**.

**What was missing:** the index saw description, keywords, briefs and produces — never the task doc, agent body or workflow, where the method lives. Measured on ~80k skills (arXiv:2603.22455), description-only routing trails body-aware routing by 37–44pp in *every* description-length quartile. This is also why the dense arm removed on Aug 14 moved nothing: it embedded the same text BM25 already saw.

**Cost:** index time only. Registry 2.4 MB → 4.4 MB. `route()` never touches the filesystem; the digest is untouched — the body is in the index, never in context.

**Two rules keep it honest.** The body doc is capped below a curated match, and candidates found *only* through a body cannot lift a NO_MATCH. That second rule came from a real regression: a greeting matched a course task doc that opens with one, sharing 4 of 5 tokens. A score cap and an overlap floor both did nothing; a stoplist would have been overfitting. Abstention is a decision, and decisions belong to curated metadata.

Judged against the rule written *before* measuring — parity up, negatives not lost, no same-language regression. 775 tests pass, `check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)