### PR TITLE
feat(gate): new content enters whole, or it does not enter

### DIFF
--- a/scripts/check-entity-admission.ts
+++ b/scripts/check-entity-admission.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+/**
+ * check-entity-admission.ts — new content enters whole, or it does not enter.
+ *
+ * Every other gate in the pack build asks a relational question: does a fence
+ * fire against the brief corpus, does a binding resolve inside the artifact,
+ * do two copies agree. None of them reads the entity's OWN metadata — which is
+ * how tracking-360 walked into the flagship on 2026-08-16 with three clones
+ * carrying no `routing:` block: each was internally consistent, nothing
+ * compared it to a previous state (there was none), and every gate stayed
+ * green. MRR for an unrouted clone is 0.05 against 1.00 routed — the clone
+ * shipped, and was invisible.
+ *
+ * This is the entity-metadata slice of the admission bar. The full bar is the
+ * ensemble the build already runs — validate-squad, check-not-for-fires --pack,
+ * check-clone-bindings --pack, check-copy-drift — plus this file:
+ *
+ *   HARD (always fails — cheap to fix, zero debt in the source today):
+ *     clone MANIFEST parses
+ *     clone has routing.one_liner        (the definition of "enriched")
+ *     clone category is bare             (not the numbered legacy `09-…` form)
+ *     every entity has .nirvana-surface.json
+ *
+ *   BASELINED (absolute for NEW entities; recorded debt for existing ones):
+ *     clone has validation_verdict       (68 gaps in today's source)
+ *     clone has source_material          (23 gaps in today's source)
+ *
+ * The split follows the fence gate's lesson: verdict and source_material are
+ * produced by the validation pipeline, not by a text edit — a bar that fails
+ * 68 entities with no path out is a bar everyone learns to skip. So existing
+ * debt is recorded per entity and may only shrink; an entity the baseline has
+ * never seen enters complete. `--record` refuses to add debt without
+ * `--allow-regression`.
+ *
+ * The baseline lives beside the machine's global state (like the fence
+ * ceiling): it names library entities, which never belong in the engine repo,
+ * and it must not move with the working directory.
+ *
+ * Usage:
+ *   bun scripts/check-entity-admission.ts --pack <content-dir>     # the bar (exit 1 on any violation)
+ *   bun scripts/check-entity-admission.ts --pack <dir> --record    # write the debt baseline
+ *   bun scripts/check-entity-admission.ts --pack <dir> --json
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { parseArgs, paths as nrvPaths } from "../skills/_shared/lib/bun-helpers.ts";
+
+const require_ = createRequire(import.meta.url);
+const YAML = require_("yaml");
+
+const { flags } = parseArgs(process.argv.slice(2));
+const packDir = typeof flags.pack === "string" ? flags.pack : null;
+if (!packDir || !existsSync(packDir)) {
+  console.error("usage: check-entity-admission.ts --pack <content-dir> [--record] [--json]");
+  process.exit(2);
+}
+
+const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
+
+const BASELINE = flags.baseline && typeof flags.baseline === "string"
+  ? flags.baseline // tests point this at a fixture; never at the machine's
+  : join((nrvPaths as Record<string, string>).NIRVANA_HOME ?? ".", ".nirvana", ".admission-baseline.json");
+
+type Gap = "no_verdict" | "no_source";
+function loadBaseline(): Record<string, Gap[]> | null {
+  if (!existsSync(BASELINE)) return null;
+  try { return JSON.parse(readFileSync(BASELINE, "utf8")).entities ?? {}; } catch { return null; }
+}
+
+interface Violation { entity: string; kind: "hard" | "debt"; problem: string; }
+const violations: Violation[] = [];
+const debtNow: Record<string, Gap[]> = {};
+const scanned = new Set<string>();
+
+// ── clones ─────────────────────────────────────────────────────────────────
+const clonesRoot = join(packDir, "mind-clones");
+let clones = 0;
+if (existsSync(clonesRoot)) {
+  for (const slug of readdirSync(clonesRoot)) {
+    const mf = join(clonesRoot, slug, "MANIFEST.yaml");
+    if (!existsSync(mf)) continue;
+    clones++;
+    scanned.add(slug);
+    let doc: Record<string, unknown> = {};
+    try { doc = YAML.parse(readFileSync(mf, "utf8")) ?? {}; }
+    catch { violations.push({ entity: slug, kind: "hard", problem: "MANIFEST.yaml does not parse" }); continue; }
+    const man = (doc.manifest ?? doc) as Record<string, unknown>;
+    const routing = (doc.routing ?? {}) as Record<string, unknown>;
+
+    if (!routing.one_liner) {
+      violations.push({ entity: slug, kind: "hard", problem: "no routing.one_liner — invisible to semantic dispatch (MRR 0.05 vs 1.00)" });
+    }
+    const cat = String(doc.category ?? man.category ?? "");
+    if (/^\d\d-/.test(cat)) {
+      violations.push({ entity: slug, kind: "hard", problem: `numbered legacy category "${cat}" — the library is bare-form` });
+    }
+    const gaps: Gap[] = [];
+    if (!(doc.validation_verdict ?? man.validation_verdict)) gaps.push("no_verdict");
+    if (!(doc.source_material ?? man.source_material)) gaps.push("no_source");
+    if (gaps.length) debtNow[slug] = gaps;
+  }
+}
+
+// ── surface files, every kind ──────────────────────────────────────────────
+let entities = 0;
+for (const kind of ["squads", "businesses", "mind-clones"]) {
+  const root = join(packDir, kind);
+  if (!existsSync(root)) continue;
+  for (const slug of readdirSync(root)) {
+    const dir = join(root, slug);
+    const manifest = kind === "squads" ? "squad.yaml" : kind === "businesses" ? "business.yaml" : "MANIFEST.yaml";
+    if (!existsSync(join(dir, manifest))) continue;
+    entities++;
+    if (!existsSync(join(dir, ".nirvana-surface.json"))) {
+      violations.push({ entity: `${kind}/${slug}`, kind: "hard", problem: "no .nirvana-surface.json — outside the changes/drift mechanism" });
+    }
+  }
+}
+
+// ── the debt verdict ───────────────────────────────────────────────────────
+const baseline = loadBaseline();
+if (flags.record) {
+  const prev = baseline ?? {};
+  const grew = Object.entries(debtNow).filter(([slug, gaps]) =>
+    gaps.some((g) => !(prev[slug] ?? []).includes(g)));
+  if (baseline && grew.length && !flags["allow-regression"]) {
+    console.error(`\n${RED}Refusing to record: ${grew.length} entity(ies) would gain NEW debt.${RST}`);
+    for (const [slug, gaps] of grew.slice(0, 10)) console.error(`  ${slug}: ${gaps.join(", ")}`);
+    console.error(`\n${DIM}  Fix the metadata, or record deliberately with --allow-regression.${RST}\n`);
+    process.exit(1);
+  }
+  // MERGE, never replace: the baseline is global per slug while a pack is one
+  // slice of the library. Recording from pack A must not erase what only pack
+  // B can see. An entity scanned here and clean has its debt cleared; an
+  // entity not in this pack keeps its record untouched.
+  const merged: Record<string, Gap[]> = { ...(baseline ?? {}) };
+  for (const slug of scanned) {
+    if (debtNow[slug]) merged[slug] = debtNow[slug];
+    else delete merged[slug];
+  }
+  mkdirSync(dirname(BASELINE), { recursive: true });
+  writeFileSync(BASELINE, JSON.stringify({ recorded_at: new Date().toISOString(), entities: merged }, null, 2) + "\n");
+  console.log(`${GRN}Admission debt recorded${RST} — ${Object.keys(merged).length} entity(ies) with gaps (${Object.keys(debtNow).length} in this pack)`);
+  console.log(`${DIM}  ${BASELINE.replace(process.env.HOME ?? "~", "~")}${RST}`);
+  process.exit(0);
+}
+
+for (const [slug, gaps] of Object.entries(debtNow)) {
+  for (const g of gaps) {
+    const known = baseline ? (baseline[slug] ?? []).includes(g) : false;
+    if (!known) {
+      const label = g === "no_verdict" ? "no validation_verdict" : "no source_material";
+      violations.push({
+        entity: slug, kind: "debt",
+        problem: baseline && slug in baseline
+          ? `${label} — a NEW gap on a known entity`
+          : `${label} — new content enters complete`,
+      });
+    }
+  }
+}
+
+if (flags.json) {
+  console.log(JSON.stringify({ clones, entities, violations, debt: debtNow, baseline_present: !!baseline }, null, 2));
+  process.exit(violations.length || !baseline ? 1 : 0);
+}
+
+console.log(`\n${BOLD}ENTITY ADMISSION — new content enters whole${RST}`);
+console.log(`${DIM}  ${entities} entities (${clones} clones) · ${packDir.replace(process.env.HOME ?? "~", "~")}${RST}\n`);
+
+if (!baseline) {
+  console.log(`  ${YEL}No debt baseline recorded.${RST} ${DIM}Run: check-entity-admission.ts --pack <dir> --record${RST}\n`);
+  process.exit(1);
+}
+if (!violations.length) {
+  const debtCount = Object.keys(debtNow).length;
+  console.log(`  ${GRN}Every entity meets the bar.${RST}${debtCount ? `${DIM} (${debtCount} carrying recorded metadata debt — may only shrink)${RST}` : ""}\n`);
+  process.exit(0);
+}
+for (const v of violations.slice(0, 20)) {
+  console.log(`  ${RED}✗${RST} ${v.entity.padEnd(34)} ${v.problem}`);
+}
+if (violations.length > 20) console.log(`  ${DIM}… and ${violations.length - 20} more${RST}`);
+console.log(`\n${DIM}  HARD problems are fixed in the entity; debt problems mean a new or grown`);
+console.log(`  metadata gap — run the validation pipeline, or record deliberately.${RST}\n`);
+process.exit(1);

--- a/skills/harness/tests/entity-admission.test.ts
+++ b/skills/harness/tests/entity-admission.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The admission bar: new content enters whole, or it does not enter.
+ *
+ * Every other pack gate asks a relational question — does a fence fire, does a
+ * binding resolve, do copies agree. None reads the entity's OWN metadata, which
+ * is how three clones with no `routing:` block walked into the flagship on
+ * 2026-08-16: internally consistent, no previous state to regress from, every
+ * gate green. This gate is the absolute bar for that slice, with the fence
+ * gate's debt pattern: HARD problems always fail; metadata the validation
+ * pipeline produces (verdict, source_material) is baselined — recorded debt may
+ * only shrink, and an entity the baseline never saw enters complete.
+ *
+ * Every case here plants the defect and demands exit 1. That rule exists
+ * because this gate's sibling spent its first day wired in without --strict,
+ * printing 46% dead in red and exiting 0.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const GATE = join(REPO, "scripts", "check-entity-admission.ts");
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch {} });
+
+/** A minimal pack content dir. Every entity is complete unless the caller
+ *  breaks it on purpose. */
+function pack(mutate: (root: string) => void = () => {}): string {
+  const root = mkdtempSync(join(tmpdir(), "admission-"));
+  ROOTS.push(root);
+  const clone = join(root, "mind-clones", "jane-doe");
+  mkdirSync(clone, { recursive: true });
+  writeFileSync(join(clone, "MANIFEST.yaml"), [
+    "category: storytelling-narrative",
+    "validation_verdict: APPROVED",
+    "source_material:",
+    "  primary: [a-book]",
+    "routing:",
+    '  one_liner: "Jane Doe — the choice for planted-fixture storytelling"',
+    "",
+  ].join("\n"), "utf8");
+  writeFileSync(join(clone, ".nirvana-surface.json"), "{}", "utf8");
+  const squad = join(root, "squads", "one-squad");
+  mkdirSync(squad, { recursive: true });
+  writeFileSync(join(squad, "squad.yaml"), "name: one-squad\nversion: 1.0.0\n", "utf8");
+  writeFileSync(join(squad, ".nirvana-surface.json"), "{}", "utf8");
+  mutate(root);
+  return root;
+}
+
+/** Run with a fixture baseline so the machine's is never read or written. */
+function run(root: string, opts: { baseline?: Record<string, string[]>; record?: boolean } = {}) {
+  const bl = join(root, "baseline.json");
+  if (opts.baseline) writeFileSync(bl, JSON.stringify({ recorded_at: "test", entities: opts.baseline }), "utf8");
+  const args = [GATE, "--pack", root, "--baseline", bl];
+  if (opts.record) args.push("--record");
+  const r = spawnSync(process.execPath, args, { cwd: REPO, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("hard problems always fail", () => {
+  test("a clone with no routing block does not enter", () => {
+    const root = pack((r) => {
+      writeFileSync(join(r, "mind-clones", "jane-doe", "MANIFEST.yaml"),
+        "category: storytelling-narrative\nvalidation_verdict: APPROVED\nsource_material: {primary: [x]}\n", "utf8");
+    });
+    const r = run(root, { baseline: {} });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("no routing.one_liner");
+  });
+
+  test("a numbered legacy category does not enter", () => {
+    const root = pack((r) => {
+      writeFileSync(join(r, "mind-clones", "jane-doe", "MANIFEST.yaml"), [
+        "category: 06-storytelling-narrative",
+        "validation_verdict: APPROVED",
+        "source_material: {primary: [x]}",
+        "routing:",
+        '  one_liner: "Jane Doe — fixture"',
+      ].join("\n"), "utf8");
+    });
+    const r = run(root, { baseline: {} });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("numbered legacy category");
+  });
+
+  test("a missing surface file does not enter", () => {
+    const root = pack((r) => rmSync(join(r, "squads", "one-squad", ".nirvana-surface.json")));
+    const r = run(root, { baseline: {} });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("no .nirvana-surface.json");
+  });
+});
+
+describe("metadata debt is baselined — shrink only, and new content enters complete", () => {
+  const noVerdict = (r: string) =>
+    writeFileSync(join(r, "mind-clones", "jane-doe", "MANIFEST.yaml"), [
+      "category: storytelling-narrative",
+      "source_material: {primary: [x]}",
+      "routing:",
+      '  one_liner: "Jane Doe — fixture"',
+    ].join("\n"), "utf8");
+
+  test("a NEW clone missing validation_verdict does not enter", () => {
+    const root = pack(noVerdict);
+    const r = run(root, { baseline: {} });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("new content enters complete");
+  });
+
+  test("the same gap on a BASELINED clone passes — recorded debt", () => {
+    const root = pack(noVerdict);
+    const r = run(root, { baseline: { "jane-doe": ["no_verdict"] } });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("recorded metadata debt");
+  });
+
+  test("a NEW gap on a baselined clone still fails", () => {
+    const root = pack((r) =>
+      writeFileSync(join(r, "mind-clones", "jane-doe", "MANIFEST.yaml"), [
+        "category: storytelling-narrative",
+        "routing:",
+        '  one_liner: "Jane Doe — fixture"',
+      ].join("\n"), "utf8"));
+    const r = run(root, { baseline: { "jane-doe": ["no_verdict"] } });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("NEW gap on a known entity");
+  });
+
+  test("--record refuses to add debt without --allow-regression", () => {
+    const root = pack(noVerdict);
+    const r = run(root, { baseline: {}, record: true });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("would gain NEW debt");
+  });
+
+  test("a clean pack passes, and no baseline at all refuses rather than approves", () => {
+    expect(run(pack(), { baseline: {} }).code).toBe(0);
+    const r = run(pack());
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("No debt baseline recorded");
+  });
+});


### PR DESCRIPTION
The admission bar from the correction plan (Phase 1). Every existing pack gate asks a relational question; none reads the entity's own metadata — the gap three unrouted clones walked through into the flagship on 16/08.

**HARD** (always fails, zero debt today): MANIFEST parses · `routing.one_liner` · bare category · surface file.
**BASELINED** (new entities enter complete; 41 recorded gaps may only shrink): `validation_verdict` · `source_material`.

Wired into `build-all-packs.sh` before every zip; 16/16 packs pass; 8 planted-defect tests, each demanding exit 1.

Building it produced its own war story: the growth guard silently refused the initial multi-pack recording (each pack's debt looked new against the baseline the previous pack wrote), and `/dev/null` turned sixteen refusals into apparent success — the baseline held 21 entities instead of the union of 41. `--record` now merges per scanned entity, and the initial fill is explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)