### PR TITLE
feat(protocol): offer upstream contribution PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,41 @@ audit chain), and a pointer to run `nrv init` per project ...
 
 Rules: replace an existing managed block, never append a second; edit only the content between the markers; never reformat or delete the user's own lines. The block is removable by the user or by `nrv uninstall`.
 
+<!-- nirvana:upstream-contribution:v1 -->
+## 11. Upstream contribution offers
+
+Offer an upstream contribution in either qualified situation: a confirmed
+defect or correction belongs to the shared Nirvana engine/core, or the user
+proposes an improvement idea that applies to the shared Nirvana engine/core.
+Do not offer one for project-only behavior, personal configuration, user
+content, paid packs, or unverified hypotheses.
+
+Follow this consent workflow:
+
+1. For a confirmed defect, finish and validate the local workaround before you
+   offer an upstream contribution.
+2. For an improvement idea, explain that accepting the offer means turning it
+   into a concrete change, implementing it, testing it, and preparing the
+   contribution.
+3. Obtain explicit initial consent before creating a fork or branch, pushing
+   code, or opening a PR or pull request.
+4. After initial consent, check for an equivalent open PR or pull request before
+   doing duplicate work.
+5. Prepare a focused change from the current upstream default branch, with
+   relevant tests, user-visible changelogs when applicable, and the repository's
+   pull request template.
+6. Before external publication, show the complete proposed PR title and body to
+   the user and wait for explicit final approval.
+7. Create the PR ready for review by default. Use a draft only when a concrete
+   blocker prevents review, and explain that blocker.
+8. Inspect the CLA check after publication. CLA signatures are normally
+   one-time per contributor. If it is already satisfied, report that without
+   asking again. If the CLA check requires a signature, give the user the PR
+   link and this exact phrase:
+   `I have read the CLA Document and I hereby sign the CLA`. Do not sign or
+   attest legal consent for the user.
+<!-- /nirvana:upstream-contribution:v1 -->
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### Upstream contributions require explicit consent
+
+Nirvana now offers to prepare an upstream pull request when a confirmed fix or
+improvement idea belongs to the shared engine/core. Project-only behavior,
+personal configuration, user content, paid packs, and unverified hypotheses are
+excluded. The protocol requires consent before GitHub work, a complete title
+and body preview before publication, and a second explicit approval before a
+review-ready PR is opened. It also reports the CLA check after publication and
+asks for the repository's exact signature phrase only when the contributor has
+not already satisfied it.
+
 ## 0.7.3 — 2026-08-20
 
 ### The engine learns what relates to what

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,20 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Contribuições upstream exigem consentimento explícito
+
+O Nirvana agora oferece preparar um pull request upstream quando uma correção
+confirmada ou ideia de melhoria pertence ao engine/core compartilhado.
+Comportamentos exclusivos do projeto, configuração pessoal, conteúdo do usuário,
+packs pagos e hipóteses não verificadas ficam de fora. O protocolo exige
+consentimento antes do trabalho no GitHub, a apresentação do título e do corpo
+completos antes da publicação e uma segunda aprovação explícita antes de abrir
+um PR pronto para revisão. Ele também informa o estado da CLA após a publicação
+e só pede a frase exata de assinatura do repositório quando o colaborador ainda
+não a tiver satisfeito.
+
 ## 0.7.3 — 2026-08-20
 
 ### O engine aprende o que se relaciona com o quê

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,41 @@ audit chain), and a pointer to run `nrv init` per project ...
 
 Rules: replace an existing managed block, never append a second; edit only the content between the markers; never reformat or delete the user's own lines. The block is removable by the user or by `nrv uninstall`.
 
