### PR TITLE
fix(windows): avoid nul files from agent hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### Portable agent hook commands on Windows
+
+Claude Code, Gemini CLI, and Antigravity audit hooks no longer append
+shell-specific null-device redirections. Some Windows hook runners interpreted
+`2>nul` as a regular relative path and created a `nul` file in the active
+project, which also disrupted OneDrive synchronization. The hook scripts are
+already fail-safe and exit successfully on internal errors, so the redirection
+was unnecessary.
+
 ## 0.7.3 — 2026-08-20
 
 ### The engine learns what relates to what

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,17 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Comandos portáveis dos hooks de agentes no Windows
+
+Os hooks de auditoria do Claude Code, Gemini CLI e Antigravity não acrescentam
+mais redirecionamentos de dispositivo nulo específicos do shell. Alguns runners
+de hooks no Windows interpretavam `2>nul` como um caminho relativo comum e
+criavam um arquivo `nul` no projeto ativo, o que também interrompia o sincronismo
+do OneDrive. Os scripts dos hooks já são fail-safe e encerram com sucesso em
+caso de erro interno, portanto o redirecionamento era desnecessário.
+
 ## 0.7.3 — 2026-08-20
 
 ### O engine aprende o que se relaciona com o quê

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -43,11 +43,6 @@ const SKILLS_DIR = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
 const HOOK_SCRIPT = path.join(SKILLS_DIR, "_shared", "scripts", "audit-emit-from-hook.ts");
 const SESSION_START_SCRIPT = path.join(SKILLS_DIR, "_shared", "scripts", "gemini-session-start.ts");
-// stderr suppression that's valid on the shell each runtime uses to run hooks:
-// cmd.exe wants `2>nul` and has no `|| true`; POSIX shells want the bash form.
-// Hook paths are ALWAYS quoted below so a space in the username (C:\Users\John Doe)
-// doesn't truncate argv.
-const HOOK_SUPPRESS = process.platform === "win32" ? "2>nul" : "2>/dev/null || true";
 
 interface HookSpec {
   matcher?: string;
@@ -70,7 +65,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre claude-code ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre claude-code`,
           async: true,
           timeout: 5,
         }],
@@ -80,7 +75,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post claude-code ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post claude-code`,
           async: true,
           timeout: 5,
         }],
@@ -96,7 +91,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre gemini-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre gemini-cli`,
           timeout: 5000,
         }],
       }],
@@ -105,7 +100,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post gemini-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post gemini-cli`,
           timeout: 5000,
         }],
       }],
@@ -113,7 +108,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-session-start",
           type: "command",
-          command: `bun "${SESSION_START_SCRIPT}" ${HOOK_SUPPRESS}`,
+          command: `bun "${SESSION_START_SCRIPT}"`,
           timeout: 5000,
         }],
       }],
@@ -131,7 +126,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre antigravity-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre antigravity-cli`,
           timeout: 5000,
         }],
       }],
@@ -140,7 +135,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post antigravity-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post antigravity-cli`,
           timeout: 5000,
         }],
       }],
@@ -148,7 +143,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-session-start",
           type: "command",
-          command: `bun "${SESSION_START_SCRIPT}" ${HOOK_SUPPRESS}`,
+          command: `bun "${SESSION_START_SCRIPT}"`,
           timeout: 5000,
         }],
       }],

--- a/skills/harness/tests/hook-command-portability.test.ts
+++ b/skills/harness/tests/hook-command-portability.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const hookInstaller = fs.readFileSync(path.join(ROOT, "skills/_shared/scripts/install.ts"), "utf8");
+
+describe("agent hook command portability", () => {
+  test("does not append shell-specific null-device redirections", () => {
+    expect(hookInstaller).not.toContain("HOOK_SUPPRESS");
+    expect(hookInstaller).not.toMatch(/2\s*>\s*(?:nul|\/dev\/null)/i);
+  });
+});


### PR DESCRIPTION
## What this changes

Windows hook commands for Claude Code, Gemini CLI, and Antigravity no longer append shell-specific null-device redirections. Some hook runners interpret `2>nul` as a relative file path and create a literal `nul` entry in the active project, which breaks OneDrive synchronization.

The audit and session-start scripts already fail safely, so the redirection was unnecessary. This change removes it from the canonical hook installer, adds a regression test that rejects future null-device redirections, and documents the behavior in both changelogs.

## How it was tested

- `bun test skills/harness/tests/hook-command-portability.test.ts skills/harness/tests/install-teaches-init.test.ts`: 8 passed, 0 failed.
- TDD regression check: the new portability test failed against the original `HOOK_SUPPRESS` implementation and passed after the fix.
- Windows smoke test in a temporary directory under the project: pre-hook, post-hook, and session-start commands were exercised through the relevant `cmd.exe` and PowerShell runners. Every command returned exit code 0, settings remained valid JSON, audit events were preserved, and no `nul` item was created.
- `bun run check:all`: static command/audit/source/changelog/version checks passed; the aggregate command stopped at content-library ratchets because this public checkout has no local coverage or `not_for` baselines.
- `bun test`: 884 passed, 30 skipped, 25 failed. The observed failures are in environment-dependent suites outside the changed files, including Windows symlink permissions, locale formatting, runtime shim execution, Bash path handling inside a Windows/OneDrive path, and tests requiring unavailable runtime fixtures.

## Checklist

- [ ] `bun test skills/harness/tests` passes
- [x] No hardcoded model names (the engine never prescribes a model — it inherits the runtime's)
- [x] No paid pack content, secrets, or `.env` values added to the engine
- [ ] **I have read and agree to the Nirvana-OS CLA v1.0** ([CLA.md](../CLA.md))

The CLA checkbox is intentionally left for the contributor to confirm personally.
