### PR TITLE
fix(lock): Windows answers contention with EPERM, not only EEXIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### Contention on Windows stopped looking like a crash
+
+`withLock` treated anything but `EEXIST` as a real error. Windows has a
+second answer for "somebody else has this": a directory whose deletion is
+still pending rejects `mkdir` with `EPERM`, and an indexer or antivirus
+holding a handle turns it into `EACCES` or `EBUSY`. All three are the
+ordinary rm/mkdir race between two contenders, and rethrowing them made a
+spend-tracker or cooldown write die instead of waiting its turn. They now
+poll like `EEXIST` does — on Windows only, since on POSIX those codes still
+mean what they say. When the wait does time out, the message reports the code
+it kept receiving rather than blaming a live holder that may not exist.
+
 ## 0.7.11 — 2026-08-23
 
 ### The engine instructed the runtimes to watch, never to work

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,21 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Unreleased
+
+### Disputa de lock no Windows deixou de parecer falha
+
+O `withLock` tratava qualquer coisa que não fosse `EEXIST` como erro real. O
+Windows tem uma segunda resposta para "outro processo já tem isto": um
+diretório com exclusão pendente recusa o `mkdir` com `EPERM`, e um indexador
+ou antivírus segurando um handle transforma isso em `EACCES` ou `EBUSY`. Os
+três são a corrida comum de rm/mkdir entre dois contendores, e relançá-los
+matava uma escrita de spend-tracker ou de cooldown em vez de deixá-la esperar
+a vez. Agora eles fazem poll como o `EEXIST` — só no Windows, porque no POSIX
+esses códigos continuam significando o que dizem. Quando a espera realmente
+estoura, a mensagem informa o código que vinha recebendo em vez de acusar um
+dono vivo que pode não existir.
+
 ## 0.7.11 — 2026-08-23
 
 ### O engine mandava os runtimes vigiarem, nunca trabalharem

--- a/skills/_shared/lib/file-lock.ts
+++ b/skills/_shared/lib/file-lock.ts
@@ -82,6 +82,23 @@ export function lockDirFor(targetPath: string): string {
 
 /** Acquire the lock for `targetPath` (blocking, sync). Throws after
  * `timeoutMs` of contention against a live holder. */
+/**
+ * Did mkdir fail because somebody else holds the lock, or for a real reason?
+ *
+ * POSIX answers EEXIST and nothing else. Windows has a second answer: a
+ * directory whose deletion is still pending rejects mkdir with EPERM (and,
+ * with an indexer or antivirus holding a handle, EACCES or EBUSY). That is
+ * the ordinary rm/mkdir race between two contenders — the same situation
+ * EEXIST describes — so rethrowing it turned contention into a hard failure.
+ * It surfaced as a rare red on the Windows runner in the lost-update test;
+ * on a buyer's machine it would abort a spend-tracker or cooldown write.
+ */
+export function isContention(e: unknown): boolean {
+  const code = (e as NodeJS.ErrnoException)?.code;
+  if (code === "EEXIST") return true;
+  return process.platform === "win32" && (code === "EPERM" || code === "EACCES" || code === "EBUSY");
+}
+
 export function acquireLockSync(targetPath: string, opts: FileLockOpts = {}): FileLock {
   const timeoutMs = opts.timeoutMs ?? 10_000;
   const staleMs = opts.staleMs ?? 30_000;
@@ -90,6 +107,11 @@ export function acquireLockSync(targetPath: string, opts: FileLockOpts = {}): Fi
   fs.mkdirSync(path.dirname(dir), { recursive: true });
 
   const deadline = Date.now() + timeoutMs;
+  // Windows can answer contention with EPERM/EACCES/EBUSY, which also cover
+  // "this path is genuinely not writable". Waiting it out is right for the
+  // first case and merely slow for the second — so the timeout says which
+  // answer it kept getting instead of blaming a process that may not exist.
+  let lastWindowsCode: string | undefined;
   for (;;) {
     try {
       fs.mkdirSync(dir); // atomic: exactly one contender wins
@@ -106,7 +128,9 @@ export function acquireLockSync(targetPath: string, opts: FileLockOpts = {}): Fi
         },
       };
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      if (!isContention(e)) throw e;
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code !== "EEXIST") lastWindowsCode = code;
     }
     if (isStale(dir, staleMs)) {
       // Takeover: remove and re-contend. The rm/mkdir race between multiple
@@ -115,7 +139,10 @@ export function acquireLockSync(targetPath: string, opts: FileLockOpts = {}): Fi
       continue;
     }
     if (Date.now() >= deadline) {
-      throw new Error(`file-lock: timed out after ${timeoutMs}ms waiting for ${dir} (held by a live process)`);
+      throw new Error(
+        `file-lock: timed out after ${timeoutMs}ms waiting for ${dir} `
+        + (lastWindowsCode ? `(mkdir kept failing with ${lastWindowsCode} — contention, or the path is not writable)` : "(held by a live process)"),
+      );
     }
     sleepSync(pollMs);
   }

--- a/skills/harness/tests/file-lock.test.ts
+++ b/skills/harness/tests/file-lock.test.ts
@@ -11,7 +11,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
 
-import { acquireLockSync, withLock, lockDirFor } from "../../_shared/lib/file-lock.ts";
+import { acquireLockSync, withLock, lockDirFor, isContention } from "../../_shared/lib/file-lock.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-file-lock-test-"));
 const LOCK_MODULE = path.resolve(import.meta.dir, "..", "..", "_shared", "lib", "file-lock.ts");
@@ -32,6 +32,38 @@ function runWorkers(script: string, argvPerWorker: string[][], env: Record<strin
     child.on("error", reject);
   })));
 }
+
+describe("file-lock — what counts as contention", () => {
+  // A Windows runner went red here once: mkdir on a lock dir whose deletion was
+  // still pending answers EPERM, not EEXIST, and rethrowing it turned an
+  // ordinary race between two contenders into a dead worker.
+  const platform = process.platform;
+  const asPlatform = (p: string) => Object.defineProperty(process, "platform", { value: p, configurable: true });
+  afterAll(() => asPlatform(platform));
+
+  test("EEXIST is contention on every platform", () => {
+    for (const p of ["win32", "darwin", "linux"]) {
+      asPlatform(p);
+      expect(isContention({ code: "EEXIST" })).toBe(true);
+    }
+  });
+
+  test("a pending delete (EPERM/EACCES/EBUSY) is contention on Windows only", () => {
+    for (const code of ["EPERM", "EACCES", "EBUSY"]) {
+      asPlatform("win32");
+      expect(isContention({ code })).toBe(true);
+      asPlatform("linux");
+      expect(isContention({ code })).toBe(false);
+    }
+  });
+
+  test("a real error is never swallowed", () => {
+    asPlatform("win32");
+    expect(isContention({ code: "ENOSPC" })).toBe(false);
+    expect(isContention(new Error("no code at all"))).toBe(false);
+    expect(isContention(undefined)).toBe(false);
+  });
+});
 
 describe("file-lock — concurrent writers", () => {
   test("two subprocesses increment a shared counter with no lost updates", async () => {


### PR DESCRIPTION
The lost-update test went red once on the Windows runner and passed on rerun. The cause is real, not flake: a lock directory pending deletion rejects `mkdir` with `EPERM` on Windows (`EACCES`/`EBUSY` when a handle is held), and `acquireLockSync` rethrew anything that was not `EEXIST` — turning ordinary contention into a dead caller. On a buyer's machine that is an aborted spend-tracker or cooldown write.

Those codes now poll like `EEXIST`, on win32 only, and the timeout message names the code it kept receiving instead of blaming a live holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)