### PR TITLE
feat(serve): session library scope (global default) + seat reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,15 @@ carries the gate verdict and promotes `_SUMMARY.md` and
 `_QA-RESERVATIONS.md` to fields, so a delivery accepted with reservations
 arrives honest. `/events` streams the project's audit log as SSE. A server
 restart no longer orphans work: each run persists beside its artifacts and
-rehydrates on lookup. Full guide: `references/06-api.md`.
+rehydrates on lookup.
+
+A session declares which library its briefs may route to: `global` (the
+default) sees the operator's own businesses, squads and clones — without it
+every brief falls to the generalist, which the first live run showed
+plainly — and `isolated` keeps the project-only scope a multi-tenant host
+needs. `/v1/health` also reports seat consumption, because a fleet of API
+workers consumes one licence seat per host today. Full guide:
+`references/06-api.md`.
 
 ## 0.7.7 — 2026-08-22
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -39,7 +39,15 @@ carrega o veredito do gate e promove `_SUMMARY.md` e `_QA-RESERVATIONS.md` a
 campos, então uma entrega aceita com ressalvas chega honesta. `/events`
 transmite o log de auditoria do projeto por SSE. Reiniciar o servidor não
 orfana mais trabalho: cada run persiste ao lado dos artefatos e é
-reidratado na consulta. Guia completo: `references/06-api.md`.
+reidratado na consulta.
+
+Uma sessão declara para qual biblioteca seus briefs podem rotear: `global`
+(o padrão) enxerga as empresas, squads e clones do operador — sem isso todo
+brief cai no generalista, como a primeira execução ao vivo mostrou — e
+`isolated` mantém o escopo só-do-projeto que um host multi-tenant precisa.
+O `/v1/health` também reporta consumo de seats, porque hoje uma frota de
+workers de API consome um seat de licença por host. Guia completo:
+`references/06-api.md`.
 
 ## 0.7.7 — 2026-08-22
 

--- a/skills/harness/lib/serve/runs.ts
+++ b/skills/harness/lib/serve/runs.ts
@@ -154,7 +154,9 @@ export function start(memo: RunMemo, opts: { budgetUsd?: number } = {}): Promise
       cwd: memo.session.dir,
       env: {
         ...process.env,
-        NIRVANA_SCOPE: "project",
+        // `merge` lets the project see the operator's global library on top
+        // of its own; `project` is the isolated tenant case.
+        NIRVANA_SCOPE: memo.session.library === "isolated" ? "project" : "merge",
         NIRVANA_PROJECT_ROOT: memo.session.dir,
         NIRVANA_TRACE_ID: memo.trace_id,
       },

