### PR TITLE
feat(doctor): every agent runtime, from the driver's roster

### DIFF
--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -1641,6 +1641,19 @@ function dispatchToRunner(opts: RunHeadlessOpts): RunHeadlessResult {
   }
 }
 
+/** The runtime roster, from the single source of truth. `RUNTIMES` used to be
+ * reachable only through the __testables seam, so consumers that needed the
+ * list (nrv doctor) grew hardcoded copies — the doctor's had 3 of the 9, and
+ * grok/pi/agy/kimi/qwen/opencode never appeared in its report on any OS.
+ * Derive from here; a 10th adapter then shows up everywhere automatically. */
+export function listRuntimes(): { name: Runtime; cli: string }[] {
+  return RUNTIMES.map((r) => ({ name: r.name as Runtime, cli: r.cli }));
+}
+
+// Mirrors RUNTIMES above. Kept as a literal Record<Runtime, string> ON PURPOSE:
+// the exhaustive key type makes adding a Runtime member a compile error here,
+// which a derived Object.fromEntries would silently satisfy. The mirror is
+// drift-proofed by doctor-runtimes.test.ts instead.
 const RUNTIME_BINS: Record<Runtime, string> = {
   "claude-code": "claude",
   "codex": "codex",

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -107,12 +107,19 @@ for (const rt of listRuntimes()) {
     add(`runtime: ${rt.name}`, "WARN", `'${rt.cli}' not found in PATH`);
   }
 }
+// Zero runtimes on a USER machine is critical — nothing can dispatch. On a
+// headless CI runner it is the expected state of the world: the smoke job
+// installs the engine on a bare image precisely to prove the install works
+// before any runtime exists. Same fact, different severity per context —
+// shipping this as unconditional FAIL turned every CI run red on all three
+// platforms within the hour.
+const headlessCI = process.env.CI === "true";
 add(
   "runtime: dispatch",
-  runtimesOnPath > 0 ? "PASS" : "FAIL",
+  runtimesOnPath > 0 ? "PASS" : headlessCI ? "WARN" : "FAIL",
   runtimesOnPath > 0
     ? `${runtimesOnPath}/${listRuntimes().length} agent runtime(s) on PATH`
-    : "no agent runtime on PATH — dispatch cannot run; install one (claude, codex, gemini, …)",
+    : `no agent runtime on PATH — dispatch cannot run; install one (claude, codex, gemini, …)${headlessCI ? " (CI environment: reported as warning)" : ""}`,
 );
 
 // SECTION 1a-bis: CLAUDE CODE AUTH — a persistent CLAUDE_CODE_OAUTH_TOKEN export

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -28,6 +28,7 @@ import { paths as nrvPaths } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope } from "../../_shared/lib/scope.ts";
 import { RUNTIME_SKILL_DIRS, PROJECT_CONTRACT_FILES } from "../../_shared/lib/runtime-dirs.ts";
 import { scanLibrary, authorsPacks, STRIP_HINT } from "../../_shared/lib/watermark-scan.ts";
