### PR TITLE
feat(init): adopting Nirvana asks before changing an existing project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,12 @@ skills/harness/tests/reports/
 # skills/harness/scripts/build-golden-set.ts; only the hand-written
 # golden-negatives.json is committed.
 skills/harness/baselines/golden-routing.json
+
+# The project-skeleton TEMPLATES are product files, not local state. The plain
+# `.env` / `.nirvana/` patterns above swallowed them silently: they existed on
+# the author's machine, never reached the repo, and every install shipped
+# without them — while the tarball carries an allowlist expecting exactly
+# these paths. (Field report, 2026-08-18.)
+!skills/_shared/templates/project-skeleton/.env
+!skills/_shared/templates/project-skeleton/.nirvana/
+!skills/_shared/templates/project-skeleton/.nirvana/README.md

--- a/skills/_shared/lib/bun-helpers.ts
+++ b/skills/_shared/lib/bun-helpers.ts
@@ -196,12 +196,20 @@ export const expandPath = (p: string) =>
 // ─────────────────────────────────────────────────────────────────────
 
 let _quiet = false;
+// Streams carry meaning: info/ok are progress and go to STDOUT; warn/fail are
+// problems and go to STDERR. Everything used to go to stderr, and PowerShell
+// paints stderr red — so a healthy `nrv init` rendered as a wall of red
+// "errors" on Windows, [ok] lines included. Color only when the stream is a
+// TTY and NO_COLOR is unset: yellow for warn, red for fail, so a warning never
+// reads as a failure even on terminals that tint stderr themselves.
+const paint = (stream: NodeJS.WriteStream, code: string, msg: string): string =>
+  stream.isTTY && !process.env.NO_COLOR ? `\x1b[${code}m${msg}\x1b[0m` : msg;
 export const log = {
   setQuiet(v: boolean) { _quiet = v; },
-  info(msg: string) { if (!_quiet) console.error(`[info] ${msg}`); },
-  ok(msg: string) { if (!_quiet) console.error(`[ok]   ${msg}`); },
-  warn(msg: string) { if (!_quiet) console.error(`[warn] ${msg}`); },
-  fail(msg: string) { console.error(`[fail] ${msg}`); },
+  info(msg: string) { if (!_quiet) console.log(`[info] ${msg}`); },
+  ok(msg: string) { if (!_quiet) console.log(paint(process.stdout, "32", `[ok]   ${msg}`)); },
+  warn(msg: string) { if (!_quiet) console.error(paint(process.stderr, "33", `[warn] ${msg}`)); },
+  fail(msg: string) { console.error(paint(process.stderr, "31", `[fail] ${msg}`)); },
 };
 
 // ─────────────────────────────────────────────────────────────────────

