### PR TITLE
feat(engine): add explicit action execution contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Explicit action execution contract
+
+The engine now resolves `action`, `workflow`, and `auto` execution modes with
+deterministic configuration precedence, validates versioned action input and
+output, and records the selected execution identity without payload data.
+Existing squads remain on workflows unless a caller or configuration selects
+another mode.
+
 ### Contention on Windows stopped looking like a crash
 
 `withLock` treated anything but `EEXIST` as a real error. Windows has a

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,14 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Unreleased
 
+### Contrato explícito de execução por ação
+
+O engine agora resolve os modos `action`, `workflow` e `auto` com precedência
+determinística de configuração, valida entrada e saída de ações versionadas e
+registra a identidade da execução sem dados do payload. Squads existentes
+continuam em workflows, salvo quando uma chamada ou configuração seleciona
+outro modo.
+
 ### Disputa de lock no Windows deixou de parecer falha
 
 O `withLock` tratava qualquer coisa que não fosse `EEXIST` como erro real. O

--- a/docs/action-execution-contract.pt-BR.md
+++ b/docs/action-execution-contract.pt-BR.md
@@ -1,0 +1,74 @@
+# Contrato de execução por ação
+
+O contrato permite escolher, de forma explícita e auditável, entre uma ação estável de um squad e o workflow tradicional. O engine é dono da fronteira, resolução, validação e auditoria; a lógica de negócio continua no squad. Uma ação tem `id`, `version`, validação de entrada e saída e uma função de execução.
+
+Esta mudança adiciona a fundação do contrato ao engine. Ela não migra squads, não altera manifests existentes automaticamente e não move implementações para o engine.
+
+## Resolução da política
+
+O modo pode ser `action`, `workflow` ou `auto`. A precedência é determinística:
+
+1. escolha explícita da invocação;
+2. configuração do projeto;
+3. configuração do squad;
+4. padrão do engine, que é `workflow`.
+
+`action` exige uma ação disponível e falha explicitamente se ela não existir ou se a entrada ou saída for inválida. `workflow` executa o fluxo tradicional e é o padrão. `auto` usa a ação quando disponível e recorre ao workflow quando ela não está disponível. Assim, um squad sem mapeamento continua compatível.
+
+## Exemplo: fechamento contábil mensal
+
+Imagine um squad de negócios responsável pelo fechamento mensal, com coleta de extratos, conciliação, saldos e relatório. Uma ação pode encapsular o fechamento validado de um período.
+
+Configuração do projeto:
+
+```yaml
+execution:
+  mode: auto
+  actionId: accounting.close-month
+```
+
+Declaração proposta para um squad piloto, não uma migração feita por esta mudança:
+
+```yaml
+actions:
+  - id: accounting.close-month
+    version: 1.0.0
+    input: accounting-close-month.v1
+    output: accounting-close-result.v1
+```
+
+Invocação com fallback:
+
+```ts
+await invokeAction({
+  mode: "auto",
+  actionId: "accounting.close-month",
+  action: closeMonthAction,
+  input: { period: "2026-07", ledger: "br-gaap" },
+  workflow: runMonthlyClosingWorkflow,
+  audit: emit,
+});
+```
+
+Se a ação não estiver disponível, `auto` usa o workflow. Se o caller escolher `action`, não há conversão silenciosa: a indisponibilidade é erro explícito.
+
+Se o projeto optar por preservar o fluxo existente:
+
+```yaml
+execution:
+  mode: workflow
+```
+
+O workflow de fechamento continua sendo executado. Com `mode: workflow`, ele permanece escolhido mesmo que exista uma ação. Sem política informada, `invokeAction` também escolhe `workflow`.
+
+## Ações específicas e operação automatizada
+
+É possível invocar uma operação específica como `accounting.reconcile-bank-statement` por identificador estável. A versão permite evoluir o contrato sem mudar o significado de execuções anteriores. Em `action`, entradas, saídas ou IDs incompatíveis interrompem a chamada com erro verificável. Em `auto`, um ID incompatível torna a ação solicitada indisponível e aciona o fallback para workflow.
+
+Ao selecionar uma ação, a auditoria registra `execution_selected` com modo, `action_id` e `action_version`. Uma seleção direta de workflow registra `execution_selected` com `mode: workflow`. Quando `auto` precisa recorrer ao workflow, registra `execution_fallback` com `mode: auto`, `fallback: workflow` e `reason: action_unavailable`. Nenhum desses eventos inclui entrada, saída ou segredos.
+
+Uma CLI humana pode oferecer prompt interativo. Execuções automatizadas não devem bloquear esperando resposta: precisam receber política na invocação ou configuração. Sem política, o padrão é `workflow`.
+
+## Migração
+
+Comece por uma operação pequena, declare ID, versão e contratos, implemente no próprio squad, mantenha o workflow como fallback e observe a auditoria. Só depois altere a política para `action`. Outros squads podem permanecer em workflows. Esta mudança não altera manifests nem migra squads automaticamente.

