### PR TITLE
feat(gate): pdf-valid rubric — PDF deliverables stop being invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The gate finally covers PDF
+
+PDF is one of the most common deliverable formats and the auto gate never
+saw it: `.pdf` was not gateable, so a PDF-only delivery came out
+INDETERMINATE — the first field run to notice had to gate by hand with qpdf
+and emit `x_quality_gate_tooling_gap`. The new `pdf-valid` rubric closes the
+structural half: header, `%%EOF` trailer, stub floor, and page count via
+qpdf or pdfinfo when present — falling back to a declared-unverified pass on
+object-stream-compressed PDFs instead of failing on the naive regex that
+reads them as zero pages. Verified live against the field run's own 2-page,
+4 MB deliverable, with and without tools on PATH.
+
 ## 0.7.7 — 2026-08-22
 
 ### Headless sessions die with the turn — the protocol now says so

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,21 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Unreleased
+
+### O gate finalmente cobre PDF
+
+PDF é um dos formatos de entrega mais comuns e o gate automático nunca o
+via: `.pdf` não era gateável, então uma entrega só-PDF saía INDETERMINATE —
+a primeira execução de campo a notar precisou gatear à mão com qpdf e emitir
+`x_quality_gate_tooling_gap`. A nova rubrica `pdf-valid` fecha a metade
+estrutural: header, trailer `%%EOF`, piso de stub, e contagem de páginas via
+qpdf ou pdfinfo quando presentes — caindo para um passe declarado-como-não-
+verificado em PDFs com object streams comprimidos, em vez de reprovar pela
+regex ingênua que os lê como zero páginas. Verificada ao vivo contra o
+próprio entregável da execução de campo (2 páginas, 4 MB), com e sem
+ferramentas na PATH.
+
 ## 0.7.7 — 2026-08-22
 
 ### Sessões headless morrem com o turno — o protocolo agora diz isso

--- a/skills/harness/rubrics/pdf-valid.ts
+++ b/skills/harness/rubrics/pdf-valid.ts
@@ -1,0 +1,104 @@
+// pdf-valid.ts — structural PDF gate (offline-safe, zero hard deps).
+//
+// PDF is one of the most common deliverable formats and the auto gate never
+// covered it: a PDF-only delivery came out INDETERMINATE, and the first field
+// run to notice (VPS, 2026-08-22) had to gate by hand with qpdf and emit
+// x_quality_gate_tooling_gap. This rubric closes that gap at the structural
+// level: header, EOF marker, stub floor, page count. Like html-valid, it is
+// a smoke gate, not a visual judgment — whether the RENDERED pages match the
+// brief remains the maestro's read or the LLM judge.
+//
+// Page counting prefers real tools when present (qpdf, then pdfinfo). With
+// neither on PATH, the fallback counts /Type /Page objects — which reads 0 on
+// object-stream-compressed PDFs (the exact trap the field run hit), so a
+// compressed PDF with valid header/EOF passes structurally with the count
+// declared unverified instead of failing on a broken heuristic.
+
+import * as fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+function toolPages(artifact: string): number | null {
+  for (const [bin, args, parse] of [
+    ["qpdf", ["--show-npages", artifact], (o: string) => parseInt(o.trim(), 10)],
+    ["pdfinfo", [artifact], (o: string) => {
+      const m = o.match(/^Pages:\s+(\d+)/m);
+      return m ? parseInt(m[1], 10) : NaN;
+    }],
+  ] as const) {
+    try {
+      const r = spawnSync(bin as string, args as string[], { encoding: "utf8", timeout: 20_000 });
+      if (r.status === 0) {
+        const n = parse(r.stdout || "");
+        if (Number.isFinite(n) && n >= 0) return n;
+      }
+    } catch { /* tool absent — try the next */ }
+  }
+  return null;
+}
+
+export async function evaluate(args: { artifact: string; content: string; offline?: boolean }) {
+  const fix_list: string[] = [];
+  let score = 1.0;
+
+  let bytes: Buffer;
+  try {
+    bytes = fs.readFileSync(args.artifact);
+  } catch (e) {
+    return { name: "pdf-valid", passed: false, score: 0, reasoning: `unreadable file: ${(e as Error).message}`, fix_list: ["Write the PDF file."] };
+  }
+
+  const head = bytes.subarray(0, 1024).toString("latin1");
+  if (!head.startsWith("%PDF-")) {
+    fix_list.push("Missing %PDF- header — the file is not a PDF.");
+    score -= 0.6;
+  }
+
+  const tail = bytes.subarray(Math.max(0, bytes.length - 2048)).toString("latin1");
+  if (!tail.includes("%%EOF")) {
+    fix_list.push("Missing %%EOF trailer — the PDF is truncated or still being written.");
+    score -= 0.4;
+  }
+
+  if (bytes.length < 5_000) {
+    fix_list.push(`File is only ${bytes.length} bytes — looks like a stub, not a document.`);
+    score -= 0.4;
+  }
+
+  let pages = toolPages(args.artifact);
+  let pagesNote: string;
+  if (pages !== null) {
+    pagesNote = `pages=${pages} (tool-verified)`;
+    if (pages < 1) {
+      fix_list.push("PDF has zero pages.");
+      score -= 0.5;
+    }
+  } else {
+    const body = bytes.toString("latin1");
+    const naive = (body.match(/\/Type\s*\/Page[^s]/g) || []).length;
+    const hasObjStm = body.includes("/ObjStm");
+    if (naive >= 1) {
+      pages = naive;
+      pagesNote = `pages≈${naive} (heuristic)`;
+    } else if (hasObjStm) {
+      // Compressed object streams hide page objects from the regex — the
+      // field-run trap. Structure is otherwise valid; declare, don't fail.
+      pagesNote = "pages unverifiable offline (object streams; install qpdf or poppler for exact count)";
+    } else {
+      pagesNote = "no page objects found";
+      fix_list.push("No page objects found and no object streams present — the PDF body looks empty.");
+      score -= 0.5;
+    }
+  }
+
+  score = Math.max(0, Math.min(1, score));
+  const passed = score >= 0.65;
+  return {
+    name: "pdf-valid",
+    passed,
+    score,
+    reasoning: passed
+      ? `Structural PDF check passed (${(bytes.length / 1024).toFixed(0)} KB, ${pagesNote}).`
+      : `Structural PDF check failed (${pagesNote}).`,
+    fix_list,
+  };
+}

