### PR TITLE
feat(gate): an employee bound to a clone that is not there runs without it, and says nothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,12 @@
     "check:coverage": "bun skills/_shared/scripts/coverage-ratchet.ts --check --strict",
     "check:notfor": "bun scripts/check-not-for-fires.ts",
     "check:clones": "bun scripts/check-capability-clones.ts --strict",
+    "check:bindings": "bun scripts/check-clone-bindings.ts --strict",
     "check:packs": "bun scripts/check-published-packs.ts --strict",
     "check:audit-parity": "bun scripts/check-audit-parity.ts --strict",
     "check:command-parity": "bun scripts/check-skillmd-command-parity.ts --strict",
     "check:changelog": "bun scripts/check-changelog-parity.ts --strict",
     "check:version": "bun scripts/check-version-parity.ts --strict",
-    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-capability-clones.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
+    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-capability-clones.ts --strict && bun scripts/check-clone-bindings.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
   }
 }

--- a/scripts/check-clone-bindings.ts
+++ b/scripts/check-clone-bindings.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+/**
+ * check-clone-bindings.ts — every clone an employee names has to be somewhere
+ * the runtime will look.
+ *
+ * A business binds a mind-clone to an employee by naming it in the employee's
+ * frontmatter (`assigned_mind_clones`), and the runtime resolves that name
+ * against the clone library. Nothing verified the name resolves. The failure is
+ * silent by construction: the employee simply runs without the persona it was
+ * written to carry, and the output is plausible prose that reads like anyone.
+ *
+ * It is worse in a pack. A pack ships `mind-clones/` alongside `businesses/`,
+ * and the installer lays those into the library. If a packaged business declares
+ * a clone the pack does not carry, the buyer installs an employee bound to
+ * nothing. Found while adding `tracking-360` to the flagship: its 17 employees
+ * declare 17 clones and the pack carried 5. The other 12 were found by listing
+ * them out by hand — which is exactly the work a gate should be doing.
+ *
+ * Some businesses also keep a `dna/` directory of symlinks into the library.
+ * That is not in the protocol — the protocol binds per employee, by reference —
+ * and symlinks cannot travel in a zip: they point at the author's absolute home.
+ * This gate reads them anyway, because in one business they are the ONLY
+ * binding, and losing that silently is the thing being prevented.
+ *
+ * Usage:
+ *   bun scripts/check-clone-bindings.ts                  # the live library
+ *   bun scripts/check-clone-bindings.ts --strict
+ *   bun scripts/check-clone-bindings.ts --pack <dir>     # a pack's content dir
+ *   bun scripts/check-clone-bindings.ts --json
+ */
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+const argv = process.argv.slice(2);
+const strict = argv.includes("--strict");
+const asJson = argv.includes("--json");
+const packDir = argv.includes("--pack") ? argv[argv.indexOf("--pack") + 1] : null;
+
+const HOME = homedir();
+/** In a pack the three kinds sit side by side; live, they are three roots. */
+const BUSINESSES = packDir ? join(packDir, "businesses") : join(HOME, "businesses");
+const CLONES = packDir ? join(packDir, "mind-clones") : join(HOME, "businesses", "_library", "dna");
+
+/** A ref in `assigned_mind_clones` may be category-prefixed
+ *  (`21-media-moguls/jane-friedman`) or flat. The slug is the last segment. */
+const slugOf = (ref: string) => (ref.lastIndexOf("/") === -1 ? ref : ref.slice(ref.lastIndexOf("/") + 1));
+
+/**
+ * `dna_reference` is a different shape: a path INTO the clone, not to it —
+ * `dna/michael-thaut-music-therapist/agent/AGENT.md`. Reading its last segment
+ * yields `AGENT`, which is not a clone and never will be; the first pass of this
+ * gate reported six businesses "missing AGENT" for exactly that reason. The
+ * clone is the directory that follows the library marker.
+ */
+function refToSlug(ref: string): string | null {
+  const parts = ref.replace(/^\$\{?DNA_LIBRARY\}?\/?/, "").split("/").filter(Boolean);
+  const i = parts.indexOf("dna");
+  const slug = i >= 0 ? parts[i + 1] : parts[0];
+  if (!slug || /\.(md|ya?ml|json)$/.test(slug)) return null;
+  return slug;
+}
+
+function declaredBy(employeeFile: string): string[] {
+  const text = readFileSync(employeeFile, "utf8");
+  const fm = text.match(/^---[\s\S]*?^---/m)?.[0] ?? "";
+  const out: string[] = [];
+  const list = fm.match(/^assigned_mind_clones\s*:\s*\n((?:[ \t]*-\s.+\n?)+)/m);
+  if (list) {
+    for (const line of list[1].split("\n")) {
+      const s = line.replace(/^[ \t]*-\s*/, "").trim();
+      if (s) out.push(slugOf(s));
+    }
+  }
+  // `dna_reference:` — the protocol's own form, a path into the clone.
+  for (const m of fm.matchAll(/^dna_reference\s*:\s*(\S+)/gm)) {
+    const slug = refToSlug(m[1]);
+    if (slug) out.push(slug);
+  }
+  return out;
+}
+
+interface Row { business: string; employee: string; clone: string; source: "employee" | "dna/" }
+const missing: Row[] = [];
+let checked = 0, businesses = 0;
+const available = new Set(existsSync(CLONES) ? readdirSync(CLONES) : []);
+
+for (const b of existsSync(BUSINESSES) ? readdirSync(BUSINESSES) : []) {
+  if (b === "_library") continue;
+  const dir = join(BUSINESSES, b);
+  if (!existsSync(join(dir, "business.yaml"))) continue;
+  businesses++;
+
+  const empDir = join(dir, "employees");
+  if (existsSync(empDir)) {
+    for (const f of readdirSync(empDir).filter((x) => x.endsWith(".md"))) {
+      for (const clone of declaredBy(join(empDir, f))) {
+        checked++;
+        if (!available.has(clone)) missing.push({ business: b, employee: f.replace(/\.md$/, ""), clone, source: "employee" });
+      }
+    }
+  }
+
+  // The symlink directory, where a business still has one.
+  const dnaDir = join(dir, "dna");
+  if (existsSync(dnaDir)) {
+    for (const e of readdirSync(dnaDir)) {
+      // Only links and directories are bindings. `medwork360/dna/` holds a
+      // README.md and nothing else, which the first pass counted as a clone
+      // named "README" — and, worse, as evidence that the business had one.
+      let entry;
+      try { entry = lstatSync(join(dnaDir, e)); } catch { continue; }
+      if (!entry.isSymbolicLink() && !entry.isDirectory()) continue;
+      const clone = e.replace(/\.md$/, "");
+      checked++;
+      if (!available.has(clone)) missing.push({ business: b, employee: "(business dna/)", clone, source: "dna/" });
+      // A symlink that no longer resolves is a binding that already broke.
+      try {
+        const p = join(dnaDir, e);
+        if (lstatSync(p).isSymbolicLink() && !existsSync(p)) {
+          missing.push({ business: b, employee: "(business dna/)", clone: `${clone} — dangling symlink`, source: "dna/" });
+        }
+      } catch { /* unreadable entry */ }
+    }
+  }
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ scope: packDir ?? "live", businesses, bindings: checked, missing }, null, 2));
+  process.exitCode = strict && missing.length ? 1 : 0;
+} else {
+  console.log(`\n${BOLD}CLONE BINDINGS — does every named clone resolve?${RST}`);
+  console.log(`${DIM}  ${businesses} businesses · ${checked} bindings · ${available.size} clones in ${packDir ? "the pack" : "the library"}${RST}`);
+  console.log(`${DIM}  ${CLONES.replace(HOME, "~")}${RST}\n`);
+
+  if (!missing.length) {
+    console.log(`${GRN}  Every clone an employee names is present.${RST}\n`);
+    process.exitCode = 0;
+  } else {
+    const byBiz = new Map<string, Row[]>();
+    for (const m of missing) byBiz.set(m.business, [...(byBiz.get(m.business) ?? []), m]);
+    console.log(`  unresolved: ${RED}${missing.length}${RST} across ${byBiz.size} business(es)\n`);
+    for (const [b, rows] of byBiz) {
+      console.log(`  ${RED}▼${RST} ${BOLD}${b}${RST} ${DIM}— ${rows.length}${RST}`);
+      for (const r of rows.slice(0, 12)) {
+        console.log(`      ${YEL}${r.clone}${RST} ${DIM}← ${r.employee}${RST}`);
+      }
+      if (rows.length > 12) console.log(`      ${DIM}… and ${rows.length - 12} more${RST}`);
+    }
+    console.log(`\n${DIM}  An employee bound to a clone that is not there runs without it, and says`);
+    console.log(`  nothing. In a pack that means the buyer installs the business and gets`);
+    console.log(`  prose that reads like anyone.${RST}\n`);
+    process.exitCode = strict ? 1 : 0;
+  }
+}

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -454,10 +454,14 @@ function resolveClonesByPriority(args: BuildArgs, employeeContent: string, bizDi
   }
 
   // 4. decision trace
