### PR TITLE
fix(businesses): the prompt told the agent no useful clone existed, then listed one at 0.93

### DIFF
--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -454,10 +454,14 @@ function resolveClonesByPriority(args: BuildArgs, employeeContent: string, bizDi
   }
 
   // 4. decision trace
+  // The last branch used to read "no useful clone" — a verdict the system is not
+  // entitled to, and one it contradicts three lines later by listing a strong
+  // candidate. Nothing was auto-injected; whether a clone is useful here is the
+  // agent's call, made against the ranked list.
   const decision = hadRequested ? "REQUESTED by the user"
     : hadDefaults ? "ASSIGNED to the employee"
     : personas.length ? "found by SEARCH for the task"
-    : "DEFAULT — no useful clone, employee persona";
+    : "YOURS — none auto-injected, pick from the ranked candidates";
 
   return { personas, suggestions, decision, missingClones };
 }
@@ -576,7 +580,16 @@ export function buildEmployeePrompt(args: BuildArgs): string {
       if (block) contributionsBlock = `\n\n---\n\n${block}\n\n`;
     } catch { /* contributions are best-effort */ }
     if (inj.suggestions.length) {
-      cloneSuggestions = ["", "**Other candidates by search** (you may swap/add; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):",
+      // The header has to follow what actually happened. When nothing was
+      // injected these are not "other" candidates — they are the only ones, and
+      // calling them "other" beside the line "no clone was injected" reads as
+      // "there is nothing here", which is how a well-ranked clone gets ignored:
+      // a compliance business asking about LGPD is shown `bruno-bioni` at 0.93
+      // and told, one line above, that no useful clone exists.
+      const header = inj.personas.length
+        ? "**Other candidates by search** (you may swap/add; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):"
+        : "**Candidates for this task, ranked** (take one or more; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):";
+      cloneSuggestions = ["", header,
         ...inj.suggestions.slice(0, 5).map(h => `- ${h.normalized.toFixed(2)} \`${h.slug}\`${h.one_liner ? " — " + h.one_liner : ""}`)].join("\n");
     }
   }
@@ -626,7 +639,7 @@ ${employeeContent}
 
 ## MIND-CLONES YOU EMBODY — decision: ${cloneDecision}
 
-> System order: clone **REQUESTED** by the user → else **SEARCH** for the most useful one for the task → else **default persona**. The clones below are already embodied IN FULL (AGENT + SOUL + DNA); deliver the work AS IF the clone had produced it, under your employee instructions.${dnaContent || "\n\n(no useful clone for this task — operate as the employee's default persona, without a clone)"}${cloneSuggestions}
+> System order: clone **REQUESTED** by the user → else **SEARCH** for the most useful one for the task → else **you choose**. The clones below are already embodied IN FULL (AGENT + SOUL + DNA); deliver the work AS IF the clone had produced it, under your employee instructions.${dnaContent || "\n\n**No clone was auto-injected — choosing is yours.** Read the candidates below and take one or more, whichever help you think this task through. Inspect any of them with `nrv ask <slug>`. Working without a clone is a legitimate answer, but it is the answer you reach when none of them fits, not the one you start from."}${cloneSuggestions}
 
 ---
 