--- a/skills/_shared/scripts/init-project.ts
+++ b/skills/_shared/scripts/init-project.ts
@@ -117,7 +117,7 @@ function copyFile(src: string, dst: string, overwrite = false) {
  * If `dst` doesn't exist, it's created from scratch with just the snippet.
  * Preserves the user's pre-existing content untouched (we never overwrite).
  */
-function appendWithMarker(src: string, dst: string, marker: string): boolean {
+function appendWithMarker(src: string, dst: string, marker: string, label = "snippet"): boolean {
   if (!fs.existsSync(src)) {
     log.warn(`snippet missing: ${src}`);
     return false;
@@ -126,16 +126,19 @@ function appendWithMarker(src: string, dst: string, marker: string): boolean {
   if (fs.existsSync(dst)) {
     const existing = fs.readFileSync(dst, "utf8");
     if (existing.includes(marker)) {
-      log.info(`marker present, no append: ${dst}`);
+      log.info(`${label} already present: ${dst}`);
       return false;
     }
     fs.appendFileSync(dst, snippet);
-    log.ok(`appended writing contract to ${dst}`);
+    // Two different contracts used to log the same "appended writing contract"
+    // line, so one run printed it twice and the reader could not tell WHAT
+    // changed in their file. The label says which contract landed.
+    log.ok(`appended ${label} to ${dst}`);
     return true;
   }
   ensureDir(path.dirname(dst));
   fs.writeFileSync(dst, snippet, "utf8");
-  log.ok(`created ${dst} (snippet only — no base template)`);
+  log.ok(`created ${dst} (${label} only — no base template)`);
   return true;
 }
 
@@ -201,6 +204,10 @@ USAGE
   bun init-project.ts <target_dir>                    create project at <target_dir>
   bun init-project.ts <target_dir> --scope=project    set NIRVANA_SCOPE=project in .env
   bun init-project.ts <target_dir> --scope=merge      set NIRVANA_SCOPE=merge in .env
+  bun init-project.ts <target_dir> --orchestrators=always     Nirvana is the default orchestrator
+  bun init-project.ts <target_dir> --orchestrators=on-demand  Nirvana acts only when explicitly asked
+                                   (no flag + existing AGENTS/CLAUDE/GEMINI.md + TTY → you are asked,
+                                    on-demand recommended; non-interactive keeps "always")
   bun init-project.ts <target_dir> --with-skills      symlink .agents/skills → ~/.nirvana/skills
   bun init-project.ts <target_dir> --copy             embed a snapshot of all skills (portable)
   bun init-project.ts <target_dir> --link             re-run skill linking (no-op without --with-skills)
@@ -256,7 +263,7 @@ EXAMPLES
 `);
 }
 
-function main() {
+async function main() {
   const { positional, flags } = parseArgs();
 
   if (flags.h || flags.help) {
@@ -283,6 +290,11 @@ function main() {
   const withSkills = !!flags["with-skills"] || useCopy;
   const scope = (flags["scope"] as string) || null;
   const force = !!flags.force;
+  let orchestrators = (flags["orchestrators"] as string) || null;
+  if (orchestrators && orchestrators !== "always" && orchestrators !== "on-demand") {
+    log.fail(`--orchestrators must be "always" or "on-demand" (got "${orchestrators}")`);
+    process.exit(EXIT.INVALID_ARGS);
+  }
 
   if (!fs.existsSync(TEMPLATE_DIR)) {
     log.fail(`Template not found: ${TEMPLATE_DIR}`);
@@ -293,7 +305,20 @@ function main() {
   ensureDir(target);
 
   if (!linkOnly) {
-    copyFile(path.join(TEMPLATE_DIR, ".env"), path.join(target, ".env"), force);
+    // The .env is a promised output — the final hint tells the user to edit it
+    // and --scope rewrites it. When the template is missing (one install
+    // shipped without it), the old flow warned, finished "[ok] done" and
+    // pointed the user at a file that did not exist; --scope crashed on the
+    // read. A generic fallback keeps the promise; the warn still names the
+    // missing template so the install can be repaired.
+    if (!copyFile(path.join(TEMPLATE_DIR, ".env"), path.join(target, ".env"), force)
+        && !fs.existsSync(path.join(target, ".env"))) {
+      fs.writeFileSync(path.join(target, ".env"),
+        "# Nirvana project config (generated fallback — template was missing).\n" +
+        "# Full reference: .env.example — scope: global | project | merge\n" +
+        "NIRVANA_SCOPE=global\n", "utf8");
+      log.ok(`wrote ${path.join(target, ".env")} (generated fallback)`);
+    }
     copyFile(path.join(TEMPLATE_DIR, ".env.example"), path.join(target, ".env.example"), true);
     copyFile(path.join(TEMPLATE_DIR, ".gitignore"), path.join(target, ".gitignore"), force);
     copyFile(path.join(TEMPLATE_DIR, "README.md"), path.join(target, "README.md"), force);
@@ -310,9 +335,54 @@ function main() {
     //      already present (idempotent). Pre-existing user rules are preserved.
     const agentsTemplate = path.join(SKILLS_ROOT, "_shared", "templates", "AGENTS.md");
     const writingContractSnippet = path.join(SKILLS_ROOT, "_shared", "templates", "writing-contract-snippet.md");
+    const onDemandSnippet = path.join(SKILLS_ROOT, "_shared", "templates", "on-demand-contract-snippet.md");
     const WRITING_CONTRACT_MARKER = "<!-- nirvana-os:writing-contract:v1 -->";
     const INVOCATION_CONTRACT_MARKER = "<!-- nirvana-os:invocation-contract:v1 -->";
-    if (fs.existsSync(agentsTemplate)) {
+    const ON_DEMAND_MARKER = "<!-- nirvana-os:on-demand-contract:v1 -->";
+
+    // How Nirvana behaves in THIS project is the owner's call, and it matters
+    // most exactly when the project already has instruction files: appending
+    // the invocation contract to a pre-existing AGENTS.md turns Nirvana into
+    // the default orchestrator for every agent in the repo — a significant,
+    // silent behavior change for a project that was already configured.
+    //
+    //   always    → Nirvana is the default orchestrator (the full contract)
+    //   on-demand → Nirvana acts only when explicitly asked ("use o Nirvana
+    //               para X"); instruction files gain one short marked note and
+    //               nothing else
+    //
+    // Interactive TTY with pre-existing instruction files and no flag: ask,
+    // recommending on-demand. Non-interactive without a flag keeps the
+    // historical default (always) so CI and scripts do not change behavior.
+    const preexisting = ["AGENTS.md", "CLAUDE.md", "GEMINI.md"].filter((n) => fs.existsSync(path.join(target, n)));
+    if (!orchestrators && preexisting.length && process.stdin.isTTY && process.stdout.isTTY) {
+      const readline = require("node:readline/promises");
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      const answer = (await rl.question(
+        `\nThis project already has ${preexisting.join(", ")}.\n` +
+        `How should Nirvana's orchestrators behave here?\n` +
+        `  [1] on-demand (recommended for existing projects) — act only when explicitly asked\n` +
+        `  [2] always — Nirvana becomes the default orchestrator for every agent\n` +
+        `Choice [1/2, default 1]: `)).trim();
+      rl.close();
+      orchestrators = answer === "2" ? "always" : "on-demand";
+    }
+    if (!orchestrators) {
+      orchestrators = "always";
+      if (preexisting.length) {
+        log.info(`pre-existing instruction files found; using --orchestrators=always (the historical default). Pass --orchestrators=on-demand to keep Nirvana opt-in here.`);
+      }
+    }
+
+    if (orchestrators === "on-demand") {
+      // Structure and global skills stay available; instruction files gain ONE
+      // short marked note telling agents Nirvana exists and acts only on
+      // explicit request. No invocation contract, no writing contract — the
+      // project's configured behavior stays its own.
+      for (const name of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) {
+        appendWithMarker(onDemandSnippet, path.join(target, name), ON_DEMAND_MARKER, "on-demand contract");
+      }
+    } else if (fs.existsSync(agentsTemplate)) {
       for (const name of ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]) {
         const dst = path.join(target, name);
         // Phase 1: only copy the base if the file is absent (never overwrite
@@ -331,10 +401,10 @@ function main() {
           // So the invocation contract is appended too, under its own marker,
           // with the user's rules untouched above it.
           log.warn(`exists, kept: ${dst}`);
-          appendWithMarker(agentsTemplate, dst, INVOCATION_CONTRACT_MARKER);
+          appendWithMarker(agentsTemplate, dst, INVOCATION_CONTRACT_MARKER, "invocation contract");
         }
         // Phase 2: append the writing contract (idempotent via marker).
-        appendWithMarker(writingContractSnippet, dst, WRITING_CONTRACT_MARKER);
+        appendWithMarker(writingContractSnippet, dst, WRITING_CONTRACT_MARKER, "writing contract");
       }
     } else {
       log.warn(`AGENTS.md template missing: ${agentsTemplate} — skipping agent contract`);
@@ -342,6 +412,12 @@ function main() {
 
     if (scope && scope !== "global") {
       const envPath = path.join(target, ".env");
+      if (!fs.existsSync(envPath)) {
+        // Unreachable while the fallback above holds, but --scope crashing
+        // with a raw ENOENT stack was how the missing template surfaced.
+        log.fail(`cannot set scope: ${envPath} does not exist`);
+        process.exit(EXIT.FAILURES);
+      }
       let env = fs.readFileSync(envPath, "utf8");
       env = env.replace(/^NIRVANA_SCOPE=.*$/m, `NIRVANA_SCOPE=${scope}`);
       fs.writeFileSync(envPath, env);
@@ -494,4 +570,4 @@ function main() {
   process.exit(EXIT.OK);
 }
 
-main();
+await main();

--- a/skills/_shared/templates/on-demand-contract-snippet.md
+++ b/skills/_shared/templates/on-demand-contract-snippet.md
@@ -1,0 +1,14 @@
+
+<!-- nirvana-os:on-demand-contract:v1 -->
+## Nirvana-OS — available on demand
+
+Nirvana-OS is installed in this environment, in **on-demand mode**: it is NOT
+the default orchestrator for this project. Do not route ordinary work through
+it, and do not treat its protocols as this project's defaults.
+
+Invoke it ONLY when the user explicitly asks — "use o Nirvana para X", "use
+Nirvana to X", "dispatch this to a squad/business". On that request, invoke the
+`harness` skill with the user's brief verbatim and let it orchestrate
+(businesses → squads → quality gate → audit). Utility lookups on request:
+`nrv list-squads`, `nrv list-businesses`, `nrv find-clone "<need>"`,
+`nrv glance`.

--- a/skills/_shared/templates/project-skeleton/.env
+++ b/skills/_shared/templates/project-skeleton/.env
@@ -1,0 +1,9 @@
+# Nirvana project config — the ACTIVE settings this project runs with.
+# Full reference of every variable: .env.example (same directory).
+# The initializer copies this file; `nrv init --scope=<mode>` rewrites the line below.
+
+# Visibility of squads/businesses/mind-clones to this project.
+#   global  → only ~/squads/* and ~/businesses/* (default)
+#   project → only <project>/.nirvana/{squads,businesses,mind-clones}/*
+#   merge   → both; project entries override global entries with the same slug
+NIRVANA_SCOPE=global

--- a/skills/_shared/templates/project-skeleton/.nirvana/README.md
+++ b/skills/_shared/templates/project-skeleton/.nirvana/README.md
@@ -1,0 +1,13 @@
+# .nirvana/ — this project's Nirvana state
+
+Created by `nrv init`. What lives here:
+
+| Path | What it is |
+|---|---|
+| `squads/`, `businesses/`, `mind-clones/` | project-local entities (visible under `NIRVANA_SCOPE=project` or `merge`) |
+| `briefs/` | enriched briefs the orchestrator writes before dispatching |
+| `plans/` | project plans |
+| `outputs/<trace>/` | dispatched runs' artifacts and audit trails |
+
+The global library (`~/squads`, `~/businesses`) stays untouched; scope is picked
+in the project's `.env` (`NIRVANA_SCOPE`).

--- a/skills/harness/tests/init-existing-project.test.ts
+++ b/skills/harness/tests/init-existing-project.test.ts
@@ -85,3 +85,103 @@ describe("a project that already has a contract file", () => {
     }
   }, INIT_TIMEOUT_MS);
 });