+  // The last branch used to read "no useful clone" — a verdict the system is not
+  // entitled to, and one it contradicts three lines later by listing a strong
+  // candidate. Nothing was auto-injected; whether a clone is useful here is the
+  // agent's call, made against the ranked list.
   const decision = hadRequested ? "REQUESTED by the user"
     : hadDefaults ? "ASSIGNED to the employee"
     : personas.length ? "found by SEARCH for the task"
-    : "DEFAULT — no useful clone, employee persona";
+    : "YOURS — none auto-injected, pick from the ranked candidates";
 
   return { personas, suggestions, decision, missingClones };
 }
@@ -576,7 +580,16 @@ export function buildEmployeePrompt(args: BuildArgs): string {
       if (block) contributionsBlock = `\n\n---\n\n${block}\n\n`;
     } catch { /* contributions are best-effort */ }
     if (inj.suggestions.length) {
-      cloneSuggestions = ["", "**Other candidates by search** (you may swap/add; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):",
+      // The header has to follow what actually happened. When nothing was
+      // injected these are not "other" candidates — they are the only ones, and
+      // calling them "other" beside the line "no clone was injected" reads as
+      // "there is nothing here", which is how a well-ranked clone gets ignored:
+      // a compliance business asking about LGPD is shown `bruno-bioni` at 0.93
+      // and told, one line above, that no useful clone exists.
+      const header = inj.personas.length
+        ? "**Other candidates by search** (you may swap/add; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):"
+        : "**Candidates for this task, ranked** (take one or more; inspect with `nrv ask <slug>` or `nrv find-clone \"<task>\"`):";
+      cloneSuggestions = ["", header,
         ...inj.suggestions.slice(0, 5).map(h => `- ${h.normalized.toFixed(2)} \`${h.slug}\`${h.one_liner ? " — " + h.one_liner : ""}`)].join("\n");
     }
   }