+<!-- nirvana:upstream-contribution:v1 -->
+## 11. Upstream contribution offers
+
+Offer an upstream contribution in either qualified situation: a confirmed
+defect or correction belongs to the shared Nirvana engine/core, or the user
+proposes an improvement idea that applies to the shared Nirvana engine/core.
+Do not offer one for project-only behavior, personal configuration, user
+content, paid packs, or unverified hypotheses.
+
+Follow this consent workflow:
+
+1. For a confirmed defect, finish and validate the local workaround before you
+   offer an upstream contribution.
+2. For an improvement idea, explain that accepting the offer means turning it
+   into a concrete change, implementing it, testing it, and preparing the
+   contribution.
+3. Obtain explicit initial consent before creating a fork or branch, pushing
+   code, or opening a PR or pull request.
+4. After initial consent, check for an equivalent open PR or pull request before
+   doing duplicate work.
+5. Prepare a focused change from the current upstream default branch, with
+   relevant tests, user-visible changelogs when applicable, and the repository's
+   pull request template.
+6. Before external publication, show the complete proposed PR title and body to
+   the user and wait for explicit final approval.
+7. Create the PR ready for review by default. Use a draft only when a concrete
+   blocker prevents review, and explain that blocker.
+8. Inspect the CLA check after publication. CLA signatures are normally
+   one-time per contributor. If it is already satisfied, report that without
+   asking again. If the CLA check requires a signature, give the user the PR
+   link and this exact phrase:
+   `I have read the CLA Document and I hereby sign the CLA`. Do not sign or
+   attest legal consent for the user.
+<!-- /nirvana:upstream-contribution:v1 -->
+
 
 
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -250,6 +250,41 @@ audit chain), and a pointer to run `nrv init` per project ...
 
 Rules: replace an existing managed block, never append a second; edit only the content between the markers; never reformat or delete the user's own lines. The block is removable by the user or by `nrv uninstall`.
 
+<!-- nirvana:upstream-contribution:v1 -->
+## 11. Upstream contribution offers
+
+Offer an upstream contribution in either qualified situation: a confirmed
+defect or correction belongs to the shared Nirvana engine/core, or the user
+proposes an improvement idea that applies to the shared Nirvana engine/core.
+Do not offer one for project-only behavior, personal configuration, user
+content, paid packs, or unverified hypotheses.
+
+Follow this consent workflow:
+
+1. For a confirmed defect, finish and validate the local workaround before you
+   offer an upstream contribution.
+2. For an improvement idea, explain that accepting the offer means turning it
+   into a concrete change, implementing it, testing it, and preparing the
+   contribution.
+3. Obtain explicit initial consent before creating a fork or branch, pushing
+   code, or opening a PR or pull request.
+4. After initial consent, check for an equivalent open PR or pull request before
+   doing duplicate work.
+5. Prepare a focused change from the current upstream default branch, with
+   relevant tests, user-visible changelogs when applicable, and the repository's
+   pull request template.
+6. Before external publication, show the complete proposed PR title and body to
+   the user and wait for explicit final approval.
+7. Create the PR ready for review by default. Use a draft only when a concrete
+   blocker prevents review, and explain that blocker.
+8. Inspect the CLA check after publication. CLA signatures are normally
+   one-time per contributor. If it is already satisfied, report that without
+   asking again. If the CLA check requires a signature, give the user the PR
+   link and this exact phrase:
+   `I have read the CLA Document and I hereby sign the CLA`. Do not sign or
+   attest legal consent for the user.
+<!-- /nirvana:upstream-contribution:v1 -->
+
 
 
 

