### PR TITLE
fix(serve): library scope never defaults to project; files always stay in the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### Where the intelligence comes from is not where the files are written
+
+The first `nrv serve` cut created every session with `NIRVANA_SCOPE=project`,
+conflating two decisions that must stay apart: a session's LIBRARY (which
+businesses, squads and clones a brief may route to) and its FILES (logs,
+outputs, run state). The library must never default to the project — a
+session that starts blind sends every brief to the generalist.
+
+A global session (the default) now initialises with `merge`: the operator's
+library resolves, project entries win on conflict, and artifacts still land
+inside the session. Isolated sessions keep the project-only source a
+multi-tenant host needs. Either way the server pins `HARNESS_LOGS_DIR` and
+`NIRVANA_PROJECT_ROOT` to the session, so pointing
+`NIRVANA_SERVE_SESSIONS_ROOT` at a mounted volume puts every caller's
+outputs, logs and run state on that volume.
+
 ## 0.7.8 — 2026-08-22
 
 ### The gate finally covers PDF

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,25 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Unreleased
+
+### De onde vem a inteligência não é onde os arquivos nascem
+
+O primeiro corte do `nrv serve` criava toda sessão com
+`NIRVANA_SCOPE=project`, confundindo duas decisões que precisam ficar
+separadas: a BIBLIOTECA da sessão (para quais empresas, squads e clones um
+brief pode rotear) e os ARQUIVOS dela (logs, outputs, estado de run). A
+biblioteca jamais pode nascer com escopo de projeto — uma sessão que começa
+cega manda todo brief para o generalista.
+
+Uma sessão global (o padrão) agora inicializa com `merge`: a biblioteca do
+operador resolve, entradas do projeto vencem em conflito, e os artefatos
+continuam nascendo dentro da sessão. Sessões isoladas mantêm a fonte
+só-do-projeto que um host multi-tenant precisa. Em ambos os casos o servidor
+fixa `HARNESS_LOGS_DIR` e `NIRVANA_PROJECT_ROOT` na sessão, então apontar
+`NIRVANA_SERVE_SESSIONS_ROOT` para um volume montado coloca outputs, logs e
+estado de todos os chamadores nesse volume.
+
 ## 0.7.8 — 2026-08-22
 
 ### O gate finalmente cobre PDF

--- a/skills/harness/lib/serve/runs.ts
+++ b/skills/harness/lib/serve/runs.ts
@@ -154,10 +154,14 @@ export function start(memo: RunMemo, opts: { budgetUsd?: number } = {}): Promise
       cwd: memo.session.dir,
       env: {
         ...process.env,
-        // `merge` lets the project see the operator's global library on top
-        // of its own; `project` is the isolated tenant case.
+        // Where the intelligence is FOUND (merge: the operator's library,
+        // project entries winning on conflict). Where files are WRITTEN is
+        // decided separately, below: always inside this session.
         NIRVANA_SCOPE: memo.session.library === "isolated" ? "project" : "merge",
+        // Artifacts, logs and run state stay in this session — a mounted
+        // volume simply IS this directory on a server.
         NIRVANA_PROJECT_ROOT: memo.session.dir,
+        HARNESS_LOGS_DIR: path.join(memo.session.dir, ".nirvana", "logs", "harness"),
         NIRVANA_TRACE_ID: memo.trace_id,
       },
       stdio: ["ignore", "pipe", "pipe"],

--- a/skills/harness/lib/serve/sessions.ts
+++ b/skills/harness/lib/serve/sessions.ts
@@ -53,6 +53,30 @@ const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
     ? path.join(process.env.HOME || "", ".nirvana", "skills")
     : path.resolve(import.meta.dir, "..", "..", ".."));
 