@@ -626,7 +639,7 @@ ${employeeContent}
 
 ## MIND-CLONES YOU EMBODY — decision: ${cloneDecision}
 
-> System order: clone **REQUESTED** by the user → else **SEARCH** for the most useful one for the task → else **default persona**. The clones below are already embodied IN FULL (AGENT + SOUL + DNA); deliver the work AS IF the clone had produced it, under your employee instructions.${dnaContent || "\n\n(no useful clone for this task — operate as the employee's default persona, without a clone)"}${cloneSuggestions}
+> System order: clone **REQUESTED** by the user → else **SEARCH** for the most useful one for the task → else **you choose**. The clones below are already embodied IN FULL (AGENT + SOUL + DNA); deliver the work AS IF the clone had produced it, under your employee instructions.${dnaContent || "\n\n**No clone was auto-injected — choosing is yours.** Read the candidates below and take one or more, whichever help you think this task through. Inspect any of them with `nrv ask <slug>`. Working without a clone is a legitimate answer, but it is the answer you reach when none of them fits, not the one you start from."}${cloneSuggestions}
 
 ---
 

--- a/skills/businesses/tests/employee-clone-choice.test.ts
+++ b/skills/businesses/tests/employee-clone-choice.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What an employee is told when no mind-clone was auto-injected.
+ *
+ * The protocol's intent is that the agent CHOOSES: search ranks the library, the
+ * employee reads the candidates and takes whichever help it think the task
+ * through — or none, if none fits. The prompt said the opposite of that in three
+ * places at once.
+ *
+ * The section header announced `DEFAULT — no useful clone, employee persona`.
+ * The body said `(no useful clone for this task — operate as the employee's
+ * default persona, without a clone)`. And then, three lines below, it listed the
+ * candidates under the heading **Other** candidates.
+ *
+ * Measured against the real library: a compliance business asked about an LGPD
+ * programme is shown `bruno-bioni` — Brazil's applied-LGPD reference — at 0.93,
+ * directly beneath a sentence telling it no useful clone exists. "No useful
+ * clone" is a verdict the system is not entitled to and contradicts on the next
+ * line; an agent that believes it will never open the list.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildEmployeePrompt } from "../lib/employee-prompt.ts";
+
+/**
+ * A project-scoped root, so the fixture businesses are the ones resolved rather
+ * than whatever `~/businesses` happens to hold. `resolveScope` walks up for a
+ * `.env` and reads NIRVANA_SCOPE; under "project" it looks in
+ * `<root>/.nirvana/businesses/`.
+ */
+const ROOT = mkdtempSync(join(tmpdir(), "biz-"));
+mkdirSync(join(ROOT, ".nirvana", "businesses"), { recursive: true });
+writeFileSync(join(ROOT, ".env"), "NIRVANA_SCOPE=project\n", "utf8");
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+/** A business with one employee and no declared clone — the state 43 of the
+ *  library's 60 businesses are in, and the one the wording is about. */
+function business(slug: string): string {
+  const dir = join(ROOT, ".nirvana", "businesses", slug);
+  mkdirSync(join(dir, "employees"), { recursive: true });
+  writeFileSync(join(dir, "business.yaml"), `name: ${slug}\ndescription: a business\n`, "utf8");
+  writeFileSync(join(dir, "employees", "analyst.md"), "# Analyst\n\nDoes the work.\n", "utf8");
+  return dir;
+}
+
+function prompt(slug: string, brief: string): string {
+  business(slug);
+  return buildEmployeePrompt({
+    business_slug: slug,
+    employee: "analyst",
+    project_dir: ROOT,
+    brief,
+    trace_id: "test",
+  } as Parameters<typeof buildEmployeePrompt>[0]);
+}
+
+describe("choosing a clone is the agent's call, and the prompt says so", () => {
+  const p = prompt("alpha-co", "montar o programa de compliance LGPD com matriz de risco");
+
+  test("it never claims no useful clone exists", () => {
+    // The system ranks; it does not get to conclude that nothing is useful.
+    expect(p).not.toContain("no useful clone");
+  });
+
+  test("the decision line hands the choice over", () => {
+    expect(p).toContain("YOURS — none auto-injected");
+  });
+
+  test("working without a clone is offered as an outcome, not a starting point", () => {
+    expect(p).toContain("choosing is yours");
+    expect(p).toContain("not the one you start from");
+  });
+
+  test("the system order ends in the agent, not in a default", () => {
+    expect(p).toContain("else **you choose**");
+  });
+});
+
+describe("the section still renders when the library is absent", () => {
+  test("no candidates found is not an error", () => {
+    // On CI there is no clone registry at all. The block must still explain the
+    // choice rather than crash or fall silent.
+    const p = prompt("beta-co", "uma tarefa qualquer sem correspondência");
+    expect(p).toContain("MIND-CLONES YOU EMBODY");
+    expect(p.length).toBeGreaterThan(0);
+  });
+});

