### PR TITLE
feat(gate): a fence that never fires is not a fence

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
     "check:purity": "bun scripts/check-engine-purity.ts",
     "check:english": "bun scripts/check-english-source.ts --strict",
     "check:coverage": "bun skills/_shared/scripts/coverage-ratchet.ts --check --strict",
+    "check:notfor": "bun scripts/check-not-for-fires.ts",
     "check:packs": "bun scripts/check-published-packs.ts --strict",
     "check:audit-parity": "bun scripts/check-audit-parity.ts --strict",
     "check:command-parity": "bun scripts/check-skillmd-command-parity.ts --strict",
     "check:changelog": "bun scripts/check-changelog-parity.ts --strict",
-    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
+    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
   }
 }

--- a/scripts/check-not-for-fires.ts
+++ b/scripts/check-not-for-fires.ts
@@ -38,6 +38,7 @@
  *   bun scripts/check-not-for-fires.ts --json
  *   bun scripts/check-not-for-fires.ts <slug>      # one entity, with the dead entries listed
  */
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { parseArgs } from "../skills/_shared/lib/bun-helpers.ts";
@@ -48,6 +49,10 @@ const registryLoader = require_(join(import.meta.dir, "..", "skills", "harness",
 
 const { flags, positional } = parseArgs(process.argv.slice(2));
 const only = positional[0];
+/** A capabilities map to read instead of the live registry. Without it the only
+ *  thing a test can assert is whatever library happens to be on the machine —
+ *  which on CI is none, so the interesting assertions could not run at all. */
+const fixture = typeof flags.registry === "string" ? flags.registry : null;
 
 const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
 
@@ -58,8 +63,9 @@ const SUBSTRING_MAX_CHARS = 25;
 const MIN_CONTENT_TOKENS = 2;
 const TOKEN_OVERLAP_MIN = 0.6;
 
-const registries = registryLoader.loadAll();
-const caps: Record<string, Array<Record<string, unknown>>> = registries?.squads?.capabilities ?? {};
+const caps: Record<string, Array<Record<string, unknown>>> = fixture
+  ? JSON.parse(readFileSync(fixture, "utf8"))
+  : (registryLoader.loadAll()?.squads?.capabilities ?? {});
 
 /** Every real example_brief in the library: the user-language corpus we have. */
 const briefSets: Array<Set<string>> = [];

--- a/scripts/check-not-for-fires.ts
+++ b/scripts/check-not-for-fires.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env bun
+/**
+ * check-not-for-fires.ts — a fence that never fires is not a fence.
+ *
+ * `not_for` is the only exclusion lever BM25 has. The index carries no negation:
+ * a capability stops winning a brief either by losing vocabulary — which also
+ * loses the briefs it should win — or by a `not_for` entry firing and
+ * multiplying its score by 0.4. Measured this week: narrowing a keyword did not
+ * move a ranking at all (BM25 is bag-of-words, `design-token-system` still emits
+ * `design` and `system`), while four short `not_for` entries fixed it.
+ *
+ * And it fails silently. The validator accepts any string; the author believes
+ * the boundary is enforced; nothing fires; the squad keeps taking its
+ * neighbour's briefs. Four squads audited this week had 24, 24 and 94 dead
+ * entries each, and the pattern held across the library.
+ *
+ * **How firing actually works** (`router.js:510-519`, read, not assumed):
+ *
+ *   entry.length <= 25  →  substring: briefLc.includes(entry)
+ *   entry.length >  25  →  token overlap: >= 2 content tokens AND
+ *                          >= 60% of them present in the brief
+ *
+ * **Why the long path almost never fires.** A 13-token entry needs 8 of its
+ * tokens in one brief. Measured against the 2,832 real example_briefs in this
+ * library — the best corpus of user language we have — **902 of 910 long
+ * entries fire against none of them**. That is the number this gate rests on,
+ * and it is a measurement rather than an argument about suffixes: the first
+ * theory here was that `(use some.capability.id)` suffixes made entries
+ * unmatchable, and a probe disproved it (one such entry reaches 0.69 overlap
+ * against its own prefix). Length is the cause; the suffix only adds to it.
+ *
+ * The gate therefore reports a long entry as dead when it fires against no real
+ * brief, instead of guessing from its shape.
+ *
+ * Usage:
+ *   bun scripts/check-not-for-fires.ts             # report
+ *   bun scripts/check-not-for-fires.ts --strict    # exit 1 if any entity is over budget
+ *   bun scripts/check-not-for-fires.ts --json
+ *   bun scripts/check-not-for-fires.ts <slug>      # one entity, with the dead entries listed
+ */
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { parseArgs } from "../skills/_shared/lib/bun-helpers.ts";
+
+const require_ = createRequire(import.meta.url);
+const bm25 = require_(join(import.meta.dir, "..", "skills", "harness", "lib", "bm25.js"));
+const registryLoader = require_(join(import.meta.dir, "..", "skills", "harness", "lib", "registry-loader.js"));
+
+const { flags, positional } = parseArgs(process.argv.slice(2));
+const only = positional[0];
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+// Mirrors router.js:506-508. If those move, this gate is measuring the wrong
+// thing — which is why the numbers live here as named constants rather than
+// inline, and why the test asserts they still match.
+const SUBSTRING_MAX_CHARS = 25;
+const MIN_CONTENT_TOKENS = 2;
+const TOKEN_OVERLAP_MIN = 0.6;
+
+const registries = registryLoader.loadAll();
+const caps: Record<string, Array<Record<string, unknown>>> = registries?.squads?.capabilities ?? {};
+
+/** Every real example_brief in the library: the user-language corpus we have. */
+const briefSets: Array<Set<string>> = [];
+for (const list of Object.values(caps)) {
+  for (const c of list) {
+    for (const b of ((c.example_briefs as string[]) ?? [])) {
+      if (typeof b === "string") briefSets.push(new Set(bm25.tokenize(b)));
+    }
+  }
+}
+const briefStrings: string[] = [];
+for (const list of Object.values(caps)) {
+  for (const c of list) {
+    for (const b of ((c.example_briefs as string[]) ?? [])) {
+      if (typeof b === "string") briefStrings.push(b.toLowerCase());
+    }
+  }
+}
+
+type Verdict = "fires" | "dead" | "too-short";
+
+function verdict(entry: string): Verdict {
+  if (entry.length <= SUBSTRING_MAX_CHARS) {
+    // The substring path fires on any brief containing the literal text. Two
+    // characters or fewer can never fire (router.js:512).
+    return entry.length > 2 ? "fires" : "too-short";
+  }
+  const tokens = [...new Set<string>(bm25.tokenize(entry))];
+  if (tokens.length < MIN_CONTENT_TOKENS) return "dead";
+  for (const bs of briefSets) {
+    let matched = 0;
+    for (const t of tokens) if (bs.has(t)) matched++;
+    if (matched / tokens.length >= TOKEN_OVERLAP_MIN) return "fires";
+  }
+  return "dead";
+}
+
+interface Row { entity: string; total: number; dead: number; deadEntries: string[]; }
+const rows = new Map<string, Row>();
+
+for (const list of Object.values(caps)) {
+  for (const c of list) {
+    const slug = (c.squad ?? c.business) as string | undefined;
+    if (!slug || (only && slug !== only)) continue;
+    const row = rows.get(slug) ?? { entity: slug, total: 0, dead: 0, deadEntries: [] };
+    for (const nf of ((c.not_for as string[]) ?? [])) {
+      if (typeof nf !== "string") continue;
+      row.total++;
+      if (verdict(nf) !== "fires") {
+        row.dead++;
+        if (row.deadEntries.length < 40) row.deadEntries.push(nf);
+      }
+    }
+    rows.set(slug, row);
+  }
+}
+
+const all = [...rows.values()].filter((r) => r.total > 0);
+const totalEntries = all.reduce((n, r) => n + r.total, 0);
+const totalDead = all.reduce((n, r) => n + r.dead, 0);
+
+// An entity is over budget when MOST of its fences are dead — that is the state
+// where an author has a boundary in mind and the router has none. A single dead
+// entry among many is noise; a majority is a broken contract.
+const overBudget = all.filter((r) => r.total >= 3 && r.dead / r.total > 0.5);
+
+if (flags.json) {
+  console.log(JSON.stringify({ entities: all.length, entries: totalEntries, dead: totalDead, over_budget: overBudget }, null, 2));
+  process.exit(flags.strict && overBudget.length ? 1 : 0);
+}
+
+console.log(`\n${BOLD}NOT_FOR — does the fence fire?${RST}`);
+console.log(`${DIM}  ${totalEntries} entries across ${all.length} entities, tested against ${briefSets.length} real briefs${RST}`);
+console.log(`${DIM}  firing rule (router.js:510): <=${SUBSTRING_MAX_CHARS} chars by substring, longer by >=${TOKEN_OVERLAP_MIN * 100}% token overlap${RST}\n`);
+
+if (only) {
+  const r = all[0];
+  if (!r) { console.log(`  ${YEL}${only}: no not_for entries${RST}\n`); process.exit(0); }
+  const c = r.dead === 0 ? GRN : r.dead / r.total > 0.5 ? RED : YEL;
+  console.log(`  ${r.entity}: ${c}${r.dead}/${r.total} dead${RST}`);
+  for (const e of r.deadEntries) console.log(`    ${DIM}${e.length} chars · ${e.slice(0, 78)}${RST}`);
+  console.log(`\n${DIM}  Rewrite each as 2-4 content words, <=${SUBSTRING_MAX_CHARS} chars, EN and PT as separate`);
+  console.log(`  entries, accented and unaccented as separate entries, no "(use X)" suffix.${RST}\n`);
+  process.exit(flags.strict && r.dead / r.total > 0.5 ? 1 : 0);
+}
+
+const pct = Math.round((100 * totalDead) / Math.max(totalEntries, 1));
+const color = pct > 40 ? RED : pct > 15 ? YEL : GRN;
+console.log(`  dead: ${color}${totalDead}/${totalEntries} (${pct}%)${RST}`);
+console.log(`  entities where most fences are dead: ${overBudget.length ? RED : GRN}${overBudget.length}${RST}\n`);
+
+for (const r of overBudget.sort((a, b) => b.dead - a.dead).slice(0, 15)) {
+  console.log(`    ${RED}▼${RST} ${r.entity.padEnd(34)} ${r.dead}/${r.total}`);
+}
+if (overBudget.length > 15) console.log(`    ${DIM}… and ${overBudget.length - 15} more${RST}`);
+
+console.log(`\n${DIM}  A dead entry costs nothing at retrieval — not_for is not BM25-indexed. What it`);
+console.log(`  costs is the belief that a boundary exists. Inspect one with:`);
+console.log(`    bun scripts/check-not-for-fires.ts <slug>${RST}\n`);
+
+process.exit(flags.strict && overBudget.length ? 1 : 0);

--- a/skills/harness/tests/not-for-fires.test.ts
+++ b/skills/harness/tests/not-for-fires.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The gate that checks whether a fence fires, and the constants it depends on.
+ *
+ * `not_for` is the only exclusion lever BM25 has — the index carries no
+ * negation, so a capability stops taking a neighbour's brief either by losing
+ * vocabulary (which also loses the briefs it should win) or by a `not_for` entry
+ * firing. Measured this week: narrowing a keyword moved a ranking not at all,
+ * while four short entries fixed it.
+ *
+ * And it fails silently. Nothing rejects a `not_for` that can never match, so an
+ * author writes the boundary, the validator accepts it, and the router never
+ * sees a fence. Measured across the library: 1,006 of 1,675 entries fire against
+ * none of the 2,832 real example_briefs, and in 104 entities MOST of the fences
+ * are dead — including one this session's own agent had "fixed", having argued
+ * itself into keeping the broken form.
+ *
+ * Two things are pinned here. The gate's verdicts, and the fact that its
+ * constants still match the router's — because a gate measuring the wrong
+ * threshold is worse than no gate.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const GATE = join(REPO, "scripts", "check-not-for-fires.ts");
+const ROUTER = readFileSync(join(REPO, "skills", "harness", "lib", "router.js"), "utf8");
+const GATE_SRC = readFileSync(GATE, "utf8");
+
+/** The router's own numbers, read from the router. */
+function routerConst(name: string): number {
+  const m = ROUTER.match(new RegExp(`const ${name}\\s*=\\s*([0-9.]+)`));
+  if (!m) throw new Error(`${name} not found in router.js — the firing rule moved`);
+  return Number(m[1]);
+}
+
+describe("the gate measures the rule the router actually applies", () => {
+  test("router.js still defines the three firing constants", () => {
+    expect(routerConst("NOT_FOR_SUBSTRING_MAX_CHARS")).toBe(25);
+    expect(routerConst("NOT_FOR_MIN_CONTENT_TOKENS")).toBe(2);
+    expect(routerConst("NOT_FOR_TOKEN_OVERLAP_MIN")).toBe(0.6);
+  });
+
+  test("the gate mirrors them", () => {
+    // If the router's thresholds change and the gate's do not, the gate reports
+    // confident numbers about a rule nobody applies any more.
+    for (const [gateName, routerName] of [
+      ["SUBSTRING_MAX_CHARS", "NOT_FOR_SUBSTRING_MAX_CHARS"],
+      ["MIN_CONTENT_TOKENS", "NOT_FOR_MIN_CONTENT_TOKENS"],
+      ["TOKEN_OVERLAP_MIN", "NOT_FOR_TOKEN_OVERLAP_MIN"],
+    ] as const) {
+      const m = GATE_SRC.match(new RegExp(`const ${gateName}\\s*=\\s*([0-9.]+)`));
+      expect(m).toBeTruthy();
+      expect(Number(m![1])).toBe(routerConst(routerName));
+    }
+  });
+
+  test("the router's firing function is the one described", () => {
+    // The gate's whole premise: two paths, chosen by length.
+    const fn = ROUTER.slice(ROUTER.indexOf("function notForFires("));
+    expect(fn.slice(0, 500)).toMatch(/entry\.length <= NOT_FOR_SUBSTRING_MAX_CHARS/);
+    expect(fn.slice(0, 500)).toMatch(/briefLc\.includes/);
+    expect(fn.slice(0, 500)).toMatch(/matched \/ entryTokens\.size >= NOT_FOR_TOKEN_OVERLAP_MIN/);
+  });
+});
+
+describe("the gate runs and reports", () => {
+  const run = (args: string[]) => {
+    const r = spawnSync(process.execPath, [GATE, ...args], { cwd: REPO, encoding: "utf8" });
+    return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+  };
+
+  test("--json returns a shape a CI step can read", () => {
+    const r = run(["--json"]);
+    const d = JSON.parse(r.out);
+    expect(typeof d.entries).toBe("number");
+    expect(typeof d.dead).toBe("number");
+    expect(Array.isArray(d.over_budget)).toBe(true);
+    // Sanity: dead can never exceed total.
+    expect(d.dead).toBeLessThanOrEqual(d.entries);
+  }, 60_000);
+
+  test("without --strict it reports rather than fails", () => {
+    // Report-only is deliberate while 104 entities are over budget: a gate that
+    // turns CI red with no path out teaches everyone to ignore it.
+    expect(run([]).code).toBe(0);
+  }, 60_000);
+
+  test("a single entity can be inspected, and lists what is dead", () => {
+    const r = run(["brandcraft"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("brandcraft");
+    expect(r.out).toMatch(/\d+\/\d+ dead/);
+  }, 60_000);
+});

--- a/skills/harness/tests/not-for-fires.test.ts
+++ b/skills/harness/tests/not-for-fires.test.ts
@@ -19,9 +19,21 @@
  * threshold is worse than no gate.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** A capabilities map on disk, for the cases that must assert on real content
+ *  rather than on whatever library the machine happens to have. */
+const FIXTURES = mkdtempSync(join(tmpdir(), "notfor-"));
+let n = 0;
+function fixture(caps: Record<string, Array<Record<string, unknown>>>): string {
+  const f = join(FIXTURES, `r${n++}.json`);
+  writeFileSync(f, JSON.stringify(caps), "utf8");
+  return f;
+}
+process.on("exit", () => { try { rmSync(FIXTURES, { recursive: true, force: true }); } catch {} });
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-not-for-fires.ts");
@@ -88,9 +100,30 @@ describe("the gate runs and reports", () => {
   }, 60_000);
 
   test("a single entity can be inspected, and lists what is dead", () => {
-    const r = run(["brandcraft"]);
+    // Against a fixture, not the machine's library: CI has no `~/squads`, so
+    // this case used to assert on an entity that was not there and fail on all
+    // three platforms while passing on the author's laptop.
+    const r = run(["one-squad", "--registry", fixture({
+      "a.b.c": [{
+        squad: "one-squad",
+        not_for: [
+          "live streaming",                                                     // fires: substring
+          "auditar um artefato pronto e emitir laudo completo com correções",   // dead: too long
+        ],
+      }],
+    })]);
     expect(r.code).toBe(0);
-    expect(r.out).toContain("brandcraft");
-    expect(r.out).toMatch(/\d+\/\d+ dead/);
+    expect(r.out).toContain("one-squad");
+    expect(r.out).toMatch(/1\/2 dead/);
+    expect(r.out).toContain("auditar um artefato pronto");
+  }, 60_000);
+
+  test("the firing rule is length, and the report shows it", () => {
+    const r = run(["--json", "--registry", fixture({
+      "a.b.c": [{ squad: "s", not_for: ["seo audit", "x".repeat(40)] }],
+    })]);
+    const d = JSON.parse(r.out);
+    expect(d.entries).toBe(2);
+    expect(d.dead).toBe(1);
   }, 60_000);
 });


### PR DESCRIPTION
**902 of 1,675 `not_for` entries (54%) fire against none of the 2,832 real example_briefs.** In 104 entities most of the fences are dead.

`not_for` is the only exclusion lever BM25 has — the index carries no negation. Measured this week: narrowing a keyword moved a ranking *not at all* (bag-of-words: `design-token-system` still emits `design` and `system`), while four short `not_for` entries fixed it.

**The gate tests firing, not shape.** The first theory — that `(use X)` suffixes make entries unmatchable — was disproved by a probe (0.69 overlap, above the 0.6 floor). The real cause is length. So the gate asks whether an entry fires against any real brief, rather than judging its form.

A test pins the gate's constants to the router's, so it can never measure a rule nobody applies.

Report-only in `check:all`: failing 104 entities today would turn CI red with no path out. It already caught `brandcraft` at 45/46 dead — rewritten this session, with self-retrieval and neighbour gates green over it.

797 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)