### PR TITLE
fix(run-kernel): close the database when initialize fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A failed `openKernel` no longer leaks the database handle
+
+`openKernel` opened the SQLite `Database` and only then ran `initialize`
+(the journal pragmas and the schema). When `initialize` threw, the handle
+stayed open and the file stayed locked. On Windows, `PRAGMA journal_mode =
+WAL` right after a child process died failed with `SQLITE_IOERR_TRUNCATE`,
+and every later `rmSync` on that directory cascaded into `EBUSY` during
+teardown (run 32929139083). `openKernel` now closes the `Database` before
+rethrowing the original error, untouched; the success path is unchanged. The
+regression test provokes the failure with a file that is not a SQLite
+database at the kernel path (SQLite reads nothing at open, so the first
+pragma is what fails) and checks that `close` ran once, that the caller
+receives the `SQLiteError` itself, and that the file can be removed and
+reopened right away.
+
 ### Every dispatched instruction carries the scope guard
 
 A dispatched executor used to receive its scope only implicitly, and a

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,21 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Um `openKernel` que falha não vaza mais o handle do banco
+
+O `openKernel` abria o `Database` SQLite e só então rodava o `initialize`
+(os pragmas de journal e o schema). Quando o `initialize` lançava, o handle
+ficava aberto e o arquivo, travado. No Windows, o `PRAGMA journal_mode =
+WAL` logo após a morte de um processo filho falhava com
+`SQLITE_IOERR_TRUNCATE`, e cada `rmSync` seguinte naquele diretório virava
+`EBUSY` em cascata no teardown (run 32929139083). O `openKernel` agora fecha
+o `Database` antes de relançar o erro original, intacto; o caminho de sucesso
+não muda. O teste de regressão provoca a falha com um arquivo que não é um
+banco SQLite no caminho do kernel (o SQLite não lê nada ao abrir, então é o
+primeiro pragma que falha) e verifica que o `close` rodou uma vez, que o
+chamador recebe o próprio `SQLiteError` e que o arquivo pode ser removido e
+reaberto na hora.
+
 ### Toda instrução despachada carrega a guarda de escopo
 
 Um executor despachado recebia seu escopo só de forma implícita, e uma

--- a/skills/harness/lib/run-kernel/store.ts
+++ b/skills/harness/lib/run-kernel/store.ts
@@ -117,7 +117,14 @@ function initialize(db: Database): void {
 export function openKernel(dbPath: string): KernelHandle {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   const db = new Database(dbPath);
-  initialize(db);
+  try {
+    initialize(db);
+  } catch (error) {
+    // A handle that outlives a failed initialize keeps the file locked (EBUSY on Windows at
+    // teardown), so release it before the caller sees the original error.
+    try { db.close(); } catch { /* the initialize error is the one to report */ }
+    throw error;
+  }
   return { db, path: dbPath, close: () => db.close() };
 }
 

--- a/skills/harness/tests/run-kernel.test.ts
+++ b/skills/harness/tests/run-kernel.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Database, SQLiteError } from "bun:sqlite";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -303,4 +304,36 @@ console.log(count);
     expect(events.map(event => event.sequence)).toEqual(events.map((_, index) => index + 1));
     expect(getRun(handle, "prj_busy", "run_parent")?.state).toBe("running");
   }, 30000);
+});
+
+describe("opening a kernel", () => {
+  // openKernel opens the Database and only then runs initialize (the journal pragmas and the
+  // schema). On Windows, PRAGMA journal_mode = WAL right after a child process died failed with
+  // SQLITE_IOERR_TRUNCATE, and the handle left open kept the file locked: every rmSync on that
+  // directory cascaded into EBUSY during teardown (run 32929139083). A file that is not a SQLite
+  // database provokes the same shape deterministically: SQLite reads nothing at open, so
+  // new Database() succeeds and the first pragma fails with SQLITE_NOTADB.
+  test("closes the database and rethrows the original error when initialize fails", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-kernel-"));
+    roots.push(root);
+    const kernelPath = path.join(root, "kernel.sqlite");
+    fs.writeFileSync(kernelPath, "not a sqlite database\n", "utf8");
+    // Unlinking an open file succeeds on POSIX, so rmSync below only proves the fix on Windows;
+    // the spy makes a leaked handle visible on every OS.
+    const close = spyOn(Database.prototype, "close");
+    try {
+      let thrown: unknown;
+      try { openKernel(kernelPath); } catch (error) { thrown = error; }
+      expect(thrown).toBeInstanceOf(SQLiteError);
+      expect((thrown as SQLiteError).code).toBe("SQLITE_NOTADB");
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      close.mockRestore();
+    }
+    fs.rmSync(kernelPath);
+    const reopened = openKernel(kernelPath);
+    handles.push(reopened);
+    createRun(reopened, runInput());
+    expect(getRun(reopened, "prj_a", "run_a")?.state).toBe("prepared");
+  });
 });


### PR DESCRIPTION
## Summary

`openKernel` (`skills/harness/lib/run-kernel/store.ts`) opened the SQLite `Database` and only then ran `initialize`. When `initialize` threw, the handle stayed open and the file stayed locked. On Windows that showed up as `SQLITE_IOERR_TRUNCATE` on `PRAGMA journal_mode = WAL` right after a child process died, followed by an `EBUSY` cascade during teardown (run 32929139083, job 98057857031).

- `openKernel` now closes the `Database` when `initialize` throws and rethrows the original error, untouched. The success path is unchanged.
- Regression test in `skills/harness/tests/run-kernel.test.ts` ("opening a kernel").
- `CHANGELOG.md` and `CHANGELOG.pt-BR.md` under Unreleased, in parity.

## How the initialize failure is provoked

A file that is not a SQLite database is written at the kernel path. SQLite reads nothing at open, so `new Database()` succeeds and the first statement of `initialize` (`PRAGMA journal_mode = WAL`) fails with `SQLITE_NOTADB`. That is the same shape as the Windows failure: a live handle whose initialize threw. A directory at the path would not work, since it fails inside `new Database()` itself (`SQLITE_CANTOPEN`) before any handle exists.

The test then proves three things: `Database.prototype.close` ran exactly once during the failed open (a `spyOn`, since unlinking an open file succeeds on POSIX and `rmSync` alone only catches the leak on Windows), the caller receives the `SQLiteError` itself with code `SQLITE_NOTADB`, and the file can be removed and a fresh kernel opened at the same path right away. Without the fix the test fails on every OS (`close` called 0 times).

## Validation

- `bun test skills/harness/tests/run-kernel.test.ts skills/harness/tests/agent-x-canary-recovery.test.ts`: 20 pass
- `bun test skills/harness/tests`: 970 pass, 4 skip, 1 fail. The one failure is `buyer-path.test.ts`, which fails identically on the untouched base `bf94028` in this worktree: `scripts/install.ts` copies the repo `node_modules` without dereferencing on macOS, and this worktree's `node_modules` is a symlink, so `yaml` is unresolvable inside the fake buyer HOME. Local environment only; CI installs from a fresh checkout.
- `bun scripts/check-english-source.ts --strict`: clean
- `bun scripts/check-changelog-parity.ts --strict`: clean
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