--- a/skills/_shared/templates/AGENTS.md
+++ b/skills/_shared/templates/AGENTS.md
@@ -250,3 +250,38 @@ audit chain), and a pointer to run `nrv init` per project ...
 ```
 
 Rules: replace an existing managed block, never append a second; edit only the content between the markers; never reformat or delete the user's own lines. The block is removable by the user or by `nrv uninstall`.
+
+<!-- nirvana:upstream-contribution:v1 -->
+## 11. Upstream contribution offers
+
+Offer an upstream contribution in either qualified situation: a confirmed
+defect or correction belongs to the shared Nirvana engine/core, or the user
+proposes an improvement idea that applies to the shared Nirvana engine/core.
+Do not offer one for project-only behavior, personal configuration, user
+content, paid packs, or unverified hypotheses.
+
+Follow this consent workflow:
+
+1. For a confirmed defect, finish and validate the local workaround before you
+   offer an upstream contribution.
+2. For an improvement idea, explain that accepting the offer means turning it
+   into a concrete change, implementing it, testing it, and preparing the
+   contribution.
+3. Obtain explicit initial consent before creating a fork or branch, pushing
+   code, or opening a PR or pull request.
+4. After initial consent, check for an equivalent open PR or pull request before
+   doing duplicate work.
+5. Prepare a focused change from the current upstream default branch, with
+   relevant tests, user-visible changelogs when applicable, and the repository's
+   pull request template.
+6. Before external publication, show the complete proposed PR title and body to
+   the user and wait for explicit final approval.
+7. Create the PR ready for review by default. Use a draft only when a concrete
+   blocker prevents review, and explain that blocker.
+8. Inspect the CLA check after publication. CLA signatures are normally
+   one-time per contributor. If it is already satisfied, report that without
+   asking again. If the CLA check requires a signature, give the user the PR
+   link and this exact phrase:
+   `I have read the CLA Document and I hereby sign the CLA`. Do not sign or
+   attest legal consent for the user.
+<!-- /nirvana:upstream-contribution:v1 -->

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -126,6 +126,41 @@ The point of rule 4 is the difference between degrading and lying. Working witho
 
 ---
 
+<!-- nirvana:upstream-contribution:v1 -->
+## Upstream contribution offers
+
+Offer an upstream contribution in either qualified situation: a confirmed
+defect or correction belongs to the shared Nirvana engine/core, or the user
+proposes an improvement idea that applies to the shared Nirvana engine/core.
+Do not offer one for project-only behavior, personal configuration, user
+content, paid packs, or unverified hypotheses.
+
+Follow this consent workflow:
+
+1. For a confirmed defect, finish and validate the local workaround before you
+   offer an upstream contribution.
+2. For an improvement idea, explain that accepting the offer means turning it
+   into a concrete change, implementing it, testing it, and preparing the
+   contribution.
+3. Obtain explicit initial consent before creating a fork or branch, pushing
+   code, or opening a PR or pull request.
+4. After initial consent, check for an equivalent open PR or pull request before
+   doing duplicate work.
+5. Prepare a focused change from the current upstream default branch, with
+   relevant tests, user-visible changelogs when applicable, and the repository's
+   pull request template.
+6. Before external publication, show the complete proposed PR title and body to
+   the user and wait for explicit final approval.
+7. Create the PR ready for review by default. Use a draft only when a concrete
+   blocker prevents review, and explain that blocker.
+8. Inspect the CLA check after publication. CLA signatures are normally
+   one-time per contributor. If it is already satisfied, report that without
+   asking again. If the CLA check requires a signature, give the user the PR
+   link and this exact phrase:
+   `I have read the CLA Document and I hereby sign the CLA`. Do not sign or
+   attest legal consent for the user.
+<!-- /nirvana:upstream-contribution:v1 -->
+
 ---
 
 ## Pipeline — Agentic Mode

--- a/skills/harness/tests/upstream-contribution-contract-travels.test.ts
+++ b/skills/harness/tests/upstream-contribution-contract-travels.test.ts
@@ -1,0 +1,74 @@
+// upstream-contribution-contract-travels.test.ts — engine/core fixes and ideas
+// must reach both the harness orchestrator and every project runtime without
+// turning consent into an implied GitHub write.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const read = (relative: string): string => fs.readFileSync(path.join(ROOT, relative), "utf8");
+
+const effectiveSources = [
+  ["harness", read("skills/harness/SKILL.md")],
+  ["nrv init template", read("skills/_shared/templates/AGENTS.md")],
+  ["repository contract", read("AGENTS.md")],
+] as const;
+
+function upstreamContract(source: string): string {
+  const startMarker = "<!-- nirvana:upstream-contribution:v1 -->";
+  const endMarker = "<!-- /nirvana:upstream-contribution:v1 -->";
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end + endMarker.length);
+}
+
+describe("the upstream contribution offer reaches every orchestrator path", () => {
+  test.each(effectiveSources)("%s carries both qualified triggers and the exclusions", (_name, source) => {
+    const contract = upstreamContract(source);
+    expect(contract).toMatch(/confirmed\s+(?:defect|correction|fix)[\s\S]*shared\s+(?:Nirvana\s+)?engine\/core/i);
+    expect(contract).toMatch(/improvement idea[\s\S]*shared (?:Nirvana )?engine\/core/i);
+    for (const excluded of [/project-only/i, /personal configuration/i, /user\s+content/i, /paid packs/i, /unverified (?:hypotheses|hypothesis)/i]) {
+      expect(contract).toMatch(excluded);
+    }
+  });
+
+  test.each(effectiveSources)("%s requires initial consent before GitHub mutation", (_name, source) => {
+    const contract = upstreamContract(source);
+    expect(contract).toMatch(/finish[\s\S]*validate[\s\S]*local workaround[\s\S]*offer/i);
+    expect(contract).toMatch(/initial consent[\s\S]*(?:fork|branch)[\s\S]*push[\s\S]*(?:PR|pull request)/i);
+    expect(contract).toMatch(/after initial consent[\s\S]*equivalent open (?:PR|pull request)/i);
+  });
+
+  test.each(effectiveSources)("%s requires a complete preview and final publication approval", (_name, source) => {
+    const contract = upstreamContract(source);
+    expect(contract).toMatch(/complete proposed PR title and body[\s\S]*explicit final approval/i);
+    expect(contract).toMatch(/ready for review by default/i);
+    expect(contract).toMatch(/draft\s+only\s+when[\s\S]*concrete\s+blocker/i);
+    expect(contract).toMatch(/improvement idea[\s\S]*concrete change[\s\S]*implement[\s\S]*test/i);
+  });
+
+  test.each(effectiveSources)("%s handles the contributor CLA conditionally", (_name, source) => {
+    const contract = upstreamContract(source);
+    expect(contract).toMatch(/CLA\s+signatures?\s+(?:are|is)\s+normally\s+one-time/i);
+    expect(contract).toMatch(/already\s+satisfied[\s\S]*report\s+that[\s\S]*without\s+asking\s+again/i);
+    expect(contract).toMatch(/if (?:the )?CLA check[\s\S]*requires a signature/i);
+    expect(contract).toMatch(/requires a signature[\s\S]*give the user the PR\s+link/i);
+    expect(contract).toContain("I have read the CLA Document and I hereby sign the CLA");
+    expect(contract).toMatch(/do not sign[\s\S]*(?:for|on behalf of) the user/i);
+  });
+});
+
+describe("the project contract reaches the runtime-specific files", () => {
+  test("nrv init consumes the protected template", () => {
+    const init = read("skills/_shared/scripts/init-project.ts");
+    expect(init).toContain('"_shared", "templates", "AGENTS.md"');
+  });
+
+  test("root runtime instruction copies are byte-identical", () => {
+    const canonical = read("AGENTS.md");
+    expect(read("CLAUDE.md")).toBe(canonical);
+    expect(read("GEMINI.md")).toBe(canonical);
+  });
+});


### PR DESCRIPTION
## What this changes

Nirvana now offers to prepare an upstream pull request when a confirmed fix or improvement idea belongs to the shared engine/core. It does not offer this for project-only behavior, personal configuration, user content, paid packs, or unverified hypotheses.

The workflow requires initial consent before any GitHub mutation, checks for an equivalent open PR, and shows the complete title and body for final approval before publication. PRs are opened ready for review by default, with drafts reserved for concrete blockers.

After publication, Nirvana checks the CLA status. Existing signatures are not requested again. When a signature is required, Nirvana provides the PR link and the repository's exact signature phrase without signing on the user's behalf.

## How it was tested

- `bun test skills/harness/tests/upstream-contribution-contract-travels.test.ts skills/harness/tests/behavioral-rules-travel.test.ts skills/harness/tests/init-existing-project.test.ts`: 33 passed, 0 failed.
- Behavioral probes: 0 of 5 baseline agents offered the contribution; 5 of 5 fresh agents followed the new consent and preview workflow after the protocol change.
- `bun scripts/sync-agent-docs.ts --check`, changelog parity, English source, capability clone, clone binding, engine purity, and dispatch contract checks passed.
- Full `bun test`: 897 passed, 30 skipped, and 25 environment-dependent failures outside this change on the Windows/OneDrive checkout.

## Checklist

- [ ] `bun test skills/harness/tests` passes
- [x] No hardcoded model names (the engine never prescribes a model; it inherits the runtime's)
- [x] No paid pack content, secrets, or `.env` values added to the engine
- [x] **I have read and agree to the Nirvana-OS CLA v2.0** ([CLA.md](https://github.com/gutomec/nirvana-os-engine/blob/main/CLA.md))
