### PR TITLE
fix(install): never persist a temporary HOME on the Windows user PATH (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A temporary HOME no longer reaches the Windows user PATH
+
+`wireLocalBinOnPath()` persists `%USERPROFILE%\.local\bin` to the user PATH
+through the registry. The USERPROFILE a test sets decides the path being
+written; the `User` target is always the hive of the account running the
+process. Every test that installed into a temporary HOME therefore left
+`%TEMP%\nrv-*\home\.local\bin` on the real user PATH, and deleting the
+directory never removed the entry: 22 of them on one machine, most pointing
+nowhere (#87). The installer now refuses to persist a `.local\bin` that
+lives under a temporary directory, and `NIRVANA_SKIP_PATH_PERSIST=1` skips
+the registry write and the broadcast outright, while the current process
+still gets the entry. Every test that runs an installer in a fake HOME sets
+the flag through one shared helper, and a Windows-only regression test reads
+`HKCU\Environment\Path` before and after two real installs in a temporary
+HOME, one with the flag and one without.
+
+For machines already affected, `nrv doctor` reports the temporary entries
+with a count and which ones no longer exist, and
+`nrv install --repair-path` lists them without writing; `--apply` removes
+exactly those, keeps every other entry verbatim and in order, preserves the
+value kind, and broadcasts the change.
+
 ## 0.8.0 — 2026-08-25
 
 ### The runtime, Glance and Gauntlet program is documented from its proofs

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,30 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Unreleased
+
+### Um HOME temporário não chega mais ao PATH do usuário no Windows
+
+O `wireLocalBinOnPath()` persiste `%USERPROFILE%\.local\bin` no PATH do
+usuário pelo registro. O USERPROFILE que um teste define decide o caminho
+gravado; o alvo `User` é sempre o hive da conta que roda o processo. Todo
+teste que instalava num HOME temporário deixava, portanto,
+`%TEMP%\nrv-*\home\.local\bin` no PATH real do usuário, e apagar o diretório
+nunca removia a entrada: 22 delas numa máquina, a maioria apontando para
+lugar nenhum (#87). O instalador agora se recusa a persistir um `.local\bin`
+que fique sob um diretório temporário, e `NIRVANA_SKIP_PATH_PERSIST=1` pula a
+escrita no registro e o broadcast de uma vez, enquanto o processo atual
+continua recebendo a entrada. Todo teste que roda um instalador num HOME
+falso define a flag por um único helper compartilhado, e um teste de
+regressão só para Windows lê `HKCU\Environment\Path` antes e depois de duas
+instalações reais num HOME temporário, uma com a flag e outra sem.
+
+Para máquinas já afetadas, o `nrv doctor` reporta as entradas temporárias
+com contagem e quais já não existem, e `nrv install --repair-path` as lista
+sem gravar nada; `--apply` remove exatamente essas, mantém todas as outras
+como estão e na mesma ordem, preserva o tipo do valor e faz o broadcast da
+mudança.
+
 ## 0.8.0 — 2026-08-25
 
 ### O programa de runtime, Glance e Gauntlet está documentado pelas provas

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,6 +107,24 @@ rm -rf ~/squads/ ~/businesses/    # this deletes your capability library
 
 ---
 
+## Windows: the user PATH
+
+On Windows the installer adds `%USERPROFILE%\.local\bin` to the **user** PATH in the registry (`HKCU\Environment\Path`) and broadcasts the change, so `nrv` resolves in new terminals without a logoff. Two things keep that write from landing where it should not:
+
+- **`NIRVANA_SKIP_PATH_PERSIST=1`** skips the registry write and the broadcast (and the shell-profile append on macOS and Linux). The current process still gets `.local\bin` on its own PATH. The engine tests set it whenever they install into a temporary HOME.
+- **A temporary HOME is never persisted.** When `%USERPROFILE%\.local\bin` resolves under `%TEMP%`, `%TMP%`, `%LOCALAPPDATA%\Temp` or the process tmpdir, the installer says so and leaves the registry alone, flag or not.
+
+Engines up to 0.8.0 had neither, and running the test suite on Windows left `%TEMP%\nrv-*\home\.local\bin` entries on the real user PATH (issue #87). `nrv doctor` reports them. To remove them:
+
+```bash
+nrv install --repair-path          # lists the temporary nrv-* entries, writes nothing
+nrv install --repair-path --apply  # removes exactly those, keeps every other entry and its order
+```
+
+The repair rewrites the value with the kind it had (a `REG_EXPAND_SZ` stays unexpanded) and broadcasts `WM_SETTINGCHANGE`. Open a new terminal to see the clean PATH.
+
+---
+
 ## Troubleshooting
 
 **`nrv: command not found`** — `~/.local/bin` is not on `$PATH`. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc and open a new terminal.

--- a/bin/nrv
+++ b/bin/nrv
@@ -132,7 +132,7 @@ case "$cmd" in
   install)
     # nrv install — overloaded: with --bootstrap routes to the system installer.
     # Default routes to the asset installer (Tier 0/1: businesses, squads, mind-clones, packs).
-    if [[ "${1:-}" == "--bootstrap" || "${1:-}" == "--check" || "${1:-}" == "--starter" || "${1:-}" == "--no-starter" || "${1:-}" == "--dry" ]]; then
+    if [[ "${1:-}" == "--bootstrap" || "${1:-}" == "--check" || "${1:-}" == "--starter" || "${1:-}" == "--no-starter" || "${1:-}" == "--dry" || "${1:-}" == "--repair-path" ]]; then
       exec "$BUN_BIN" "$SKILLS/_shared/scripts/install.ts" "$@"
     fi
     exec "$BUN_BIN" "$SKILLS/_shared/scripts/install-asset.ts" "$@" ;;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,6 +16,7 @@ nrv <subcommand> [args]
 |---|---|
 | `nrv install --bootstrap` | Wire audit hooks into Claude Code, Gemini-CLI, and Antigravity (run once after installing; idempotent). |
 | `nrv install --check` | Report status; exit 0 if ready, 1 if it needs setup. |
+| `nrv install --repair-path` | Windows: list temporary `nrv-*` entries left on the user PATH (nothing written); `--apply` removes exactly those. |
 | `nrv doctor` | Full system diagnostic (binaries, skills, hooks, patches). |
 
 ## Talk to it / run work

--- a/skills/_shared/lib/windows-user-path.ts
+++ b/skills/_shared/lib/windows-user-path.ts
@@ -1,0 +1,77 @@
+// windows-user-path.ts — the user PATH Windows keeps in the registry, and what
+// the engine may put there.
+//
+// On Windows the user PATH is a registry value (HKCU\Environment\Path), and the
+// installer persists %USERPROFILE%\.local\bin into it so `nrv` resolves in new
+// terminals. The `User` target is the account running the process, whatever
+// USERPROFILE says: a test that ran the installer with a fake HOME under %TEMP%
+// wrote that fake path into the real hive, and nothing removed it after the
+// directory was deleted (issue #87: 22 entries on one machine, most pointing
+// nowhere). This module holds the guard the installer applies before
+// persisting, the detection `nrv doctor` runs, the removal
+// `nrv install --repair-path` performs, and the registry access they share.
+//
+// The string logic is pure and uses Windows PATH semantics whatever the host
+// (case-insensitive, `;` between entries, either separator), so it is tested on
+// every platform; only the registry access is Windows-only.
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+/** Set to "1" to keep the installer from persisting ~/.local/bin anywhere (the
+ *  Windows registry, a POSIX shell startup file). The current process still gets
+ *  the entry on its own PATH. Every test that runs an installer in a fake HOME
+ *  sets it — see skills/harness/tests/helpers/fake-home.ts. */
+export const SKIP_PATH_PERSIST_ENV = "NIRVANA_SKIP_PATH_PERSIST";
+
+export function skipPathPersist(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[SKIP_PATH_PERSIST_ENV] === "1";
+}
+
+/** Normalize an entry for comparison only: trimmed, backslashes, no trailing
+ *  separator, lower case. Never written back — entries are kept verbatim. */
+function normalizeEntry(entry: string): string {
+  return entry.trim().replace(/\//g, "\\").replace(/\\+$/, "").toLowerCase();
+}
+
+/** `entry` is `root` itself or lies below it. */
+export function isUnderRoot(entry: string, root: string): boolean {
+  const e = normalizeEntry(entry);
+  const r = normalizeEntry(root);
+  return r !== "" && (e === r || e.startsWith(r + "\\"));
+}
+
+/** The temporary roots a persisted PATH entry must never live under: the
+ *  process tmpdir plus whatever %TEMP%, %TMP% and %LOCALAPPDATA%\Temp name. The
+ *  affected entries were written under one shell's TEMP and may be inspected
+ *  from another, so every candidate counts. */
+export function tempRoots(env: NodeJS.ProcessEnv = process.env): string[] {
+  const candidates = [os.tmpdir(), env.TEMP, env.TMP, env.LOCALAPPDATA ? path.join(env.LOCALAPPDATA, "Temp") : undefined];
+  const seen = new Set<string>();
+  const roots: string[] = [];
+  for (const c of candidates) {
+    if (!c) continue;
+    const key = normalizeEntry(c);
+    if (key === "" || seen.has(key)) continue;
+    seen.add(key);
+    roots.push(c);
+  }
+  return roots;
+}
+
+export function isUnderTempRoot(entry: string, roots: string[] = tempRoots()): boolean {
+  return roots.some((r) => isUnderRoot(entry, r));
+}
+
+/** Best-effort WM_SETTINGCHANGE (0x1A) to HWND_BROADCAST, so an already-running
+ *  Explorer reloads its environment block and terminals opened afterwards
+ *  inherit the new user PATH without a logoff. Runs in its own process and its
+ *  own try: a failure here can never undo a registry write that already
+ *  happened. */
+export function broadcastEnvironmentChange(): void {
+  const ps =
+    "$s='[DllImport(\"user32.dll\")] public static extern int SendMessageTimeout(IntPtr h,int m,IntPtr w,string l,int f,int t,out IntPtr r);'; " +
+    "Add-Type -MemberDefinition $s -Name W -Namespace N | Out-Null; " +
+    "$r=[IntPtr]::Zero; [void][N.W]::SendMessageTimeout([IntPtr]0xffff,0x1A,[IntPtr]::Zero,'Environment',2,5000,[ref]$r)";
+  try { spawnSync("powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps], { encoding: "utf8", timeout: 8000 }); } catch { /* best-effort */ }
+}

--- a/skills/_shared/lib/windows-user-path.ts
+++ b/skills/_shared/lib/windows-user-path.ts
@@ -14,6 +14,7 @@
 // The string logic is pure and uses Windows PATH semantics whatever the host
 // (case-insensitive, `;` between entries, either separator), so it is tested on
 // every platform; only the registry access is Windows-only.
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -41,26 +42,126 @@ export function isUnderRoot(entry: string, root: string): boolean {
   return r !== "" && (e === r || e.startsWith(r + "\\"));
 }
 
+/** The long form of a Windows path whose components may be 8.3 short names
+ *  (C:\Users\RUNNER~1\...): TEMP is often set that way, while the registry holds
+ *  what the installer expanded at the time. Only for paths that exist. */
+function longForm(p: string): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  try { return fs.realpathSync.native(p); } catch { return undefined; }
+}
+
 /** The temporary roots a persisted PATH entry must never live under: the
- *  process tmpdir plus whatever %TEMP%, %TMP% and %LOCALAPPDATA%\Temp name. The
- *  affected entries were written under one shell's TEMP and may be inspected
- *  from another, so every candidate counts. */
+ *  process tmpdir plus whatever %TEMP%, %TMP% and %LOCALAPPDATA%\Temp name, each
+ *  in its short and long spelling. The affected entries were written under one
+ *  shell's TEMP and may be inspected from another, so every candidate counts. */
 export function tempRoots(env: NodeJS.ProcessEnv = process.env): string[] {
   const candidates = [os.tmpdir(), env.TEMP, env.TMP, env.LOCALAPPDATA ? path.join(env.LOCALAPPDATA, "Temp") : undefined];
   const seen = new Set<string>();
   const roots: string[] = [];
   for (const c of candidates) {
     if (!c) continue;
-    const key = normalizeEntry(c);
-    if (key === "" || seen.has(key)) continue;
-    seen.add(key);
-    roots.push(c);
+    for (const form of [c, longForm(c)]) {
+      if (!form) continue;
+      const key = normalizeEntry(form);
+      if (key === "" || seen.has(key)) continue;
+      seen.add(key);
+      roots.push(form);
+    }
   }
   return roots;
 }
 
 export function isUnderTempRoot(entry: string, roots: string[] = tempRoots()): boolean {
   return roots.some((r) => isUnderRoot(entry, r));
+}
+
+/** PATH entries as stored, verbatim — empty entries included, so joining the
+ *  survivors reproduces the original string minus what was removed. */
+export function splitPath(value: string): string[] {
+  return value.split(";");
+}
+
+export function joinPath(entries: string[]): string {
+  return entries.join(";");
+}
+
+/** Expand %NAME% references the way a REG_EXPAND_SZ value is expanded, from the
+ *  given env (names are case-insensitive). Unknown names stay as written. */
+export function expandEnv(entry: string, env: NodeJS.ProcessEnv = process.env): string {
+  if (!entry.includes("%")) return entry;
+  const byLowerName = new Map<string, string>();
+  for (const [name, value] of Object.entries(env)) if (value !== undefined) byLowerName.set(name.toLowerCase(), value);
+  return entry.replace(/%([^%]+)%/g, (whole, name: string) => byLowerName.get(name.toLowerCase()) ?? whole);
+}
+
+/** An entry the installer wrote from a temporary HOME: under one of the temp
+ *  roots, with a directory segment carrying `nrv-` below that root
+ *  (%TEMP%\nrv-buyer-abc\home\.local\bin). Anything else on the PATH is someone
+ *  else's and is never touched. */
+export function isTempNrvEntry(entry: string, roots: string[], env: NodeJS.ProcessEnv = process.env): boolean {
+  const expanded = expandEnv(entry, env);
+  const root = roots.find((r) => isUnderRoot(expanded, r));
+  if (!root) return false;
+  const below = normalizeEntry(expanded).slice(normalizeEntry(root).length);
+  return below.split("\\").some((segment) => segment.includes("nrv-"));
+}
+
+export function findTempNrvEntries(value: string, roots: string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  return splitPath(value).filter((e) => isTempNrvEntry(e, roots, env));
+}
+
+export interface PathRepair { before: string[]; after: string[]; removed: string[] }
+
+/** Drop exactly the temporary nrv entries. Every other entry keeps its text and
+ *  its position; nothing is trimmed, expanded or de-duplicated on the way. */
+export function removeTempNrvEntries(value: string, roots: string[], env: NodeJS.ProcessEnv = process.env): PathRepair {
+  const before = splitPath(value);
+  const removed: string[] = [];
+  const after: string[] = [];
+  for (const entry of before) (isTempNrvEntry(entry, roots, env) ? removed : after).push(entry);
+  return { before, after, removed };
+}
+
+// ─── Registry access (Windows only) ───────────────────────────────────
+
+export type UserPathKind = "String" | "ExpandString";
+export interface UserPathValue { value: string; kind: UserPathKind }
+
+function powershell(script: string, env?: NodeJS.ProcessEnv) {
+  return spawnSync("powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script], { encoding: "utf8", timeout: 15000, env });
+}
+
+/** HKCU\Environment\Path as stored — unexpanded, with its value kind — or null
+ *  when there is no such value, no registry to ask, or a kind this module will
+ *  not rewrite. Through PowerShell rather than `reg query` so the value arrives
+ *  as UTF-8 whatever the console code page: an entry mangled on the way in
+ *  would be written back mangled. */
+export function readUserPath(): UserPathValue | null {
+  if (process.platform !== "win32") return null;
+  const script =
+    "try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}; " +
+    "$k=[Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment'); if ($null -eq $k) { exit 3 }; " +
+    "$v=$k.GetValue('Path',$null,[Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames); if ($null -eq $v) { exit 3 }; " +
+    "Write-Output ([string]$k.GetValueKind('Path')); Write-Output ([string]$v)";
+  const r = powershell(script);
+  if (r.status !== 0) return null;
+  const lines = (r.stdout ?? "").split(/\r?\n/);
+  const kind = lines[0]?.trim();
+  if (kind !== "String" && kind !== "ExpandString") return null;
+  return { value: lines[1] ?? "", kind };
+}
+
+/** Write HKCU\Environment\Path back with the kind it had. The value travels in
+ *  an environment variable, not on the command line, so quoting and code pages
+ *  cannot alter it. False when the write did not happen. */
+export function writeUserPath(next: UserPathValue): boolean {
+  if (process.platform !== "win32") return false;
+  const script =
+    "$v=[string]$env:NRV_USER_PATH; " +
+    "$k=[Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment',$true); if ($null -eq $k) { exit 3 }; " +
+    `$k.SetValue('Path',$v,[Microsoft.Win32.RegistryValueKind]::${next.kind}); Write-Output 'written'`;
+  const r = powershell(script, { ...process.env, NRV_USER_PATH: next.value });
+  return r.status === 0 && /written/.test(r.stdout ?? "");
 }
 
 /** Best-effort WM_SETTINGCHANGE (0x1A) to HWND_BROADCAST, so an already-running

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -21,6 +21,7 @@
  *   nrv install --dry      # show what would change, don't write
  *   nrv install --uninstall  # remove our hooks (keeps user's other settings)
  *   nrv install --check    # report installation status, exit 0/1
+ *   nrv install --repair-path [--apply]  # Windows: drop temporary nrv-* entries from the user PATH
  *   nrv install -h         # this message
  */
 
@@ -30,7 +31,10 @@ import * as os from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { parseArgs, EXIT, log } from "../lib/bun-helpers.ts";
-import { SKIP_PATH_PERSIST_ENV, skipPathPersist, isUnderTempRoot, broadcastEnvironmentChange } from "../lib/windows-user-path.ts";
+import {
+  SKIP_PATH_PERSIST_ENV, skipPathPersist, isUnderTempRoot, broadcastEnvironmentChange,
+  readUserPath, writeUserPath, removeTempNrvEntries, tempRoots, expandEnv, joinPath,
+} from "../lib/windows-user-path.ts";
 
 // ─── Marker that identifies hooks added by this script ────────────────
 // Any hook whose command contains one of these tokens is "ours" and is
@@ -401,6 +405,50 @@ function installDependencies(repoRoot: string, dry: boolean): { ok: boolean; not
   return { ok, notes };
 }
 
+// ─── Windows user PATH repair (issue #87) ─────────────────────────────
+// Engines up to 0.8.0 persisted %USERPROFILE%\.local\bin to the user PATH even
+// when USERPROFILE was a test's temporary HOME, and deleting that HOME never
+// removed the entry. Reports what would go by default; --apply rewrites the
+// value with exactly those entries dropped — everything else verbatim, in its
+// order, with the value kind it had — then broadcasts WM_SETTINGCHANGE so new
+// terminals see it.
+function repairUserPath(apply: boolean): number {
+  console.log("Windows user PATH repair (HKCU\\Environment\\Path)\n");
+  if (process.platform !== "win32") {
+    console.log("  only Windows keeps the user PATH in the registry — nothing to repair here.");
+    return EXIT.OK;
+  }
+  const reg = readUserPath();
+  if (!reg) {
+    console.log("  no user PATH value in HKCU\\Environment (or it could not be read) — nothing to repair.");
+    return EXIT.OK;
+  }
+  const { before, after, removed } = removeTempNrvEntries(reg.value, tempRoots());
+  const show = (entries: string[]) => entries.forEach((e, i) => {
+    const mark = removed.includes(e) ? `   ← temporary nrv entry${fs.existsSync(expandEnv(e)) ? "" : " (missing on disk)"}` : "";
+    console.log(`    ${String(i + 1).padStart(2)}. ${e === "" ? "(empty)" : e}${mark}`);
+  });
+  console.log(`  before (${before.length} entries):`);
+  show(before);
+  if (removed.length === 0) {
+    console.log("\n  no temporary nrv entries — nothing to remove.");
+    return EXIT.OK;
+  }
+  console.log(`\n  after (${after.length} entries):`);
+  show(after);
+  if (!apply) {
+    console.log(`\n(dry run — ${removed.length} entr${removed.length === 1 ? "y" : "ies"} would be removed, nothing written. Re-run with --apply to remove them.)`);
+    return EXIT.OK;
+  }
+  if (!writeUserPath({ value: joinPath(after), kind: reg.kind })) {
+    console.log("\n✗ could not write HKCU\\Environment\\Path — nothing changed.");
+    return EXIT.FAILURES;
+  }
+  broadcastEnvironmentChange();
+  console.log(`\n✓ removed ${removed.length} entr${removed.length === 1 ? "y" : "ies"}; user PATH rewritten (${reg.kind}) and WM_SETTINGCHANGE broadcast — new terminals see the clean PATH.`);
+  return EXIT.OK;
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────
 function main() {
   const { flags } = parseArgs();
@@ -412,6 +460,9 @@ USAGE
   nrv install --dry        show what would change, don't write anything
   nrv install --check      report status (exit 0 = ready, 1 = needs setup)
   nrv install --uninstall  remove our hooks (keeps user's other settings)
+  nrv install --repair-path          Windows: list temporary nrv-* entries left on the
+                                     user PATH by earlier test runs (nothing written)
+  nrv install --repair-path --apply  remove exactly those entries, keep the rest as is
   nrv install -h           this help
 
 WHAT IT DOES
@@ -436,6 +487,8 @@ inline, with no dispatch, no quality gate and no audit trail.
 `);
     process.exit(EXIT.OK);
   }
+
+  if (flags["repair-path"]) process.exit(repairUserPath(!!flags.apply && !flags.dry));
 
   const dryRun = !!flags.dry;
   const uninstall = !!flags.uninstall;

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -30,6 +30,7 @@ import * as os from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { parseArgs, EXIT, log } from "../lib/bun-helpers.ts";
+import { SKIP_PATH_PERSIST_ENV, skipPathPersist, isUnderTempRoot, broadcastEnvironmentChange } from "../lib/windows-user-path.ts";
 
 // ─── Marker that identifies hooks added by this script ────────────────
 // Any hook whose command contains one of these tokens is "ours" and is
@@ -237,8 +238,30 @@ function wireLocalBinOnPath(dry: boolean): string[] {
   const notes: string[] = [];
   const home = os.homedir();
   const localBin = path.join(home, ".local", "bin");
+  // Issue #87: the persistence target is the REAL user's — the registry hive on
+  // Windows, the shell rc files elsewhere — even when HOME/USERPROFILE point at
+  // a fake home, so a test that ran this with a temporary HOME left that path on
+  // the real user PATH for good. Two guards, both stated in the output:
+  // NIRVANA_SKIP_PATH_PERSIST=1 (every fake-home test sets it), and on Windows,
+  // where the hive is shared, a localBin under a temporary directory is never
+  // persisted, flag or not. The current process still gets it on its own PATH.
+  const skipReason = skipPathPersist() ? `${SKIP_PATH_PERSIST_ENV}=1`
+    : process.platform === "win32" && isUnderTempRoot(localBin) ? `${localBin} is under a temporary directory`
+    : null;
   if (process.platform === "win32") {
-    if (dry) { notes.push(`would add ${localBin} to the user PATH (Windows)`); return notes; }
+    if (dry) {
+      notes.push(skipReason ? `would not persist ${localBin} to the user PATH (${skipReason})` : `would add ${localBin} to the user PATH (Windows)`);
+      return notes;
+    }
+    // Make the CURRENT install process see it, so the post-install `nrv index`
+    // (this same run) resolves the launcher without a restart.
+    if (!(process.env.PATH || "").split(";").some(p => p.trim().replace(/\\+$/, "").toLowerCase() === localBin.toLowerCase())) {
+      process.env.PATH = `${localBin};${process.env.PATH || ""}`;
+    }
+    if (skipReason) {
+      notes.push(`not persisting ${localBin} to the user PATH (${skipReason}) — this process only; registry untouched, no WM_SETTINGCHANGE broadcast.`);
+      return notes;
+    }
     // 1) PERSIST to the USER PATH via the registry ([Environment]::SetEnvironmentVariable
     //    'User') — NOT setx, which truncates PATH at 1024 chars. Idempotent.
     const persistPs =
@@ -252,29 +275,20 @@ function wireLocalBinOnPath(dry: boolean): string[] {
       persisted = r.stdout || "";
     } catch { /* fall through to the manual-add note below */ }
 
-    // Make the CURRENT install process see it too, so the post-install `nrv index`
-    // (this same run) resolves the launcher without a restart.
-    if (!(process.env.PATH || "").split(";").some(p => p.trim().replace(/\\+$/, "").toLowerCase() === localBin.toLowerCase())) {
-      process.env.PATH = `${localBin};${process.env.PATH || ""}`;
-    }
-
-    // 2) BEST-EFFORT broadcast WM_SETTINGCHANGE (0x1A) to HWND_BROADCAST so an
-    //    already-running Explorer reloads its environment block — terminals opened
-    //    afterwards inherit the new PATH WITHOUT a logoff/restart. Isolated in its
-    //    own process+try so a failure here can NEVER undo the persistence above.
-    if (/added/.test(persisted)) {
-      const bcastPs =
-        "$s='[DllImport(\"user32.dll\")] public static extern int SendMessageTimeout(IntPtr h,int m,IntPtr w,string l,int f,int t,out IntPtr r);'; " +
-        "Add-Type -MemberDefinition $s -Name W -Namespace N | Out-Null; " +
-        "$r=[IntPtr]::Zero; [void][N.W]::SendMessageTimeout([IntPtr]0xffff,0x1A,[IntPtr]::Zero,'Environment',2,5000,[ref]$r)";
-      try { spawnSync("powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", bcastPs], { encoding: "utf8", timeout: 8000 }); } catch { /* best-effort */ }
-    }
+    // 2) BEST-EFFORT broadcast so terminals opened afterwards inherit the new
+    //    PATH WITHOUT a logoff/restart. Its own process and try, so a failure
+    //    here can NEVER undo the persistence above.
+    if (/added/.test(persisted)) broadcastEnvironmentChange();
 
     if (/added/.test(persisted)) {
       notes.push(`added ${localBin} to the user PATH (Windows) — new terminals work immediately (no restart).`);
       notes.push(`  this window only: run  set PATH=%USERPROFILE%\\.local\\bin;%PATH%`);
     } else if (/present/.test(persisted)) { /* already there */ }
     else notes.push(`não consegui ajustar o PATH automaticamente — adicione "%USERPROFILE%\\.local\\bin" ao PATH do usuário.`);
+    return notes;
+  }
+  if (skipReason) {
+    notes.push(`${dry ? "would not persist" : "not persisting"} ~/.local/bin to a shell profile (${skipReason}).`);
     return notes;
   }
   const marker = "# nirvana-os: nrv on PATH";
@@ -407,6 +421,12 @@ WHAT IT DOES
        - Gemini-CLI:  ~/.gemini/settings.json  (BeforeTool/AfterTool/SessionStart)
   3. Creates timestamped backups before modifying any file
   4. Smoke-tests the audit pipe (writes a sentinel event)
+
+ENVIRONMENT
+  NIRVANA_SKIP_PATH_PERSIST=1  never persist ~/.local/bin to the user PATH
+                               (Windows registry / shell profile); this process
+                               only. Set by every test that installs into a
+                               temporary HOME.
 
 After install, every Write/Edit/Bash by Claude Code OR Gemini-CLI lands in
 ~/.harness-logs/<today>/audit.jsonl automatically. Watch with 'nrv watch'.

--- a/skills/_shared/tests/runtime-links.test.ts
+++ b/skills/_shared/tests/runtime-links.test.ts
@@ -19,6 +19,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { fakeHomeEnv } from "../../harness/tests/helpers/fake-home.ts";
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SKILLS = ["harness", "businesses", "squads", "_shared", "nirvana-os"];
@@ -74,7 +75,7 @@ function install(
   const r = spawnSync(
     process.execPath,
     [path.join(fakeRepo, "scripts", "install.ts"), "--no-starter", "--no-index", "--no-hermes", ...extraArgs],
-    { env: { ...process.env, HOME: home, USERPROFILE: home, NIRVANA_PACKS_DIR: path.join(home, "no-packs"), ...envOverride }, encoding: "utf8" },
+    { env: fakeHomeEnv(home, { NIRVANA_PACKS_DIR: path.join(home, "no-packs"), ...envOverride }), encoding: "utf8" },
   );
   return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }
@@ -83,7 +84,7 @@ function uninstall(home: string): { code: number; out: string } {
   const r = spawnSync(
     process.execPath,
     [path.join(REPO, "skills", "_shared", "scripts", "uninstall-engine.ts")],
-    { env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: "utf8" },
+    { env: fakeHomeEnv(home), encoding: "utf8" },
   );
   return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }

--- a/skills/_shared/tests/windows-user-path.test.ts
+++ b/skills/_shared/tests/windows-user-path.test.ts
@@ -3,13 +3,21 @@
 //
 // The Windows regression test (harness/tests/windows-path-persist.test.ts)
 // proves the registry does not move; it runs only where the registry exists.
-// The decisions it depends on are string logic with Windows PATH semantics —
-// case-insensitive, `;` between entries, either separator — and those are
-// asserted here with explicit roots, so a macOS or Linux run covers them too.
+// The decisions it depends on — and the detection `nrv doctor` runs and the
+// removal `nrv install --repair-path` performs — are string logic with Windows
+// PATH semantics: case-insensitive, `;` between entries, either separator.
+// Those are asserted here with explicit roots, so a macOS or Linux run covers
+// them too.
 import { describe, expect, test } from "bun:test";
-import { isUnderRoot, isUnderTempRoot, skipPathPersist, tempRoots } from "../lib/windows-user-path.ts";
+import * as os from "node:os";
+import {
+  expandEnv, findTempNrvEntries, isTempNrvEntry, isUnderRoot, isUnderTempRoot, joinPath,
+  removeTempNrvEntries, skipPathPersist, tempRoots,
+} from "../lib/windows-user-path.ts";
 
 const TEMP = "C:\\Users\\andre\\AppData\\Local\\Temp";
+const ROOTS = [TEMP, "C:\\Windows\\Temp"];
+const ENV = { LOCALAPPDATA: "C:\\Users\\andre\\AppData\\Local", USERPROFILE: "C:\\Users\\andre" };
 
 describe("isUnderRoot — the guard the installer applies before persisting", () => {
   test("a fake HOME's .local\\bin under %TEMP% is under it", () => {
@@ -32,8 +40,8 @@ describe("isUnderRoot — the guard the installer applies before persisting", ()
   });
 
   test("the real user's .local\\bin is not under any temp root", () => {
-    expect(isUnderTempRoot("C:\\Users\\andre\\.local\\bin", [TEMP, "C:\\Windows\\Temp"])).toBe(false);
-    expect(isUnderTempRoot("C:\\Windows\\Temp\\nrv-1\\home\\.local\\bin", [TEMP, "C:\\Windows\\Temp"])).toBe(true);
+    expect(isUnderTempRoot("C:\\Users\\andre\\.local\\bin", ROOTS)).toBe(false);
+    expect(isUnderTempRoot("C:\\Windows\\Temp\\nrv-1\\home\\.local\\bin", ROOTS)).toBe(true);
   });
 
   test("an empty root never matches anything", () => {
@@ -44,14 +52,14 @@ describe("isUnderRoot — the guard the installer applies before persisting", ()
 
 describe("tempRoots — every place a temporary HOME may have been created", () => {
   test("collects tmpdir, TEMP, TMP and LOCALAPPDATA\\Temp without duplicates", () => {
-    const roots = tempRoots({ TEMP, TMP: TEMP.toLowerCase() + "\\", LOCALAPPDATA: "C:\\Users\\andre\\AppData\\Local" });
+    const roots = tempRoots({ TEMP, TMP: TEMP.toLowerCase() + "\\", LOCALAPPDATA: ENV.LOCALAPPDATA });
     expect(roots.filter((r) => isUnderRoot(r, TEMP))).toHaveLength(1);
-    expect(roots.some((r) => isUnderRoot(r, "C:\\Users\\andre\\AppData\\Local\\Temp"))).toBe(true);
-    expect(roots.length).toBeGreaterThanOrEqual(2); // the process tmpdir plus the Windows ones
+    expect(roots).toContain(os.tmpdir());
   });
 
-  test("an unset variable contributes nothing", () => {
-    expect(tempRoots({})).toHaveLength(1);
+  test("an unset or empty variable contributes nothing", () => {
+    expect(tempRoots({})).toContain(os.tmpdir());
+    expect(tempRoots({ TEMP: "", TMP: "" })).toEqual(tempRoots({}));
   });
 });
 
@@ -60,5 +68,72 @@ describe("skipPathPersist — the explicit flag", () => {
     expect(skipPathPersist({ NIRVANA_SKIP_PATH_PERSIST: "1" })).toBe(true);
     expect(skipPathPersist({ NIRVANA_SKIP_PATH_PERSIST: "true" })).toBe(false);
     expect(skipPathPersist({})).toBe(false);
+  });
+});
+
+describe("expandEnv — what a REG_EXPAND_SZ entry means", () => {
+  test("expands %NAME% case-insensitively and leaves unknown names alone", () => {
+    expect(expandEnv("%LocalAppData%\\Temp\\nrv-1\\home\\.local\\bin", ENV)).toBe(`${TEMP}\\nrv-1\\home\\.local\\bin`);
+    expect(expandEnv("%NOPE%\\bin", ENV)).toBe("%NOPE%\\bin");
+    expect(expandEnv("C:\\plain", ENV)).toBe("C:\\plain");
+  });
+});
+
+describe("isTempNrvEntry — exactly what the installer wrote from a temporary HOME", () => {
+  test("the entries from the issue match", () => {
+    expect(isTempNrvEntry(`${TEMP}\\nrv-buyer-Ab12Cd\\home\\.local\\bin`, ROOTS, ENV)).toBe(true);
+    expect(isTempNrvEntry(`${TEMP}\\nrv-update-safety-x9\\home\\.local\\bin`, ROOTS, ENV)).toBe(true);
+    expect(isTempNrvEntry("%LOCALAPPDATA%\\Temp\\nrv-runtime-links-q1\\home\\.local\\bin", ROOTS, ENV)).toBe(true);
+  });
+
+  test("a temp entry without an nrv- segment is someone else's", () => {
+    expect(isTempNrvEntry(`${TEMP}\\some-tool\\bin`, ROOTS, ENV)).toBe(false);
+    expect(isTempNrvEntry(`${TEMP}\\install-order-abc\\bin`, ROOTS, ENV)).toBe(false);
+  });
+
+  test("an nrv- path outside every temp root is never a candidate", () => {
+    expect(isTempNrvEntry("C:\\Users\\andre\\nrv-projects\\bin", ROOTS, ENV)).toBe(false);
+    expect(isTempNrvEntry("C:\\Users\\andre\\.local\\bin", ROOTS, ENV)).toBe(false);
+  });
+
+  test("the temp root itself, or an nrv- segment in the root, does not count", () => {
+    expect(isTempNrvEntry(TEMP, ROOTS, ENV)).toBe(false);
+    expect(isTempNrvEntry("D:\\nrv-temp\\bin", ["D:\\nrv-temp"], ENV)).toBe(false);
+  });
+});
+
+describe("removeTempNrvEntries — the repair, on a PATH string", () => {
+  const stale1 = `${TEMP}\\nrv-buyer-A1\\home\\.local\\bin`;
+  const stale2 = "%LOCALAPPDATA%\\Temp\\nrv-buyer-B2\\home\\.local\\bin";
+  const value = [
+    "C:\\Users\\andre\\.local\\bin", stale1, "%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps",
+    stale2, "", "C:\\Program Files\\Git\\cmd", `${TEMP}\\other-tool`, "",
+  ].join(";");
+
+  test("finds both spellings, in PATH order", () => {
+    expect(findTempNrvEntries(value, ROOTS, ENV)).toEqual([stale1, stale2]);
+  });
+
+  test("removes exactly those and keeps everything else verbatim, order and empties included", () => {
+    const { before, after, removed } = removeTempNrvEntries(value, ROOTS, ENV);
+    expect(before).toHaveLength(8);
+    expect(removed).toEqual([stale1, stale2]);
+    expect(joinPath(after)).toBe(
+      "C:\\Users\\andre\\.local\\bin;%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps;;C:\\Program Files\\Git\\cmd;" + `${TEMP}\\other-tool;`,
+    );
+  });
+
+  test("a clean PATH comes back byte-identical", () => {
+    const clean = "C:\\Users\\andre\\.local\\bin;C:\\Program Files\\Git\\cmd;";
+    const { after, removed } = removeTempNrvEntries(clean, ROOTS, ENV);
+    expect(removed).toEqual([]);
+    expect(joinPath(after)).toBe(clean);
+  });
+
+  test("twenty-two of them go in one pass", () => {
+    const many = Array.from({ length: 22 }, (_, i) => `${TEMP}\\nrv-buyer-${i}\\home\\.local\\bin`);
+    const { after, removed } = removeTempNrvEntries(["C:\\keep", ...many, "C:\\also-keep"].join(";"), ROOTS, ENV);
+    expect(removed).toHaveLength(22);
+    expect(after).toEqual(["C:\\keep", "C:\\also-keep"]);
   });
 });

--- a/skills/_shared/tests/windows-user-path.test.ts
+++ b/skills/_shared/tests/windows-user-path.test.ts
@@ -1,0 +1,64 @@
+// windows-user-path.test.ts — the pure PATH logic behind issue #87, on every
+// platform.
+//
+// The Windows regression test (harness/tests/windows-path-persist.test.ts)
+// proves the registry does not move; it runs only where the registry exists.
+// The decisions it depends on are string logic with Windows PATH semantics —
+// case-insensitive, `;` between entries, either separator — and those are
+// asserted here with explicit roots, so a macOS or Linux run covers them too.
+import { describe, expect, test } from "bun:test";
+import { isUnderRoot, isUnderTempRoot, skipPathPersist, tempRoots } from "../lib/windows-user-path.ts";
+
+const TEMP = "C:\\Users\\andre\\AppData\\Local\\Temp";
+
+describe("isUnderRoot — the guard the installer applies before persisting", () => {
+  test("a fake HOME's .local\\bin under %TEMP% is under it", () => {
+    expect(isUnderRoot(`${TEMP}\\nrv-buyer-abc123\\home\\.local\\bin`, TEMP)).toBe(true);
+  });
+
+  test("the root itself counts", () => {
+    expect(isUnderRoot(TEMP, TEMP)).toBe(true);
+    expect(isUnderRoot(`${TEMP}\\`, TEMP)).toBe(true);
+  });
+
+  test("a sibling that merely shares the prefix does not", () => {
+    expect(isUnderRoot(`${TEMP}2\\nrv-x\\home\\.local\\bin`, TEMP)).toBe(false);
+    expect(isUnderRoot("C:\\Users\\andre\\AppData\\Local\\Templates\\bin", TEMP)).toBe(false);
+  });
+
+  test("case and separator style do not matter, as on Windows", () => {
+    expect(isUnderRoot("c:/users/ANDRE/appdata/local/temp/nrv-1/home/.local/bin", TEMP)).toBe(true);
+    expect(isUnderRoot(`${TEMP}\\nrv-1\\home\\.local\\bin\\`, `${TEMP}\\\\`)).toBe(true);
+  });
+
+  test("the real user's .local\\bin is not under any temp root", () => {
+    expect(isUnderTempRoot("C:\\Users\\andre\\.local\\bin", [TEMP, "C:\\Windows\\Temp"])).toBe(false);
+    expect(isUnderTempRoot("C:\\Windows\\Temp\\nrv-1\\home\\.local\\bin", [TEMP, "C:\\Windows\\Temp"])).toBe(true);
+  });
+
+  test("an empty root never matches anything", () => {
+    expect(isUnderRoot("C:\\anything", "")).toBe(false);
+    expect(isUnderTempRoot("C:\\anything", [])).toBe(false);
+  });
+});
+
+describe("tempRoots — every place a temporary HOME may have been created", () => {
+  test("collects tmpdir, TEMP, TMP and LOCALAPPDATA\\Temp without duplicates", () => {
+    const roots = tempRoots({ TEMP, TMP: TEMP.toLowerCase() + "\\", LOCALAPPDATA: "C:\\Users\\andre\\AppData\\Local" });
+    expect(roots.filter((r) => isUnderRoot(r, TEMP))).toHaveLength(1);
+    expect(roots.some((r) => isUnderRoot(r, "C:\\Users\\andre\\AppData\\Local\\Temp"))).toBe(true);
+    expect(roots.length).toBeGreaterThanOrEqual(2); // the process tmpdir plus the Windows ones
+  });
+
+  test("an unset variable contributes nothing", () => {
+    expect(tempRoots({})).toHaveLength(1);
+  });
+});
+
+describe("skipPathPersist — the explicit flag", () => {
+  test("only the exact value 1 counts", () => {
+    expect(skipPathPersist({ NIRVANA_SKIP_PATH_PERSIST: "1" })).toBe(true);
+    expect(skipPathPersist({ NIRVANA_SKIP_PATH_PERSIST: "true" })).toBe(false);
+    expect(skipPathPersist({})).toBe(false);
+  });
+});

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -49,7 +49,7 @@ export const COMMANDS: Command[] = [
   { name: "help", aliases: ["--help", "-h"], custom: true, category: "first-run", summary: "Show this help", visibility: "user" },
 
   // install & lifecycle
-  { name: "install", custom: true, category: "install", args: "<source> | --bootstrap | --check", summary: "Install an asset (squad/business/clone/pack); --bootstrap wires audit hooks", visibility: "user" },
+  { name: "install", custom: true, category: "install", args: "<source> | --bootstrap | --check | --repair-path", summary: "Install an asset (squad/business/clone/pack); --bootstrap wires audit hooks; --repair-path cleans the Windows user PATH", visibility: "user" },
   { name: "uninstall", custom: true, category: "install", args: "<name> | --engine | --hooks", summary: "Remove an asset, the engine (keeps content), or just the hooks", visibility: "user" },
   { name: "installed", aliases: ["list-installed"], target: "_shared/scripts/list-installed.ts", category: "install", summary: "List active installations", visibility: "user" },
   { name: "update", aliases: ["self-update", "upgrade"], target: "harness/scripts/update.ts", category: "install", args: "[--check]", summary: "Update the engine: git pull (dev) or re-fetch the latest release (npx)", visibility: "user" },

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -29,6 +29,7 @@ import { resolveScope, enumerate } from "../../_shared/lib/scope.ts";
 import { RUNTIME_TARGETS, RUNTIME_SKILL_DIRS, PROJECT_CONTRACT_FILES } from "../../_shared/lib/runtime-dirs.ts";
 import { scanLibrary, authorsPacks, STRIP_HINT } from "../../_shared/lib/watermark-scan.ts";
 import { listRuntimes } from "../../_shared/lib/host-agent-driver.ts";
+import { expandEnv, findTempNrvEntries, readUserPath, tempRoots } from "../../_shared/lib/windows-user-path.ts";
 
 const ANSI = {
   reset: "\x1b[0m", bold: "\x1b[1m", dim: "\x1b[2m",
@@ -332,6 +333,32 @@ if (which("claude")) {
   }
 
   try { fs.rmSync(envTmp, { recursive: true, force: true }); } catch { /* tmp */ }
+
+  // user PATH (Windows): engines up to 0.8.0 persisted %USERPROFILE%\.local\bin
+  // to HKCU\Environment\Path even when USERPROFILE was a test's temporary HOME,
+  // and deleting that HOME never removed the entry (issue #87: 22 of them on
+  // one machine). The value is read as stored, so an unexpanded
+  // %LOCALAPPDATA%\Temp\nrv-* entry is found too. Only reported here;
+  // `nrv install --repair-path --apply` removes exactly these.
+  if (process.platform === "win32") {
+    const reg = readUserPath();
+    if (!reg) {
+      add("env: user PATH", "WARN", "could not read HKCU\\Environment\\Path (no such value, or PowerShell unavailable) — temporary nrv entries not checked");
+    } else {
+      const stale = findTempNrvEntries(reg.value, tempRoots());
+      if (stale.length === 0) {
+        add("env: user PATH", "PASS", "no temporary nrv entries in HKCU\\Environment\\Path");
+      } else {
+        const exists = (e: string) => fs.existsSync(expandEnv(e));
+        const missing = stale.filter((e) => !exists(e)).length;
+        const shown = stale.slice(0, 3).map((e) => `${e}${exists(e) ? "" : " (missing)"}`);
+        add("env: user PATH", "WARN",
+          `${stale.length} temporary nrv entr${stale.length === 1 ? "y" : "ies"} in HKCU\\Environment\\Path, ${missing} pointing at `
+          + `directories that no longer exist: ${shown.join("; ")}${stale.length > shown.length ? `; … ${stale.length - shown.length} more` : ""}`
+          + " — review with `nrv install --repair-path`, remove with `nrv install --repair-path --apply`");
+      }
+    }
+  }
 }
 
 // SECTION 2: SKILLS

--- a/skills/harness/scripts/nrv.ts
+++ b/skills/harness/scripts/nrv.ts
@@ -61,7 +61,7 @@ switch (cmd) {
   case "init": case "init-project": runScript(join(S, "init-project.ts"), rest);
   case "install": {
     const f = rest[0] ?? "";
-    if (["--bootstrap", "--check", "--starter", "--no-starter", "--dry"].includes(f)) runScript(join(S, "install.ts"), rest);
+    if (["--bootstrap", "--check", "--starter", "--no-starter", "--dry", "--repair-path"].includes(f)) runScript(join(S, "install.ts"), rest);
     runScript(join(S, "install-asset.ts"), rest);
   }
   case "setup": runScript(join(S, "install.ts"), rest);

--- a/skills/harness/tests/buyer-path.test.ts
+++ b/skills/harness/tests/buyer-path.test.ts
@@ -24,6 +24,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { fakeHomeEnv } from "./helpers/fake-home.ts";
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SLUG = "buyer-path-fixture";
@@ -75,16 +76,15 @@ beforeAll(() => {
   root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-buyer-"));
   home = path.join(root, "home");
   fs.mkdirSync(home, { recursive: true });
-  env = {
-    ...process.env,
-    HOME: home,
-    USERPROFILE: home,
+  // fakeHomeEnv carries NIRVANA_SKIP_PATH_PERSIST=1: on Windows the installer
+  // would otherwise persist this HOME's .local\bin to the real user PATH (#87).
+  env = fakeHomeEnv(home, {
     NIRVANA_SKIP_ENGINE_UPDATE: "1",
     // Registries must resolve to the fake HOME, not to whatever project the
     // test runner happens to sit in. Without this the overlay indexes into the
     // repo's own .nirvana/ and the assertions read the developer's library.
     NIRVANA_SCOPE: "global",
-  };
+  });
   delete env.NIRVANA_PROVENANCE;
 
   // 1. The engine, installed the way the buyer's `npx @nirvana-os/cli` does.

--- a/skills/harness/tests/helpers/fake-home.ts
+++ b/skills/harness/tests/helpers/fake-home.ts
@@ -1,0 +1,14 @@
+// fake-home.ts — the environment for a test that runs a real installer in a
+// temporary HOME.
+//
+// A fake HOME/USERPROFILE redirects every file an installer writes, but not the
+// Windows registry: wireLocalBinOnPath() persists %USERPROFILE%\.local\bin to
+// HKCU\Environment\Path, and the 'User' target is the account running the test,
+// whatever USERPROFILE says. Issue #87: 22 %TEMP%\nrv-*\home\.local\bin entries
+// on one machine, most pointing at directories long deleted. Every test that
+// spawns install.ts / setup.ts (or anything that may reach them) with a fake
+// HOME builds its env here, so NIRVANA_SKIP_PATH_PERSIST=1 can never be
+// forgotten. `extra` wins over the defaults, PATH overrides included.
+export function fakeHomeEnv(home: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...process.env, HOME: home, USERPROFILE: home, NIRVANA_SKIP_PATH_PERSIST: "1", ...extra };
+}

--- a/skills/harness/tests/license-install.test.ts
+++ b/skills/harness/tests/license-install.test.ts
@@ -10,6 +10,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fakeHomeEnv } from "./helpers/fake-home.ts";
 
 const SCRIPT = path.resolve(import.meta.dir, "..", "..", "_shared", "scripts", "license.ts");
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-lic-"));
@@ -34,7 +35,7 @@ function pack(h: string, dir = "Downloads/nirvana-os-genesis-circle-pack"): stri
 }
 
 const run = (h: string, args: string[], cwd = h) =>
-  spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8", cwd, env: { ...process.env, HOME: h, USERPROFILE: h } });
+  spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8", cwd, env: fakeHomeEnv(h) });
 
 const store = (h: string) => path.join(h, ".nirvana-license", "PROVENANCE.json");
 

--- a/skills/harness/tests/windows-path-persist.test.ts
+++ b/skills/harness/tests/windows-path-persist.test.ts
@@ -1,0 +1,79 @@
+// windows-path-persist.test.ts — an install into a temporary HOME never
+// reaches the real Windows user PATH (issue #87).
+//
+// On Windows wireLocalBinOnPath() persists %USERPROFILE%\.local\bin to
+// HKCU\Environment\Path. USERPROFILE decides the path being written; the 'User'
+// target is always the account running the test. Before the guards every
+// fake-home test left %TEMP%\nrv-*\home\.local\bin on the real user PATH: 22
+// entries on one machine, most pointing at directories long deleted.
+//
+// The registry value is read through PowerShell, independently of the code
+// under test, before and after two real installs in a temporary HOME: the
+// engine installer with NIRVANA_SKIP_PATH_PERSIST=1 (the buyer flow, as the
+// other fake-home tests run it), then the hook installer it installed, without
+// the flag, so the temporary-directory guard alone has to hold.
+//
+// Windows only by nature — the registry is the thing under test. Elsewhere the
+// tests are skipped with that reason; the pure guard logic is covered on every
+// platform by skills/_shared/tests/windows-user-path.test.ts.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fakeHomeEnv } from "./helpers/fake-home.ts";
+import { removeDir } from "./helpers/temp-dirs.ts";
+
+const IS_WINDOWS = process.platform === "win32";
+const SKIP_REASON = "Windows only: the registry value HKCU\\Environment\\Path is the thing under test";
+const REPO = path.resolve(import.meta.dir, "..", "..", "..");
+
+let root = "";
+let home = "";
+
+beforeAll(() => {
+  if (!IS_WINDOWS) return;
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-path-persist-"));
+  home = path.join(root, "home");
+  fs.mkdirSync(home, { recursive: true });
+});
+afterAll(() => { if (root) removeDir(root); });
+
+/** The user PATH as Windows stores it, read without the module under test. */
+function userPath(): string {
+  const r = spawnSync("powershell", [
+    "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+    "[Environment]::GetEnvironmentVariable('Path','User')",
+  ], { encoding: "utf8" });
+  expect(r.status).toBe(0);
+  return (r.stdout ?? "").replace(/\r?\n$/, "");
+}
+
+function run(args: string[], env: NodeJS.ProcessEnv): { code: number; out: string } {
+  const r = spawnSync(process.execPath, args, { cwd: root, env, encoding: "utf8" });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe(`the Windows user PATH survives an install into a temporary HOME (${SKIP_REASON})`, () => {
+  test.skipIf(!IS_WINDOWS)("with NIRVANA_SKIP_PATH_PERSIST=1 the installer says so and writes nothing", () => {
+    const before = userPath();
+    const r = run([path.join(REPO, "scripts", "install.ts"), "--no-starter", "--no-index", "--no-hermes"],
+      fakeHomeEnv(home, { NIRVANA_PACKS_DIR: path.join(home, "no-packs") }));
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("NIRVANA_SKIP_PATH_PERSIST=1");
+    expect(userPath()).toBe(before);
+    expect(before.toLowerCase()).not.toContain(path.join(home, ".local", "bin").toLowerCase());
+  }, 600_000);
+
+  test.skipIf(!IS_WINDOWS)("without the flag the temporary-directory guard alone holds", () => {
+    const before = userPath();
+    const env = fakeHomeEnv(home);
+    delete env.NIRVANA_SKIP_PATH_PERSIST;
+    // The hook installer the previous test installed: the script that persists.
+    const r = run([path.join(home, ".nirvana", "skills", "_shared", "scripts", "install.ts")], env);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("is under a temporary directory");
+    expect(r.out).not.toContain("added ");
+    expect(userPath()).toBe(before);
+  }, 120_000);
+});


### PR DESCRIPTION
## Cause

`wireLocalBinOnPath()` in `skills/_shared/scripts/install.ts` persists `%USERPROFILE%\.local\bin` to the user PATH through `[Environment]::SetEnvironmentVariable('PATH', …, 'User')`. The `USERPROFILE` a test sets decides the path being written; the `User` target is always the hive of the account running the process. Every test that ran an installer in a temporary HOME therefore left `%TEMP%\nrv-*\home\.local\bin` on the real `HKCU\Environment\Path`, and deleting the directory never removed the entry: 22 of them on one machine, most pointing nowhere. Closes #87.

The `nrv-update-safety-*` prefix from the issue does not exist in this tree: `nrv update` uses temporaries only for the tarball and the source and installs with the real HOME. Those entries came from an earlier engine or a fork; the repair below removes them all the same.

## Fix

- **Installer** (`fix(install)`): `NIRVANA_SKIP_PATH_PERSIST=1` skips the registry write and the `WM_SETTINGCHANGE` broadcast (and the shell-profile append on POSIX); the current process still gets `.local\bin` on its own PATH, so the post-install `nrv index` keeps resolving the launcher. Independently of the flag, on Windows a `.local\bin` under `os.tmpdir()`, `%TEMP%`, `%TMP%` or `%LOCALAPPDATA%\Temp` (short or long spelling) is never persisted. Both cases are stated in the output. Real Windows installs are unchanged.
- **Tests** (`test(install)`): `skills/harness/tests/helpers/fake-home.ts` builds the fake-HOME env with the flag already set; buyer-path, runtime-links and license-install use it (the other files the issue lists only grep installer sources and spawn nothing). `skills/harness/tests/windows-path-persist.test.ts` reads `HKCU\Environment\Path` through PowerShell, independently of the code under test, before and after two real installs in a temporary HOME, one with the flag and one without, and asserts the value did not move; off Windows it is skipped with the reason in the title. `skills/_shared/tests/windows-user-path.test.ts` covers the pure guard, detection and removal logic on every platform.
- **Clean-up** (`feat(doctor)`): `nrv doctor` warns with the count of temporary `nrv-` entries under a temp root and how many point at directories that no longer exist. `nrv install --repair-path` lists them and writes nothing; `nrv install --repair-path --apply` removes exactly those, keeps every other entry verbatim and in order, preserves the value kind (`REG_EXPAND_SZ` stays unexpanded) and broadcasts. Both dispatchers route the flag to the hook installer.
- **Docs**: INSTALL.md Windows section; `Unreleased` entries in both changelogs, in parity.

## How to clean an affected machine

```
nrv doctor                          # reports the entries
nrv install --repair-path           # lists them, nothing written
nrv install --repair-path --apply   # removes exactly those and broadcasts the change
```

## Validation

`bun test skills`: 1241 pass, 3 skip, 0 fail on macOS. `check-english-source`, `check-changelog-parity`, `check-version-parity`, `check-engine-purity`, `check-skillmd-command-parity`, `check-cli-parity`, `sync-agent-docs --check` and `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