+import { listRuntimes } from "../../_shared/lib/host-agent-driver.ts";
 
 const ANSI = {
   reset: "\x1b[0m", bold: "\x1b[1m", dim: "\x1b[2m",
@@ -72,9 +73,9 @@ const bins = [
   { name: "node", required: false },
   { name: "python3", required: false },
   { name: "git", required: true },
-  { name: "codex", required: false },
-  { name: "claude", required: false },
-  { name: "gemini", required: false },
+  // Agent runtimes are NOT listed here — they come from the driver's own
+  // roster below. This array used to carry 3 of the 9 (codex, claude, gemini),
+  // so the other six never appeared in the report even when installed.
 ];
 
 for (const b of bins) {
@@ -90,6 +91,29 @@ for (const b of bins) {
     add(`binary: ${b.name}`, b.required ? "FAIL" : "WARN", "not found in PATH");
   }
 }
+
+// SECTION 1a: AGENT RUNTIMES — one line per adapter the dispatch engine
+// supports, from the driver's roster (never a local copy). Each is individually
+// optional: dispatch falls through to the next one on PATH. What is NOT
+// optional is having at least one — with zero runtimes no dispatch can run,
+// which is a FAIL on the summary line, not nine quiet WARNs.
+let runtimesOnPath = 0;
+for (const rt of listRuntimes()) {
+  const p = which(rt.cli);
+  if (p) {
+    runtimesOnPath++;
+    add(`runtime: ${rt.name}`, "PASS", p);
+  } else {
+    add(`runtime: ${rt.name}`, "WARN", `'${rt.cli}' not found in PATH`);
+  }
+}
+add(
+  "runtime: dispatch",
+  runtimesOnPath > 0 ? "PASS" : "FAIL",
+  runtimesOnPath > 0
+    ? `${runtimesOnPath}/${listRuntimes().length} agent runtime(s) on PATH`
+    : "no agent runtime on PATH — dispatch cannot run; install one (claude, codex, gemini, …)",
+);
 
 // SECTION 1a-bis: CLAUDE CODE AUTH — a persistent CLAUDE_CODE_OAUTH_TOKEN export
 // in a shell startup file (the pattern our own docs used to recommend) makes the

--- a/skills/harness/tests/doctor-runtimes.test.ts
+++ b/skills/harness/tests/doctor-runtimes.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The doctor reports every runtime the dispatch engine supports, from the
+ * driver's own roster — never from a local copy.
+ *
+ * The dispatch driver supports nine agent CLIs (RUNTIMES). The doctor's
+ * BINARIES section carried a private, hardcoded list holding three of them, so
+ * grok, pi, agy, kimi, qwen and opencode never appeared in the report even
+ * when installed and perfectly dispatchable — on every OS. Duplicated lists
+ * drift; these cases lock the three lists (RUNTIMES, RUNTIME_BINS, the
+ * doctor's probe set) to one source of truth.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { listRuntimes, __testables } from "../../_shared/lib/host-agent-driver.ts";
+
+const DOCTOR = join(import.meta.dir, "..", "scripts", "doctor-system.ts");
+
+describe("listRuntimes is the roster, verbatim", () => {
+  test("it returns exactly the adapters RUNTIMES declares, in order", () => {
+    const fromSeam = __testables.RUNTIMES.map((r: { name: string; cli: string }) => ({ name: r.name, cli: r.cli }));
+    expect(listRuntimes()).toEqual(fromSeam);
+    // The number is not pinned by hand on purpose: a 10th adapter must flow
+    // through without editing this test. What IS pinned is non-emptiness and
+    // uniqueness — an empty or duplicated roster is a broken driver.
+    const names = listRuntimes().map((r) => r.name);
+    expect(names.length).toBeGreaterThanOrEqual(9);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("RUNTIME_BINS mirrors it exactly — the literal is drift-proofed here", () => {
+    // The Record<Runtime, string> literal is kept (its exhaustive key type
+    // makes a missing Runtime member a compile error), and THIS is the check
+    // that its values never drift from the adapters'.
+    for (const rt of listRuntimes()) {
+      // runtimeAvailable resolves through RUNTIME_BINS; the probe command it
+      // builds must target the same binary the adapter declares. Read the
+      // mapping straight from the source to compare without exporting it.
+      const src = readFileSync(join(import.meta.dir, "..", "..", "_shared", "lib", "host-agent-driver.ts"), "utf8");
+      const m = src.match(new RegExp(`"${rt.name}":\\s*"([^"]+)"`));
+      expect(m, `RUNTIME_BINS has no entry for ${rt.name}`).toBeTruthy();
+      expect(m![1]).toBe(rt.cli);
+    }
+  });
+});
+
+describe("the doctor consumes the roster instead of copying it", () => {
+  const src = readFileSync(DOCTOR, "utf8");
+
+  test("it imports and iterates listRuntimes", () => {
+    expect(src).toContain('import { listRuntimes }');
+    expect(src).toContain("for (const rt of listRuntimes())");
+  });
+
+  test("its bins array carries no agent runtime", () => {
+    // The infra binaries stay; every runtime binary name inside the bins
+    // literal would be the drift starting over.
+    const bins = src.slice(src.indexOf("const bins = ["), src.indexOf("];", src.indexOf("const bins = [")));
+    for (const rt of listRuntimes()) {
+      expect(bins, `bins hardcodes the runtime binary "${rt.cli}"`).not.toContain(`"${rt.cli}"`);
+    }
+    for (const infra of ["bun", "git", "node", "python3"]) expect(bins).toContain(`"${infra}"`);
+  });
+
+  test("no runtime is individually fatal, and zero runtimes is", () => {
+    // Each missing runtime is a WARN (dispatch falls through to the next);
+    // the FAIL belongs to the summary line alone, when none is on PATH.
+    expect(src).toMatch(/add\(`runtime: \$\{rt\.name\}`, "WARN"/);
+    expect(src).toContain('runtimesOnPath > 0 ? "PASS" : "FAIL"');
+  });
+});

--- a/skills/harness/tests/doctor-runtimes.test.ts
+++ b/skills/harness/tests/doctor-runtimes.test.ts
@@ -66,6 +66,9 @@ describe("the doctor consumes the roster instead of copying it", () => {
     // Each missing runtime is a WARN (dispatch falls through to the next);
     // the FAIL belongs to the summary line alone, when none is on PATH.
     expect(src).toMatch(/add\(`runtime: \$\{rt\.name\}`, "WARN"/);
-    expect(src).toContain('runtimesOnPath > 0 ? "PASS" : "FAIL"');
+    // FAIL on a user machine; WARN on a headless CI runner, where zero
+    // runtimes is the expected state (the smoke job installs the engine on a
+    // bare image to prove the install itself).
+    expect(src).toContain('runtimesOnPath > 0 ? "PASS" : headlessCI ? "WARN" : "FAIL"');
   });
 });


### PR DESCRIPTION
`nrv doctor` probed 3 of the 9 runtimes the dispatch driver supports, from its own hardcoded copy of the list. grok, pi, agy, kimi, qwen and opencode never appeared even when installed — on any OS.

- `listRuntimes()` exported from the driver (name + cli, straight from `RUNTIMES`)
- doctor iterates it in a RUNTIME section: missing runtime = WARN, and a `runtime: dispatch` summary that is PASS with ≥1 on PATH, FAIL with zero
- `RUNTIME_BINS` stays a literal on purpose (exhaustive `Record<Runtime, string>` is a compile-time check a derived object would lose); the mirror is drift-proofed by test
- tests also assert the doctor's `bins` array carries no runtime binary and its probe set IS `listRuntimes()`

On this machine: 9 lines, 6 PASS, `dispatch 6/9`. Suites `skills/harness` + `skills/_shared`: **853 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)