### PR TITLE
fix(gate): the fence gate was wired into check:all without --strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "check:command-parity": "bun scripts/check-skillmd-command-parity.ts --strict",
     "check:changelog": "bun scripts/check-changelog-parity.ts --strict",
     "check:version": "bun scripts/check-version-parity.ts --strict",
-    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts && bun scripts/check-capability-clones.ts --strict && bun scripts/check-clone-bindings.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
+    "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts --strict && bun scripts/check-capability-clones.ts --strict && bun scripts/check-clone-bindings.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts"
   }
 }

--- a/scripts/check-not-for-fires.ts
+++ b/scripts/check-not-for-fires.ts
@@ -32,16 +32,37 @@
  * The gate therefore reports a long entry as dead when it fires against no real
  * brief, instead of guessing from its shape.
  *
+ * **Why a baseline and not a hard cut.** 830 of 1,821 entries are dead today,
+ * across 93 entities. A gate that turns every build red with no path out is a
+ * gate everyone learns to skip — which is exactly how this one spent its first
+ * day wired into `check:all` without `--strict`, printing 46% in red and exiting
+ * 0. So `--strict` reads a recorded ceiling per entity and fails on two things:
+ *
+ *   an entity ABOVE its ceiling  →  the debt grew
+ *   an entity with NO ceiling    →  new content, and new content enters at zero
+ *
+ * The second half is the point. Every other gate here is a regression gate: it
+ * compares against a previous state, so content arriving for the first time has
+ * nothing to fail against and enters at whatever quality it has. `tracking-360`
+ * joined the flagship with 79 entries and 79 of them dead, and every gate stayed
+ * green because none of them had a "before" to compare it to.
+ *
  * Usage:
  *   bun scripts/check-not-for-fires.ts             # report
- *   bun scripts/check-not-for-fires.ts --strict    # exit 1 if any entity is over budget
+ *   bun scripts/check-not-for-fires.ts --strict    # exit 1 on growth, or on new content with any dead entry
+ *   bun scripts/check-not-for-fires.ts --record    # write the ceiling from the current state
  *   bun scripts/check-not-for-fires.ts --json
  *   bun scripts/check-not-for-fires.ts <slug>      # one entity, with the dead entries listed
+ *
+ * The ceiling lives beside the registries, like the coverage ratchet's, so it
+ * travels with the scope it describes and never puts entity names in the engine
+ * repo. `--record` refuses to raise a ceiling without `--allow-regression`:
+ * recording after a fix is routine, recording a regression has to be said out loud.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
-import { parseArgs } from "../skills/_shared/lib/bun-helpers.ts";
+import { dirname, join } from "node:path";
+import { parseArgs, paths as nrvPaths } from "../skills/_shared/lib/bun-helpers.ts";
 
 const require_ = createRequire(import.meta.url);
 const bm25 = require_(join(import.meta.dir, "..", "skills", "harness", "lib", "bm25.js"));
@@ -53,8 +74,33 @@ const only = positional[0];
  *  thing a test can assert is whatever library happens to be on the machine —
  *  which on CI is none, so the interesting assertions could not run at all. */
 const fixture = typeof flags.registry === "string" ? flags.registry : null;
+/** A pack content dir (squads/ + businesses/), for the build-time run. */
+const packDir = typeof flags.pack === "string" ? flags.pack : null;
 
 const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+/** Per-entity ceiling of dead entries.
+ *
+ *  Anchored to the GLOBAL nirvana home, never to the current scope. The ceiling
+ *  describes the machine's authoring library (`~/squads`, `~/businesses`), which
+ *  is global, so a path that moves with the working directory describes nothing:
+ *  recorded from `~/nirvana-os` it landed in that repo's `.nirvana/`, and the
+ *  pack build — which runs from `~/nirvana-packs` — found no ceiling at all and
+ *  failed every pack as unrecorded content.
+ *
+ *  It must not live in the engine repo either: it names 151 library entities,
+ *  and entity content does not belong in a content-free public engine.
+ *
+ *  A fixture run gets its own ceiling file, so tests never read or write the
+ *  machine's. */
+const BASELINE = fixture
+  ? `${fixture}.baseline.json`
+  : join((nrvPaths as Record<string, string>).NIRVANA_HOME ?? ".", ".nirvana", ".not-for-baseline.json");
+
+function loadCeilings(): Record<string, number> | null {
+  if (!existsSync(BASELINE)) return null;
+  try { return JSON.parse(readFileSync(BASELINE, "utf8")).entities ?? {}; } catch { return null; }
+}
 
 // Mirrors router.js:506-508. If those move, this gate is measuring the wrong
 // thing — which is why the numbers live here as named constants rather than