--- a/skills/harness/lib/serve/server.ts
+++ b/skills/harness/lib/serve/server.ts
@@ -70,7 +70,23 @@ export function startServer(opts: ServeOpts) {
       // needs a liveness probe that carries no secret and no session data.
       if (p === "/v1/health") {
         const runtimes = listRuntimes().map((r) => r.name);
-        return json({ ok: true, engine: ENGINE_VERSION, runtimes, queue: queue.stats, adopted_runs: adopted }, 200, h);
+        // Seat accounting, reported before it is enforced: today a pack
+        // licence counts MACHINES, so a fleet of API workers consumes one
+        // seat per host and hits the ceiling fast. Surfacing it here lets an
+        // operator see the cost of scaling, and gives the future licence
+        // classes (nominal · server · cloud) a field that already exists.
+        return json({
+          ok: true,
+          engine: ENGINE_VERSION,
+          runtimes,
+          queue: queue.stats,
+          adopted_runs: adopted,
+          licensing: {
+            model: "per-machine",
+            seats_consumed_by_this_host: 1,
+            note: "a worker fleet consumes one seat per host; server/cloud licence classes are planned",
+          },
+        }, 200, h);
       }
 
       const key = authenticate(req);
@@ -78,11 +94,14 @@ export function startServer(opts: ServeOpts) {
 
       // ── sessions ────────────────────────────────────────────────────────
       if (p === "/v1/sessions" && req.method === "POST") {
-        const s = createSession(key.id);
-        return json({ session_id: s.id, dir: s.dir, created_at: s.created_at }, 201, h);
+        let body: { library?: string } = {};
+        try { body = await req.json() as { library?: string }; } catch { /* body is optional */ }
+        const library = body.library === "isolated" ? "isolated" : "global";
+        const s = createSession(key.id, library);
+        return json({ session_id: s.id, dir: s.dir, library: s.library, created_at: s.created_at }, 201, h);
       }
       if (p === "/v1/sessions" && req.method === "GET") {
-        return json({ sessions: listSessions(key.id).map((s) => ({ session_id: s.id, created_at: s.created_at })) }, 200, h);
+        return json({ sessions: listSessions(key.id).map((s) => ({ session_id: s.id, library: s.library ?? "global", created_at: s.created_at })) }, 200, h);
       }
 
       const mSession = /^\/v1\/sessions\/([^/]+)$/.exec(p);

--- a/skills/harness/lib/serve/sessions.ts
+++ b/skills/harness/lib/serve/sessions.ts
@@ -8,11 +8,27 @@ import { randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { serveDir } from "./auth.ts";
 
+/**
+ * Which library a session's briefs can route to.
+ *
+ * `global` (the default) lets the session see the operator's own
+ * businesses, squads and clones — the reason they bought the packs. Without
+ * it every brief falls to agent-x, which the first live E2E showed plainly:
+ * the router reported `businesses=0, squads=0, mind_clones=0` and took the
+ * generalist branch, correctly and uselessly.
+ *
+ * `isolated` keeps the project-only scope (HP7 to the letter) and is what a
+ * multi-tenant host wants: tenant A must never route into tenant B's
+ * library. Choosing at creation costs one field and saves a migration.
+ */
+export type SessionLibrary = "global" | "isolated";
+
 export interface SessionRecord {
   id: string;
   key_id: string;
   dir: string;
   created_at: string;
+  library: SessionLibrary;
   expired?: boolean;
 }
 
@@ -37,7 +53,7 @@ const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
     ? path.join(process.env.HOME || "", ".nirvana", "skills")
     : path.resolve(import.meta.dir, "..", "..", ".."));
 
-export function createSession(keyId: string): SessionRecord {
+export function createSession(keyId: string, library: SessionLibrary = "global"): SessionRecord {
   const id = "ses_" + randomBytes(8).toString("hex");
   const dir = path.join(sessionsRoot(), id);
   fs.mkdirSync(dir, { recursive: true });
@@ -50,7 +66,7 @@ export function createSession(keyId: string): SessionRecord {
       stdio: "ignore", timeout: 60_000, env: { ...process.env },
     });
   }
-  const rec: SessionRecord = { id, key_id: keyId, dir, created_at: new Date().toISOString() };
+  const rec: SessionRecord = { id, key_id: keyId, dir, created_at: new Date().toISOString(), library };
   const f = load();
   f.sessions.push(rec);
   save(f);

--- a/skills/harness/references/06-api.md
+++ b/skills/harness/references/06-api.md
@@ -42,6 +42,18 @@ curl -s $API/v1/sessions/$SID/runs/$TRACE/artifacts/relatorio.md \
   -H "Authorization: Bearer $TOKEN" -o relatorio.md
 ```
 
+## Which library a session can reach
+
+```bash
+curl -X POST $API/v1/sessions -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"library":"global"}'    # default
+```
+
+`global` lets the session route into your own businesses, squads and clones
+— the reason you bought the packs. `isolated` restricts it to the session's
+own project, which is what a multi-tenant host wants: one tenant must never
+route into another's library.
+
 ## The envelope
 
 ```json

--- a/skills/harness/references/API_PROJECTION_PROPOSAL.md
+++ b/skills/harness/references/API_PROJECTION_PROPOSAL.md
@@ -78,6 +78,22 @@ Decisions, each traceable to engine doctrine:
    Recommended: a server/API license class with its own pricing — new
    revenue, not a counting bugfix.
 
+## 4.1 Licence classes (owner-approved direction, 2026-08-22)
+
+Seat accounting is designed NOW so the Cloud track is configuration rather
+than a schema migration with live customers:
+
+| Class | Counts | For |
+|---|---|---|
+| `nominal` (today) | machines, cap 3 | an individual buyer |
+| `server` | one licence per SERVER HOST, unlimited workers on it | a buyer self-hosting `nrv serve` |
+| `cloud` | no machine counting — usage (runs/month or tokens) | the hosted Nirvana Cloud |
+
+Cheap step available immediately: add `license_class` to the licence record
+(default `nominal`, unread for now) and report seat consumption from
+`/v1/health` (shipped). When the Cloud arrives, the field is already there
+and no live licence needs rewriting.
+
 ## 5. Product ladder this unlocks
 
 1. `nrv serve` in the engine — every buyer gains; packs stay the content moat.

--- a/skills/harness/tests/serve-api.test.ts
+++ b/skills/harness/tests/serve-api.test.ts
@@ -152,6 +152,27 @@ describe("sessions and briefs", () => {
   });
 });
 
+describe("library scope", () => {
+  test("a session defaults to the operator's global library", async () => {
+    const r = await api("/v1/sessions", { method: "POST" });
+    const body = await r.json();
+    expect(body.library).toBe("global");
+  });
+
+  test("an isolated session is honoured and its runs scope to the project only", async () => {
+    const r = await api("/v1/sessions", { method: "POST", body: JSON.stringify({ library: "isolated" }) });
+    const { session_id, library } = await r.json();
+    expect(library).toBe("isolated");
+    const listed = await (await api("/v1/sessions")).json();
+    expect(listed.sessions.find((s: any) => s.session_id === session_id).library).toBe("isolated");
+  });
+
+  test("an unknown library value falls back to global rather than failing the call", async () => {
+    const r = await api("/v1/sessions", { method: "POST", body: JSON.stringify({ library: "whatever" }) });
+    expect((await r.json()).library).toBe("global");
+  });
+});
+
 describe("the exit contract maps to the envelope", () => {
   test("exit 2 → withheld with gate fail; exit 3 → indeterminate", async () => {
     const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();


### PR DESCRIPTION
The live E2E showed every API brief falling to agent-x: a fresh session sees no library at all. Sessions now declare `library`: `global` (default, NIRVANA_SCOPE=merge — the operator's own businesses and squads are reachable) or `isolated` (project-only, for multi-tenant hosts). Proved live: a paid-ads brief routes into nirvana-agencia-marketing instead of the generalist. /v1/health reports seat consumption, and the licence classes (nominal/server/cloud) are designed in the proposal so the Cloud track needs no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)