### PR TITLE
test(ci): harden Windows child-process tests

### DIFF
--- a/skills/harness/tests/activate-batch.test.ts
+++ b/skills/harness/tests/activate-batch.test.ts
@@ -15,6 +15,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const CMD = join(REPO, "skills", "harness", "scripts", "activate.ts");
@@ -69,14 +70,14 @@ describe("nrv activate --all", () => {
     expect(out).toContain("beta-squad");
     expect(out).toContain("no dependencies");   // gamma needs nothing
     expect(code).toBe(0);
-  });
+  }, spawnBudgetMs(3));
 
   test("--only-declared skips squads that need no activation", () => {
     const root = library([{ slug: "alpha-squad", check: "true" }, { slug: "gamma-squad" }]);
     const { out } = run(root, ["--all", "--only-declared"]);
     expect(out).toContain("ACTIVATING 1 SQUAD(S)");
     expect(out).not.toContain("gamma-squad");
-  });
+  }, spawnBudgetMs(2));
 
   test("a squad that cannot satisfy its dependency does not stop the walk", () => {
     // The middle squad declares a tool that does not exist and has no install
@@ -89,14 +90,14 @@ describe("nrv activate --all", () => {
     const { out } = run(root, ["--all"]);
     expect(out).toContain("zeta-squad");        // reached despite the middle one
     expect(out).toContain("SUMMARY");
-  });
+  }, spawnBudgetMs(4));
 
   test("--dry-run installs nothing and still reports", () => {
     const root = library([{ slug: "alpha-squad", check: "command -v definitely-not-installed-xyz" }]);
     const { out } = run(root, ["--all", "--dry-run"]);
     expect(out).toContain("SUMMARY");
     expect(out).not.toContain("install_failed");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("nrv activate <slug>", () => {
@@ -105,12 +106,12 @@ describe("nrv activate <slug>", () => {
     const { code, out } = run(root, ["alpha-squad"]);
     expect(out).toContain("alpha-squad");
     expect(code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("no arguments is a usage error, not a silent no-op", () => {
     const root = library([{ slug: "alpha-squad", check: "true" }]);
     expect(run(root, []).code).toBe(4);
-  });
+  }, spawnBudgetMs(1));
 
   test("--help explains the batch and exits clean", () => {
     const root = library([{ slug: "alpha-squad", check: "true" }]);
@@ -118,7 +119,7 @@ describe("nrv activate <slug>", () => {
     expect(code).toBe(0);
     expect(out).toContain("--all");
     expect(out).toContain("dependencies.yaml");
-  });
+  }, spawnBudgetMs(1));
 });
 
 describe("nrv doctor warns before the expensive run", () => {
@@ -137,5 +138,5 @@ describe("nrv doctor warns before the expensive run", () => {
     expect(out).toContain("SQUAD DEPS");
     expect(out).toContain("nirvana-absent-binary-xyz");
     expect(out).toContain("nrv activate --all");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/agent-x-canary-recovery.test.ts
+++ b/skills/harness/tests/agent-x-canary-recovery.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -6,6 +7,7 @@ import { AgentXCanaryQueue, ConversationService, createDispatchExecutionRunner, 
 import { createRun, getRun, listEvents, openKernel, transitionRun } from "../lib/run-kernel/index.ts";
 import { childState, pidAlive, shimRuntimeOnPath, waitUntil, writeFakeGlanceChild } from "./helpers/fake-glance-child.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 const queues: AgentXCanaryQueue[] = [];
@@ -36,13 +38,27 @@ function adapter(counter: { executions: number }): GlanceAgentXCanaryAdapter {
   };
 }
 
-async function waitForState(kernelPath: string, projectId: string, runId: string, state: string, attempts = 100) {
-  for (let i = 0; i < attempts; i++) {
+async function waitForState(kernelPath: string, projectId: string, runId: string, state: string, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
     const handle = openKernel(kernelPath); const current = getRun(handle, projectId, runId); handle.close();
     if (current?.state === state) return;
+    if (Date.now() > deadline) throw new Error(`run did not reach ${state} within ${timeoutMs} ms`);
     await Bun.sleep(10);
   }
-  throw new Error(`run did not reach ${state}`);
+}
+
+/** True once the kernel opens again. On the Windows runner the file can stay locked for a moment
+ * after a crashed child's pid is gone: `openKernel` right after the crash failed with
+ * SQLITE_IOERR_TRUNCATE on PR #90 (run 32929139083, attempt 1). The probe runs the same first
+ * statement as openKernel and closes its own handle either way, so a failed attempt holds nothing. */
+function kernelReleased(kernelPath: string): boolean {
+  let db: Database | undefined;
+  try { db = new Database(kernelPath); db.exec("PRAGMA journal_mode = WAL"); return true; }
+  catch (error) {
+    if (/^SQLITE_(IOERR|BUSY|LOCKED)/.test(String((error as { code?: string }).code))) return false;
+    throw error;
+  } finally { db?.close(); }
 }
 
 /** A project with one Message, a runtime shim on PATH and fake-child runners keyed by knobs. */
@@ -94,7 +110,7 @@ describe("durable agent-x canary recovery", () => {
     const events = listEvents(kernel, "prj_recovery").filter(event => event.type === "canary.recovery_enqueued");
     expect(events).toHaveLength(1);
     kernel.close(); conversations.close();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("ignores terminal and running runs without a recoverable lease", () => {
     const { root, kernelPath, conversationPath } = fixture();
@@ -111,7 +127,7 @@ describe("durable agent-x canary recovery", () => {
     expect(result.skipped).toEqual(expect.arrayContaining([{ runId: "run_terminal", reason: "state_rolled_back" }, { runId: "run_running", reason: "state_running" }]));
     expect(listEvents(kernel, "prj_states").filter(event => event.type === "canary.recovery_skipped")).toHaveLength(2);
     kernel.close(); conversations.close();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("one run skipped for a different reason on each restart records both reasons and never conflicts", () => {
     const { root, kernelPath, conversationPath } = fixture();
@@ -134,7 +150,7 @@ describe("durable agent-x canary recovery", () => {
     expect(skipped.map(event => (event.payload as { reason: string }).reason)).toEqual(["capability_unavailable", "state_rolled_back"]);
     expect(skipped.map(event => event.idempotencyKey)).toEqual(["canary.recovery_skipped:run_skip:capability_unavailable", "canary.recovery_skipped:run_skip:state_rolled_back"]);
     kernel.close(); conversations.close();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a running run whose child is dead is redispatched once across two restarts and resumes without repeating the producer", async () => {
     const fx = childFixture();
@@ -148,6 +164,7 @@ describe("durable agent-x canary recovery", () => {
     const pid = fx.childPid(runId, 1);
     child.release();
     await waitUntil(() => !pidAlive(pid), "the first child to die");
+    await waitUntil(() => kernelReleased(fx.kernelPath), "the crashed child's kernel handles to be released");
     expect(child.has("crashed")).toBe(true);
     expect(child.count("producer")).toBe(1);
     const reopened = openKernel(fx.kernelPath);
@@ -160,7 +177,7 @@ describe("durable agent-x canary recovery", () => {
     second.queue.shutdown(); second.close();
     const third = fx.queue();
     expect(third.queue.recover("prj_child", fx.root)).toMatchObject({ redispatched: [runId] });
-    await waitForState(fx.kernelPath, "prj_child", runId, "completed", 500);
+    await waitForState(fx.kernelPath, "prj_child", runId, "completed");
     // The child writes `completed` and exits; the queue records glance.child_exited only after the
     // process exit event, so the terminal state alone does not mean the journal is final.
     await waitUntil(() => fx.runEvents(runId).some(event => event.type === "glance.child_exited"), "the redispatched exit event");
@@ -193,7 +210,7 @@ describe("durable agent-x canary recovery", () => {
     expect(child.count("spawns")).toBe(1);
     expect(getRun(second.kernel, "prj_child", runId)?.state).toBe("running");
     child.release();
-    await waitForState(fx.kernelPath, "prj_child", runId, "completed", 500);
+    await waitForState(fx.kernelPath, "prj_child", runId, "completed");
     await waitUntil(() => fx.runEvents(runId).some(event => event.type === "glance.child_exited"), "the reattached exit event");
     expect(child.count("spawns")).toBe(1);
     expect(child.count("producer")).toBe(1);

--- a/skills/harness/tests/agent-x-gauntlet-cutover.test.ts
+++ b/skills/harness/tests/agent-x-gauntlet-cutover.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/gauntlet/agent-x-cutover.ts";
 import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
 import { createRun, getRun, listEvents, openKernel, type KernelHandle } from "../lib/run-kernel/index.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 const handles: KernelHandle[] = [];
@@ -95,7 +96,7 @@ describe("agent-x Gauntlet cutover", () => {
     expect(types.indexOf("gauntlet.plan_compiled")).toBeLessThan(types.indexOf("gauntlet.candidate_created"));
     expect(types.indexOf("gauntlet.candidate_created")).toBeLessThan(types.indexOf("gauntlet.evaluation_recorded"));
     expect(types.at(-1)).toBe("run.transitioned");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("persists a typed squad producer without changing the agent-x default", () => {
     const producerTarget = { kind: "squad" as const, slug: "document-factory", capabilityId: "document.generate" };
@@ -103,7 +104,7 @@ describe("agent-x Gauntlet cutover", () => {
     expect(result.run.target).toEqual(producerTarget);
     const candidate = listEvents(handle, "prj_canary").find(event => event.type === "gauntlet.candidate_created");
     expect((candidate?.payload as any).producer).toEqual(producerTarget);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("freezes the runtime and model decision in the canonical journal", () => {
     const snapshot = { runtime: { id: "codex", source: "active-session" },
@@ -112,7 +113,7 @@ describe("agent-x Gauntlet cutover", () => {
     const event = listEvents(handle, "prj_canary").find(item => item.type === "runtime.selection_snapshot");
     expect((event?.payload as any).snapshot).toEqual(snapshot);
     expect(result.run.policySnapshotRef).toBe((event?.payload as any).ref);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("rejects a producer evaluating its own candidate and records a post-start failure", () => {
     const fixture = setup();
@@ -121,7 +122,7 @@ describe("agent-x Gauntlet cutover", () => {
       executeCandidate(root) { fs.mkdirSync(root, { recursive: true }); fs.writeFileSync(path.join(root, "out.md"), "valid", "utf8"); return { ok: true, sessionId: null }; },
       evaluator: evaluator(true, true), finalGate() { throw new Error("must not run"); } })).toThrow(/cannot evaluate its own/);
     expect(getRun(fixture.handle, "prj_canary", "run_self")?.state).toBe("failed");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test.each([
     [{ exitCode: 0 as const, gateOutcome: "fail-accepted" }, "delivered_with_reservations"],
@@ -129,20 +130,20 @@ describe("agent-x Gauntlet cutover", () => {
     [{ exitCode: 1 as const, gateOutcome: "indeterminate" }, "failed"],
   ])("maps final gate %p to canonical terminal %s", (gate, terminal) => {
     expect(run({ finalGate: () => gate }).result.run.state).toBe(terminal);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("withholds an evaluator rejection without invoking the final delivery gate", () => {
     const { result, finalGates } = run({ evaluator: evaluator(false) });
     expect(result).toMatchObject({ exitCode: 2, finalGateRan: false, run: { state: "withheld" }, gauntlet: { stopReason: "no_progress" } });
     expect(finalGates).toBe(0);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("stops a failed producer with an honest execution failure", () => {
     const { result, finalGates } = run({ executeCandidate: () => ({ ok: false, sessionId: null, error: "runtime crashed" }) });
     expect(result).toMatchObject({ exitCode: 1, finalGateRan: false, run: { state: "failed" },
       gauntlet: { state: "stopped", stopReason: "execution_failure", reservations: ["runtime crashed"] } });
     expect(finalGates).toBe(0);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("resumes after interruption without dispatching the persisted candidate twice", () => {
     const fixture = setup();
@@ -157,7 +158,7 @@ describe("agent-x Gauntlet cutover", () => {
     expect(getRun(fixture.handle, "prj_canary", "run_resume")?.state).toBe("running");
     expect(runAgentXGauntlet(common).run.state).toBe("completed");
     expect(executions).toBe(1);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("adopts a Run a control plane already prepared under the same runId instead of creating a second one", () => {
     const fixture = setup();
@@ -176,11 +177,11 @@ describe("agent-x Gauntlet cutover", () => {
     const events = listEvents(fixture.handle, "prj_canary").filter(event => event.runId === "run_adopted");
     expect(events.filter(event => event.type === "run.prepared")).toHaveLength(1);
     expect(new Set(events.map(event => event.traceId))).toEqual(new Set(["trace_glance"]));
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("rolls back when the light budget blocks execution before the candidate", () => {
     const { result, executions, finalGates } = run({ expectedCostUsd: 6 });
     expect(result.run.state).toBe("rolled_back");
     expect(executions).toBe(0); expect(finalGates).toBe(0);
-  });
+  }, KERNEL_BUDGET_MS);
 });

--- a/skills/harness/tests/agentic-run-tracking.test.ts
+++ b/skills/harness/tests/agentic-run-tracking.test.ts
@@ -30,6 +30,7 @@ process.env.NIRVANA_NO_DESKTOP_NOTIFY = "1";
 import { sweep, type RecoveryResult, type SalvageVerdict } from "../scripts/supervisor.ts";
 import { openLedger, openAgenticRun, openRun, getRun, markState, findNonTerminal, type LedgerHandle, type RunRow } from "../lib/run-ledger.ts";
 import { SCOPE_GUARD_PT_BR } from "../../_shared/lib/scope-guard.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 let dbSeq = 0;
 function freshLedger(): LedgerHandle {
@@ -150,7 +151,7 @@ describe("brief-squad opens the ledger run by itself", () => {
     // The agent is told how to close it, in the output it already reads.
     expect(r.stdout).toContain("nrv run-track close");
     expect(r.stdout).toContain(row.run_id);
-  });
+  }, spawnBudgetMs(1));
 });
 
 // ── 2. the supervisor's agentic door ──────────────────────────────────────
@@ -300,7 +301,7 @@ describe("nrv run-track", () => {
     const closed = runTrack(["close", runId, "--state", "delivered"]);
     expect(closed.status).toBe(0);
     expect(getRun(h, runId)!.state).toBe("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("a run the supervisor already escalated can still be closed truthfully", () => {
     // The realistic late finish: the sweep gave up at the lease, the human was
@@ -315,13 +316,13 @@ describe("nrv run-track", () => {
 
     expect(runTrack(["close", runId, "--state", "delivered"]).status).toBe(0);
     expect(getRun(h, runId)!.state).toBe("delivered");
-  });
+  }, spawnBudgetMs(1));
 
   test("closing an unknown run warns instead of failing the caller's work", () => {
     const r = runTrack(["close", "run-does-not-exist", "--state", "delivered"]);
     expect(r.status).toBe(0);
     expect(r.stderr).toContain("not found");
-  });
+  }, spawnBudgetMs(1));
 
   test("a failed close records why", () => {
     const outputs = path.join(TMP, "rt-outputs-2");
@@ -331,7 +332,7 @@ describe("nrv run-track", () => {
     const row = getRun(openLedger(ledger), runId)!;
     expect(row.state).toBe("failed");
     expect(row.last_error).toContain("cota");
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── 5. the lib door ───────────────────────────────────────────────────────

--- a/skills/harness/tests/business-delivery-parity.e2e.test.ts
+++ b/skills/harness/tests/business-delivery-parity.e2e.test.ts
@@ -6,6 +6,7 @@ import { runBusinessPostGate, type BusinessPostGateDependencies } from "../lib/b
 import { runDelivery, type DeliveryArgs } from "../lib/delivery-pipeline.ts";
 import { loadHarnessConfig } from "../lib/harness-config.ts";
 import * as runLedger from "../lib/run-ledger.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
@@ -102,7 +103,7 @@ describe("Business delivery parity E2E", () => {
     expect(boundary).toEqual(legacy);
     expect(boundary).toMatchObject({ terminal: "delivered", publicationCalls: 1,
       files: ["relatorio-final.html", "relatorio-final.pdf", "report.html"] });
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("keeps manifest failure terminal and never runs post-gate publication", () => {
     const legacy = runScenario("legacy-reference", 1);
@@ -110,5 +111,5 @@ describe("Business delivery parity E2E", () => {
     expect(boundary).toEqual(legacy);
     expect(boundary).toMatchObject({ terminal: "failed", publicationCalls: 0, files: ["report.html"] });
     expect((boundary.audit as AuditEntry[]).some(entry => entry.event === "delivered")).toBeFalse();
-  });
+  }, KERNEL_BUDGET_MS);
 });

--- a/skills/harness/tests/business-gauntlet-glance-proof.e2e.test.ts
+++ b/skills/harness/tests/business-gauntlet-glance-proof.e2e.test.ts
@@ -9,6 +9,7 @@ import { runAgentXGauntlet, shouldRunAgentXGauntlet, type AgentXGauntletEvaluato
 import { loadHarnessConfig } from "../lib/harness-config.ts";
 import { appendEvent, listEvents, openKernel, type KernelHandle } from "../lib/run-kernel/index.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 const servers: Array<{ close(): void }> = [];
@@ -130,7 +131,7 @@ describe("typed Business Gauntlet proof through Glance", () => {
     }
     expect(proof.gauntlet.candidates[0].producer).toEqual(BUSINESS);
     expect(proof.gauntlet.scorecards[0].evaluator).toEqual(EVALUATOR);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("withholds a rejected Business candidate before delivery and keeps production cutover disabled", async () => {
     const proof = await runProof(false);
@@ -138,5 +139,5 @@ describe("typed Business Gauntlet proof through Glance", () => {
     expect(proof.postGateCalls).toBe(0);
     expect(proof.timeline.some(event => event.type.startsWith("delivery."))).toBeFalse();
     expect(shouldRunAgentXGauntlet({ targetKind: "business", wantExec: true, resolvedMode: "gauntlet" })).toBeFalse();
-  });
+  }, KERNEL_BUDGET_MS);
 });

--- a/skills/harness/tests/glance-agent-x-canary-e2e.test.ts
+++ b/skills/harness/tests/glance-agent-x-canary-e2e.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { createDispatchExecutionRunner, type GlanceAgentXCanaryAdapter, type GlanceExecutionRunner } from "../lib/control-plane/index.ts";
 import { childState, shimRuntimeOnPath, writeFakeGlanceChild } from "./helpers/fake-glance-child.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 const servers: any[] = [];
@@ -60,13 +61,14 @@ async function startWithChild(knobs: Record<string, string> = {}) {
 }
 
 const headers = (base: string, key: string) => ({ "content-type": "application/json", origin: base, "idempotency-key": key });
-async function waitFor(base: string, projectId: string, runId: string, state: string, attempts = 100) {
-  for (let i = 0; i < attempts; i++) {
+async function waitFor(base: string, projectId: string, runId: string, state: string, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
     const run = await fetch(`${base}/api/v1/runs/${runId}?project_id=${projectId}`).then(r => r.json()) as any;
     if (run.state === state) return run;
+    if (Date.now() > deadline) throw new Error(`run did not reach ${state} within ${timeoutMs} ms`);
     await Bun.sleep(10);
   }
-  throw new Error(`run did not reach ${state}`);
 }
 async function conversation(base: string, projectId: string, key: string) {
   return (await fetch(`${base}/api/v1/projects/${projectId}/conversations`, { method: "POST", headers: headers(base, key), body: "{}" }).then(r => r.json()) as any).conversation_id as string;
@@ -143,7 +145,7 @@ describe("Glance agent-x light canary", () => {
     const restarted = await startServer({ port: 0, open: false, idleMin: 60, allowActions: true, theme: "apple", agentXCanaryAdapter: adapter() }); servers.push(restarted);
     const reopened = await fetch(`http://127.0.0.1:${restarted.port}/api/v1/conversations/${conversation.conversation_id}`).then(r => r.json()) as any;
     expect(reopened.messages[0].run_id).toBe(receipt.run.runId);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("missing capability records an honest terminal run", async () => {
     const { project, base } = await start();
@@ -153,7 +155,7 @@ describe("Glance agent-x light canary", () => {
     expect(receipt.run.state).toBe("rolled_back");
     const events = await fetch(`${base}/api/v1/projects/${project.project_id}/events`).then(r => r.json()) as any;
     expect(events.events.at(-1).payload.reason).toBe("capability_unavailable");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("queued run can be cancelled without invoking the adapter", async () => {
     const { project, base } = await start(adapter());
@@ -162,7 +164,7 @@ describe("Glance agent-x light canary", () => {
     const cancelled = await fetch(`${base}/api/v1/runs/${receipt.run.runId}:cancel`, { method: "POST", headers: headers(base, "cancel-command"), body: JSON.stringify({ project_id: project.project_id }) });
     expect(cancelled.status).toBe(202);
     expect(((await cancelled.json()) as any).state).toBe("rolled_back");
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("Glance child-process execution", () => {
@@ -208,8 +210,10 @@ describe("Glance child-process execution", () => {
       expect(performance.now() - startedAt).toBeLessThan(500);
     }
     child.release();
-    await waitFor(base, project.project_id, receipt.run.runId, "completed", 500);
-    expect(child.has("completed")).toBe(true);
+    await waitFor(base, project.project_id, receipt.run.runId, "completed");
+    // The child transitions the Run and only then writes its marker: wait for the marker instead of
+    // reading it the instant the kernel shows completed.
+    await child.waitFor("completed");
   }, 30000);
 
   test("cancel during execution kills the child and settles cancelled", async () => {
@@ -221,7 +225,7 @@ describe("Glance child-process execution", () => {
     const cancelled = await fetch(`${base}/api/v1/runs/${receipt.run.runId}:cancel`, { method: "POST", headers: headers(base, "cancel-running"), body: JSON.stringify({ project_id: project.project_id }) });
     expect(cancelled.status).toBe(202);
     expect(((await cancelled.json()) as any).state).toBe("cancelling");
-    await waitFor(base, project.project_id, receipt.run.runId, "cancelled", 500);
+    await waitFor(base, project.project_id, receipt.run.runId, "cancelled");
     // Windows has no catchable SIGTERM: taskkill /F ends the child before any handler runs, so the
     // fake never writes `killed` there and the exit code is the forced one, never 143.
     if (process.platform !== "win32") await child.waitFor("killed");
@@ -244,7 +248,7 @@ describe("Glance child-process execution", () => {
     const child = state(receipt.run.runId);
     await child.waitFor("holding");
     child.release();
-    const run = await waitFor(base, project.project_id, receipt.run.runId, "failed", 500);
+    const run = await waitFor(base, project.project_id, receipt.run.runId, "failed");
     expect(run.state).toBe("failed");
     const seen = (await events(base, project.project_id)).filter(event => event.runId === receipt.run.runId);
     expect(seen.at(-2).type).toBe("glance.child_exited");
@@ -281,7 +285,7 @@ describe("Glance child-process execution", () => {
     const business = await send(base, projectId, cnv, "m-business", "Use business web-studio: landing page");
     expect(business.receipt.run.target).toEqual({ kind: "business", slug: "web-studio" });
     expect(business.receipt.capability).toBe("business.dispatch");
-    await waitFor(base, projectId, business.receipt.run.runId, "completed", 500);
+    await waitFor(base, projectId, business.receipt.run.runId, "completed");
     // The child writes `completed` and exits; the queue records glance.child_exited only after the
     // process exit event, so the terminal state alone does not mean the timeline is final.
     await waitForEvent(base, projectId, business.receipt.run.runId, "glance.child_exited");
@@ -304,7 +308,7 @@ describe("Glance child-process execution", () => {
     expect(receipt.run.state).toBe("rolled_back");
     const seen = await events(base, project.project_id);
     expect(seen.at(-1).payload).toMatchObject({ reason: "capability_unavailable", capability: "agent-x.gauntlet.light" });
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("Glance shutdown", () => {

--- a/skills/harness/tests/helpers/test-budgets.ts
+++ b/skills/harness/tests/helpers/test-budgets.ts
@@ -1,0 +1,24 @@
+// test-budgets.ts — explicit per-test timeouts for the tests that leave the process or drive the
+// Run Kernel, sized from the smoke runner rather than from Bun's default.
+//
+// Bun gives every test 5 s. On windows-latest that is what one cold `bun <script>.ts` costs (a
+// 0.6 MB bundle transpiled under the runner's antivirus), and when the disk is busy it is also
+// what a handful of Run Kernel transactions cost: `PRAGMA synchronous = FULL` makes every event an
+// fsync, and the runner has been measured 20-35x slower than usual at that. Evidence:
+//   - run 32928964511: three multi-target-cli tests that spawn two engines each timed out at
+//     5.0-5.1 s; the same tests take 1.4-1.7 s on a normal Windows run.
+//   - run 32929953479, attempt 1: an in-process Gauntlet cutover test timed out at 5.5 s, its
+//     neighbours took 2.9-4.6 s and the suite took 186 s instead of ~150 s; the same tests take
+//     150-350 ms on a normal Windows run.
+// The budgets below are wall-clock reality with headroom, not slack for a hang: a hang still
+// fails, only later.
+
+/** A test that spawns `processes` Bun processes (engines, fake dispatch children, doctor runs).
+ * A cold first spawn has cost 7.8 s on the runner, a warm one 0.4-2.5 s. */
+export function spawnBudgetMs(processes: number): number {
+  return 10_000 + 5_000 * processes;
+}
+
+/** A test that drives the Run Kernel or a Gauntlet in-process: fsync-bound SQLite, measured up to
+ * 5.5 s per test on the slowest runner against 150-350 ms normally. */
+export const KERNEL_BUDGET_MS = 30_000;

--- a/skills/harness/tests/multi-target-cli.test.ts
+++ b/skills/harness/tests/multi-target-cli.test.ts
@@ -11,13 +11,15 @@ import { projectMultiTargetRun } from "../lib/gauntlet/multi-target-projection.t
 import { getRun, listEvents, openKernel } from "../lib/run-kernel/store.ts";
 import { multiTargetRunId, validatePlanFile } from "../scripts/multi-target.ts";
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
+import { removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
 const SCRIPT = path.join(REPO, "skills", "harness", "scripts", "multi-target.ts");
 const ENGINE = { NIRVANA_MULTI_TARGET_ENGINE: "1" };
 
 const roots: string[] = [];
-afterEach(() => { for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true }); });
+afterEach(() => { for (const root of roots.splice(0)) removeDir(root); });
 
 const PLAN = {
   schemaVersion: "nirvana.multi-target-plan/v1alpha1",
@@ -137,7 +139,7 @@ describe("nrv multi-target plan", () => {
     const r2 = nrv(setup, ["plan", setup.planFile]);
     expect(r2.status).toBe(4);
     expect(r2.stderr).toContain("/policy/limits/maxCostUsd: reservation rejected");
-  });
+  }, spawnBudgetMs(3));
 
   test("compiles the manifest, policy and reservation, writes the workspace and executes nothing", () => {
     const setup = fixture();
@@ -162,7 +164,7 @@ describe("nrv multi-target plan", () => {
     expect(compiled).toHaveLength(1);
     expect(compiled[0]).toMatchObject({ trace_id: setup.projectId, project_id: setup.projectId, node_count: 5 });
     expect(compiled[0].waves).toEqual([["brief-main"], ["business-a", "business-b"], ["squad-c"], ["final-output"]]);
-  });
+  }, spawnBudgetMs(1));
 
   test("--project overrides the plan's id; without it the file name is the trace id", () => {
     const setup = fixture();
@@ -170,7 +172,7 @@ describe("nrv multi-target plan", () => {
     expect(fs.existsSync(path.join(setup.projectRoot, ".nirvana", "outputs", "proj-other", "manifest.json"))).toBeTrue();
     fs.writeFileSync(setup.planFile, JSON.stringify({ ...PLAN, projectId: "proj-declared" }));
     expect(nrv(setup, ["plan", setup.planFile]).stdout).toContain("Plano multi-target: proj-declared");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("nrv multi-target run", () => {
@@ -185,7 +187,7 @@ describe("nrv multi-target run", () => {
     expect(spawns(setup)).toEqual([]);
     expect(fs.existsSync(setup.kernel)).toBeFalse();
     expect(fs.existsSync(setup.workspace)).toBeFalse();
-  });
+  }, spawnBudgetMs(2));
 
   test("executes the waves through the dispatch adapters, completes the Run, audits every node and is idempotent", () => {
     const setup = fixture();
@@ -269,7 +271,7 @@ describe("nrv multi-target run", () => {
     expect(human.stdout).toContain("plano delivered");
     expect(human.stdout).toContain("squad-c");
     expect(spawns(setup)).toHaveLength(4);
-  });
+  }, spawnBudgetMs(8));
 
   test("a node that exits 2 withholds the Run, blocks its consumers and the command exits 2", () => {
     const setup = fixture();
@@ -291,7 +293,7 @@ describe("nrv multi-target run", () => {
     expect(terminal).toMatchObject({ state: "withheld", kernel_state: "withheld", exit: 2 });
     expect(nrv(setup, ["run", setup.planFile], ENGINE).status).toBe(2);
     expect(spawns(setup)).toHaveLength(2);
-  });
+  }, spawnBudgetMs(4));
 
   test("a crash after the first execution wave resumes without re-spawning the completed nodes", () => {
     const setup = fixture();
@@ -325,7 +327,7 @@ describe("nrv multi-target run", () => {
     });
     const started = auditEvents(setup).filter((event) => event.event === "x_multi_target_run_started");
     expect(started.map((event) => event.resumed)).toEqual([false, true]);
-  });
+  }, spawnBudgetMs(7));
 
   test("a Run that exists for a different plan is refused with exit 4", () => {
     const setup = fixture();
@@ -335,7 +337,7 @@ describe("nrv multi-target run", () => {
     expect(r.status).toBe(4);
     expect(r.stderr).toContain("já existe com outro plano");
     expect(spawns(setup)).toHaveLength(4);
-  });
+  }, spawnBudgetMs(6));
 });
 
 describe("nrv multi-target status and usage", () => {
@@ -353,7 +355,7 @@ describe("nrv multi-target status and usage", () => {
     expect(noProject.status).toBe(4);
     expect(noProject.stderr).toContain("--project");
     expect(spawns(setup)).toHaveLength(4);
-  });
+  }, spawnBudgetMs(8));
 
   test("usage: no subcommand or an unknown one exits 4; help exits 0", () => {
     const setup = fixture();
@@ -361,5 +363,5 @@ describe("nrv multi-target status and usage", () => {
     expect(nrv(setup, ["bogus", setup.planFile]).status).toBe(4);
     expect(nrv(setup, ["plan"]).status).toBe(4);
     expect(nrv(setup, ["help"]).status).toBe(0);
-  });
+  }, spawnBudgetMs(4));
 });

--- a/skills/harness/tests/multi-target-dispatch-adapters.test.ts
+++ b/skills/harness/tests/multi-target-dispatch-adapters.test.ts
@@ -242,8 +242,12 @@ describe("multi-target dispatch adapters", () => {
     const controller = new AbortController();
     const pending = ports.standard.run(nodeInput(plan, "business-a", { signal: controller.signal }));
     const captureFile = join(setup.workspaceRoot, "businesses", "business-a", "outputs", "dispatch-capture.json");
+    // The fake writes its capture, then its spawn-log line, then sleeps. Aborting the instant the capture
+    // existed killed it between the two writes on the Windows runner (PR #96, run 32931392895: spawnCount
+    // read 0), so the spawn record is the signal to wait for; once it is on disk the kill can land anywhere.
     const deadline = Date.now() + 10_000;
-    while (!existsSync(captureFile) && Date.now() < deadline) await Bun.sleep(20);
+    while (spawnCount(setup) < 1 && Date.now() < deadline) await Bun.sleep(20);
+    expect(spawnCount(setup)).toBe(1);
     expect(existsSync(captureFile)).toBeTrue();
     const abortedAt = Date.now();
     controller.abort("lease_lost");

--- a/skills/harness/tests/multi-target-dispatch-adapters.test.ts
+++ b/skills/harness/tests/multi-target-dispatch-adapters.test.ts
@@ -12,6 +12,7 @@ import { createRun, listEvents, openKernel, type KernelHandle } from "../lib/run
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
 import { SCOPE_GUARD_EN } from "../../_shared/lib/scope-guard.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 const handles: KernelHandle[] = [];
@@ -123,7 +124,7 @@ describe("multi-target dispatch adapters", () => {
     expect(captured.cwd).toBe(setup.projectRoot);
     expect(captured.brief).toStartWith("Deliver part A.");
     expect(existsSync(join(setup.workspaceRoot, "businesses", "business-a", MULTI_TARGET_RESULT_MARKER))).toBeTrue();
-  });
+  }, spawnBudgetMs(1));
 
   test("gauntlet business adds the Gauntlet flags, allowlists the slug and passes every intensity through", async () => {
     const setup = fixture();
@@ -146,7 +147,7 @@ describe("multi-target dispatch adapters", () => {
       expect(readFileSync(join(setup.workspaceRoot, "businesses", "business-b", "DISPATCH-INSTRUCTION.md"), "utf8")).toContain(`gauntlet (intensity ${intensity})`);
     }
     expect(spawnCount(setup)).toBe(3);
-  });
+  }, spawnBudgetMs(3));
 
   test("squad and synthesis select the target with --squad and --agent-x, never --auto, and pass the intensity through", async () => {
     const setup = fixture();
@@ -176,7 +177,7 @@ describe("multi-target dispatch adapters", () => {
     expect(synthesisCapture.argv).toContain("--gauntlet-intensity=exhaustive");
     expect(synthesisCapture.brief).toStartWith("Write the final report.");
     expect(synthesisCapture.brief).toContain(join(setup.workspaceRoot, "squads", "squad-c", "outputs", "_SUMMARY.md"));
-  });
+  }, spawnBudgetMs(3));
 
   test("exit codes 0, 2, 3 and 1 map onto delivered, withheld, withheld (indeterminate) and failed", async () => {
     const setup = fixture();
@@ -193,7 +194,7 @@ describe("multi-target dispatch adapters", () => {
     expect(outcomes[3][1]).toContain("dispatch exit 1");
     expect(outcomes[3][1]).toContain("fake dispatch stopped with exit 1");
     expect(spawnCount(setup)).toBe(4);
-  });
+  }, spawnBudgetMs(4));
 
   test("DISPATCH-INSTRUCTION.md names the upstream _SUMMARY.md paths, the downstreams and the output path", async () => {
     const setup = fixture();
@@ -213,7 +214,7 @@ describe("multi-target dispatch adapters", () => {
     expect(text).toContain(join(setup.workspaceRoot, "squads", "squad-c", "outputs", "_SUMMARY.md"));
     expect(text.slice(text.indexOf("## 6. Scope isolation"))).toContain(SCOPE_GUARD_EN);
     expect(existsSync(join(setup.workspaceRoot, "squads", "squad-c", "outputs"))).toBeTrue();
-  });
+  }, spawnBudgetMs(1));
 
   test("the result marker prevents a second spawn for the same key while a different key runs again", async () => {
     const setup = fixture();
@@ -232,7 +233,7 @@ describe("multi-target dispatch adapters", () => {
     const other = await ports.standard.run(nodeInput(plan, "business-a", { idempotencyKey: "another-plan" }));
     expect(spawnCount(setup)).toBe(2);
     expect(other).toMatchObject({ state: "delivered", reportedCostUsd: 0.6 });
-  });
+  }, spawnBudgetMs(2));
 
   test("an aborted signal kills the subprocess and returns failed without a marker", async () => {
     const setup = fixture();
@@ -256,7 +257,7 @@ describe("multi-target dispatch adapters", () => {
     early.abort("early");
     expect(await ports.standard.run(nodeInput(plan, "business-b", { signal: early.signal }))).toEqual({ state: "failed", reportedCostUsd: 0, reason: "aborted: early" });
     expect(spawnCount(setup)).toBe(1);
-  });
+  }, spawnBudgetMs(1));
 
   test("coordinator, kernel ports and adapters run the waves through the fake dispatch and resume without re-spawning", async () => {
     const setup = fixture();
@@ -317,5 +318,5 @@ describe("multi-target dispatch adapters", () => {
     expect(events.filter((event) => event.type === "multi_target.lease_released").map((event) => (event.payload as { nodeId: string }).nodeId).sort())
       .toEqual(["business-a", "business-b", "final-output", "squad-c"]);
     kernel.close();
-  });
+  }, spawnBudgetMs(4));
 });

--- a/skills/harness/tests/revise-delivery.test.ts
+++ b/skills/harness/tests/revise-delivery.test.ts
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
 import { SCOPE_GUARD_PT_BR } from "../../_shared/lib/scope-guard.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const SKILLS = path.resolve(import.meta.dir, "..", "..");
 const REVISE = path.join(SKILLS, "harness", "scripts", "revise.ts");
@@ -221,7 +222,7 @@ describe("nrv revise — the outcome goes through the delivery pipeline", () => 
     const r = spawnSync(process.execPath, [REVISE], { encoding: "utf8" });
     expect(r.status).toBe(4);
     expect(r.stderr).toContain("Usage: nrv revise");
-  });
+  }, spawnBudgetMs(1));
 
   test("a FAILED revision still judges what is on disk instead of abandoning it", () => {
     // The runtime errors, but the artifacts exist. Old behavior: exit 1, nothing
@@ -231,7 +232,7 @@ describe("nrv revise — the outcome goes through the delivery pipeline", () => 
     expect(events(c)).toContain("revision_failed");  // the error is never swallowed
     expect(events(c)).toContain("x_runtime_errored_with_artifacts");
     expect(events(c)).toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("a FAILED revision whose artifacts fail the gate is WITHHELD, never delivered", () => {
     const c = runRevise({ "guia.md": FAILING_MD }, { runtimeFails: true });
@@ -239,12 +240,12 @@ describe("nrv revise — the outcome goes through the delivery pipeline", () => 
     expect(events(c)).toContain("x_runtime_errored_with_artifacts");
     expect(events(c)).toContain("x_delivery_withheld");
     expect(events(c)).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("a FAILED revision with nothing on disk keeps the historical exit 1", () => {
     const c = runRevise({}, { runtimeFails: true });
     expect(c.status).toBe(1);
     expect(events(c)).toContain("revision_failed");
     expect(events(c)).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/runtime-snapshot-after-catalog-update.e2e.test.ts
+++ b/skills/harness/tests/runtime-snapshot-after-catalog-update.e2e.test.ts
@@ -19,6 +19,7 @@ import {
 import { multiTargetRunId } from "../scripts/multi-target.ts";
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS, spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
 const MULTI_TARGET = path.join(REPO, "skills", "harness", "scripts", "multi-target.ts");
@@ -162,7 +163,7 @@ describe("runtime snapshot survives a catalog update (criterion 6)", () => {
       expect((await server.run(setup.projectId, "run_second")).policySnapshotRef, boot).not.toBe(frozen.ref);
       server.stop();
     }
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a stale catalog marks the snapshot and lets the Run proceed; NIRVANA_ALLOW_STALE_CATALOG=1 resolves it with a warning", () => {
     const setup = fixture();
@@ -186,7 +187,7 @@ describe("runtime snapshot survives a catalog update (criterion 6)", () => {
     expect(allowed.errors).toBeUndefined();
     process.env[ALLOW_STALE_ENV] = "1";
     expect(freezeExecutionSnapshot(RUNTIME)).toEqual(allowed);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a missing required feature or model rolls the Run back before the producer with the broker's explanation", () => {
     const setup = fixture();
@@ -212,7 +213,7 @@ describe("runtime snapshot survives a catalog update (criterion 6)", () => {
     expect(model.errors?.[0]).toContain("No model");
     expect(model.rejected).toEqual([{ model: "fixture-provider/text-model/1", reasons: ["capability 'video_generation' requires native, model provides unavailable"] }]);
     expect(model.evidence).toBeUndefined();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("without a descriptor the snapshot is the previous literal plus the reason, and missing directories are skipped", () => {
     const setup = fixture();
@@ -238,7 +239,7 @@ describe("runtime snapshot survives a catalog update (criterion 6)", () => {
     expect(resolveCatalogDirs({ env: {}, projectRoot: setup.root, homeDir: home })).toEqual([userCatalog, projectCatalog]);
     const configured = [setup.catalogDir, path.join(setup.root, "missing")].join(path.delimiter);
     expect(resolveCatalogDirs({ env: { [CATALOG_DIR_ENV]: configured }, projectRoot: setup.root, homeDir: home })).toEqual([setup.catalogDir]);
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("nrv multi-target run freezes the coordinator's runtime snapshot", () => {
@@ -318,5 +319,5 @@ describe("nrv multi-target run freezes the coordinator's runtime snapshot", () =
     expect(deliveredSnapshot.snapshot).toMatchObject({ runtime: { id: "codex", source: "flag", resolved: true, version: "1.2.0" },
       provider: { id: "fixture-provider", resolved: true }, model: { id: "fixture-provider/text-model/1", resolved: true } });
     expect(deliveredRun.events.filter(event => event.type === "runtime.selection_snapshot")).toHaveLength(1);
-  });
+  }, spawnBudgetMs(3));
 });

--- a/skills/harness/tests/serve-queue-sse.test.ts
+++ b/skills/harness/tests/serve-queue-sse.test.ts
@@ -14,6 +14,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const root = mkdtempSync(join(tmpdir(), "serve-queue-"));
 const dispatchFixture = join(root, "slow-dispatch.ts");
@@ -113,7 +114,7 @@ describe("queue", () => {
     // second starts only after the first finished — serialization proved
     expect(bStart).toBeGreaterThanOrEqual(aEnd - 5);
     expect(aStart).toBeLessThan(bStart);
-  });
+  }, spawnBudgetMs(2));
 
   test("different sessions DO run in parallel under the cap", async () => {
     writeFileSync(marksFile, "");
@@ -130,7 +131,7 @@ describe("queue", () => {
     const ends = marks.filter((m) => m.phase === "end").map((m) => m.at).sort();
     // the second run started before the first one ended — real overlap
     expect(starts[1]).toBeLessThan(ends[1]);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("SSE", () => {
@@ -163,5 +164,5 @@ describe("SSE", () => {
       if (ev.event === "run.finished") continue;
       expect(ev.trace_id ?? ev.project_id).toBe(r.trace_id);
     }
-  });
+  }, spawnBudgetMs(1));
 });

--- a/skills/harness/tests/watermark-gate.test.ts
+++ b/skills/harness/tests/watermark-gate.test.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const DOCTOR = path.join(import.meta.dir, "..", "scripts", "doctor-system.ts");
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-watermark-gate-"));
@@ -61,7 +62,7 @@ describe("watermark gate", () => {
     const line = watermarkLine(library({ clean: 3, author: true }).env);
     expect(line).toContain("✓");
     expect(line).toContain("clean");
-  });
+  }, spawnBudgetMs(1));
 
   test("THE INCIDENT: a marker on a pack-authoring machine FAILS", () => {
     // This is the case that shipped undetected. The author builds packs from this
@@ -74,7 +75,7 @@ describe("watermark gate", () => {
     // against the live library, erasing 59 attribution tags.
     expect(line).not.toContain("strip-base-watermarks");
     expect(line).toContain("never ~/squads");
-  });
+  }, spawnBudgetMs(1));
 
   test("the same marker on a buyer machine is a WARN, not a failure", () => {
     // A buyer's installed content is SUPPOSED to be watermarked. Failing there would
@@ -82,7 +83,7 @@ describe("watermark gate", () => {
     const line = watermarkLine(library({ marked: 2, author: false }).env);
     expect(line).toContain("⚠");
     expect(line).toContain("normal for installed paid content");
-  });
+  }, spawnBudgetMs(1));
 
   test("a 22-char string that is NOT alone on a line is not a marker", () => {
     // Prose and code mention such strings; only a line that is nothing but the tag
@@ -92,7 +93,7 @@ describe("watermark gate", () => {
     fs.mkdirSync(d, { recursive: true });
     fs.writeFileSync(path.join(d, "README.md"), "the id aBcDeFgHiJkLmNoPqRsTuV appears inline here.\n");
     expect(watermarkLine(lib.env)).toContain("✓");
-  });
+  }, spawnBudgetMs(1));
 
   test("no content library at all is not a failure", () => {
     const root = path.join(TMP, "empty-machine");
@@ -102,5 +103,5 @@ describe("watermark gate", () => {
       NIRVANA_PACKS_DIR: root, NIRVANA_SCOPE_QUIET: "1",
     } as Record<string, string>);
     expect(line).toContain("✓");
-  });
+  }, spawnBudgetMs(1));
 });


### PR DESCRIPTION
## Why

`smoke (windows-latest)` failed on `main` and on documentation-only PRs while ubuntu and macos stayed green. The last twenty smoke runs, read with `--log-failed` (and the attempt-1 logs of the two runs that were rerun), give this real failure list on code that is on `main` today:

| Run | Commit | Failing test | Cause |
| --- | --- | --- | --- |
| [32928964511](https://github.com/gutomec/nirvana-os-engine/actions/runs/32928964511/job/98057367037) | main `7ef608e` | `nrv multi-target run` x3 (exit 2, crash-resume, different plan) | timed out at Bun's 5 s default (5.0-5.1 s); 1.4-1.7 s on a normal Windows run. Each test spawns two engines plus 2-5 fake dispatch children. |
| [32929953479](https://github.com/gutomec/nirvana-os-engine/actions/runs/32929953479) attempt 1 (PR #95) | `477972d` | `agent-x Gauntlet cutover > persists a typed squad producer` | timed out at 5.5 s; neighbours took 2.9-4.6 s, the suite 186 s instead of ~150 s. In-process SQLite with `synchronous = FULL`, runner disk 20-35x slower than usual. |
| [32929139083](https://github.com/gutomec/nirvana-os-engine/actions/runs/32929139083) attempt 1 (PR #90) | `e85deb6` | `durable agent-x canary recovery > a running run whose child is dead is redispatched once` | `openKernel` right after the crashed child's pid was gone: `SQLITE_IOERR_TRUNCATE` on `PRAGMA journal_mode = WAL`; the handle the failed open left behind then made `afterEach` fail with `EBUSY`. |
| [32931392895](https://github.com/gutomec/nirvana-os-engine/actions/runs/32931392895) attempt 1 (PR #96) | feat/scope-guard `607c490` | `multi-target dispatch adapters > an aborted signal kills the subprocess and returns failed without a marker` | `spawnCount` read 0 after the abort: the test aborted the instant `dispatch-capture.json` existed and the kill landed before the fake appended its spawn-log line (the whole test took 34 ms). The rerun passed (job 98064983974). |
| [32928287472](https://github.com/gutomec/nirvana-os-engine/actions/runs/32928287472/job/98055457846) | main `7e0ae5d` | `Glance child-process execution > use squad / use business prepare typed Runs` | `glance.child_exited` missing from the timeline: the race `fee579f` fixed (this run predates it). |
| [32928293935](https://github.com/gutomec/nirvana-os-engine/actions/runs/32928293935) attempts 1 and 2 | release/0.8.1 `fa04145` | same test as above | same cause, same fix already on `main`. |
| [32918826276](https://github.com/gutomec/nirvana-os-engine/actions/runs/32918826276/job/98028072311) | week1-readme `fb02b7f` | `init-existing-project > keeps the user's rules AND gains the invocation contract` | the first `init-project.ts` spawn exceeded its explicit 60 s budget once (7.6-8.0 s on green runs). Single occurrence, no timing remedy identified; left as is. |

The other failed runs in the window (`feat/glance-service-mode` x3, `release/0.8.0` `d60171f`) failed on ubuntu and macos too, so they are code defects at those commits rather than Windows timing.

## What changed (tests and test helpers only)

- **`helpers/test-budgets.ts`** (new): `spawnBudgetMs(processes)` and `KERNEL_BUDGET_MS`, sized from the measured runs and documented there. Applied as explicit timeouts to the tests that spawn processes or drive the Run Kernel in the files that failed or came within 3x of the default on the slowest runner: `multi-target-cli`, `agent-x-gauntlet-cutover`, `agent-x-canary-recovery`, `glance-agent-x-canary-e2e`, `business-gauntlet-glance-proof.e2e`, `multi-target-dispatch-adapters`, `activate-batch`, `agentic-run-tracking`, `serve-queue-sse`, `runtime-snapshot-after-catalog-update.e2e`, `business-delivery-parity.e2e`, `watermark-gate`, `revise-delivery`.
- **`agent-x-canary-recovery.test.ts`**: `waitForState` waits on a deadline instead of a count; after the crashed child dies the test waits, with a deadline, until the kernel opens again (a probe that runs the same first statement as `openKernel` and closes its own handle) before reading it.
- **`glance-agent-x-canary-e2e.test.ts`**: `waitFor` waits on a deadline; the responsiveness test waits for the child's `completed` marker instead of reading it the instant the kernel shows `completed` (the child transitions the Run and only then writes the marker).
- **`multi-target-dispatch-adapters.test.ts`**: the abort test waits, with a deadline, for the fake dispatch's spawn record before aborting; the fake writes its capture, then the spawn-log line, then sleeps, so once the record is on disk the kill can land anywhere.
- **`multi-target-cli.test.ts`**: temporary roots go through `removeDir`, which tolerates the `EBUSY` a departing child leaves on Windows.

No platform skips, no loosened assertions, no fixed sleeps. Every changed file was run three times in a row locally; `bun scripts/check-english-source.ts --strict` and `git diff --check` are clean.

## Verification

Three consecutive green `smoke (windows-latest)` jobs on the same commit (`f454110`), the first from the PR event and two from `gh run rerun`:

| Attempt | Trigger | `smoke (windows-latest)` job | Result |
| --- | --- | --- | --- |
| [32932984324](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324) attempt 1 | pull_request | [98068651180](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324/job/98068651180) | success, 1261 tests, 0 fail |
| [32932984324](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324/attempts/2) attempt 2 | `gh run rerun` | [98069343040](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324/job/98069343040) | success |
| [32932984324](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324/attempts/3) attempt 3 | `gh run rerun` | [98069960370](https://github.com/gutomec/nirvana-os-engine/actions/runs/32932984324/job/98069960370) | success |

The pre-rebase commit `7a25b08` was also green on Windows ([32931900397](https://github.com/gutomec/nirvana-os-engine/actions/runs/32931900397), job 98065609239). The branch was rebased onto `cb688ea` after PRs #95 and #96 landed, because GitHub does not build the merge ref of a conflicting PR and therefore ran no `pull_request` workflow for the second commit.

Do not merge until a maintainer has read this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