+/**
+ * Two different things travel under the word "scope", and conflating them
+ * was a real defect in the first cut of this server:
+ *
+ *   WHERE THE INTELLIGENCE COMES FROM — businesses, squads, mind-clones.
+ *   This must default to the operator's library (`merge`), never to the
+ *   empty project. A session that starts blind routes every brief to the
+ *   generalist, which is the least of what the system can do.
+ *
+ *   WHERE THE FILES ARE WRITTEN — logs, outputs, run state, HANDOFF.
+ *   These always stay inside the session's own directory (or a mounted
+ *   volume pointing at it), because isolation of ARTIFACTS is what keeps
+ *   one caller's work out of another's.
+ *
+ * `merge` gives exactly that split: the library resolves globally, the
+ * project's own entries win on conflict, and everything written lands in
+ * the project. `isolated` (multi-tenant) is the only case that narrows the
+ * source to the project itself.
+ */
+const SCOPE_FOR_LIBRARY: Record<SessionLibrary, string> = {
+  global: "merge",
+  isolated: "project",
+};
+
 export function createSession(keyId: string, library: SessionLibrary = "global"): SessionRecord {
   const id = "ses_" + randomBytes(8).toString("hex");
   const dir = path.join(sessionsRoot(), id);
@@ -62,7 +86,7 @@ export function createSession(keyId: string, library: SessionLibrary = "global")
   // invokes the scripted cascade directly), but we record the warning.
   const init = path.join(SKILLS_ROOT, "_shared", "scripts", "init-project.ts");
   if (fs.existsSync(init)) {
-    spawnSync(process.env.NIRVANA_SERVE_BUN || "bun", [init, dir, "--scope=project"], {
+    spawnSync(process.env.NIRVANA_SERVE_BUN || "bun", [init, dir, `--scope=${SCOPE_FOR_LIBRARY[library]}`], {
       stdio: "ignore", timeout: 60_000, env: { ...process.env },
     });
   }

--- a/skills/harness/references/06-api.md
+++ b/skills/harness/references/06-api.md
@@ -54,6 +54,32 @@ curl -X POST $API/v1/sessions -H "Authorization: Bearer $TOKEN" \
 own project, which is what a multi-tenant host wants: one tenant must never
 route into another's library.
 
+## Two scopes that must never be confused
+
+Where the INTELLIGENCE comes from and where the FILES are written are
+different decisions, and the API keeps them apart:
+
+| | Global session (default) | Isolated session |
+|---|---|---|
+| Businesses, squads, clones resolve from | the operator's library, project entries winning on conflict (`merge`) | the session's project only |
+| Logs, outputs, run state are written to | the session directory | the session directory |
+
+The library must never default to the project: a session that starts blind
+routes every brief to the generalist, which is the least the system can do.
+Artifact isolation is what keeps one caller's work out of another's, and it
+holds in both modes — the server pins `HARNESS_LOGS_DIR` and
+`NIRVANA_PROJECT_ROOT` to the session on every dispatch.
+
+**On a server, point sessions at a volume**: `nrv serve` writes sessions
+under `~/.nirvana/serve/sessions` unless `NIRVANA_SERVE_SESSIONS_ROOT` says
+otherwise. Mount a volume there and every session's outputs, logs and run
+state land on it — survives container replacement, and backing up one path
+backs up every caller's work.
+
+```bash
+NIRVANA_SERVE_SESSIONS_ROOT=/data/nirvana-sessions nrv serve --port 7777
+```
+
 ## The envelope
 
 ```json

--- a/skills/harness/tests/serve-api.test.ts
+++ b/skills/harness/tests/serve-api.test.ts
@@ -167,6 +167,35 @@ describe("library scope", () => {
     expect(listed.sessions.find((s: any) => s.session_id === session_id).library).toBe("isolated");
   });
 
+  test("a global session writes NIRVANA_SCOPE=merge — the library is never project by default", async () => {
+    const r = await api("/v1/sessions", { method: "POST" });
+    const { session_id } = await r.json();
+    const env = readFileSync(join(root, "sessions", session_id, ".env"), "utf8");
+    // The source of intelligence resolves globally; a session that starts
+    // blind would route every brief to the generalist.
+    expect(env).toContain("NIRVANA_SCOPE=merge");
+    expect(env).not.toContain("NIRVANA_SCOPE=project");
+  });
+
+  test("an isolated session is the only one scoped to the project itself", async () => {
+    const r = await api("/v1/sessions", { method: "POST", body: JSON.stringify({ library: "isolated" }) });
+    const { session_id } = await r.json();
+    const env = readFileSync(join(root, "sessions", session_id, ".env"), "utf8");
+    expect(env).toContain("NIRVANA_SCOPE=project");
+  });
+
+  test("files are written inside the session regardless of where the library comes from", async () => {
+    process.env.FIXTURE_EXIT = "0";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+      method: "POST", body: JSON.stringify({ brief: "onde os arquivos nascem" }),
+    })).json();
+    await waitTerminal(session_id, trace_id);
+    // outputs under the session, never in a shared root
+    const artifact = join(root, "sessions", session_id, ".nirvana", "outputs", trace_id, "deliverable.md");
+    expect(readFileSync(artifact, "utf8")).toContain("conteúdo real");
+  });
+
   test("an unknown library value falls back to global rather than failing the call", async () => {
     const r = await api("/v1/sessions", { method: "POST", body: JSON.stringify({ library: "whatever" }) });
     expect((await r.json()).library).toBe("global");


### PR DESCRIPTION
Owner caught it: the source of intelligence and the location of files are different decisions, and the first serve cut set both to `project` — so every API session started blind and every brief fell to the generalist. Global sessions now init with `merge` (operator's library resolves, project wins on conflict); isolated sessions keep project-only. Artifacts, logs and run state are pinned to the session in both modes, and `NIRVANA_SERVE_SESSIONS_ROOT` documents the volume story for servers. Three tests pin the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)