### PR TITLE
fix(windows): remove shell-specific redirection from hook commands

### DIFF
--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -43,11 +43,6 @@ const SKILLS_DIR = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
 const HOOK_SCRIPT = path.join(SKILLS_DIR, "_shared", "scripts", "audit-emit-from-hook.ts");
 const SESSION_START_SCRIPT = path.join(SKILLS_DIR, "_shared", "scripts", "gemini-session-start.ts");
-// stderr suppression that's valid on the shell each runtime uses to run hooks:
-// cmd.exe wants `2>nul` and has no `|| true`; POSIX shells want the bash form.
-// Hook paths are ALWAYS quoted below so a space in the username (C:\Users\John Doe)
-// doesn't truncate argv.
-const HOOK_SUPPRESS = process.platform === "win32" ? "2>nul" : "2>/dev/null || true";
 
 interface HookSpec {
   matcher?: string;
@@ -70,7 +65,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre claude-code ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre claude-code`,
           async: true,
           timeout: 5,
         }],
@@ -80,7 +75,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post claude-code ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post claude-code`,
           async: true,
           timeout: 5,
         }],
@@ -96,7 +91,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre gemini-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre gemini-cli`,
           timeout: 5000,
         }],
       }],
@@ -105,7 +100,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post gemini-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post gemini-cli`,
           timeout: 5000,
         }],
       }],
@@ -113,7 +108,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-session-start",
           type: "command",
-          command: `bun "${SESSION_START_SCRIPT}" ${HOOK_SUPPRESS}`,
+          command: `bun "${SESSION_START_SCRIPT}"`,
           timeout: 5000,
         }],
       }],
@@ -131,7 +126,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-pre",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" pre antigravity-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" pre antigravity-cli`,
           timeout: 5000,
         }],
       }],
@@ -140,7 +135,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-audit-post",
           type: "command",
-          command: `bun "${HOOK_SCRIPT}" post antigravity-cli ${HOOK_SUPPRESS}`,
+          command: `bun "${HOOK_SCRIPT}" post antigravity-cli`,
           timeout: 5000,
         }],
       }],
@@ -148,7 +143,7 @@ const AGENTS_TO_INSTALL: AgentInstallSpec[] = [
         hooks: [{
           name: "nirvana-session-start",
           type: "command",
-          command: `bun "${SESSION_START_SCRIPT}" ${HOOK_SUPPRESS}`,
+          command: `bun "${SESSION_START_SCRIPT}"`,
           timeout: 5000,
         }],
       }],

--- a/skills/harness/tests/hook-command-portability.test.ts
+++ b/skills/harness/tests/hook-command-portability.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const hookInstaller = fs.readFileSync(path.join(ROOT, "skills/_shared/scripts/install.ts"), "utf8");
+
+describe("agent hook command portability", () => {
+  test("does not append shell-specific null-device redirections", () => {
+    expect(hookInstaller).not.toContain("HOOK_SUPPRESS");
+    expect(hookInstaller).not.toMatch(/2\s*>\s*(?:nul|\/dev\/null)/i);
+  });
+});


### PR DESCRIPTION
## What this changes

Removes shell-specific stderr redirection from the eight hook commands installed for Claude Code, Gemini CLI, and Antigravity. The hook scripts already catch failures and exit successfully, so persisting `2>nul` or `2>/dev/null || true` makes the commands shell-dependent without adding fault tolerance.

This is the minimal remaining behavior from #59. #61 fixed the Windows wrappers and generated launchers, while #79 hardened the `nrv.cmd` launcher. Neither changed `skills/_shared/scripts/install.ts`. This replacement starts from current `main` at `aa7996b` and does not rebase the obsolete #59 branch.

## How it was tested

- Regression test on unchanged `aa7996b`: 0 pass, 1 fail at the `HOOK_SUPPRESS` assertion.
- `bun test skills/harness/tests/hook-command-portability.test.ts`: 1 pass, 0 fail.
- `bun test skills/harness/tests/hook-command-portability.test.ts skills/_shared/tests/cmd-wrappers.test.ts skills/harness/tests/install-teaches-init.test.ts`: 11 pass, 0 fail.
- `git diff --check`: pass.
- `bun test skills` under local Windows PowerShell: 934 pass, 36 fail. The unchanged base under the same command had 927 pass and 42 fail, with 34 shared failure names. The shared failures reproduce machine, locale, CRLF executable resolution, symlink privilege, and Bash-from-PowerShell issues unrelated to this delta.
- `bun run check:all` under local Windows PowerShell: both the branch and unchanged base stop at the same missing local coverage and `NOT_FOR` baselines.
- Exact-base evidence: [GitHub Actions run 32625444525](https://github.com/gutomec/nirvana-os-engine/actions/runs/32625444525) is green for `aa7996b` on Ubuntu, macOS, Windows, and the gates job. This branch still needs its own CI run.

## Checklist

- [ ] `bun test skills/harness/tests` passes
- [x] No hardcoded model names (the engine never prescribes a model; it inherits the runtime's)
- [x] No paid pack content, secrets, or `.env` values added to the engine
- [ ] **I have read and agree to the Nirvana-OS CLA v1.0** ([CLA.md](../CLA.md))