--- a/skills/harness/lib/action-contract.ts
+++ b/skills/harness/lib/action-contract.ts
@@ -1,0 +1,59 @@
+/** Generic execution boundary for stable squad actions. */
+export type ExecutionMode = "action" | "workflow" | "auto";
+export type ExecutionSource = "explicit" | "project" | "squad" | "default";
+
+export interface ActionContract<I = unknown, O = unknown> {
+  id: string;
+  version: string;
+  input: (value: unknown) => value is I;
+  output: (value: unknown) => value is O;
+  run: (input: I) => Promise<O> | O;
+}
+export interface ExecutionConfig { mode?: ExecutionMode; actionId?: string; }
+export interface ResolvedExecution { mode: ExecutionMode; actionId?: string; source: ExecutionSource; }
+export interface InvokeOptions<I = unknown, O = unknown> {
+  action?: ActionContract<I, O>;
+  actionId?: string;
+  input: unknown;
+  mode?: ExecutionMode;
+  workflow?: () => Promise<O> | O;
+  audit?: (event: "execution_selected" | "execution_fallback", payload: Record<string, unknown>) => void;
+}
+
+export class ActionContractError extends Error {}
+
+export function resolveExecution(explicit: ExecutionConfig = {}, project: ExecutionConfig = {}, squad: ExecutionConfig = {}): ResolvedExecution {
+  const selected = explicit.mode !== undefined ? [explicit, "explicit"] : project.mode !== undefined ? [project, "project"] : squad.mode !== undefined ? [squad, "squad"] : [{ mode: "workflow" }, "default"];
+  const config = selected[0] as ExecutionConfig;
+  const source = selected[1] as ExecutionSource;
+  return { mode: config.mode ?? "workflow", ...(config.actionId ? { actionId: config.actionId } : {}), source };
+}
+
+export async function invokeAction<I, O>(options: InvokeOptions<I, O>): Promise<O> {
+  const mode = options.mode ?? "workflow";
+  const action = options.action;
+  const emit = options.audit;
+  const actionUnavailable = !action
+    || (options.actionId !== undefined && options.actionId !== action.id);
+  if (mode === "workflow") {
+    if (!options.workflow) throw new ActionContractError("workflow unavailable");
+    if (emit) emit("execution_selected", { mode: "workflow" });
+    return await options.workflow();
+  }
+  if (mode === "auto" && actionUnavailable) {
+    if (!options.workflow) throw new ActionContractError("workflow unavailable");
+    if (emit) emit("execution_fallback", {
+      mode: "auto",
+      fallback: "workflow",
+      reason: "action_unavailable",
+    });
+    return await options.workflow();
+  }
+  if (!action) throw new ActionContractError("action unavailable");
+  if (options.actionId && options.actionId !== action.id) throw new ActionContractError(`action '${options.actionId}' unavailable`);
+  if (!action.input(options.input)) throw new ActionContractError(`invalid input for action '${action.id}'`);
+  if (emit) emit("execution_selected", { mode: "action", action_id: action.id, action_version: action.version });
+  const output = await action.run(options.input);
+  if (!action.output(output)) throw new ActionContractError(`invalid output for action '${action.id}'`);
+  return output;
+}