--- a/skills/businesses/tests/employee-clone-choice.test.ts
+++ b/skills/businesses/tests/employee-clone-choice.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What an employee is told when no mind-clone was auto-injected.
+ *
+ * The protocol's intent is that the agent CHOOSES: search ranks the library, the
+ * employee reads the candidates and takes whichever help it think the task
+ * through — or none, if none fits. The prompt said the opposite of that in three
+ * places at once.
+ *
+ * The section header announced `DEFAULT — no useful clone, employee persona`.
+ * The body said `(no useful clone for this task — operate as the employee's
+ * default persona, without a clone)`. And then, three lines below, it listed the
+ * candidates under the heading **Other** candidates.
+ *
+ * Measured against the real library: a compliance business asked about an LGPD
+ * programme is shown `bruno-bioni` — Brazil's applied-LGPD reference — at 0.93,
+ * directly beneath a sentence telling it no useful clone exists. "No useful
+ * clone" is a verdict the system is not entitled to and contradicts on the next
+ * line; an agent that believes it will never open the list.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildEmployeePrompt } from "../lib/employee-prompt.ts";
+
+/**
+ * A project-scoped root, so the fixture businesses are the ones resolved rather
+ * than whatever `~/businesses` happens to hold. `resolveScope` walks up for a
+ * `.env` and reads NIRVANA_SCOPE; under "project" it looks in
+ * `<root>/.nirvana/businesses/`.
+ */
+const ROOT = mkdtempSync(join(tmpdir(), "biz-"));
+mkdirSync(join(ROOT, ".nirvana", "businesses"), { recursive: true });
+writeFileSync(join(ROOT, ".env"), "NIRVANA_SCOPE=project\n", "utf8");
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+/** A business with one employee and no declared clone — the state 43 of the
+ *  library's 60 businesses are in, and the one the wording is about. */
+function business(slug: string): string {
+  const dir = join(ROOT, ".nirvana", "businesses", slug);
+  mkdirSync(join(dir, "employees"), { recursive: true });
+  writeFileSync(join(dir, "business.yaml"), `name: ${slug}\ndescription: a business\n`, "utf8");
+  writeFileSync(join(dir, "employees", "analyst.md"), "# Analyst\n\nDoes the work.\n", "utf8");
+  return dir;
+}
+
+function prompt(slug: string, brief: string): string {
+  business(slug);
+  return buildEmployeePrompt({
+    business_slug: slug,
+    employee: "analyst",
+    project_dir: ROOT,
+    brief,
+    trace_id: "test",
+  } as Parameters<typeof buildEmployeePrompt>[0]);
+}
+
+describe("choosing a clone is the agent's call, and the prompt says so", () => {
+  const p = prompt("alpha-co", "montar o programa de compliance LGPD com matriz de risco");
+
+  test("it never claims no useful clone exists", () => {
+    // The system ranks; it does not get to conclude that nothing is useful.
+    expect(p).not.toContain("no useful clone");
+  });
+
+  test("the decision line hands the choice over", () => {
+    expect(p).toContain("YOURS — none auto-injected");
+  });
+
+  test("working without a clone is offered as an outcome, not a starting point", () => {
+    expect(p).toContain("choosing is yours");
+    expect(p).toContain("not the one you start from");
+  });
+
+  test("the system order ends in the agent, not in a default", () => {
+    expect(p).toContain("else **you choose**");
+  });
+});
+
+describe("the section still renders when the library is absent", () => {
+  test("no candidates found is not an error", () => {
+    // On CI there is no clone registry at all. The block must still explain the
+    // choice rather than crash or fall silent.
+    const p = prompt("beta-co", "uma tarefa qualquer sem correspondência");
+    expect(p).toContain("MIND-CLONES YOU EMBODY");
+    expect(p.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The intent is that the agent **chooses**: search ranks the library, the employee reads the candidates and takes whichever help it think the task through — or none, when none fits. The prompt said the opposite in three places at once.

Rendered against the real library — a compliance business asked about an LGPD programme:

```
MIND-CLONES YOU EMBODY — decision: DEFAULT — no useful clone, employee persona

(no useful clone for this task — operate as the employee's default persona, without a clone)
**Other candidates by search** (you may swap/add):
- 1.00 `jai-ramaswamy` — Arquiteto de compliance da era cripto…
- 0.93 `bruno-bioni`   — Jurista de LGPD aplicada…
```

`bruno-bioni` is Brazil's applied-LGPD reference and he is right there, one line under a sentence saying no useful clone exists. An agent that believes that sentence never opens the list.

After:

```
MIND-CLONES YOU EMBODY — decision: YOURS — none auto-injected, pick from the ranked candidates

**No clone was auto-injected — choosing is yours.** Read the candidates below and take one or
more, whichever help you think this task through. Working without a clone is a legitimate
answer, but it is the answer you reach when none of them fits, not the one you start from.
**Candidates for this task, ranked** (take one or more):
```

The coverage gate still decides what gets *auto-injected*; it no longer gets to narrate a verdict about usefulness on top of that.

Five tests, hermetic — a project-scoped fixture business rather than `~/businesses`, so they assert the same thing on CI as here.

This changes 43 of the library's 60 businesses without touching any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)