--- a/skills/harness/tests/clone-bindings.test.ts
+++ b/skills/harness/tests/clone-bindings.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Every clone an employee names has to be somewhere the runtime will look.
+ *
+ * A business binds a mind-clone to an employee by naming it in the employee's
+ * frontmatter, and the runtime resolves that name against the clone library.
+ * Nothing verified the name resolves, and the failure is silent by
+ * construction: the employee runs without the persona it was written to carry
+ * and produces plausible prose that reads like anyone.
+ *
+ * In a pack it is worse. Found while adding `tracking-360` to the flagship: its
+ * seventeen employees name seventeen clones and the pack carried five. The other
+ * twelve were located by listing them out by hand — which is the work a gate
+ * should be doing.
+ *
+ * The reference forms are the part worth pinning. `assigned_mind_clones` holds
+ * the slug, optionally category-prefixed. `dna_reference` holds a path INTO the
+ * clone — `dna/michael-thaut-music-therapist/agent/AGENT.md` — so reading its
+ * last segment yields `AGENT`, and the first pass of this gate duly reported six
+ * businesses missing a clone named AGENT.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const GATE = join(REPO, "scripts", "check-clone-bindings.ts");
+const ROOT = mkdtempSync(join(tmpdir(), "bindings-"));
+afterAll(() => rmSync(ROOT, { recursive: true, force: true }));
+
+interface Pack { clones: string[]; employees: Record<string, string> }
+
+/** A pack content dir: businesses/<slug>/employees/*.md + mind-clones/<slug>/. */
+function pack(name: string, p: Pack): string {
+  const dir = join(ROOT, name);
+  mkdirSync(join(dir, "businesses", "acme", "employees"), { recursive: true });
+  mkdirSync(join(dir, "mind-clones"), { recursive: true });
+  writeFileSync(join(dir, "businesses", "acme", "business.yaml"), "name: acme\n", "utf8");
+  for (const c of p.clones) mkdirSync(join(dir, "mind-clones", c), { recursive: true });
+  for (const [emp, fm] of Object.entries(p.employees)) {
+    writeFileSync(join(dir, "businesses", "acme", "employees", `${emp}.md`), `---\nname: ${emp}\n${fm}---\n\n# ${emp}\n`, "utf8");
+  }
+  return dir;
+}
+
+function run(dir: string, args: string[] = []) {
+  const r = spawnSync(process.execPath, [GATE, "--pack", dir, ...args], { cwd: REPO, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("a named clone that is not shipped is caught", () => {
+  test("the failure this gate exists for", () => {
+    // tracking-360's shape: employees name clones the pack does not carry.
+    const dir = pack("short", {
+      clones: ["simo-ahava-tracking"],
+      employees: { engineer: "assigned_mind_clones:\n  - simo-ahava-tracking\n  - david-vallejo-tracking\n" },
+    });
+    const r = run(dir, ["--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("david-vallejo-tracking");
+    expect(r.out).not.toContain("simo-ahava-tracking\x1b");  // the present one is not flagged
+  });
+
+  test("a complete pack passes", () => {
+    const dir = pack("complete", {
+      clones: ["simo-ahava-tracking", "david-vallejo-tracking"],
+      employees: { engineer: "assigned_mind_clones:\n  - simo-ahava-tracking\n  - david-vallejo-tracking\n" },
+    });
+    const r = run(dir, ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Every clone an employee names is present");
+  });
+});
+
+describe("the two reference forms", () => {
+  test("a category-prefixed ref resolves to its slug", () => {
+    const dir = pack("prefixed", {
+      clones: ["jane-friedman"],
+      employees: { editor: "assigned_mind_clones:\n  - 21-media-moguls/jane-friedman\n" },
+    });
+    expect(run(dir, ["--strict"]).code).toBe(0);
+  });
+
+  test("dna_reference points INTO the clone, and the slug is not the file", () => {
+    // Reading the last segment gives `AGENT`. Six businesses were reported
+    // missing a clone by that name before this was fixed.
+    const dir = pack("dnaref", {
+      clones: ["michael-thaut-music-therapist"],
+      employees: { therapist: "dna_reference: dna/michael-thaut-music-therapist/agent/AGENT.md\n" },
+    });
+    const r = run(dir, ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toContain("AGENT");
+  });
+});
+
+describe("the business dna/ directory", () => {
+  test("a loose README is not a binding", () => {
+    // `medwork360/dna/` holds a README.md and nothing else. Counting it as a
+    // clone reported a missing one named "README" AND implied the business had
+    // a binding it does not have — the more damaging half of that mistake.
+    const dir = pack("readme", { clones: [], employees: {} });
+    mkdirSync(join(dir, "businesses", "acme", "dna"), { recursive: true });
+    writeFileSync(join(dir, "businesses", "acme", "dna", "README.md"), "# notes\n", "utf8");
+    const r = run(dir, ["--strict"]);
+    expect(r.code).toBe(0);
+    expect(r.out).not.toContain("README");
+    expect(r.out).toContain("0 bindings");
+  });
+
+  test("a dangling symlink is a binding that already broke", () => {
+    const dir = pack("dangling", { clones: ["present-one"], employees: {} });
+    const dna = join(dir, "businesses", "acme", "dna");
+    mkdirSync(dna, { recursive: true });
+    symlinkSync(join(ROOT, "nowhere", "gone-clone"), join(dna, "gone-clone"));
+    const r = run(dir, ["--strict"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("gone-clone");
+  });
+});
+
+describe("it reports what it inspected", () => {
+  test("counts are printed, so an empty check is visibly empty", () => {
+    const dir = pack("counted", {
+      clones: ["a-clone"],
+      employees: { one: "assigned_mind_clones:\n  - a-clone\n" },
+    });
+    expect(run(dir).out).toMatch(/1 businesses · 1 bindings · 1 clones/);
+  });
+
+  test("--json is shaped for a build step", () => {
+    const dir = pack("json", { clones: [], employees: { one: "assigned_mind_clones:\n  - absent\n" } });
+    const d = JSON.parse(run(dir, ["--json"]).out);
+    expect(d.bindings).toBe(1);
+    expect(d.missing[0].clone).toBe("absent");
+    expect(d.missing[0].employee).toBe("one");
+  });
+});


### PR DESCRIPTION
A business binds a mind-clone to an employee by naming it in the employee's frontmatter, and the runtime resolves that name against the clone library. **Nothing verified the name resolves**, and the failure is silent by construction — the employee runs without the persona it was written to carry.

In a pack it is worse: a packaged business naming a clone the pack does not carry hands the buyer an employee bound to nothing.

Found while adding `tracking-360` to the flagship — 17 employees, 17 named clones, 5 in the pack. The other 12 were located by listing them out by hand.

```
CLONE BINDINGS — does every named clone resolve?
  60 businesses · 171 bindings · 558 clones in the library
  Every clone an employee names is present.
```

Wired into `check:all` and into the pack build, per pack.

### The reference forms, and how the first pass got them wrong

Worth recording, because seven of the gate's first eight findings were its own instrument:

- `assigned_mind_clones` holds a slug, optionally category-prefixed — `21-media-moguls/jane-friedman`
- `dna_reference` holds a path **into** the clone — `dna/michael-thaut-music-therapist/agent/AGENT.md`. Reading its last segment yields `AGENT`, so six businesses were reported missing a clone by that name.
- `medwork360/dna/` holds a lone `README.md`, which counted as a clone called "README" — and, more damagingly, as evidence of a binding that business does not have.

Eight tests, hermetic, including the failure the gate exists for and both reference forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)