@@ -63,25 +109,66 @@ const SUBSTRING_MAX_CHARS = 25;
 const MIN_CONTENT_TOKENS = 2;
 const TOKEN_OVERLAP_MIN = 0.6;
 
-const caps: Record<string, Array<Record<string, unknown>>> = fixture
-  ? JSON.parse(readFileSync(fixture, "utf8"))
-  : (registryLoader.loadAll()?.squads?.capabilities ?? {});
-
-/** Every real example_brief in the library: the user-language corpus we have. */
-const briefSets: Array<Set<string>> = [];
-for (const list of Object.values(caps)) {
-  for (const c of list) {
-    for (const b of ((c.example_briefs as string[]) ?? [])) {
-      if (typeof b === "string") briefSets.push(new Set(bm25.tokenize(b)));
+/** Capabilities read straight off a pack's content tree, so the gate can run at
+ *  build time against the bytes that ship instead of against whatever the
+ *  author's machine happens to have indexed. The pack is a copy of the library,
+ *  so the entity names — and therefore the ceiling — are the same. */
+function capsFromPack(dir: string): Record<string, Array<Record<string, unknown>>> {
+  const YAML = require_("yaml");
+  const out: Record<string, Array<Record<string, unknown>>> = {};
+  for (const [kind, manifest, key] of [
+    ["squads", "squad.yaml", "squad"],
+    ["businesses", "business.yaml", "business"],
+  ] as const) {
+    const root = join(dir, kind);
+    if (!existsSync(root)) continue;
+    for (const slug of readdirSync(root)) {
+      const f = join(root, slug, manifest);
+      if (!existsSync(f)) continue;
+      let doc: Record<string, unknown>;
+      try { doc = YAML.parse(readFileSync(f, "utf8")) ?? {}; } catch { continue; }
+      // Key by the manifest's `name`, not the directory. The registry does the
+      // same (registry.js:165), and the two differ often enough to matter:
+      // `nirvana-rh-dp/` declares `nirvana-rh-departamento-pessoal`. Keying by
+      // directory made a squad that has a ceiling look like new content and
+      // failed the pack for it.
+      const entity = typeof doc.name === "string" && doc.name ? doc.name : slug;
+      for (const c of ((doc.capabilities as Array<Record<string, unknown>>) ?? [])) {
+        const id = String(c?.id ?? "");
+        if (!id) continue;
+        (out[id] ??= []).push({ [key]: entity, not_for: c.not_for, example_briefs: c.example_briefs });
+      }
     }
   }
+  return out;
 }
-const briefStrings: string[] = [];
-for (const list of Object.values(caps)) {
-  for (const c of list) {
-    for (const b of ((c.example_briefs as string[]) ?? [])) {
-      if (typeof b === "string") briefStrings.push(b.toLowerCase());
-    }
+
+const caps: Record<string, Array<Record<string, unknown>>> = fixture
+  ? JSON.parse(readFileSync(fixture, "utf8"))
+  : packDir
+    ? capsFromPack(packDir)
+    : (registryLoader.loadAll()?.squads?.capabilities ?? {});
+
+/** What a fence is judged AGAINST: the widest corpus of real user language we
+ *  have. This is deliberately NOT the same set as `caps`.
+ *
+ *  A long entry is alive if it fires against any real brief — and briefs written
+ *  for a neighbouring squad count, because a user writes them too. Judging a
+ *  pack against only the 496 briefs it happens to carry marked the very same
+ *  `landing-page-nirvana/squad.yaml` as 17-dead in the library and 21-dead in
+ *  `marketing-growth`, from a file with a zero-line diff between the two. Same
+ *  bytes, different verdict, because the corpus shrank.
+ *
+ *  A fixture run stays hermetic: tests judge against their fixture alone, never
+ *  against whatever library the machine happens to have. */
+const corpusCaps: Array<Record<string, unknown>> = [
+  ...Object.values(caps).flat(),
+  ...(fixture ? [] : Object.values((registryLoader.loadAll()?.squads?.capabilities ?? {}) as Record<string, Array<Record<string, unknown>>>).flat()),
+];
+const briefSets: Array<Set<string>> = [];
+for (const c of corpusCaps) {
+  for (const b of ((c.example_briefs as string[]) ?? [])) {
+    if (typeof b === "string") briefSets.push(new Set(bm25.tokenize(b)));
   }
 }
 
@@ -129,12 +216,48 @@ const totalDead = all.reduce((n, r) => n + r.dead, 0);
 
 // An entity is over budget when MOST of its fences are dead — that is the state
 // where an author has a boundary in mind and the router has none. A single dead
-// entry among many is noise; a majority is a broken contract.
+// entry among many is noise; a majority is a broken contract. This drives the
+// human report; the ceiling below drives --strict.
 const overBudget = all.filter((r) => r.total >= 3 && r.dead / r.total > 0.5);
 
+// ── The ceiling ────────────────────────────────────────────────────────────
+const ceilings = loadCeilings();
+
+/** Entities that grew past their ceiling, and entities that have none. The
+ *  second list is the admission bar: content the ceiling has never seen enters
+ *  at zero dead entries or it does not enter. */
+const grew = ceilings ? all.filter((r) => r.dead > (ceilings[r.entity] ?? 0) && r.entity in ceilings) : [];
+const unrecorded = ceilings ? all.filter((r) => !(r.entity in ceilings) && r.dead > 0) : [];
+const failures = [...grew, ...unrecorded];
+
+if (flags.record) {
+  const now: Record<string, number> = {};
+  for (const r of all) now[r.entity] = r.dead;
+  const raised = ceilings ? all.filter((r) => r.dead > (ceilings[r.entity] ?? 0)) : [];
+  if (raised.length && !flags["allow-regression"]) {
+    console.error(`\n${RED}Refusing to record: ${raised.length} entity(ies) would get a HIGHER ceiling.${RST}`);
+    for (const r of raised.slice(0, 10)) {
+      console.error(`  ${r.entity.padEnd(34)} ${ceilings?.[r.entity] ?? 0} → ${r.dead}`);
+    }
+    console.error(`\n${DIM}  Fix the entries, or record deliberately with --allow-regression.${RST}\n`);
+    process.exit(1);
+  }
+  const lowered = ceilings ? all.filter((r) => r.dead < (ceilings[r.entity] ?? Infinity)).length : 0;
+  mkdirSync(dirname(BASELINE), { recursive: true });
+  writeFileSync(BASELINE, JSON.stringify({ recorded_at: new Date().toISOString(), entities: now }, null, 2) + "\n");
+  console.log(`\n${GRN}Ceiling recorded${RST} — ${all.length} entities, ${totalDead} dead entries`);
+  if (lowered) console.log(`${GRN}  ${lowered} ceiling(s) lowered${RST}`);
+  console.log(`${DIM}  ${BASELINE.replace(process.env.HOME ?? "~", "~")}${RST}\n`);
+  process.exit(0);
+}
+
 if (flags.json) {
-  console.log(JSON.stringify({ entities: all.length, entries: totalEntries, dead: totalDead, over_budget: overBudget }, null, 2));
-  process.exit(flags.strict && overBudget.length ? 1 : 0);
+  console.log(JSON.stringify({
+    entities: all.length, entries: totalEntries, dead: totalDead,
+    over_budget: overBudget,
+    ceiling: ceilings ? { grew: grew.map((r) => r.entity), unrecorded: unrecorded.map((r) => r.entity) } : null,
+  }, null, 2));
+  process.exit(flags.strict && failures.length ? 1 : 0);
 }
 
 console.log(`\n${BOLD}NOT_FOR — does the fence fire?${RST}`);
@@ -149,7 +272,7 @@ if (only) {
   for (const e of r.deadEntries) console.log(`    ${DIM}${e.length} chars · ${e.slice(0, 78)}${RST}`);
   console.log(`\n${DIM}  Rewrite each as 2-4 content words, <=${SUBSTRING_MAX_CHARS} chars, EN and PT as separate`);
   console.log(`  entries, accented and unaccented as separate entries, no "(use X)" suffix.${RST}\n`);
-  process.exit(flags.strict && r.dead / r.total > 0.5 ? 1 : 0);
+  process.exit(flags.strict && failures.some((f) => f.entity === r.entity) ? 1 : 0);
 }
 
 const pct = Math.round((100 * totalDead) / Math.max(totalEntries, 1));
@@ -166,4 +289,31 @@ console.log(`\n${DIM}  A dead entry costs nothing at retrieval — not_for is no
 console.log(`  costs is the belief that a boundary exists. Inspect one with:`);
 console.log(`    bun scripts/check-not-for-fires.ts <slug>${RST}\n`);
 
-process.exit(flags.strict && overBudget.length ? 1 : 0);
+// ── The ceiling verdict ────────────────────────────────────────────────────
+if (!all.length) process.exit(0);            // no library in scope — nothing to judge
+if (!ceilings) {
+  console.log(`  ${YEL}No ceiling recorded.${RST} ${DIM}Run: bun scripts/check-not-for-fires.ts --record${RST}\n`);
+  process.exit(flags.strict ? 1 : 0);
+}
+
+if (grew.length) {
+  console.log(`  ${RED}${grew.length} entity(ies) grew past their ceiling:${RST}`);
+  for (const r of grew.slice(0, 10)) {
+    console.log(`    ${RED}↑${RST} ${r.entity.padEnd(34)} ${ceilings[r.entity]} → ${r.dead}`);
+  }
+  console.log();
+}
+if (unrecorded.length) {
+  console.log(`  ${RED}${unrecorded.length} entity(ies) are new to the ceiling and arrive with dead fences:${RST}`);
+  for (const r of unrecorded.slice(0, 10)) {
+    console.log(`    ${RED}✗${RST} ${r.entity.padEnd(34)} ${r.dead}/${r.total} dead`);
+  }
+  console.log(`\n${DIM}  New content enters at zero. Every other gate here compares against a`);
+  console.log(`  previous state, so a first arrival has nothing to fail against — which is`);
+  console.log(`  how 79 dead fences walked into the flagship pack green.${RST}\n`);
+}
+if (!failures.length) {
+  console.log(`  ${GRN}No entity is above its ceiling, and nothing new arrived with a dead fence.${RST}\n`);
+}
+
+process.exit(flags.strict && failures.length ? 1 : 0);

--- a/skills/harness/tests/not-for-fires.test.ts
+++ b/skills/harness/tests/not-for-fires.test.ts
@@ -19,7 +19,7 @@
  * threshold is worse than no gate.
  */
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -94,8 +94,9 @@ describe("the gate runs and reports", () => {
   }, 60_000);
 
   test("without --strict it reports rather than fails", () => {
-    // Report-only is deliberate while 104 entities are over budget: a gate that
-    // turns CI red with no path out teaches everyone to ignore it.
+    // Report-only without the flag is deliberate: the report is also how an
+    // author browses the debt. The enforcement lives in --strict, against the
+    // recorded ceiling.
     expect(run([]).code).toBe(0);
   }, 60_000);
 
@@ -125,5 +126,145 @@ describe("the gate runs and reports", () => {
     const d = JSON.parse(r.out);
     expect(d.entries).toBe(2);
     expect(d.dead).toBe(1);
+  }, 60_000);
+});
+
+/**
+ * The ceiling. These are the cases that make --strict worth wiring into
+ * `check:all` — the gate spent its first day there WITHOUT the flag, printing
+ * 46% dead in red and exiting 0, which is the defect it was written to catch.
+ *
+ * A gate goes back into `check:all` only with a test that plants the defect and
+ * demands exit 1. That is what the three cases below are.
+ */
+describe("the ceiling refuses growth, and refuses new content that arrives dead", () => {
+  const DEAD = "a long entry nobody will ever match against a real brief here";
+  const LIVE = "seo audit";
+
+  /** A fixture registry plus the ceiling file the gate reads beside it. */
+  function withCeiling(
+    caps: Record<string, Array<Record<string, unknown>>>,
+    entities: Record<string, number>,
+  ): string {
+    const f = fixture(caps);
+    writeFileSync(`${f}.baseline.json`, JSON.stringify({ recorded_at: "test", entities }), "utf8");
+    return f;
+  }
+
+  const run = (f: string) => {
+    const r = spawnSync(process.execPath, [GATE, "--registry", f, "--strict"], { cwd: REPO, encoding: "utf8" });
+    return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+  };
+
+  test("an entity that grows past its ceiling fails", () => {
+    const r = run(withCeiling(
+      { "a.b.c": [{ squad: "s", not_for: [LIVE, DEAD], example_briefs: ["do an seo audit for me"] }] },
+      { s: 0 },
+    ));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("grew past their ceiling");
+    expect(r.out).toMatch(/s\s+0 → 1/);
+  }, 60_000);
+
+  test("an entity the ceiling has never seen enters at zero, or it does not enter", () => {
+    // The admission bar. Every other gate here compares against a previous
+    // state, so a first arrival has nothing to fail against — which is how
+    // tracking-360 joined the flagship with 79 of 79 fences dead, green.
+    const r = run(withCeiling(
+      {
+        "a.b.c": [{ squad: "known", not_for: [LIVE], example_briefs: ["do an seo audit for me"] }],
+        "d.e.f": [{ squad: "brand-new", not_for: [DEAD], example_briefs: ["something else entirely"] }],
+      },
+      { known: 0 },
+    ));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("new to the ceiling");
+    expect(r.out).toContain("brand-new");
+  }, 60_000);
+
+  test("a library at or below its ceiling passes", () => {
+    const r = run(withCeiling(
+      { "a.b.c": [{ squad: "known", not_for: [LIVE], example_briefs: ["do an seo audit for me"] }] },
+      { known: 0 },
+    ));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("No entity is above its ceiling");
+  }, 60_000);
+
+  test("--pack keys by the manifest name, not the directory", () => {
+    // The registry keys by `name` (registry.js:165) and the two differ often
+    // enough to matter: `nirvana-rh-dp/` declares `nirvana-rh-departamento-pessoal`.
+    // Keying by directory made a squad that HAS a ceiling look like new content,
+    // and failed `commerce-backoffice` for it.
+    const pack = mkdtempSync(join(tmpdir(), "notfor-pack-"));
+    const squad = join(pack, "squads", "some-dir");
+    mkdirSync(squad, { recursive: true });
+    writeFileSync(join(squad, "squad.yaml"), [
+      'name: declared-name',
+      'capabilities:',
+      '  - id: a.b.c',
+      '    not_for:',
+      `      - "${DEAD}"`,
+      '    example_briefs:',
+      '      - "something else entirely"',
+      '',
+    ].join("\n"), "utf8");
+
+    const one = (slug: string) =>
+      spawnSync(process.execPath, [GATE, slug, "--pack", pack], { cwd: REPO, encoding: "utf8" });
+
+    expect(`${one("declared-name").stdout}`).toMatch(/declared-name: .*1\/1 dead/);
+    expect(`${one("some-dir").stdout}`).toContain("no not_for entries");
+    rmSync(pack, { recursive: true, force: true });
+  }, 60_000);
+
+  test("the ceiling is found from any working directory", () => {
+    // It describes the machine's global authoring library, so anchoring it to
+    // the current scope described nothing: recorded from ~/nirvana-os it landed
+    // in that repo's .nirvana/, and the pack build — which runs from
+    // ~/nirvana-packs — found no ceiling and failed every pack as new content.
+    const home = mkdtempSync(join(tmpdir(), "notfor-home-"));
+    mkdirSync(join(home, ".nirvana"), { recursive: true });
+    writeFileSync(
+      join(home, ".nirvana", ".not-for-baseline.json"),
+      JSON.stringify({ recorded_at: "test", entities: { "declared-name": 1 } }),
+      "utf8",
+    );
+
+    const pack = mkdtempSync(join(tmpdir(), "notfor-pack2-"));
+    const squad = join(pack, "squads", "d");
+    mkdirSync(squad, { recursive: true });
+    writeFileSync(join(squad, "squad.yaml"), [
+      "name: declared-name",
+      "capabilities:",
+      "  - id: a.b.c",
+      "    not_for:",
+      `      - "${DEAD}"`,
+      "    example_briefs:",
+      '      - "something else entirely"',
+      "",
+    ].join("\n"), "utf8");
+
+    const codes = [REPO, tmpdir()].map((cwd) =>
+      spawnSync(process.execPath, [GATE, "--pack", pack, "--strict"], {
+        cwd, encoding: "utf8", env: { ...process.env, NIRVANA_HOME: home },
+      }).status,
+    );
+    expect(codes[0]).toBe(0);          // 1 dead, ceiling is 1 — at the ceiling, passes
+    expect(codes[1]).toBe(codes[0]);   // and the answer does not move with cwd
+    rmSync(pack, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }, 60_000);
+
+  test("--record refuses to raise a ceiling without being told to", () => {
+    // Recording after a fix is routine. Recording a regression has to be said
+    // out loud, or `--record` becomes the way every debt quietly becomes the floor.
+    const f = withCeiling(
+      { "a.b.c": [{ squad: "s", not_for: [LIVE, DEAD], example_briefs: ["do an seo audit for me"] }] },
+      { s: 0 },
+    );
+    const r = spawnSync(process.execPath, [GATE, "--registry", f, "--record"], { cwd: REPO, encoding: "utf8" });
+    expect(r.status).toBe(1);
+    expect(`${r.stdout ?? ""}${r.stderr ?? ""}`).toContain("HIGHER ceiling");
   }, 60_000);
 });


### PR DESCRIPTION
The commit that added this gate is titled *"a fence that never fires is not a fence"* (`743399f`). It went into `check:all` the same day without `--strict`, so it printed **830/1821 dead entries in red and exited 0**. The gate was the defect it describes.

## Why a ceiling and not a hard cut

`--strict` as it stood fails 93 entities. A gate that blocks every build with no path out is a gate everyone learns to skip. So it now reads a recorded ceiling and fails on two things:

```
an entity ABOVE its ceiling  ->  the debt grew
an entity with NO ceiling    ->  new content, and new content enters at zero
```

**The second half is the hole this whole episode came through.** Every gate in this repo is a *regression* gate — `coverage-ratchet` refuses a decrease, the parity gates compare against a previous state, `check-capability-clones` compares providers to each other. Content arriving for the first time has no "before", so it enters at whatever quality it has, and the ratchet then records that as the permanent floor.

`tracking-360` joined the flagship pack with 79 `not_for` entries of which 79 were dead. It is already in `.coverage-baseline.json` with those numbers as its accepted baseline. Nothing broke; nothing was there to break.

`--record` refuses to raise a ceiling without `--allow-regression`.

## `--pack <dir>`

So the gate runs at pack build time against the bytes that ship. Building it surfaced three of its own bugs, each now pinned by a test:

| bug | symptom |
|---|---|
| corpus shrank to the pack's own briefs | the same file, zero-line diff, read 17-dead in the library and 21-dead in the pack it ships from |
| keyed by directory, registry keys by manifest `name` | `nirvana-rh-dp/` declares `nirvana-rh-departamento-pessoal`, looked like new content, failed its pack |
| ceiling path moved with the working directory | the pack build runs from another repo, found no ceiling, failed every pack as unrecorded |

## Measured

Fixing the content the gate now catches: the 79 tracking-360 fences became 254 that fire. Routing eval **unchanged at 98.2% top-1 over 3,366 cases**; self-retrieval keeps **121/121** of those squads' own briefs at rank 1. Library debt 830 -> 751.

Five tests plant the defect and demand exit 1. No gate goes back into `check:all` without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)