### PR TITLE
test(ci): wait for the child exit event before asserting the canonical timeline

### DIFF
--- a/skills/harness/tests/glance-agent-x-canary-e2e.test.ts
+++ b/skills/harness/tests/glance-agent-x-canary-e2e.test.ts
@@ -77,6 +77,15 @@ async function send(base: string, projectId: string, conversationId: string, key
 }
 const events = async (base: string, projectId: string) => ((await fetch(`${base}/api/v1/projects/${projectId}/events?limit=500`).then(r => r.json())) as any).events as any[];
 const typeOf = (event: any) => event.type === "run.transitioned" ? `run.transitioned:${event.payload.to}` : event.type;
+/** Polls the journal until the Run has recorded `type`: the child writes its terminal state and exits, and the
+ * queue records glance.child_exited only when the process exit event arrives. */
+async function waitForEvent(base: string, projectId: string, runId: string, type: string, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await events(base, projectId)).some(event => event.runId === runId && event.type === type)) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${type} on ${runId}`);
+    await Bun.sleep(10);
+  }
+}
 
 /** Consumes the SSE stream from `after` until `until` holds (heartbeats keep reads short). */
 async function readStream(base: string, projectId: string, after: number, until: (seen: any[]) => boolean, timeoutMs = 30000) {
@@ -273,6 +282,9 @@ describe("Glance child-process execution", () => {
     expect(business.receipt.run.target).toEqual({ kind: "business", slug: "web-studio" });
     expect(business.receipt.capability).toBe("business.dispatch");
     await waitFor(base, projectId, business.receipt.run.runId, "completed", 500);
+    // The child writes `completed` and exits; the queue records glance.child_exited only after the
+    // process exit event, so the terminal state alone does not mean the timeline is final.
+    await waitForEvent(base, projectId, business.receipt.run.runId, "glance.child_exited");
     expect(state(business.receipt.run.runId).argv().argv.slice(0, 2)).toEqual(["--business", "web-studio"]);
     const all = await events(base, projectId);
     expect(all.filter(event => event.runId === business.receipt.run.runId).map(typeOf)).toEqual(standardTimeline);


### PR DESCRIPTION
## What

Test-only. `skills/harness/tests/glance-agent-x-canary-e2e.test.ts` gains a `waitForEvent` helper (polls `/events`, 10 s bound, clear timeout message) and the `use squad <slug>:` / `use business <slug>:` test now waits for the business Run's `glance.child_exited` before reading the journal and asserting the canonical timeline.

## Why

`smoke (windows-latest)` on PR #93 failed in run [32928293935](https://github.com/gutomec/nirvana-os-engine/actions/runs/32928293935), job [98055474817](https://github.com/gutomec/nirvana-os-engine/actions/runs/32928293935/job/98055474817):

```
(fail) Glance child-process execution > `use squad <slug>:` and `use business <slug>:` prepare typed Runs; ...
  expect(all.filter(event => event.runId === business.receipt.run.runId).map(typeOf)).toEqual(standardTimeline);
  - Expected  - 1   "glance.child_exited"
```

The child writes `run.transitioned:completed` into the kernel and then exits; the parent queue appends `glance.child_exited` only when the process exit event arrives (`agent-x-canary-queue.ts`, `runChild`). The test polled the Run state, saw `completed`, and read the journal inside that window. The same code passed on run 32927946047; process exit lands later on the Windows runner. Same class of race fixed in `agent-x-canary-recovery.test.ts` by 49059ed, same pattern applied here.

## Audit of the other `glance.child_exited` assertions

- `a Message runs in a child dispatch ... over SSE` and the squad half of the typed-Runs test: `readStream` already consumes the stream until `glance.child_exited`, no change.
- `cancel during execution ...`: asserts after `cancelled`, which the queue writes in `settleCancelled` after appending `glance.child_exited`, ordered by construction.
- `a child that exits without a terminal transition ...`: asserts after `failed`, written in `settleAfterExit` after `glance.child_exited`, same.
- `agent-x-canary-recovery.test.ts`: both child tests already wait (49059ed).

## Validation

- `bun test skills/harness/tests/glance-agent-x-canary-e2e.test.ts skills/harness/tests/agent-x-canary-recovery.test.ts` three times in a row: 15 pass, 0 fail.
- `bun scripts/check-english-source.ts --strict`: clean.
- `git diff --check`: clean.

Do not merge from this PR's automation; the author merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