--- a/skills/harness/lib/audit.js
+++ b/skills/harness/lib/audit.js
@@ -34,6 +34,7 @@ const ALLOWED_EVENTS = new Set([
   'escalation_trigger_fired', 'human_notification_required', 'human_response_received',
   'resume', 'approval_checkpoint', 'approval_granted', 'approval_rejected',
   'budget_violation', 'memory_write', 'isolation_violation', 'validation_failed',
+  'execution_selected', 'execution_fallback',
   'humanization_applied', 'humanization_skipped', 'loop_detected', 'context_budget_warning',
   'stall_detected', 'stall_retry', 'gate_failed', 'gate_passed',
   // Phase A — dispatch quality invariants (see docs/plans/dispatch-quality-gate-and-mind-clone-injection.md)

--- a/skills/harness/references/03-audit.md
+++ b/skills/harness/references/03-audit.md
@@ -69,7 +69,7 @@ when the docs prescribe a non-enum, non-`x_` event or when code emits one.
 
 <!-- BEGIN GENERATED: audit-events (scripts/gen-audit-events-doc.ts — do not edit by hand) -->
 
-96 events in the closed enum (declaration order of `ALLOWED_EVENTS` in `lib/audit.js`):
+98 events in the closed enum (declaration order of `ALLOWED_EVENTS` in `lib/audit.js`):
 
 ```
 brief_received
@@ -92,6 +92,8 @@ budget_violation
 memory_write
 isolation_violation
 validation_failed
+execution_selected
+execution_fallback
 humanization_applied
 humanization_skipped
 loop_detected

--- a/skills/harness/tests/action-contract.test.ts
+++ b/skills/harness/tests/action-contract.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ActionContractError,
+  type ActionContract,
+  invokeAction,
+  resolveExecution,
+} from "../lib/action-contract";
+
+interface CloseInput {
+  period: string;
+  secret?: string;
+}
+
+interface CloseOutput {
+  period: string;
+  closed: boolean;
+}
+
+const closeMonthAction: ActionContract<CloseInput, CloseOutput> = {
+  id: "accounting.close-month",
+  version: "1.0.0",
+  input: (value: unknown): value is CloseInput => {
+    return typeof value === "object"
+      && value !== null
+      && typeof (value as Record<string, unknown>).period === "string";
+  },
+  output: (value: unknown): value is CloseOutput => {
+    return typeof value === "object"
+      && value !== null
+      && typeof (value as Record<string, unknown>).period === "string"
+      && (value as Record<string, unknown>).closed === true;
+  },
+  run: async (input) => ({ period: input.period, closed: true }),
+};
+
+describe("action execution policy", () => {
+  test("resolves mode and action identity from the highest-precedence configured layer", () => {
+    const cases = [
+      {
+        explicit: { mode: "action" as const, actionId: "explicit.action" },
+        project: { mode: "auto" as const, actionId: "project.action" },
+        squad: { mode: "workflow" as const, actionId: "squad.action" },
+        want: { mode: "action", actionId: "explicit.action", source: "explicit" },
+      },
+      {
+        explicit: {},
+        project: { mode: "auto" as const, actionId: "project.action" },
+        squad: { mode: "action" as const, actionId: "squad.action" },
+        want: { mode: "auto", actionId: "project.action", source: "project" },
+      },
+      {
+        explicit: {},
+        project: {},
+        squad: { mode: "action" as const, actionId: "squad.action" },
+        want: { mode: "action", actionId: "squad.action", source: "squad" },
+      },
+      {
+        explicit: {},
+        project: {},
+        squad: {},
+        want: { mode: "workflow", source: "default" },
+      },
+    ];
+
+    for (const { explicit, project, squad, want } of cases) {
+      expect(resolveExecution(explicit, project, squad)).toEqual(want);
+    }
+  });
+
+  test("uses workflow by default even when an action is available", async () => {
+    let actionRuns = 0;
+    const action = {
+      ...closeMonthAction,
+      run: async (input: CloseInput) => {
+        actionRuns += 1;
+        return { period: input.period, closed: true as const };
+      },
+    };
+
+    const result = await invokeAction({
+      action,
+      input: { period: "2026-07" },
+      workflow: async () => ({ period: "workflow", closed: true }),
+    });
+
+    expect(result).toEqual({ period: "workflow", closed: true });
+    expect(actionRuns).toBe(0);
+  });
+
+  test("records an explicit workflow choice as selected, not fallback", async () => {
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+    await invokeAction({
+      mode: "workflow",
+      action: closeMonthAction,
+      input: { period: "2026-07" },
+      workflow: async () => ({ period: "workflow", closed: true }),
+      audit: (event, payload) => events.push({ event, payload }),
+    });
+
+    expect(events).toEqual([
+      { event: "execution_selected", payload: { mode: "workflow" } },
+    ]);
+  });
+
+  test("runs an explicit versioned action and audits only its stable identity", async () => {
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+    const result = await invokeAction({
+      mode: "action",
+      actionId: "accounting.close-month",
+      action: closeMonthAction,
+      input: { period: "2026-07", secret: "do-not-audit" },
+      audit: (event, payload) => events.push({ event, payload }),
+    });
+
+    expect(result).toEqual({ period: "2026-07", closed: true });
+    expect(events).toEqual([
+      {
+        event: "execution_selected",
+        payload: {
+          mode: "action",
+          action_id: "accounting.close-month",
+          action_version: "1.0.0",
+        },
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("do-not-audit");
+  });
+
+  test("rejects invalid action input before the action runs", async () => {
+    let actionRuns = 0;
+    const action = {
+      ...closeMonthAction,
+      run: async (input: CloseInput) => {
+        actionRuns += 1;
+        return { period: input.period, closed: true as const };
+      },
+    };
+
+    await expect(invokeAction({
+      mode: "action",
+      action,
+      input: { period: 202607 },
+    })).rejects.toThrow("invalid input for action 'accounting.close-month'");
+    expect(actionRuns).toBe(0);
+  });
+
+  test("rejects an invalid action output", async () => {
+    const action = {
+      ...closeMonthAction,
+      run: async () => ({ period: "2026-07", closed: false }),
+    } as unknown as ActionContract<CloseInput, CloseOutput>;
+
+    await expect(invokeAction({
+      mode: "action",
+      action,
+      input: { period: "2026-07" },
+    })).rejects.toThrow("invalid output for action 'accounting.close-month'");
+  });
+
+  test("fails explicitly when action mode has no matching action", async () => {
+    let workflowRuns = 0;
+    const workflow = async () => {
+      workflowRuns += 1;
+      return { period: "workflow", closed: true };
+    };
+
+    await expect(invokeAction({
+      mode: "action",
+      input: { period: "2026-07" },
+      workflow,
+    })).rejects.toBeInstanceOf(ActionContractError);
+    await expect(invokeAction({
+      mode: "action",
+      actionId: "accounting.other",
+      action: closeMonthAction,
+      input: { period: "2026-07" },
+      workflow,
+    })).rejects.toThrow("action 'accounting.other' unavailable");
+    expect(workflowRuns).toBe(0);
+  });
+
+  test("auto falls back when the action is unavailable and records no input", async () => {
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+    const result = await invokeAction<CloseInput, CloseOutput>({
+      mode: "auto",
+      action: undefined,
+      input: { period: "2026-07", secret: "do-not-audit" },
+      workflow: async () => ({ period: "workflow", closed: true }),
+      audit: (event, payload) => events.push({ event, payload }),
+    });
+
+    expect(result).toEqual({ period: "workflow", closed: true });
+    expect(events).toEqual([
+      {
+        event: "execution_fallback",
+        payload: { mode: "auto", fallback: "workflow", reason: "action_unavailable" },
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("do-not-audit");
+  });
+
+  test("auto treats a mismatched action identity as unavailable", async () => {
+    let actionRuns = 0;
+    let workflowRuns = 0;
+    const action = {
+      ...closeMonthAction,
+      run: async (input: CloseInput) => {
+        actionRuns += 1;
+        return { period: input.period, closed: true as const };
+      },
+    };
+
+    const result = await invokeAction({
+      mode: "auto",
+      actionId: "accounting.other",
+      action,
+      input: { period: "2026-07" },
+      workflow: async () => {
+        workflowRuns += 1;
+        return { period: "workflow", closed: true };
+      },
+    });
+
+    expect(result).toEqual({ period: "workflow", closed: true });
+    expect(actionRuns).toBe(0);
+    expect(workflowRuns).toBe(1);
+  });
+
+  test("auto prefers an available action", async () => {
+    let workflowRuns = 0;
+
+    const result = await invokeAction({
+      mode: "auto",
+      action: closeMonthAction,
+      input: { period: "2026-07" },
+      workflow: async () => {
+        workflowRuns += 1;
+        return { period: "workflow", closed: true };
+      },
+    });
+
+    expect(result).toEqual({ period: "2026-07", closed: true });
+    expect(workflowRuns).toBe(0);
+  });
+});

--- a/skills/harness/tests/audit-emit.test.ts
+++ b/skills/harness/tests/audit-emit.test.ts
@@ -72,4 +72,27 @@ describe("audit.emit — event contract", () => {
     expect(audit.ALLOWED_EVENTS.has("gate_passed")).toBe(true);
     expect(audit.ALLOWED_EVENTS.has("gate_failed")).toBe(true);
   });
+
+  test("writes action execution lifecycle events without extension remapping", () => {
+    process.env.NIRVANA_AUDIT_STRICT = "1";
+    try {
+      audit.emit("execution_selected", {
+        mode: "action",
+        action_id: "accounting.close-month",
+        action_version: "1.0.0",
+      });
+      audit.emit("execution_fallback", {
+        mode: "auto",
+        fallback: "workflow",
+        reason: "action_unavailable",
+      });
+    } finally {
+      delete process.env.NIRVANA_AUDIT_STRICT;
+    }
+
+    expect(todayLines().map(({ event, mode }) => ({ event, mode }))).toEqual([
+      { event: "execution_selected", mode: "action" },
+      { event: "execution_fallback", mode: "auto" },
+    ]);
+  });
 });


### PR DESCRIPTION
### Resumo

Esta atualização porta o contrato explícito de execução para a main atual e resolve o conflito da PR sem apagar as entradas de changelog das versões `0.7.10`, `0.7.11` e da correção de lock no Windows.

### Entrega

- Adiciona a fronteira genérica para `action`, `workflow` e `auto`.
- Mantém precedência determinística: invocação explícita, projeto, squad e padrão `workflow`.
- Preserva IDs e versões estáveis no evento de seleção.
- Valida entrada antes da ação e saída depois dela.
- Mantém erro explícito no modo `action` quando a ação não existe ou o ID diverge.
- Em `auto`, usa o workflow quando a ação está ausente ou seu ID não corresponde ao solicitado.
- Emite `execution_selected` para seleção direta e `execution_fallback` com `{mode: "auto", fallback: "workflow", reason: "action_unavailable"}` no fallback.
- Não inclui entrada, saída ou segredos nos eventos.
- Registra os dois eventos no enum canônico e regenera a referência de auditoria.
- Adiciona testes comportamentais, documentação PT-BR e changelogs bilíngues.

### Escopo

Esta mudança entrega somente a fundação. Ela não conecta runtimes novos, não migra squads e não altera manifests automaticamente.

### Verificação executada

- Matriz relevante: 41 testes aprovados, 0 falhas, 186 assertions.
- Referência de auditoria sincronizada com 98 eventos canônicos.
- Audit parity estrita: 0 discrepâncias acionáveis.
- Changelog parity estrita: 51 versões e 122 seções em paridade.
- English source check: 0 arquivos sinalizados.
- Build Bun do novo módulo: aprovado.
- Checkout original e índice real do worktree preservados.

Uma execução ampla de baseline foi interrompida após reproduzir falhas preexistentes específicas de Windows, locale e resolução de `yaml` em árvores temporárias. A matriz relacionada à mudança permaneceu verde.