--- a/skills/harness/scripts/quality-gate.ts
+++ b/skills/harness/scripts/quality-gate.ts
@@ -55,6 +55,7 @@ export const GATEABLE_EXTS: ReadonlySet<string> = new Set([
   ".md", ".txt", ".json", ".yaml", ".yml",
   ".png", ".jpg", ".jpeg", ".webp",
   ".html", ".ts", ".js", ".py",
+  ".pdf",
 ]);
 
 export function rubricsForExt(ext: string): string[] {
@@ -74,6 +75,8 @@ export function rubricsForExt(ext: string): string[] {
       return ["brief-fidelity"];
     case ".html":
       return ["html-valid"];
+    case ".pdf":
+      return ["pdf-valid"];
     case ".ts":
     case ".js":
     case ".py":

--- a/skills/harness/tests/pdf-valid.test.ts
+++ b/skills/harness/tests/pdf-valid.test.ts
@@ -1,0 +1,90 @@
+// pdf-valid.test.ts — the gate finally covers PDF.
+//
+// The failure this prevents (VPS field report, 2026-08-22): a PDF-only
+// delivery was invisible to the auto gate (.pdf was not gateable), so the
+// dispatched agent had to gate by hand with qpdf and emit
+// x_quality_gate_tooling_gap. Also pins the object-stream trap: a naive
+// /Type /Page regex reads 0 pages on compressed PDFs and must not fail them.
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evaluate } from "../rubrics/pdf-valid.ts";
+import { GATEABLE_EXTS, rubricsForExt } from "../scripts/quality-gate.ts";
+
+const tmp = mkdtempSync(join(tmpdir(), "pdf-valid-"));
+const PAD = "%".repeat(6000); // clears the stub floor without changing structure
+
+function minimalPdf(): string {
+  return [
+    "%PDF-1.4",
+    "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj",
+    "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj",
+    "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >> endobj",
+    `% ${PAD}`,
+    "trailer << /Root 1 0 R >>",
+    "%%EOF",
+  ].join("\n");
+}
+
+describe("pdf-valid rubric", () => {
+  test(".pdf is gateable and mapped to pdf-valid", () => {
+    expect(GATEABLE_EXTS.has(".pdf")).toBeTrue();
+    expect(rubricsForExt(".pdf")).toEqual(["pdf-valid"]);
+  });
+
+  test("a minimal valid PDF passes", async () => {
+    const p = join(tmp, "ok.pdf");
+    writeFileSync(p, minimalPdf(), "latin1");
+    const r = await evaluate({ artifact: p, content: "" });
+    expect(r.passed).toBe(true);
+  });
+
+  test("a truncated PDF (no %%EOF) fails with a named fix", async () => {
+    const p = join(tmp, "trunc.pdf");
+    writeFileSync(p, minimalPdf().replace("%%EOF", ""), "latin1");
+    const r = await evaluate({ artifact: p, content: "" });
+    expect(r.passed).toBe(false);
+    expect(r.fix_list.some((f) => f.includes("%%EOF"))).toBe(true);
+  });
+
+  test("a non-PDF byte blob fails on the header", async () => {
+    const p = join(tmp, "fake.pdf");
+    writeFileSync(p, "<html>not a pdf</html>" + PAD);
+    const r = await evaluate({ artifact: p, content: "" });
+    expect(r.passed).toBe(false);
+    expect(r.fix_list.some((f) => f.includes("%PDF-"))).toBe(true);
+  });
+
+  test("object-stream PDFs with zero regex-visible pages still pass structurally", async () => {
+    // /ObjStm present, no /Type /Page in clear text — the compressed-PDF trap.
+    const p = join(tmp, "objstm.pdf");
+    writeFileSync(p, ["%PDF-1.7", "9 0 obj << /Type /ObjStm /N 4 >> stream", "endstream endobj", `% ${PAD}`, "%%EOF"].join("\n"), "latin1");
+    const prevPath = process.env.PATH;
+    process.env.PATH = "/nonexistent"; // force the no-tools branch
+    try {
+      const r = await evaluate({ artifact: p, content: "" });
+      expect(r.passed).toBe(true);
+      expect(r.reasoning).toContain("unverifiable");
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  test("an empty-body PDF (no pages, no object streams) fails", async () => {
+    const p = join(tmp, "empty.pdf");
+    writeFileSync(p, ["%PDF-1.4", `% ${PAD}`, "%%EOF"].join("\n"), "latin1");
+    const prevPath = process.env.PATH;
+    process.env.PATH = "/nonexistent";
+    try {
+      const r = await evaluate({ artifact: p, content: "" });
+      expect(r.passed).toBe(false);
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+});
+
+// cleanup
+process.on("beforeExit", () => rmSync(tmp, { recursive: true, force: true }));

--- a/skills/harness/tests/revise-delivery.test.ts
+++ b/skills/harness/tests/revise-delivery.test.ts
@@ -60,7 +60,10 @@ const STUB_PNG = Buffer.concat([
   Buffer.alloc(300, 7),
 ]);
 
-const NON_GATEABLE_PDF = "%PDF-1.7\n" + "conteúdo binário simulado ".repeat(20) + "\n%%EOF\n";
+// .pdf became gateable in the pdf-valid change (2026-08-22) — the
+// nothing-to-judge fixture must be an extension the gate really cannot
+// read, or this test would silently exercise the wrong path.
+const NON_GATEABLE_BLOB = "PK\u0003\u0004" + "conteúdo binário simulado ".repeat(20);
 
 let caseSeq = 0;
 
@@ -156,7 +159,7 @@ describe("nrv revise — the outcome goes through the delivery pipeline", () => 
   }, 30_000);
 
   test("nothing the gate can judge → exit 3, INDETERMINATE, no delivered", () => {
-    const c = runRevise({ "relatorio.pdf": NON_GATEABLE_PDF });
+    const c = runRevise({ "relatorio.zip": NON_GATEABLE_BLOB });
     expect(c.status).toBe(3);
     expect(events(c)).toContain("x_gate_skipped_no_files");
     expect(events(c)).not.toContain("gate_passed");

--- a/skills/harness/tests/supervisor-sweep.test.ts
+++ b/skills/harness/tests/supervisor-sweep.test.ts
@@ -556,7 +556,9 @@ const STUB_PNG = Buffer.concat([
   Buffer.alloc(300, 7),
 ]);
 
-const NON_GATEABLE_PDF = "%PDF-1.7\n" + "conteúdo binário simulado ".repeat(20) + "\n%%EOF\n";
+// .pdf became gateable in the pdf-valid change (2026-08-22); use a blob the
+// gate really cannot judge so the INDETERMINATE path stays exercised.
+const NON_GATEABLE_BLOB = "PK\u0003\u0004" + "conteúdo binário simulado ".repeat(20);
 
 let redispatchSeq = 0;
 
@@ -603,7 +605,7 @@ function quietDelivery(revisionCalls: unknown[] = []): RedispatchOverrides {
 describe("supervisor redispatch — the outcome goes through the delivery pipeline", () => {
   test("THE FAIL-OPEN, CLOSED: only non-gateable artifacts → INDETERMINATE, never delivered", () => {
     const h = freshLedger();
-    const { row } = redispatchCase(h, { "relatorio.pdf": NON_GATEABLE_PDF });
+    const { row } = redispatchCase(h, { "relatorio.zip": NON_GATEABLE_BLOB });
     const res = redispatchRun(h, row, quietDelivery());
     // Old behavior: {ok:true, finalState:"delivered", detail:"…gate indeterminate"}.
     expect(res.ok).toBe(false);
@@ -769,7 +771,7 @@ describe("supervisor redispatch — the outcome goes through the delivery pipeli
   test("through the sweep: a withheld redispatch is NOT counted as recovered", () => {
     const h = freshLedger();
     const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], { stdio: "ignore" });
-    const { row } = redispatchCase(h, { "relatorio.pdf": NON_GATEABLE_PDF });
+    const { row } = redispatchCase(h, { "relatorio.zip": NON_GATEABLE_BLOB });
     markState(h, row.run_id, "failed");
     markState(h, row.run_id, "running", { childPid: child.pid });
     const s = sweep({


### PR DESCRIPTION
Closes the gap the VPS field run reported via x_quality_gate_tooling_gap: .pdf was not gateable at all. Structural rubric (header/EOF/stub/pages via qpdf→pdfinfo→declared-unverified fallback for object streams), proven against the field run's own panda-final.pdf with and without tools on PATH. The visual half (rendered pages vs brief) remains the maestro's read or the LLM judge, same as html-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)