### PR TITLE
feat(gate): two providers that say the same thing are one answer the router cannot pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "check:english": "bun scripts/check-english-source.ts --strict",
     "check:coverage": "bun skills/_shared/scripts/coverage-ratchet.ts --check --strict",
     "check:notfor": "bun scripts/check-not-for-fires.ts",
+    "check:clones": "bun scripts/check-capability-clones.ts --strict",
     "check:packs": "bun scripts/check-published-packs.ts --strict",
     "check:audit-parity": "bun scripts/check-audit-parity.ts --strict",
     "check:command-parity": "bun scripts/check-skillmd-command-parity.ts --strict",
     "check:changelog": "bun scripts/check-changelog-parity.ts --strict",
-    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
+    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-capability-clones.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
   }
 }

--- a/scripts/check-brief.ts
+++ b/scripts/check-brief.ts
@@ -84,14 +84,26 @@ const bad: Finding[] = [];
 const ok = { path: 0, script: 0, slug: 0 };
 let slugsChecked = 0;
 
-/** Absolute or ~-relative paths. Relative paths are ambiguous without a cwd and
- *  are left alone rather than guessed at. */
-for (const m of text.matchAll(/(?:^|[\s`"'(])((?:~|\/)[\w./~-]{6,})/g)) {
-  const raw = m[1].replace(/[.,;:)`"']+$/, "");
-  if (isPlanned(m.index ?? 0)) continue;
-  const p = expand(raw);
-  if (existsSync(p)) { ok.path++; continue; }
-  bad.push({ kind: "path", value: raw, note: "does not exist" });
+/**
+ * Absolute or ~-relative paths, in both shapes. Relative paths are ambiguous
+ * without a cwd and are left alone rather than guessed at.
+ *
+ * The Windows form is not optional politeness: the engine ships to Windows
+ * buyers, briefs get written there, and a checker that recognises only
+ * `/usr/...` reports "0 paths checked" on a brief full of `C:\...` — passing
+ * green while inspecting nothing, which is the one thing a preflight must never
+ * do.
+ */
+const POSIX_PATH = /(?:^|[\s`"'(])((?:~|\/)[\w./~-]{6,})/g;
+const WINDOWS_PATH = /(?:^|[\s`"'(])([A-Za-z]:[\\/](?:[\w.~-]+[\\/])*[\w.~-]+)/g;
+for (const re of [POSIX_PATH, WINDOWS_PATH]) {
+  for (const m of text.matchAll(re)) {
+    const raw = m[1].replace(/[.,;:)`"']+$/, "");
+    if (isPlanned(m.index ?? 0)) continue;
+    const p = expand(raw);
+    if (existsSync(p)) { ok.path++; continue; }
+    bad.push({ kind: "path", value: raw, note: "does not exist" });
+  }
 }
 
 /** `bun <script>` / `node <script>` — the script must be there. */

--- a/scripts/check-brief.ts
+++ b/scripts/check-brief.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+/**
+ * check-brief.ts — verify a dispatch brief before an agent burns an hour on it.
+ *
+ * Two briefs went out this session with instructions that could not be followed:
+ * one told an agent to run `coverage-ratchet.ts`, which existed on another
+ * branch; another told it to edit a squad in `genesis-content/squads/`, where
+ * that squad has never lived. Both agents recovered — one of them caught a `cp`
+ * that would have deleted three capabilities from the installed library — but
+ * each lost a detour, and the errors were one command away from being caught.
+ *
+ * At one dispatch that is an annoyance. Across 195 it is a class of failure, and
+ * the failures are silent in the worst way: the agent improvises, produces
+ * something plausible against the wrong target, and reports success.
+ *
+ * So: extract every checkable claim from the brief and check it.
+ *
+ *   file paths        must exist on disk
+ *   script commands   the script named after `bun`/`node` must exist
+ *   entity slugs      must be in the live registry
+ *
+ * Deliberately conservative: it only flags what it can prove wrong. A path
+ * inside a fenced code block that is meant as an example, a slug the brief asks
+ * the agent to CREATE — those would be false positives, so the brief marks them
+ * with a trailing `(new)` or the checker leaves anything it cannot resolve
+ * unjudged and says so. A preflight that cries wolf is a preflight people skip.
+ *
+ * Usage:
+ *   bun scripts/check-brief.ts brief.md
+ *   bun scripts/check-brief.ts brief.md --strict     # exit 1 on any hard failure
+ *   cat brief.md | bun scripts/check-brief.ts -
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { parseArgs } from "../skills/_shared/lib/bun-helpers.ts";
+
+const require_ = createRequire(import.meta.url);
+const { flags, positional } = parseArgs(process.argv.slice(2));
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+const src = positional[0];
+if (!src) {
+  console.error("usage: bun scripts/check-brief.ts <brief.md|-> [--strict]");
+  process.exit(2);
+}
+const text = src === "-" ? readFileSync(0, "utf8") : readFileSync(src, "utf8");
+
+const HOME = homedir();
+const expand = (p: string) => (p.startsWith("~/") ? join(HOME, p.slice(2)) : p);
+
+/**
+ * Known entity slugs, from the live registry — or from a file, so this can be
+ * tested on a machine that has no library. CI is exactly that machine, and a
+ * test that silently checks nothing there is worse than no test.
+ */
+const slugs = new Set<string>();
+if (typeof flags.slugs === "string") {
+  for (const s of JSON.parse(readFileSync(flags.slugs, "utf8")) as string[]) slugs.add(s);
+} else {
+  try {
+    const all = require_(join(import.meta.dir, "..", "skills", "harness", "lib", "registry-loader.js")).loadAll();
+    for (const s of Object.keys(all?.squads?.squads ?? {})) slugs.add(s);
+    for (const b of Object.keys(all?.businesses?.businesses ?? {})) slugs.add(b);
+  } catch { /* no registry: slug checks are skipped, and said so below */ }
+}
+
+/** The line a match sits on. Both `lastIndexOf` and `indexOf` return -1 at the
+ *  edges of the text, and a negative index makes `slice` count from the end —
+ *  which silently returns "" for a single-line brief, disabling every per-line
+ *  escape below. */
+function lineAt(idx: number): string {
+  const start = text.lastIndexOf("\n", Math.max(idx - 1, 0));
+  const end = text.indexOf("\n", idx);
+  return text.slice(start < 0 ? 0 : start + 1, end < 0 ? text.length : end);
+}
+/** A brief may legitimately name something the agent will CREATE. */
+const isPlanned = (idx: number) => /\(new\)|will create|vai criar|to create/i.test(lineAt(idx));
+
+interface Finding { kind: "path" | "script" | "slug"; value: string; note: string; }
+const bad: Finding[] = [];
+const ok = { path: 0, script: 0, slug: 0 };
+let slugsChecked = 0;
+
+/** Absolute or ~-relative paths. Relative paths are ambiguous without a cwd and
+ *  are left alone rather than guessed at. */
+for (const m of text.matchAll(/(?:^|[\s`"'(])((?:~|\/)[\w./~-]{6,})/g)) {
+  const raw = m[1].replace(/[.,;:)`"']+$/, "");
+  if (isPlanned(m.index ?? 0)) continue;
+  const p = expand(raw);
+  if (existsSync(p)) { ok.path++; continue; }
+  bad.push({ kind: "path", value: raw, note: "does not exist" });
+}
+
+/** `bun <script>` / `node <script>` — the script must be there. */
+for (const m of text.matchAll(/\b(?:bun|node)\s+((?:~|\/|\.\/|[\w.-]+\/)[\w./~-]+\.(?:ts|js|mjs|sh))/g)) {
+  const raw = m[1];
+  const cands = [expand(raw), resolve(join(import.meta.dir, ".."), raw), resolve(HOME, raw)];
+  if (cands.some((c) => existsSync(c) && statSync(c).isFile())) { ok.script++; continue; }
+  bad.push({ kind: "script", value: raw, note: "no such script — check the branch it lives on" });
+}
+
+/**
+ * Slugs the brief names as targets or neighbours.
+ *
+ * Only hyphenated names are judged. Thirteen of the 255 entities are a single
+ * word, and several of those words are `documentation`, `testing` and
+ * `monitoring` — which appear in backticks in ordinary prose for reasons that
+ * have nothing to do with a squad. Catching those thirteen would cost a false
+ * alarm on every brief that mentions testing, and a preflight that cries wolf
+ * is a preflight people stop running.
+ */
+if (slugs.size > 0) {
+  const seen = new Set<string>();
+  for (const m of text.matchAll(/`([a-z][a-z0-9]+(?:-[a-z0-9]+){1,5})`/g)) {
+    const s = m[1];
+    if (seen.has(s)) continue;
+    // Only judge things that look like entity slugs, not filenames or flags.
+    if (/\.(ts|js|md|ya?ml|json|sh)$/.test(s) || s.startsWith("-")) continue;
+    seen.add(s);
+    if (isPlanned(m.index ?? 0)) continue;
+    slugsChecked++;
+    if (slugs.has(s)) { ok.slug++; continue; }
+    bad.push({ kind: "slug", value: s, note: "not in the registry" });
+  }
+}
+
+console.log(`\n${BOLD}BRIEF PREFLIGHT${RST} ${DIM}${src === "-" ? "(stdin)" : src}${RST}`);
+console.log(`${DIM}  checked ${ok.path + bad.filter((b) => b.kind === "path").length} paths · ${ok.script + bad.filter((b) => b.kind === "script").length} scripts · ${slugsChecked} slugs${RST}`);
+if (slugs.size === 0) console.log(`${YEL}  registry unavailable — slug checks skipped${RST}`);
+console.log();
+
+if (bad.length === 0) {
+  console.log(`${GRN}  Every path, script and slug in this brief resolves.${RST}\n`);
+  process.exit(0);
+}
+
+for (const f of bad) {
+  console.log(`  ${RED}✗${RST} ${f.kind.padEnd(7)} ${f.value}`);
+  console.log(`      ${DIM}${f.note}${RST}`);
+}
+console.log(`\n${DIM}  An agent given an unresolvable instruction improvises, and reports success`);
+console.log(`  against the wrong target. Fix the brief, not the agent.${RST}`);
+console.log(`${DIM}  If a path or slug is meant to be created by the agent, mark it "(new)" on`);
+console.log(`  the same line and this check will leave it alone.${RST}\n`);
+
+process.exit(flags.strict ? 1 : 0);

--- a/scripts/check-capability-clones.ts
+++ b/scripts/check-capability-clones.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+/**
+ * check-capability-clones.ts — when two squads say the same thing, the router
+ * has no way to choose between them.
+ *
+ * A capability id may legitimately have several providers: nine squads can all
+ * define a design language, and the router is meant to pick the one whose angle
+ * fits the brief. It picks by BM25 over each provider's own description,
+ * keywords and example_briefs. So the moment two providers carry byte-identical
+ * text, that mechanism has nothing to work with — both score the same, the
+ * decision falls to tie-breaking noise, and a confident-looking HIGH is a coin
+ * toss.
+ *
+ * This is not hypothetical. Two bulk injections shipped the same capability into
+ * many squads at once with the text copied verbatim: `media.video.compose` into
+ * ten squads and three `frontend.*` capabilities into seven to nine each. Nine
+ * of the ten video copies carried NO keywords and NO example_briefs at all —
+ * the two fields the index weights ×3 and ×2 — so the injected capability
+ * competed on description alone, identically, everywhere.
+ *
+ * Measured after differentiating the video ten: held-out briefs that a person
+ * might actually type went from routing to nothing or to the wrong squad, to
+ * six of seven landing on the right one with HIGH confidence. The seventh
+ * returns AMBIGUOUS, which is the router declining to guess — a correct answer,
+ * not a miss.
+ *
+ * What this gate reports is the identical text, not the shared id. Sharing an id
+ * is the design. Sharing the words is the defect.
+ *
+ * Usage:
+ *   bun scripts/check-capability-clones.ts              # report
+ *   bun scripts/check-capability-clones.ts --strict     # exit 1 if any clone
+ *   bun scripts/check-capability-clones.ts --json
+ *   bun scripts/check-capability-clones.ts <capability-id>
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require_ = createRequire(import.meta.url);
+const registryLoader = require_(join(import.meta.dir, "..", "skills", "harness", "lib", "registry-loader.js"));
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+const argv = process.argv.slice(2);
+const strict = argv.includes("--strict");
+const asJson = argv.includes("--json");
+/** A capabilities map to read instead of the live registry. Without it the only
+ *  testable path is "this machine happens to be clean", which proves nothing
+ *  about the case the gate exists to catch. */
+const fixture = argv.includes("--registry") ? argv[argv.indexOf("--registry") + 1] : null;
+const only = argv.find((a, i) => !a.startsWith("--") && argv[i - 1] !== "--registry");
+
+const md5 = (v: unknown) => createHash("md5").update(JSON.stringify(v ?? null)).digest("hex");
+
+/** The fields the index actually scores a provider on. Two providers that agree
+ *  on all three are indistinguishable to BM25, whatever else differs. */
+const signature = (c: Record<string, unknown>) => md5([c.description, c.keywords, c.example_briefs]);
+
+interface Group { id: string; providers: number; camps: string[][]; cloned: number; }
+
+const caps: Record<string, Array<Record<string, unknown>>> = fixture
+  ? JSON.parse(readFileSync(fixture, "utf8"))
+  : (registryLoader.loadAll()?.squads?.capabilities ?? {});
+const groups: Group[] = [];
+
+for (const [id, list] of Object.entries(caps)) {
+  if (only && id !== only) continue;
+  const provs = list.filter((c) => c.squad);
+  if (provs.length < 2) continue;
+  const bySig = new Map<string, string[]>();
+  for (const c of provs) {
+    const s = signature(c);
+    bySig.set(s, [...(bySig.get(s) ?? []), String(c.squad)]);
+  }
+  const camps = [...bySig.values()];
+  const cloned = camps.filter((g) => g.length > 1).reduce((n, g) => n + g.length, 0);
+  groups.push({ id, providers: provs.length, camps, cloned });
+}
+
+const shared = groups.length;
+const instances = groups.reduce((n, g) => n + g.providers, 0);
+const clones = groups.reduce((n, g) => n + g.cloned, 0);
+const affected = groups.filter((g) => g.cloned > 0);
+
+if (asJson) {
+  console.log(JSON.stringify({
+    shared_ids: shared,
+    provider_instances: instances,
+    cloned_instances: clones,
+    affected: affected.map((g) => ({ id: g.id, providers: g.providers, cloned: g.cloned, camps: g.camps.filter((c) => c.length > 1) })),
+  }, null, 2));
+  process.exitCode = strict && clones ? 1 : 0;
+} else {
+  console.log(`\n${BOLD}CAPABILITY CLONES — can the router tell these apart?${RST}`);
+  console.log(`${DIM}  ${shared} capability ids have more than one provider (${instances} instances)${RST}`);
+  console.log(`${DIM}  compared on the fields BM25 scores: description, keywords, example_briefs${RST}\n`);
+
+  if (clones === 0) {
+    console.log(`${GRN}  Every provider of a shared capability describes itself differently.${RST}\n`);
+    process.exitCode = 0;
+  } else {
+    const pct = Math.round((100 * clones) / Math.max(instances, 1));
+    console.log(`  indistinguishable: ${clones > 0 ? RED : GRN}${clones}/${instances} (${pct}%)${RST}\n`);
+
+    for (const g of affected.sort((a, b) => b.cloned - a.cloned)) {
+      console.log(`  ${RED}▼${RST} ${BOLD}${g.id}${RST} ${DIM}— ${g.cloned} of ${g.providers} providers${RST}`);
+      for (const camp of g.camps.filter((c) => c.length > 1)) {
+        console.log(`      ${YEL}identical${RST}  ${camp.join(", ")}`);
+      }
+      for (const camp of g.camps.filter((c) => c.length === 1)) {
+        console.log(`      ${DIM}distinct   ${camp[0]}${RST}`);
+      }
+    }
+
+    console.log(`\n${DIM}  Sharing an id is the design — several squads can do the same kind of work.`);
+    console.log(`  Sharing the words is the defect: give each provider the keywords and`);
+    console.log(`  example_briefs of ITS angle. Removing the capability is not the fix.${RST}\n`);
+    process.exitCode = strict ? 1 : 0;
+  }
+}

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -17,6 +17,13 @@
  * state at build time too — there was never a reason for those to be different
  * lists, only an accident that they were.
  *
+ * `.runs` was missing from this list until a rebuild was inspected file by file:
+ * `brandcraft/.runs/` holds 64 files and 36 MB of leftover Remotion renders from
+ * two runs on the author's machine, and it was shipping inside four packs. The
+ * name appeared in three private exclusion lists — the pack assembler's `find`,
+ * a manual rsync, the reconciler — and in the one list that four consumers read,
+ * it did not.
+ *
  * `SQUAD-DOCTOR-REPORT.md` is here for the same reason, though it is a file and
  * looks authored: the doctor used to write it into the squad directory, so it
  * travelled into the packs. Eighteen of them are sitting in built artifacts
@@ -26,7 +33,7 @@
  * `.nirvana/state/squads/<slug>/`; this entry stops the old ones travelling.
  */
 export const RUN_STATE_EXCLUDES: Record<string, string[]> = {
-  squads: ["projects", "outputs", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
+  squads: ["projects", "outputs", ".runs", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
   businesses: ["memory/projects", "memory/learned.md", ".squad-state", ".squads-outputs", ".vercel"],
   "mind-clones": [],
 };

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -16,9 +16,17 @@
  * One list, four consumers. A directory that is run state on install is run
  * state at build time too — there was never a reason for those to be different
  * lists, only an accident that they were.
+ *
+ * `SQUAD-DOCTOR-REPORT.md` is here for the same reason, though it is a file and
+ * looks authored: the doctor used to write it into the squad directory, so it
+ * travelled into the packs. Eighteen of them are sitting in built artifacts
+ * right now — a diagnostic about the seller's machine, in the buyer's product.
+ * It is also stamped with a fresh timestamp on every run, which made any two
+ * copies of a squad disagree forever. The doctor now writes under
+ * `.nirvana/state/squads/<slug>/`; this entry stops the old ones travelling.
  */
 export const RUN_STATE_EXCLUDES: Record<string, string[]> = {
-  squads: ["projects", "outputs", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal"],
+  squads: ["projects", "outputs", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
   businesses: ["memory/projects", "memory/learned.md", ".squad-state", ".squads-outputs", ".vercel"],
   "mind-clones": [],
 };

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -46,8 +46,27 @@ export const RUN_STATE_NAMES: string[] = [
 /**
  * True when a path sits inside run state. Takes a path RELATIVE to the
  * component root, with either separator.
+ *
+ * Pass `kind` whenever you know it. Without it the check falls back to
+ * RUN_STATE_NAMES, which is the FIRST SEGMENT of each entry — and for a business
+ * that first segment is `memory`, from `memory/projects`. Matching on the bare
+ * name therefore excluded the whole `memory/` directory, so every pack shipped
+ * its businesses without `memory/permanent.md`: the file the business protocol
+ * documents as the long-term knowledge every employee reads as authoritative
+ * context. Forty-six businesses, silently, in every pack on the shelf.
+ *
+ * With `kind`, an entry is matched as a contiguous run of path segments, so
+ * `memory/projects` excludes exactly that and leaves `memory/permanent.md`
+ * alone.
  */
-export function isRunStatePath(rel: string): boolean {
-  const segs = rel.split(/[\\/]/);
-  return segs.some((s) => RUN_STATE_NAMES.includes(s));
+export function isRunStatePath(rel: string, kind?: keyof typeof RUN_STATE_EXCLUDES): boolean {
+  const segs = rel.split(/[\\/]/).filter(Boolean);
+  if (!kind) return segs.some((s) => RUN_STATE_NAMES.includes(s));
+  return (RUN_STATE_EXCLUDES[kind] ?? []).some((entry) => {
+    const parts = entry.split("/").filter(Boolean);
+    for (let i = 0; i + parts.length <= segs.length; i++) {
+      if (parts.every((p, j) => segs[i + j] === p)) return true;
+    }
+    return false;
+  });
 }

--- a/skills/harness/tests/capability-clones.test.ts
+++ b/skills/harness/tests/capability-clones.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The gate that asks whether the router can tell two providers apart.
+ *
+ * A capability id may have many providers — nine squads can each define a
+ * design language, and the router is supposed to pick the one whose angle fits.
+ * It picks by BM25 over each provider's description, keywords and
+ * example_briefs. When two providers carry identical text there is nothing to
+ * pick with: both score the same and a confident HIGH is a coin toss.
+ *
+ * Two bulk injections shipped exactly that. `media.video.compose` went into ten
+ * squads with the text copied verbatim and, in nine of them, with no keywords
+ * and no example_briefs at all — the fields weighted ×3 and ×2. Three
+ * `frontend.*` capabilities went into seven to nine squads the same way.
+ *
+ * The distinction this pins: sharing an id is the design, sharing the words is
+ * the defect. A gate that flagged the shared id would fire on 22 legitimate
+ * capabilities and be switched off the same week.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const GATE = join(REPO, "scripts", "check-capability-clones.ts");
+const tmp = mkdtempSync(join(tmpdir(), "clones-"));
+
+type Cap = { squad: string; description: string; keywords?: string[]; example_briefs?: string[] };
+
+function run(caps: Record<string, Cap[]>, args: string[] = []) {
+  const f = join(tmp, `r${Object.keys(caps).join("_").replace(/\W/g, "")}.json`);
+  writeFileSync(f, JSON.stringify(caps), "utf8");
+  const r = spawnSync(process.execPath, [GATE, "--registry", f, ...args], { cwd: REPO, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+const cap = (squad: string, description = "does the thing", keywords = ["a", "b"]): Cap =>
+  ({ squad, description, keywords, example_briefs: ["some brief"] });
+
+describe("what counts as a clone", () => {
+  test("identical text across two providers is a clone", () => {
+    const r = run({ "x.y.z": [cap("alpha"), cap("beta")] }, ["--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("alpha, beta");
+  });
+
+  test("different keywords make them distinguishable", () => {
+    // The actual fix applied to the library: same work, each squad's own words.
+    const r = run({
+      "x.y.z": [cap("alpha", "does the thing", ["dashboard", "echarts"]), cap("beta", "does the thing", ["landing page", "shadcn"])],
+    }, ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("describes itself differently");
+  });
+
+  test("different example_briefs alone are enough", () => {
+    const a = { ...cap("alpha"), example_briefs: ["build me a dashboard"] };
+    const b = { ...cap("beta"), example_briefs: ["build me a landing page"] };
+    expect(run({ "x.y.z": [a, b] }, ["--strict"]).code).toBe(0);
+  });
+
+  test("a capability with a single provider is never a clone", () => {
+    expect(run({ "x.y.z": [cap("alpha")], "p.q.r": [cap("beta")] }, ["--strict"]).code).toBe(0);
+  });
+
+  test("sharing an id is not itself the finding", () => {
+    // 22 capability ids in the library legitimately have several providers. A
+    // gate that flagged those would be noise, and noise gets switched off.
+    const r = run({
+      "x.y.z": [cap("alpha", "d", ["one"]), cap("beta", "d", ["two"]), cap("gamma", "d", ["three"])],
+    });
+    expect(r.out).toContain("1 capability ids have more than one provider (3 instances)");
+    expect(r.out).toContain("describes itself differently");
+  });
+});
+
+describe("partial cloning is reported precisely", () => {
+  test("it separates the identical camp from the distinct providers", () => {
+    // The real shape of the defect: eight copies identical, one already curated.
+    const r = run({
+      "frontend.design_language.define": [
+        cap("alpha"), cap("beta"), cap("gamma"),
+        cap("delta", "a genuinely different description", ["own", "words"]),
+      ],
+    });
+    expect(r.out).toContain("alpha, beta, gamma");
+    expect(r.out).toContain("delta");
+    expect(r.out).toMatch(/3 of 4 providers/);
+  });
+});
+
+describe("the gate is usable from a build step", () => {
+  test("--json carries the camps", () => {
+    const d = JSON.parse(run({ "x.y.z": [cap("alpha"), cap("beta")] }, ["--json"]).out);
+    expect(d.shared_ids).toBe(1);
+    expect(d.provider_instances).toBe(2);
+    expect(d.cloned_instances).toBe(2);
+    expect(d.affected[0].camps[0]).toEqual(["alpha", "beta"]);
+  });
+
+  test("without --strict it reports rather than fails", () => {
+    expect(run({ "x.y.z": [cap("alpha"), cap("beta")] }).code).toBe(0);
+  });
+
+  test("a single capability id can be inspected", () => {
+    const r = run({ "x.y.z": [cap("alpha"), cap("beta")], "p.q.r": [cap("c"), cap("d")] }, ["x.y.z"]);
+    expect(r.out).toContain("alpha, beta");
+    expect(r.out).not.toContain("p.q.r");
+  });
+});
+
+process.on("exit", () => { try { rmSync(tmp, { recursive: true, force: true }); } catch {} });

--- a/skills/harness/tests/check-brief.test.ts
+++ b/skills/harness/tests/check-brief.test.ts
@@ -86,6 +86,16 @@ describe("it stays quiet when the brief is right", () => {
     expect(r.out).toMatch(/checked 1 paths · 1 scripts · 1 slugs/);
   });
 
+  test("a Windows path is seen, on any platform", () => {
+    // The suite creates its fixtures under tmpdir, which on Windows is a
+    // `C:\...` path. A checker that only knows POSIX reported "0 paths checked"
+    // there and passed — inspecting nothing while looking green.
+    const r = run("Edit C:\\Users\\someone\\nirvana-packs\\squads\\ghost\\squad.yaml", ["--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("does not exist");
+    expect(r.out).toMatch(/checked 1 paths/);
+  });
+
   test("a single-word name is not judged as a slug", () => {
     // 13 of the 255 entities are one word, and three of those words are
     // `documentation`, `testing` and `monitoring`. Judging bare words would

--- a/skills/harness/tests/check-brief.test.ts
+++ b/skills/harness/tests/check-brief.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The preflight that reads a dispatch brief before an agent does.
+ *
+ * Two briefs went out this session naming things that could not be found — a
+ * script that lived on another branch, a squad directory under a name it never
+ * had. Both agents improvised and recovered, but improvising against a wrong
+ * target is the failure mode that reports success. At 195 dispatches it stops
+ * being an annoyance.
+ *
+ * What is pinned here is mostly the SILENCE. A checker that flags a path the
+ * brief asks the agent to create, or a slug that is really a filename, gets
+ * switched off within a day — so the false-positive cases carry as much weight
+ * as the true ones.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const CHECK = join(REPO, "scripts", "check-brief.ts");
+
+const tmp = mkdtempSync(join(tmpdir(), "brief-"));
+
+/**
+ * The slug list is injected rather than read from the machine's library, and
+ * the "real path" cases point at files this suite creates. CI has no `~/squads`
+ * and no registry, so a suite that leaned on either would assert nothing there
+ * while passing on the author's laptop — the shadow-suite failure this project
+ * has already been bitten by.
+ */
+const SLUGS = join(tmp, "slugs.json");
+writeFileSync(SLUGS, JSON.stringify(["brandcraft", "design-system-nirvana"]), "utf8");
+
+/** A real file on disk for the path cases to resolve against. */
+const REAL_DIR = join(tmp, "squads", "brandcraft");
+mkdirSync(REAL_DIR, { recursive: true });
+const REAL_FILE = join(REAL_DIR, "squad.yaml");
+writeFileSync(REAL_FILE, "name: brandcraft\n", "utf8");
+
+function run(body: string, args: string[] = []) {
+  const f = join(tmp, `b${Math.abs(hash(body))}.md`);
+  writeFileSync(f, body, "utf8");
+  const r = spawnSync(process.execPath, [CHECK, f, "--slugs", SLUGS, ...args], { cwd: REPO, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+// Deterministic name per body: Math.random() would leave the tmpdir unreadable
+// when a case fails and you want to look at the fixture.
+function hash(s: string) { let h = 0; for (const c of s) h = (h * 31 + c.charCodeAt(0)) | 0; return h; }
+
+describe("it catches what a stale brief gets wrong", () => {
+  test("a path that does not exist", () => {
+    const r = run("Edit ~/nirvana-packs/genesis-content/squads/no-such-squad-here/squad.yaml");
+    expect(r.out).toContain("does not exist");
+    expect(r.out).toContain("no-such-squad-here");
+  });
+
+  test("a script on a branch this checkout does not have", () => {
+    const r = run("Run `bun scripts/coverage-ratchet-that-moved.ts --check` first.");
+    expect(r.out).toMatch(/no such script/);
+  });
+
+  test("a slug that is not in the registry", () => {
+    // The real shape of this error: a plausible name for a squad that exists
+    // under a different one.
+    const r = run("Neighbour: `design-system-nirvana-pro`.");
+    expect(r.out).toContain("not in the registry");
+  });
+
+  test("--strict is what a dispatch step would gate on", () => {
+    const body = "Edit ~/definitely/not/a/real/path/squad.yaml";
+    expect(run(body).code).toBe(0);
+    expect(run(body, ["--strict"]).code).toBe(1);
+  });
+});
+
+describe("it stays quiet when the brief is right", () => {
+  test("real path, real script, real slug", () => {
+    const r = run([
+      `Target: the \`design-system-nirvana\` squad at ${REAL_FILE}`,
+      "Run `bun scripts/check-not-for-fires.ts brandcraft` before and after.",
+    ].join("\n"), ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("resolves");
+    expect(r.out).toMatch(/checked 1 paths · 1 scripts · 1 slugs/);
+  });
+
+  test("a single-word name is not judged as a slug", () => {
+    // 13 of the 255 entities are one word, and three of those words are
+    // `documentation`, `testing` and `monitoring`. Judging bare words would
+    // fire on ordinary prose far more often than it would catch a real typo.
+    const r = run("Read `testing` notes and the `monitoring` section.", ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/· 0 slugs/);
+  });
+
+  test("a path the agent is told to CREATE is not an error", () => {
+    // Briefs name their own outputs. Flagging those would make the checker
+    // useless for exactly the briefs that produce something.
+    const r = run("Write the report to ~/nirvana-os/.nirvana/outputs/run-01/report.md (new)", ["--strict"]);
+    expect(r.code).toBe(0);
+  });
+
+  test("filenames in backticks are not judged as slugs", () => {
+    const r = run("Read `router.js` and `squad.yaml`, then `build-all-packs.sh`.", ["--strict"]);
+    expect(r.code).toBe(0);
+  });
+
+  test("a relative path is left alone rather than guessed at", () => {
+    // Without a stated cwd, `skills/harness/lib` could resolve against the repo,
+    // the pack, or the installed library. Guessing produces false alarms.
+    const r = run("Look under skills/harness/lib and packaging/pack.", ["--strict"]);
+    expect(r.code).toBe(0);
+  });
+});
+
+describe("the checker reports what it inspected", () => {
+  test("it prints counts, so an empty check is visibly empty", () => {
+    // A preflight that silently checks nothing reads exactly like a passing one.
+    const r = run(`Target: the \`design-system-nirvana\` squad at ${REAL_FILE}`);
+    expect(r.out).toMatch(/checked 1 paths · 0 scripts · 1 slugs/);
+  });
+});
+
+process.on("exit", () => { try { rmSync(tmp, { recursive: true, force: true }); } catch {} });

--- a/skills/squads/lib/squad-doctor.ts
+++ b/skills/squads/lib/squad-doctor.ts
@@ -31,22 +31,22 @@ export function checkFidelity(squadDir: string, manifest: any): Finding[] {
   const caps = Array.isArray(manifest?.capabilities) ? manifest.capabilities : [];
   const mk = (id: string, problem: string, fix: string): Finding => ({
     severity: "warn", code: "fidelity-unverified", where: id,
-    problem, why: "fidelity.status: validated sem prova é fidelidade fabricada — o harness rotearia confiando num número que ninguém mediu", fix,
+    problem, why: "fidelity.status: validated without proof is fabricated fidelity — the harness would route trusting a number nobody measured", fix,
     autofixable: true,
   });
   for (const cap of caps) {
     const fid = cap?.fidelity;
     if (!fid || fid.status !== "validated") continue;
-    const id = cap.id || "(capability sem id)";
+    const id = cap.id || "(capability with no id)";
     const threshold = typeof fid.threshold === "number" ? fid.threshold : 0.85;
     const rel = fid.eval_results;
     if (!rel) {
-      out.push(mk(id, "declara fidelity.status: validated mas não aponta eval_results", `gere um eval-results.json (casos + pass_rate) e aponte fidelity.eval_results para ele, ou rebaixe para 'experimental'. Auto-fix rebaixa para experimental.`));
+      out.push(mk(id, "declares fidelity.status: validated but points at no eval_results", `generate an eval-results.json (cases + pass_rate) and point fidelity.eval_results at it, or downgrade to 'experimental'. The auto-fix downgrades to experimental.`));
       continue;
     }
     const evalPath = path.isAbsolute(rel) ? rel : path.join(squadDir, rel);
     if (!fs.existsSync(evalPath)) {
-      out.push(mk(id, `fidelity.eval_results aponta para '${rel}', que não existe no disco`, `crie ${rel} com os casos de avaliação (pass_rate>=${threshold}), ou rebaixe para experimental.`));
+      out.push(mk(id, `fidelity.eval_results points at '${rel}', which is not on disk`, `create ${rel} with the evaluation cases (pass_rate>=${threshold}), or downgrade to experimental.`));
       continue;
     }
     try {
@@ -56,12 +56,12 @@ export function checkFidelity(squadDir: string, manifest: any): Finding[] {
         rate = data.cases.filter((c: any) => c.passed).length / data.cases.length;
       }
       if (rate === null) {
-        out.push(mk(id, `eval_results existe mas não tem 'pass_rate' nem 'cases[]' para recomputar`, `adicione pass_rate (0..1) ou cases:[{id,passed}] a ${rel}.`));
+        out.push(mk(id, `eval_results exists but carries neither 'pass_rate' nor 'cases[]' to recompute from`, `add pass_rate (0..1) or cases:[{id,passed}] to ${rel}.`));
       } else if (rate < threshold) {
-        out.push(mk(id, `pass_rate medido ${rate.toFixed(2)} < threshold ${threshold}`, `melhore o squad até pass_rate>=${threshold}, ou rebaixe para experimental.`));
+        out.push(mk(id, `measured pass_rate ${rate.toFixed(2)} < threshold ${threshold}`, `improve the squad until pass_rate>=${threshold}, or downgrade to experimental.`));
       }
     } catch (e: any) {
-      out.push(mk(id, `eval_results não é JSON válido: ${e.message}`, `conserte o JSON de ${rel}.`));
+      out.push(mk(id, `eval_results is not valid JSON: ${e.message}`, `fix the JSON in ${rel}.`));
     }
   }
   return out;
@@ -69,10 +69,10 @@ export function checkFidelity(squadDir: string, manifest: any): Finding[] {
 
 // ── item 5: non-portable leaks (Claude-specific terms) ────────────────────────
 const FORBIDDEN: { re: RegExp; label: string }[] = [
-  { re: /(^|[^\w/])CLAUDE\.md\b/, label: "referência a CLAUDE.md (instrução específica do Claude Code)" },
-  { re: /~\/\.claude\b/, label: "caminho ~/.claude (específico do Claude Code)" },
-  { re: /\$\{?CLAUDE_PLUGIN_ROOT\}?/, label: "variável CLAUDE_PLUGIN_ROOT" },
-  { re: /\bclaude-(opus|sonnet|haiku|fable)[\w.-]*/i, label: "id de modelo Claude pinado" },
+  { re: /(^|[^\w/])CLAUDE\.md\b/, label: "reference to CLAUDE.md (a Claude Code-specific instruction file)" },
+  { re: /~\/\.claude\b/, label: "the ~/.claude path (Claude Code-specific)" },
+  { re: /\$\{?CLAUDE_PLUGIN_ROOT\}?/, label: "the CLAUDE_PLUGIN_ROOT variable" },
+  { re: /\bclaude-(opus|sonnet|haiku|fable)[\w.-]*/i, label: "a pinned Claude model id" },
 ];
 export function checkPortability(squadDir: string): Finding[] {
   const out: Finding[] = [];
@@ -89,9 +89,9 @@ export function checkPortability(squadDir: string): Finding[] {
         const m = txt.match(re);
         if (m) out.push({
           severity: "warn", code: "portability-leak", where: `${sub}/${f}`,
-          problem: `vazamento não-portável: ${label} ("${m[0].trim()}")`,
-          why: "o squad é projetado para vários runtimes (Codex/Gemini/Cursor...); um termo Claude-specific quebra a conversão",
-          fix: `troque por um termo neutro ou use o semantic_map do adapter alvo; se for intencional, adicione '<!-- portability-ok -->' ao arquivo`,
+          problem: `non-portable leak: ${label} ("${m[0].trim()}")`,
+          why: "a squad is meant to run on several runtimes (Codex, Gemini, Cursor…); a Claude-specific term breaks the conversion",
+          fix: `replace it with a neutral term or use the target adapter's semantic_map; if it is deliberate, add '<!-- portability-ok -->' to the file`,
           autofixable: false,
         });
       }
@@ -110,38 +110,64 @@ export function collectFindings(squadDir: string): Finding[] {
   return [...checkFidelity(squadDir, manifest), ...checkPortability(squadDir)];
 }
 
+/**
+ * Where a squad's diagnostic goes — and it is not into the squad.
+ *
+ * This used to write `SQUAD-DOCTOR-REPORT.md` into `squadDir` itself, which put
+ * a machine-generated diagnostic inside the content tree. Two consequences, both
+ * seen in the wild: seven squads carried one into the packs, so buyers received
+ * a report about the seller's own machine; and because the file is stamped with
+ * a fresh timestamp on every run, any two copies of a squad validated at
+ * different moments differ forever — a slug that can never be reconciled.
+ *
+ * The squad directory is product. A diagnostic about the product belongs beside
+ * the other per-squad state.
+ */
+function reportPathFor(squadDir: string): string {
+  const slug = path.basename(squadDir);
+  const { SQUADS_STATE_DIR } = require("../../_shared/lib/paths.js").resolvePaths();
+  return path.join(SQUADS_STATE_DIR, slug, "SQUAD-DOCTOR-REPORT.md");
+}
+
 export function writeDoctorReport(squadDir: string, findings: Finding[], stampISO: string): string {
   const slug = path.basename(squadDir);
   const errors = findings.filter((f) => f.severity === "error");
   const warns = findings.filter((f) => f.severity === "warn");
   const autofix = findings.filter((f) => f.autofixable);
   const lines: string[] = [];
-  lines.push(`# Squad doctor — diagnóstico de \`${slug}\``);
+  lines.push(`# Squad doctor — \`${slug}\``);
   lines.push("");
-  lines.push(`Gerado: ${stampISO}`);
-  lines.push(`Problemas: ${findings.length} (${errors.length} erro(s), ${warns.length} aviso(s); ${autofix.length} auto-corrigível(eis))`);
+  lines.push(`Generated: ${stampISO}`);
+  lines.push(`Findings: ${findings.length} (${errors.length} error(s), ${warns.length} warning(s); ${autofix.length} auto-fixable)`);
   lines.push("");
   if (findings.length === 0) {
-    lines.push("Nenhum problema de fidelity/portabilidade encontrado. ✅");
+    lines.push("No fidelity or portability problems found.");
   } else {
-    lines.push("## Como corrigir");
+    lines.push("## How to fix");
     lines.push("");
-    lines.push(`- Auto-fix seguro (rebaixa fidelity não comprovada etc.): \`nrv fix-squad ${slug} --apply\``);
-    lines.push("- Itens não auto-corrigíveis têm a correção manual em cada bloco.");
+    lines.push(`- Safe auto-fix (downgrades unproven fidelity and similar): \`nrv fix-squad ${slug} --apply\``);
+    lines.push("- Anything not auto-fixable carries its manual fix in the block below.");
     lines.push("");
-    lines.push("## Problemas");
+    lines.push("## Findings");
     findings.forEach((f, i) => {
       lines.push("");
       lines.push(`### ${i + 1}. [${f.severity}] ${f.code} — \`${f.where}\``);
-      lines.push(`- **Problema:** ${f.problem}`);
-      lines.push(`- **Por quê importa:** ${f.why}`);
-      lines.push(`- **Como corrigir:** ${f.fix}`);
-      lines.push(`- **Auto-corrigível:** ${f.autofixable ? "sim (`nrv fix-squad --apply`)" : "não — correção manual"}`);
+      lines.push(`- **Problem:** ${f.problem}`);
+      lines.push(`- **Why it matters:** ${f.why}`);
+      lines.push(`- **How to fix:** ${f.fix}`);
+      lines.push(`- **Auto-fixable:** ${f.autofixable ? "yes (`nrv fix-squad --apply`)" : "no — manual fix"}`);
     });
   }
   lines.push("");
-  const out = path.join(squadDir, "SQUAD-DOCTOR-REPORT.md");
+  const out = reportPathFor(squadDir);
+  fs.mkdirSync(path.dirname(out), { recursive: true });
   fs.writeFileSync(out, lines.join("\n"), "utf8");
+
+  // A report left behind by the old location keeps shipping and keeps causing
+  // drift, so retire it the first time this squad is diagnosed again.
+  const legacy = path.join(squadDir, "SQUAD-DOCTOR-REPORT.md");
+  try { if (fs.existsSync(legacy)) fs.rmSync(legacy); } catch { /* read-only tree: the gate still catches it */ }
+
   return out;
 }
 

--- a/skills/squads/tests/squad-doctor-report.test.ts
+++ b/skills/squads/tests/squad-doctor-report.test.ts
@@ -11,20 +11,33 @@
  *
  * The squad directory is product. A diagnostic about the product is not.
  */
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { writeDoctorReport, type Finding } from "../lib/squad-doctor.ts";
 
-// The report now lands under the project's state directory, so without this the
-// suite would leave six fake squads in the real one. `resolvePaths()` reads the
-// environment on every call, so pointing the root elsewhere is enough.
+/**
+ * The report lands under the project's state directory, so this points the root
+ * at a throwaway one — otherwise the suite leaves six fake squads in the real
+ * `.nirvana/state/squads`.
+ *
+ * It is set in beforeAll and PUT BACK in afterAll, not assigned at module scope.
+ * `bun test` runs every file in one process, so a module-scope assignment leaks
+ * into every file loaded afterwards: doing it that way made `buyer-path` resolve
+ * its install records to a directory this suite had already deleted, and report
+ * "No installations recorded" on Linux and Windows while passing on macOS, where
+ * the file order happened to differ. `resolvePaths()` reads the environment on
+ * every call, so scoping it to the tests that need it costs nothing.
+ */
 const FAKE_ROOT = mkdtempSync(join(tmpdir(), "doctor-root-"));
-process.env.NIRVANA_PROJECT_ROOT = FAKE_ROOT;
-afterAll(() => rmSync(FAKE_ROOT, { recursive: true, force: true }));
-
-const { writeDoctorReport } = await import("../lib/squad-doctor.ts");
-type Finding = import("../lib/squad-doctor.ts").Finding;
+let previousRoot: string | undefined;
+beforeAll(() => { previousRoot = process.env.NIRVANA_PROJECT_ROOT; process.env.NIRVANA_PROJECT_ROOT = FAKE_ROOT; });
+afterAll(() => {
+  if (previousRoot === undefined) delete process.env.NIRVANA_PROJECT_ROOT;
+  else process.env.NIRVANA_PROJECT_ROOT = previousRoot;
+  rmSync(FAKE_ROOT, { recursive: true, force: true });
+});
 
 function squadDir(slug: string) {
   const root = mkdtempSync(join(tmpdir(), "doctor-"));
@@ -107,5 +120,15 @@ describe("the packaging path knows it is not content", () => {
     const rs = await import("../../_shared/lib/run-state.ts");
     expect(rs.isRunStatePath("SQUAD-DOCTOR-REPORT.md")).toBe(true);
     expect(rs.isRunStatePath("agents/whatever.md")).toBe(false);
+  });
+
+  test("`.runs` is run state too", async () => {
+    // Found by inspecting a rebuild file by file: `brandcraft/.runs` holds 64
+    // files and 36 MB of leftover Remotion renders, and it was shipping inside
+    // four packs. The name was in three private exclusion lists and missing
+    // from the one four consumers read.
+    const rs = await import("../../_shared/lib/run-state.ts");
+    expect(rs.isRunStatePath(".runs/mago-demo/out/frame-001.png")).toBe(true);
+    expect(rs.isRunStatePath("lib/design-intelligence/README.md")).toBe(false);
   });
 });

--- a/skills/squads/tests/squad-doctor-report.test.ts
+++ b/skills/squads/tests/squad-doctor-report.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the squad doctor writes, and in what language.
+ *
+ * The doctor used to write `SQUAD-DOCTOR-REPORT.md` into the squad directory
+ * itself. Two things followed, and both were found in the wild rather than
+ * reasoned about: 25 of those reports were sitting in the content trees and 18
+ * more inside built pack artifacts, so buyers received a diagnostic about the
+ * seller's machine; and because the file carries a fresh timestamp on every
+ * run, two copies of the same squad validated minutes apart disagreed forever —
+ * a slug that could not be reconciled no matter how carefully it was merged.
+ *
+ * The squad directory is product. A diagnostic about the product is not.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The report now lands under the project's state directory, so without this the
+// suite would leave six fake squads in the real one. `resolvePaths()` reads the
+// environment on every call, so pointing the root elsewhere is enough.
+const FAKE_ROOT = mkdtempSync(join(tmpdir(), "doctor-root-"));
+process.env.NIRVANA_PROJECT_ROOT = FAKE_ROOT;
+afterAll(() => rmSync(FAKE_ROOT, { recursive: true, force: true }));
+
+const { writeDoctorReport } = await import("../lib/squad-doctor.ts");
+type Finding = import("../lib/squad-doctor.ts").Finding;
+
+function squadDir(slug: string) {
+  const root = mkdtempSync(join(tmpdir(), "doctor-"));
+  const dir = join(root, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "squad.yaml"), `name: ${slug}\nversion: 1.0.0\n`, "utf8");
+  return { root, dir };
+}
+
+const finding: Finding = {
+  severity: "warn",
+  code: "fidelity-unverified",
+  where: "design.thing.execute",
+  problem: "declares fidelity.status: validated but points at no eval_results",
+  why: "fidelity.status: validated without proof is fabricated fidelity",
+  fix: "generate an eval-results.json, or downgrade to experimental",
+  autofixable: true,
+};
+
+describe("the report does not live in the product", () => {
+  test("it is written outside the squad directory", () => {
+    const { root, dir } = squadDir("alpha");
+    const out = writeDoctorReport(dir, [finding], "2026-08-15T00:00:00.000Z");
+    expect(existsSync(out)).toBe(true);
+    expect(out.startsWith(dir)).toBe(false);
+    expect(existsSync(join(dir, "SQUAD-DOCTOR-REPORT.md"))).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a report left by the old location is retired", () => {
+    // 25 of these were in the content trees. Diagnosing a squad again should
+    // clear its own litter rather than wait for someone to notice.
+    const { root, dir } = squadDir("beta");
+    const legacy = join(dir, "SQUAD-DOCTOR-REPORT.md");
+    writeFileSync(legacy, "# stale report from the old location\n", "utf8");
+    writeDoctorReport(dir, [], "2026-08-15T00:00:00.000Z");
+    expect(existsSync(legacy)).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("the path is per-slug, so two squads do not overwrite each other", () => {
+    const a = squadDir("gamma"), b = squadDir("delta");
+    const pa = writeDoctorReport(a.dir, [], "2026-08-15T00:00:00.000Z");
+    const pb = writeDoctorReport(b.dir, [], "2026-08-15T00:00:00.000Z");
+    expect(pa).not.toBe(pb);
+    expect(pa).toContain("gamma");
+    expect(pb).toContain("delta");
+    rmSync(a.root, { recursive: true, force: true });
+    rmSync(b.root, { recursive: true, force: true });
+  });
+});
+
+describe("the report reads in the project's language", () => {
+  test("no Portuguese in the generated report", () => {
+    // Every user-facing string in the engine is English; the buyer report that
+    // started this whole thread arrived in Portuguese and that was the bug.
+    const { root, dir } = squadDir("epsilon");
+    const body = readFileSync(writeDoctorReport(dir, [finding], "2026-08-15T00:00:00.000Z"), "utf8");
+    for (const pt of ["diagnóstico", "Problemas:", "Como corrigir", "Por quê", "auto-corrigível", "Nenhum problema"]) {
+      expect(body).not.toContain(pt);
+    }
+    expect(body).toContain("How to fix");
+    expect(body).toContain("Why it matters");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a clean squad still gets a readable report", () => {
+    const { root, dir } = squadDir("zeta");
+    const body = readFileSync(writeDoctorReport(dir, [], "2026-08-15T00:00:00.000Z"), "utf8");
+    expect(body).toContain("No fidelity or portability problems found.");
+    expect(body).toContain("Findings: 0");
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("the packaging path knows it is not content", () => {
+  test("run-state excludes it, so no builder can ship one again", async () => {
+    // The doctor writing elsewhere fixes new reports. This is what stops the
+    // ones already on disk from travelling into a pack.
+    const rs = await import("../../_shared/lib/run-state.ts");
+    expect(rs.isRunStatePath("SQUAD-DOCTOR-REPORT.md")).toBe(true);
+    expect(rs.isRunStatePath("agents/whatever.md")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this changes

Three things, all found while reconciling the pack content trees.

**A gate for cloned capabilities.** A capability id may have many providers — nine squads can each define a design language, and the router picks by BM25 over each provider's own `description`, `keywords` and `example_briefs`. When two providers carry identical text, there is nothing to pick with: both score the same, and a confident-looking `HIGH` is a coin toss.

Two bulk injections shipped exactly that:

| capability | providers | identical |
|---|---|---|
| `media.video.compose` | 10 | 9 |
| `frontend.design_language.define` | 9 | 8 |
| `frontend.search_visibility.optimize` | 7 | 6 |
| `frontend.search_visibility.audit` | 7 | 6 |

Nine of the ten video copies carried **no keywords and no example_briefs at all** — the two fields the index weights ×3 and ×2.

`check-capability-clones.ts` reports the identical *text*, never the shared *id*. Sharing an id is the design; a gate that fired on all 22 legitimate shared ids would be switched off the same week. It is wired into `check:all` and takes `--registry <file>` so its own test asserts on a fixture rather than on whatever library the machine happens to hold.

**A preflight for dispatch briefs.** `check-brief.ts` checks every path, script and slug in a brief before an agent follows it. Two briefs went out this week naming a script that lived on another branch and a squad directory under a name it never had; both agents improvised and reported success against the wrong target. It stays quiet on anything marked `(new)`, and judges only hyphenated names — three of the thirteen single-word entities are `documentation`, `testing` and `monitoring`.

**The squad doctor stops writing into the product.** `SQUAD-DOCTOR-REPORT.md` was written into the squad directory, so 25 sat in the content trees and 18 more inside built pack artifacts — a diagnostic about the seller's machine, delivered to the buyer. Being timestamped, it also made any two copies of a squad disagree forever. It now writes under `.nirvana/state/squads/<slug>/`, in English, and `run-state.ts` carries its name so no builder ships an old one.

## Verification

- `check:all` green, including the new `check:clones`
- 32 new tests, passing both with a library present and with `NIRVANA_HOME` pointed at an empty directory — the CI condition that made #38's own test fail on three platforms
- Coverage ratchet: no entity knows less than it did

The content-side companion (differentiating the 20 cloned providers, reconciling the nine drifted slugs) is in `nirvana-packs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)