### PR TITLE
fix(gate): correctness rubric no longer fails Portuguese prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The gate learns that "todo" is Portuguese
+
+The correctness heuristic's placeholder regex carried /i, so the marker TODO
+matched the Portuguese word "todo" — any dense PT-BR prose scored as
+placeholder-ridden, and its structure check ignored bold pseudo-headings and
+lists while punishing briefs that forbid headings. Field report from a VPS
+run: gate_failed → audited x_correctness_override → gate_passed. Markers are
+now matched as the uppercase conventions they are (bracketed [INSERT/[FILL
+forms stay case-insensitive), pseudo-headings and lists count as structure,
+and six new tests pin the behavior with real PT-BR fixtures.
+
 ## 0.7.4 — 2026-08-21
 
 ### Install fixes: the silent failures buyers actually hit

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,20 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Unreleased
+
+### O gate aprende que "todo" é português
+
+A regex de placeholder da heurística de correção carregava /i, então o
+marcador TODO casava com a palavra portuguesa "todo" — qualquer prosa PT-BR
+densa pontuava como cheia de placeholders, e o check de estrutura ignorava
+pseudo-headings em negrito e listas, punindo briefs que proíbem headings.
+Relato de campo de uma VPS: gate_failed → x_correctness_override auditado →
+gate_passed. Os marcadores agora são casados como as convenções maiúsculas
+que são (as formas com colchete [INSERT/[FILL seguem case-insensitive),
+pseudo-headings e listas contam como estrutura, e seis testes novos fixam o
+comportamento com fixtures PT-BR reais.
+
 ## 0.7.4 — 2026-08-21
 
 ### Correções de instalação: as falhas silenciosas que compradores realmente sofrem

--- a/skills/harness/rubrics/correctness.ts
+++ b/skills/harness/rubrics/correctness.ts
@@ -14,8 +14,16 @@ export async function evaluate(args: { artifact: string; content: string; offlin
     score -= 0.5;
   }
 
-  // placeholder density
-  const placeholders = (content.match(/\b(TODO|TBD|PLACEHOLDER|XXX|FIXME|\[INSERT|\[FILL)\b/gi) || []).length;
+  // Placeholder density. Markers are UPPERCASE conventions and are matched
+  // case-SENSITIVELY on purpose: the old /i flag made the marker TODO match
+  // the Portuguese word "todo" ("todo o tráfego"), failing any dense PT-BR
+  // prose — a language the engine's deliverables ship in every day. A
+  // lowercase "todo" is prose; an uppercase "TODO" is a marker in any
+  // language. The bracketed forms stay case-insensitive: "[insert name]" is
+  // a placeholder at any casing and collides with no natural-language word.
+  const placeholders =
+    (content.match(/\b(TODO|TBD|PLACEHOLDER|XXX|FIXME)\b/g) || []).length +
+    (content.match(/\[(INSERT|FILL)/gi) || []).length;
   const wordCount = content.split(/\s+/).filter(Boolean).length;
   const phPerKWord = wordCount > 0 ? placeholders / (wordCount / 1000) : 0;
   if (phPerKWord > 5) {
@@ -23,10 +31,17 @@ export async function evaluate(args: { artifact: string; content: string; offlin
     score -= 0.3;
   }
 
-  // heading presence (for prose)
+  // Structure presence (for prose). Headings are ONE form of structure, not
+  // the only one: bold-line pseudo-headings ("**Identidade**") and list items
+  // are structure too (the seat-sufficiency measure learned this against 574
+  // real files), and some briefs explicitly forbid headings — a rubric that
+  // cannot see the brief must not punish obeying it. Only a long, genuinely
+  // structureless markdown wall is flagged.
   const hasHeadings = /^#{1,4}\s/m.test(content);
-  if (!hasHeadings && content.length > 500 && args.artifact.endsWith(".md")) {
-    fix_list.push("No markdown headings in a 500+ byte markdown file — add structure.");
+  const hasPseudoHeadings = /^\*\*[^*\n]{2,80}\*\*:?\s*$/m.test(content);
+  const hasLists = /^\s*(?:[-*•]|\d+[.)])\s+\S/m.test(content);
+  if (!hasHeadings && !hasPseudoHeadings && !hasLists && content.length > 500 && args.artifact.endsWith(".md")) {
+    fix_list.push("No structure (headings, bold pseudo-headings or lists) in a 500+ byte markdown file — add some, unless the brief forbids it.");
     score -= 0.2;
   }
 

--- a/skills/harness/tests/correctness-rubric.test.ts
+++ b/skills/harness/tests/correctness-rubric.test.ts
@@ -1,0 +1,54 @@
+// correctness-rubric.test.ts — the correctness heuristic must not fail
+// Portuguese prose.
+//
+// The failure this prevents (VPS field report, 2026-08-21): the placeholder
+// regex carried /i, so the marker TODO matched the Portuguese word "todo"
+// ("todo o tráfego") — any dense PT-BR text scored as placeholder-ridden.
+// Combined with a heading penalty that ignored pseudo-headings and lists
+// (and punished briefs that forbid headings), real deliverables failed the
+// gate and only passed via an audited x_correctness_override. The gate must
+// be right on its own, not right-after-override.
+
+import { describe, expect, test } from "bun:test";
+import { evaluate } from "../rubrics/correctness.ts";
+
+const PT_SENTENCE = "Todo o tráfego pago passa por revisão, e todo criativo novo herda o histórico de todo o funil antes de subir. ";
+const PT_PROSE = (PT_SENTENCE + "A operação segue o plano acordado com o cliente em todo detalhe relevante. ").repeat(12);
+
+describe("correctness rubric — language sensitivity", () => {
+  test("dense PT-BR prose full of the word 'todo' passes clean", async () => {
+    const r = await evaluate({ artifact: "nota.md", content: `**Plano de mídia**\n\n${PT_PROSE}` });
+    expect(r.passed).toBe(true);
+    expect(r.fix_list.find((f) => f.includes("placeholders"))).toBeUndefined();
+  });
+
+  test("real uppercase markers still count", async () => {
+    const marked = ("TODO: escrever esta seção. TBD. FIXME agora. ").repeat(30);
+    const r = await evaluate({ artifact: "nota.md", content: marked });
+    expect(r.fix_list.some((f) => f.includes("placeholders"))).toBe(true);
+  });
+
+  test("bracketed placeholders are markers at any casing", async () => {
+    const marked = ("O relatório de [insert client name] mostra [fill metric] em toda análise. ").repeat(30);
+    const r = await evaluate({ artifact: "nota.md", content: marked });
+    expect(r.fix_list.some((f) => f.includes("placeholders"))).toBe(true);
+  });
+});
+
+describe("correctness rubric — structure is more than headings", () => {
+  test("bold pseudo-headings count as structure", async () => {
+    const r = await evaluate({ artifact: "nota.md", content: `**Identidade**\n\n${PT_PROSE}` });
+    expect(r.fix_list.some((f) => f.includes("structure"))).toBe(false);
+  });
+
+  test("lists count as structure", async () => {
+    const r = await evaluate({ artifact: "nota.md", content: `${PT_PROSE}\n- primeiro ponto detalhado da entrega\n- segundo ponto detalhado da entrega\n` });
+    expect(r.fix_list.some((f) => f.includes("structure"))).toBe(false);
+  });
+
+  test("a genuinely structureless long wall is still flagged, without failing alone", async () => {
+    const r = await evaluate({ artifact: "nota.md", content: PT_PROSE });
+    expect(r.fix_list.some((f) => f.includes("structure"))).toBe(true);
+    expect(r.passed).toBe(true); // -0.2 alone must not fail an otherwise-real artifact
+  });
+});


### PR DESCRIPTION
Field report from a VPS run: `gate_failed → x_correctness_override → gate_passed`. Root cause confirmed at rubrics/correctness.ts:18 — the placeholder regex's /i flag made TODO match the Portuguese word "todo", and the structure check ignored pseudo-headings/lists while punishing briefs that forbid headings. Markers now match as uppercase conventions (bracketed forms stay /i), pseudo-headings and lists count as structure, six PT-BR fixture tests pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)