+
+/**
+ * On-demand mode — adopting Nirvana must not silently change a configured
+ * project.
+ *
+ * Appending the invocation contract to a pre-existing AGENTS.md turns Nirvana
+ * into the default orchestrator for every agent in the repo. That is the right
+ * default for a fresh project and a significant silent change for an existing
+ * one — the owner asked for the choice: --orchestrators=always keeps the
+ * historical behavior, --orchestrators=on-demand leaves the project's rules
+ * alone and adds one short marked note ("act only when explicitly asked").
+ * Non-interactive without a flag stays "always", so CI does not change.
+ */
+function runInitWith(dir: string, ...args: string[]) {
+  return spawnSync(process.execPath, [INIT, ".", ...args], {
+    cwd: dir, encoding: "utf8",
+    env: { ...process.env, NIRVANA_SKILLS_DIR: path.join(ROOT, "skills") },
+  });
+}
+
+describe("on-demand mode leaves the project's behavior alone", () => {
+  test("existing files gain only the on-demand note — no invocation, no writing contract", () => {
+    const dir = project("od-existing", { "AGENTS.md": "# Mine\nMY LINE\n" });
+    runInitWith(dir, "--orchestrators=on-demand");
+    const agents = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+    expect(agents).toContain("MY LINE");
+    expect(agents).toContain("nirvana-os:on-demand-contract:v1");
+    expect(agents).toContain("ONLY when the user explicitly asks");
+    expect(agents).not.toContain("nirvana-os:invocation-contract:v1");
+    expect(agents).not.toContain("nirvana-os:writing-contract:v1");
+    expect(agents).not.toMatch(/invoke the .?harness.? skill for any concrete artifact/i);
+  }, INIT_TIMEOUT_MS);
+
+  test("files init creates in on-demand mode carry the note and nothing else", () => {
+    const dir = project("od-created", { "AGENTS.md": "# Mine\n" });
+    runInitWith(dir, "--orchestrators=on-demand");
+    const claude = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
+    expect(claude).toContain("nirvana-os:on-demand-contract:v1");
+    expect(claude).not.toContain("nirvana-os:invocation-contract:v1");
+  }, INIT_TIMEOUT_MS);
+
+  test("on-demand is idempotent", () => {
+    const dir = project("od-twice", { "AGENTS.md": "# Mine\n" });
+    runInitWith(dir, "--orchestrators=on-demand");
+    const first = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+    runInitWith(dir, "--orchestrators=on-demand");
+    expect(fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8")).toBe(first);
+  }, INIT_TIMEOUT_MS);
+
+  test("an invalid mode is rejected, not guessed", () => {
+    const dir = project("od-bad");
+    const r = runInitWith(dir, "--orchestrators=sometimes");
+    expect(r.status).not.toBe(0);
+    expect(`${r.stderr}`).toContain('"always" or "on-demand"');
+  }, INIT_TIMEOUT_MS);
+
+  test("non-interactive without a flag keeps the historical default (always)", () => {
+    // The five cases in the block above run exactly this way — pinned here by
+    // name so the compat promise is explicit rather than incidental.
+    const dir = project("od-default", { "CLAUDE.md": "# Mine\n" });
+    runInit(dir);
+    expect(fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8")).toContain("nirvana-os:invocation-contract:v1");
+  }, INIT_TIMEOUT_MS);
+});
+
+describe("the promised .env exists even when the template does not", () => {
+  test("a skills tree without the template still yields a working .env, and --scope works on it", () => {
+    // One install shipped without project-skeleton/.env: init warned, finished
+    // "[ok] done", pointed the user at a file that did not exist — and --scope
+    // crashed on the read. The fallback keeps the promise the help makes.
+    const stripped = path.join(TMP, "stripped-skills");
+    fs.cpSync(path.join(ROOT, "skills", "_shared", "templates"), path.join(stripped, "_shared", "templates"), { recursive: true });
+    fs.cpSync(path.join(ROOT, "skills", "_shared", "lib"), path.join(stripped, "_shared", "lib"), { recursive: true });
+    fs.rmSync(path.join(stripped, "_shared", "templates", "project-skeleton", ".env"));
+
+    const dir = project("env-fallback");
+    const r = spawnSync(process.execPath, [INIT, ".", "--scope=project"], {
+      cwd: dir, encoding: "utf8",
+      env: { ...process.env, NIRVANA_SKILLS_DIR: stripped },
+    });
+    expect(r.status).toBe(0);
+    const env = fs.readFileSync(path.join(dir, ".env"), "utf8");
+    expect(env).toContain("NIRVANA_SCOPE=project");
+  }, INIT_TIMEOUT_MS);
+});
+
+describe("streams carry meaning — PowerShell paints stderr red", () => {
+  test("progress goes to stdout; only warnings and failures go to stderr", () => {
+    // Everything used to go to stderr, so a healthy init rendered as a wall of
+    // red on Windows, [ok] lines included.
+    const dir = project("streams", { "CLAUDE.md": "# Mine\n" });
+    const r = runInit(dir);
+    expect(`${r.stdout}`).toContain("[ok]");
+    expect(`${r.stderr}`).not.toContain("[ok]");
+    expect(`${r.stderr}`).not.toContain("[info]");
+    // and the two contract appends are distinguishable in the log
+    expect(`${r.stdout}`).toContain("appended invocation contract");
+    expect(`${r.stdout}`).toContain("appended writing contract");
+  }, INIT_TIMEOUT_MS);
+});


### PR DESCRIPTION
Field report, six defects, all fixed:

1. **Silent takeover**: init auto-appended the invocation contract to a pre-existing AGENTS.md and created CLAUDE/GEMINI.md with it — every agent in the repo switched to Nirvana as default orchestrator. Now: `--orchestrators=always|on-demand`; a TTY with pre-existing instruction files and no flag gets asked (on-demand recommended); non-interactive keeps `always` so CI is unchanged. On-demand appends one short marked note — act only when explicitly asked — and nothing else.
2. **`project-skeleton/.env` missing from the install** (the tarball carries an allowlist for it — it was designed to exist): template restored + generated fallback, so the `.env` the final hint points at always exists.
3. **`--scope=project|merge` crashed** on the missing `.env` with a raw ENOENT: guarded with a named failure (unreachable while the fallback holds).
4. **`project-skeleton/.nirvana/README.md`** restored.
5. **"appended writing contract" printed twice** for two different contracts: the label now says which one landed.
6. **Wall of red on Windows**: all log levels went to stderr and PowerShell paints stderr red. info/ok → stdout, warn → stderr yellow, fail → stderr red — shared fix in `bun-helpers`, inherited by every script.

12 init tests (5 existing + 7 new) · suites harness + _shared + businesses: **872 pass, 0 fail** · `check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)