### PR TITLE
feat(multi-target): the synthesis takes its own Gauntlet limits in the policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The synthesis of a multi-target plan takes its own Gauntlet limits
+
+Under `each-target-and-final` and `adaptive`, the aggregate reservation
+completes the synthesis first with `min(cap, synthesis limit)`, and the
+synthesis had no limit of its own: `compileMultiTargetGauntletPolicy` refused
+`policy.targets[<synthesisNodeId>]` with `target node not found`, since the
+`deliverable` node is not a target. The synthesis therefore requested the whole
+cap and every other Gauntlet target was left at its safe minimum. The
+`landing-clinica` plan, cap USD 32, squad `landing-page-nirvana` limited to
+USD 20 and synthesis unlimited, reserved USD 31 for the synthesis and USD 1 for
+the squad.
+
+The policy now accepts `policy.synthesis: { intensity?, limits? }`, and
+`policy.targets[<synthesisNodeId>]` as an alias with the same meaning; both
+snapshot and digest alike. Limits inherit conservatively, like a target's; an
+intensity above the policy's is refused with its path, and so is a `mode` on
+the synthesis, because the scope alone decides whether it runs Gauntlet. The
+compiled synthesis decision carries the effective limits with
+`source: "target-override"`, so the reservation asks `min(cap, synthesis
+limit)` for it and the balance goes to the targets. The same plan with the
+synthesis capped at USD 10: synthesis USD 10, squad USD 20, USD 2 held back.
+Without a synthesis limit nothing changes. `nrv multi-target plan` prints the
+new allocation; the policy and CLI documents describe the field.
+
 ### Every Gauntlet canary exit closes its run-ledger row, and a scripted dispatch leaves no agentic row behind
 
 The first Gauntlet smoke with judge-x (`nrv dispatch --squad

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,29 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A síntese de um plano multi-target tem limites Gauntlet próprios
+
+Nos escopos `each-target-and-final` e `adaptive`, a reserva agregada completa
+primeiro a solicitação da síntese com `min(teto, limite da síntese)`, e a
+síntese não tinha limite próprio: `compileMultiTargetGauntletPolicy` recusava
+`policy.targets[<synthesisNodeId>]` com `target node not found`, porque o nó
+`deliverable` não é um target. A síntese pedia então o teto inteiro e todo
+outro target Gauntlet ficava no piso de segurança. O plano `landing-clinica`,
+com teto USD 32, squad `landing-page-nirvana` limitado a USD 20 e síntese sem
+limite, reservava USD 31 para a síntese e USD 1 para o squad.
+
+A política agora aceita `policy.synthesis: { intensity?, limits? }`, e
+`policy.targets[<synthesisNodeId>]` como alias com o mesmo significado; as duas
+grafias geram o mesmo snapshot e o mesmo digest. Os limites herdam de forma
+conservadora, como os de um target; uma intensidade acima da global é recusada
+com o caminho, assim como um `mode` na síntese, porque só o escopo decide se
+ela roda Gauntlet. A decisão compilada da síntese leva os limites efetivos com
+`source: "target-override"`, então a reserva pede `min(teto, limite da
+síntese)` para ela e o saldo vai para os targets. O mesmo plano com a síntese
+limitada a USD 10: síntese USD 10, squad USD 20, USD 2 retidos. Sem limite na
+síntese nada muda. O `nrv multi-target plan` imprime a alocação nova; os
+documentos da política e do comando descrevem o campo.
+
 ### Toda saída de canário Gauntlet fecha a linha do run-ledger, e um dispatch scriptado não deixa linha agêntica para trás
 
 O primeiro smoke do Gauntlet com judge-x (`nrv dispatch --squad

--- a/docs/architecture/gauntlet-multi-target-cli.md
+++ b/docs/architecture/gauntlet-multi-target-cli.md
@@ -75,6 +75,26 @@ Um papel sem squad especializado (a copy de um lançamento entre o squad de pesq
 
 As ondas são `brief-main`, `squad-research`, `role-copywriter`, `squad-design` e `final-output`, uma por vez. O `DISPATCH-INSTRUCTION.md` de `agents/role-copywriter/` apresenta o executor como o agent-x no papel `role-copywriter`, aponta o `_SUMMARY.md` de `squads/squad-research/outputs/` e nomeia `squad-design` como consumidor. É o plano que `skills/harness/tests/multi-target-cli.test.ts` executa de ponta a ponta com o dispatch falso.
 
+### Limites da síntese
+
+A síntese (o nó `deliverable` em `synthesisNodeId`) pede à reserva agregada `min(teto, limite próprio)`; sem limite próprio ela pede o teto inteiro e deixa os outros targets Gauntlet no piso. `policy.synthesis` declara intensidade e limites só dela, e `policy.targets[<synthesisNodeId>]` é um alias com o mesmo significado, sem `mode`, porque o modo da síntese é do escopo ([política](gauntlet-multi-target-policy.md)). Um plano com teto USD 32, squad limitado a USD 20 e síntese limitada a USD 10:
+
+```json
+"policy": {
+  "scope": "each-target-and-final",
+  "intensity": "light",
+  "synthesisNodeId": "final-output",
+  "limits": { "maxCostUsd": 32 },
+  "synthesis": { "limits": { "maxCostUsd": 10 } },
+  "targets": {
+    "visual-brief": { "mode": "standard" },
+    "landing-page-nirvana": { "limits": { "maxCostUsd": 20 } }
+  }
+}
+```
+
+`nrv multi-target plan` imprime a alocação: `landing-page-nirvana` na onda 2 com USD 20 solicitados e concedidos, `final-output` na onda 3 com USD 10 solicitados e concedidos, saldo USD 2. Sem `synthesis`, o mesmo plano concede USD 31 à síntese e USD 1 ao squad.
+
 ## Comandos
 
 ### `plan <arquivo> [--project <id>]`

--- a/docs/architecture/gauntlet-multi-target-policy.md
+++ b/docs/architecture/gauntlet-multi-target-policy.md
@@ -53,6 +53,12 @@ Um override pode reduzir intensidade e limites, mas não ampliá-los. A intensid
 
 Referências inexistentes, ciclos, escopos, intensidades, modos, riscos e limites inválidos impedem a emissão do plano compilado.
 
+## Limites da síntese
+
+`policy.synthesis` dá à síntese intensidade e limites próprios, no formato `{ "intensity": "light", "limits": { "maxCostUsd": 10 } }`. Por conveniência, `policy.targets[<synthesisNodeId>]` tem o mesmo significado: as duas grafias produzem o mesmo snapshot e o mesmo digest, e declarar as duas é erro em `/policy/targets/<id>`. O modo da síntese continua vindo do escopo, então `mode` nessa entrada é recusado com o caminho e uma explicação, assim como `critical`, `risk` e `estimatedCostUsd`.
+
+Os limites herdam como nos targets: cada limite efetivo é o menor entre o global e o da síntese. A intensidade é mais estrita, porque um valor acima da intensidade global é erro em `/policy/synthesis/intensity`, não um corte silencioso. A decisão compilada da síntese leva os limites efetivos e `source: "target-override"`; sem override, leva os limites globais e `source: "scope"`. Num escopo que não seleciona a síntese ela fica `standard`, e o override não tem efeito. `policy.synthesis` sem `synthesisNodeId` é erro em `/policy/synthesis`.
+
 ## Reserva agregada de custo
 
 `reserveAggregateGauntletBudget` projeta uma reserva sobre o `CompiledMultiTargetPlan`. O digest da reserva inclui `policyDigest`, ligando a alocação ao snapshot exato que a originou. A função não chama executor, runtime, rede nem medidor de consumo real.
@@ -63,10 +69,10 @@ Valores são convertidos para micros de dólar antes do cálculo. Isso evita div
 
 1. reservar o piso seguro de cada decisão Gauntlet, com USD 1 para `light`, USD 2 para `balanced` e USD 5 para `exhaustive`;
 2. rejeitar a reserva inteira quando o teto ou um limite individual não comportar esses pisos;
-3. completar a solicitação da síntese, quando houver;
+3. completar a solicitação da síntese, quando houver: `min(teto, maxCostUsd da síntese)`, ou o teto inteiro quando a síntese não tem limite próprio;
 4. ratear o saldo proporcionalmente entre targets, com resíduos de um micro distribuídos pela maior fração e depois pelo ID.
 
-A soma concedida nunca supera o teto nem a solicitação individual. A síntese é protegida, mas não pode consumir os pisos já reservados para targets anteriores.
+A soma concedida nunca supera o teto nem a solicitação individual. A síntese é protegida, mas não pode consumir os pisos já reservados para os targets, e o que ela não pede fica para eles. Sem limite próprio ela pede o teto inteiro e os targets ficam no piso: num plano `light` com teto USD 32, squad limitado a USD 20 e síntese sem limite, a síntese recebe USD 31 e o squad USD 1. Com `synthesis.limits.maxCostUsd: 10`, a síntese recebe USD 10, o squad USD 20 e o saldo de USD 2 fica retido, porque nenhuma solicitação ficou em aberto. Com dois targets de USD 12 sob intensidade `balanced` e a mesma síntese de USD 10, os pisos somam USD 6, a síntese completa USD 10 e os USD 18 restantes vão USD 9 para cada target.
 
 Ausência de política ou de `maxCostUsd` retorna reserva nula e preserva o plano. Zero explícito é um teto real: um Gauntlet ativo é rejeitado porque não comporta seu piso seguro. Duração não é somada porque ondas paralelas compartilham tempo de parede. Rounds continuam como limites locais, pois somá-los não descreve consumo agregado.
 

--- a/skills/harness/lib/plan-compiler.ts
+++ b/skills/harness/lib/plan-compiler.ts
@@ -53,12 +53,21 @@ export interface GauntletPolicyLimit {
   maxRounds?: number;
 }
 
+// Own intensity and limits of the synthesis. Its mode always comes from the
+// scope, so the override carries neither `mode` nor the adaptive signals.
+export interface GauntletSynthesisOverride {
+  intensity?: GauntletIntensity;
+  limits?: GauntletPolicyLimit;
+}
+
 export interface MultiTargetGauntletPolicy {
   scope: MultiTargetGauntletScope;
   intensity?: GauntletIntensity;
   limits?: GauntletPolicyLimit;
   criticalTargetIds?: string[];
   synthesisNodeId?: string;
+  synthesis?: GauntletSynthesisOverride;
+  // `targets[synthesisNodeId]` is accepted as an alias of `synthesis`.
   targets?: Record<string, {
     mode?: "standard" | "gauntlet";
     intensity?: GauntletIntensity;
@@ -123,6 +132,34 @@ function validateLimits(path: string, limits: GauntletPolicyLimit | undefined, i
   }
 }
 
+// The synthesis override is stricter than a target override: an intensity above
+// the policy's is an error rather than a silent clamp, and every other key is
+// refused, because the scope alone decides whether the synthesis runs Gauntlet.
+function validateSynthesisOverride(
+  path: string,
+  override: GauntletSynthesisOverride,
+  parentIntensity: GauntletIntensity | undefined,
+  issues: MultiTargetPolicyIssue[]
+): void {
+  for (const key of Object.keys(override)) {
+    if (key === "intensity" || key === "limits") continue;
+    issues.push({
+      path: `${path}/${key}`,
+      message: key === "mode"
+        ? "synthesis mode comes from the scope; declare only intensity and limits"
+        : "synthesis accepts only intensity and limits",
+    });
+  }
+  if (override.intensity !== undefined) {
+    if (!POLICY_INTENSITIES.has(override.intensity)) {
+      issues.push({ path: `${path}/intensity`, message: `invalid intensity: ${override.intensity}` });
+    } else if (parentIntensity && INTENSITY_RANK[override.intensity] > INTENSITY_RANK[parentIntensity]) {
+      issues.push({ path: `${path}/intensity`, message: `must not exceed the policy intensity ${parentIntensity}` });
+    }
+  }
+  validateLimits(`${path}/limits`, override.limits, issues);
+}
+
 function inheritedLimits(parent: GauntletPolicyLimit | undefined, child: GauntletPolicyLimit | undefined): GauntletPolicyLimit | undefined {
   if (!parent && !child) return undefined;
   const cap = (key: keyof GauntletPolicyLimit): number | undefined => {
@@ -176,8 +213,28 @@ export function compileMultiTargetGauntletPolicy(
     for (const id of policy.criticalTargetIds ?? []) {
       if (!targetIds.has(id)) issues.push({ path: "/policy/criticalTargetIds", message: `target node not found: ${id}` });
     }
+    const parentIntensity = policy.intensity === undefined ? "balanced" : POLICY_INTENSITIES.has(policy.intensity) ? policy.intensity : undefined;
+    const synthesisAlias = policy.synthesisNodeId && nodes.get(policy.synthesisNodeId)?.type === "deliverable"
+      ? policy.targets?.[policy.synthesisNodeId]
+      : undefined;
+    if (policy.synthesis) {
+      if (!policy.synthesisNodeId) issues.push({ path: "/policy/synthesis", message: "requires policy.synthesisNodeId" });
+      else if (synthesisAlias) issues.push({ path: `/policy/targets/${policy.synthesisNodeId}`, message: "synthesis is already configured by policy.synthesis" });
+      validateSynthesisOverride("/policy/synthesis", policy.synthesis, parentIntensity, issues);
+    }
     for (const [id, override] of Object.entries(policy.targets ?? {})) {
-      if (!targetIds.has(id)) issues.push({ path: `/policy/targets/${id}`, message: `target node not found: ${id}` });
+      if (synthesisAlias && id === policy.synthesisNodeId) {
+        validateSynthesisOverride(`/policy/targets/${id}`, override, parentIntensity, issues);
+        continue;
+      }
+      if (!targetIds.has(id)) {
+        issues.push({
+          path: `/policy/targets/${id}`,
+          message: nodes.get(id)?.type === "deliverable"
+            ? `deliverable ${id} is not the declared synthesis; set policy.synthesisNodeId`
+            : `target node not found: ${id}`,
+        });
+      }
       if (override.mode !== undefined && override.mode !== "standard" && override.mode !== "gauntlet") {
         issues.push({ path: `/policy/targets/${id}/mode`, message: `invalid mode: ${override.mode}` });
       }
@@ -253,18 +310,30 @@ export function compileMultiTargetGauntletPolicy(
     .sort((a, b) => a.id.localeCompare(b.id))
     .map(decideTarget);
   const synthesisNode = policy?.synthesisNodeId ? nodes.get(policy.synthesisNodeId)! : undefined;
+  const synthesisOverride: GauntletSynthesisOverride | undefined = synthesisNode ? policy?.synthesis ?? policy?.targets?.[synthesisNode.id] : undefined;
   const synthesisEnabled = !!policy && !!synthesisNode && ["final-only", "each-target-and-final", "adaptive"].includes(policy.scope);
   const synthesis: CompiledGauntletDecision | null = synthesisNode ? {
     nodeId: synthesisNode.id, targetKind: "synthesis", mode: synthesisEnabled ? "gauntlet" : "standard",
-    ...(synthesisEnabled ? { intensity, limits: inheritedLimits(policy?.limits, undefined) } : {}),
-    reason: synthesisEnabled ? `selected by ${policy!.scope} scope` : "scope does not select synthesis",
-    source: "scope",
+    ...(synthesisEnabled ? {
+      intensity: inheritedIntensity(intensity, synthesisOverride?.intensity),
+      limits: inheritedLimits(policy?.limits, synthesisOverride?.limits),
+    } : {}),
+    reason: synthesisEnabled
+      ? `selected by ${policy!.scope} scope${synthesisOverride ? " with its own intensity and limits" : ""}`
+      : "scope does not select synthesis",
+    source: synthesisEnabled && synthesisOverride ? "target-override" : "scope",
   } : null;
 
+  // The alias form folds into `synthesis`, so both spellings snapshot and digest alike.
   const normalizedPolicy = policy ? {
     ...policy,
     criticalTargetIds: [...(policy.criticalTargetIds ?? [])].sort(),
-    targets: Object.fromEntries(Object.entries(policy.targets ?? {}).sort(([left], [right]) => left.localeCompare(right))),
+    ...(synthesisOverride ? { synthesis: synthesisOverride } : {}),
+    targets: Object.fromEntries(
+      Object.entries(policy.targets ?? {})
+        .filter(([id]) => id !== synthesisNode?.id)
+        .sort(([left], [right]) => left.localeCompare(right))
+    ),
   } : null;
   const snapshot = { schemaVersion: "nirvana.multi-target-gauntlet-policy/v1alpha1" as const, manifest, decisions, synthesis, policySnapshot: normalizedPolicy };
   const digest = createHash("sha256").update(canonicalJson(snapshot)).digest("hex");

--- a/skills/harness/tests/gauntlet-aggregate-budget.test.ts
+++ b/skills/harness/tests/gauntlet-aggregate-budget.test.ts
@@ -155,3 +155,69 @@ describe("aggregate Gauntlet budget reservation with agent nodes", () => {
     expect(rejected.allocations.find((item) => item.nodeId === "role-copywriter")).toMatchObject({ targetKind: "agent-x", grantedUsd: 0, reason: "aggregate_cap_rejected" });
   });
 });
+
+describe("aggregate Gauntlet budget reservation with synthesis limits", () => {
+  // The landing-clinica shape: a standard agent brief, one Gauntlet squad, the synthesis.
+  const landingGraph: DependencyGraph = {
+    nodes: [
+      { id: "brief-main", type: "brief" },
+      { id: "visual-brief", type: "agent" },
+      { id: "landing-page-nirvana", type: "squad" },
+      { id: "final-output", type: "deliverable" },
+    ],
+    edges: [
+      { id: "b1", source: "brief-main", target: "visual-brief", type: "briefs" },
+      { id: "d1", source: "landing-page-nirvana", target: "visual-brief", type: "depends_on" },
+      { id: "y1", source: "landing-page-nirvana", target: "final-output", type: "yields" },
+    ],
+  };
+  const landingPolicy: MultiTargetGauntletPolicy = {
+    scope: "each-target-and-final", intensity: "light", synthesisNodeId: "final-output", limits: { maxCostUsd: 32 },
+    targets: { "visual-brief": { mode: "standard" }, "landing-page-nirvana": { limits: { maxCostUsd: 20 } } },
+  };
+  const reserve = (policy: MultiTargetGauntletPolicy, target: DependencyGraph = landingGraph) => {
+    const compiled = compileMultiTargetGauntletPolicy(target, policy);
+    expect(compiled.issues).toEqual([]);
+    return reserveAggregateGauntletBudget(compiled.plan!).reservation!;
+  };
+  const grantedOf = (reservation: ReturnType<typeof reserve>) =>
+    Object.fromEntries(reservation.allocations.map((item) => [item.nodeId, item.grantedUsd]));
+
+  test("a capped synthesis requests min(cap, its limit) and the squad keeps its own request", () => {
+    const reservation = reserve({ ...landingPolicy, synthesis: { limits: { maxCostUsd: 10 } } });
+    expect(reservation).toMatchObject({ status: "reserved", aggregateCapUsd: 32, requestedUsd: 30, grantedUsd: 30, balanceUsd: 2 });
+    expect(grantedOf(reservation)).toEqual({ "brief-main": 0, "visual-brief": 0, "landing-page-nirvana": 20, "final-output": 10 });
+    expect(reservation.allocations.find((item) => item.nodeId === "final-output")).toMatchObject({ requestedUsd: 10, grantedUsd: 10, reason: "requested_in_full" });
+    expect(reservation.allocations.find((item) => item.nodeId === "landing-page-nirvana")).toMatchObject({ requestedUsd: 20, grantedUsd: 20, reason: "requested_in_full" });
+    expect(reservation.reason).toBe("all gauntlet requests fit within the aggregate cap");
+  });
+
+  test("without its own limit the synthesis still requests the whole cap and the squad keeps the floor", () => {
+    const reservation = reserve(landingPolicy);
+    expect(reservation).toMatchObject({ status: "reserved", requestedUsd: 52, grantedUsd: 32, balanceUsd: 0 });
+    expect(grantedOf(reservation)).toEqual({ "brief-main": 0, "visual-brief": 0, "landing-page-nirvana": 1, "final-output": 31 });
+  });
+
+  test("a synthesis limit above the cap clamps to the cap", () => {
+    const reservation = reserve({ ...landingPolicy, synthesis: { limits: { maxCostUsd: 50 } } });
+    expect(reservation.allocations.find((item) => item.nodeId === "final-output")).toMatchObject({ requestedUsd: 32, grantedUsd: 31 });
+  });
+
+  test("the balance a capped synthesis leaves is shared by the targets in proportion", () => {
+    const policy: MultiTargetGauntletPolicy = {
+      scope: "each-target-and-final", intensity: "balanced", synthesisNodeId: "final-output", limits: { maxCostUsd: 32 },
+      targets: { "business-a": { limits: { maxCostUsd: 12 } }, "business-b": { limits: { maxCostUsd: 12 } }, "squad-c": { mode: "standard" } },
+    };
+    // Floors 2 + 2 + 2; the synthesis completes to 10; the 18 left split 9 and 9.
+    expect(grantedOf(reserve({ ...policy, synthesis: { limits: { maxCostUsd: 10 } } }, graph)))
+      .toEqual({ "brief-main": 0, "business-a": 11, "business-b": 11, "squad-c": 0, "final-output": 10 });
+    // Same policy without the synthesis limit: the synthesis takes 28 and the targets stay on the floor.
+    expect(grantedOf(reserve(policy, graph)))
+      .toEqual({ "brief-main": 0, "business-a": 2, "business-b": 2, "squad-c": 0, "final-output": 28 });
+  });
+
+  test("a synthesis limit below its safe minimum rejects the reservation", () => {
+    const reservation = reserve({ ...landingPolicy, synthesis: { limits: { maxCostUsd: 0.5 } } });
+    expect(reservation).toMatchObject({ status: "rejected", grantedUsd: 0, reason: "decision final-output requests less than its safe minimum" });
+  });
+});

--- a/skills/harness/tests/multi-target-cli.test.ts
+++ b/skills/harness/tests/multi-target-cli.test.ts
@@ -705,3 +705,45 @@ describe("nrv multi-target run with a standard node and a Gauntlet synthesis in 
     expect(retried.map((event) => [event.run_id, event.previous_run_id, event.reset_nodes, event.attempt])).toEqual([[r2, r1, ["final-output"], 2], [r3, r2, ["final-output"], 3]]);
   }, spawnBudgetMs(7));
 });
+
+describe("nrv multi-target plan with synthesis limits", () => {
+  test("prints the allocation of a capped synthesis next to the squad's and refuses a mode on the synthesis", () => {
+    const setup = fixture("landing-clinica");
+    const plan = {
+      ...PLAN,
+      briefs: { "visual-brief": "Write the style guide.", "landing-page-nirvana": "Build the page.", "final-output": "Assemble the package." },
+      graph: {
+        nodes: [
+          { id: "brief-main", type: "brief" },
+          { id: "visual-brief", type: "agent" },
+          { id: "landing-page-nirvana", type: "squad" },
+          { id: "final-output", type: "deliverable" },
+        ],
+        edges: [
+          { id: "b1", source: "brief-main", target: "visual-brief", type: "briefs" },
+          { id: "d1", source: "landing-page-nirvana", target: "visual-brief", type: "depends_on" },
+          { id: "y1", source: "landing-page-nirvana", target: "final-output", type: "yields" },
+        ],
+      },
+      policy: {
+        scope: "each-target-and-final", intensity: "light", synthesisNodeId: "final-output", limits: { maxCostUsd: 32 },
+        synthesis: { limits: { maxCostUsd: 10 } },
+        targets: { "visual-brief": { mode: "standard" }, "landing-page-nirvana": { limits: { maxCostUsd: 20 } } },
+      },
+      budgetUsd: { "visual-brief": 4, "landing-page-nirvana": 20, "final-output": 6 },
+    };
+    expect(validatePlanFile(plan).plan).not.toBeNull();
+    fs.writeFileSync(setup.planFile, JSON.stringify(plan));
+    const r = nrv(setup, ["plan", setup.planFile]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("alocações (teto USD 32 · concedido USD 30 · saldo USD 2)");
+    expect(r.stdout).toMatch(/landing-page-nirvana\s+onda 2\s+solicitado 20\s+concedido 20\s+requested_in_full/);
+    expect(r.stdout).toMatch(/final-output\s+onda 3\s+solicitado 10\s+concedido 10\s+requested_in_full/);
+
+    const withMode = { ...plan, policy: { ...plan.policy, synthesis: undefined, targets: { ...plan.policy.targets, "final-output": { mode: "gauntlet" } } } };
+    fs.writeFileSync(setup.planFile, JSON.stringify(withMode));
+    const refused = nrv(setup, ["plan", setup.planFile]);
+    expect(refused.status).toBe(4);
+    expect(refused.stderr).toContain("/policy/targets/final-output/mode: synthesis mode comes from the scope");
+  }, spawnBudgetMs(2));
+});

--- a/skills/harness/tests/multi-target-gauntlet-policy.test.ts
+++ b/skills/harness/tests/multi-target-gauntlet-policy.test.ts
@@ -196,3 +196,79 @@ describe("multi-target Gauntlet policy compiler with agent nodes", () => {
     expect(decisionOf({ scope: "final-only", synthesisNodeId: "final-output", targets: { "role-copywriter": { mode: "gauntlet" } } })).toMatchObject({ mode: "gauntlet", source: "target-override" });
   });
 });
+
+// The synthesis takes its own intensity and limits; its mode stays the scope's.
+describe("multi-target Gauntlet policy compiler with synthesis limits", () => {
+  const base: MultiTargetGauntletPolicy = {
+    scope: "each-target-and-final", intensity: "balanced", synthesisNodeId: "final-output",
+    limits: { maxCostUsd: 32, maxDurationSeconds: 600, maxRounds: 4 },
+  };
+  const compiled = (policy: MultiTargetGauntletPolicy) => {
+    const result = compileMultiTargetGauntletPolicy(graph, policy);
+    expect(result.issues).toEqual([]);
+    return result.plan!;
+  };
+  const issuesOf = (policy: MultiTargetGauntletPolicy) => {
+    const result = compileMultiTargetGauntletPolicy(graph, policy);
+    expect(result.plan).toBeNull();
+    return result.issues;
+  };
+
+  test("policy.synthesis sets the synthesis intensity and limits, inheriting only downwards", () => {
+    const plan = compiled({ ...base, synthesis: { intensity: "light", limits: { maxCostUsd: 10, maxDurationSeconds: 900, maxRounds: 2 } } });
+    expect(plan.synthesis).toEqual({
+      nodeId: "final-output", targetKind: "synthesis", mode: "gauntlet", intensity: "light",
+      limits: { maxCostUsd: 10, maxDurationSeconds: 600, maxRounds: 2 },
+      reason: "selected by each-target-and-final scope with its own intensity and limits", source: "target-override",
+    });
+    // The targets do not see the synthesis override.
+    expect(plan.decisions.find((decision) => decision.nodeId === "squad-c")).toMatchObject({
+      mode: "gauntlet", intensity: "balanced", limits: { maxCostUsd: 32, maxDurationSeconds: 600, maxRounds: 4 }, source: "scope",
+    });
+  });
+
+  test("without an override the synthesis keeps the scope intensity and the global limits", () => {
+    expect(compiled(base).synthesis).toMatchObject({
+      intensity: "balanced", limits: { maxCostUsd: 32, maxDurationSeconds: 600, maxRounds: 4 },
+      reason: "selected by each-target-and-final scope", source: "scope",
+    });
+  });
+
+  test("targets[synthesisNodeId] is an alias of policy.synthesis with the same snapshot and digest", () => {
+    const direct = compiled({ ...base, synthesis: { limits: { maxCostUsd: 10 } } });
+    const alias = compiled({ ...base, targets: { "final-output": { limits: { maxCostUsd: 10 } } } });
+    expect(alias).toEqual(direct);
+    expect(alias.policySnapshot).toMatchObject({ synthesis: { limits: { maxCostUsd: 10 } }, targets: {} });
+  });
+
+  test("the digest changes with the synthesis limit", () => {
+    const ten = compiled({ ...base, synthesis: { limits: { maxCostUsd: 10 } } });
+    const twelve = compiled({ ...base, synthesis: { limits: { maxCostUsd: 12 } } });
+    expect(twelve.digest).not.toBe(ten.digest);
+    expect(ten.digest).not.toBe(compiled(base).digest);
+  });
+
+  test("a scope that does not select the synthesis leaves it standard even with limits", () => {
+    expect(compiled({ ...base, scope: "each-target", synthesis: { limits: { maxCostUsd: 10 } } }).synthesis).toEqual({
+      nodeId: "final-output", targetKind: "synthesis", mode: "standard", reason: "scope does not select synthesis", source: "scope",
+    });
+  });
+
+  test("rejects invalid limits, an intensity above the policy, a mode on the synthesis and a synthesis without node", () => {
+    expect(issuesOf({ ...base, synthesis: { limits: { maxCostUsd: -1, maxRounds: 1.5 } } }).map((issue) => issue.path))
+      .toEqual(["/policy/synthesis/limits/maxCostUsd", "/policy/synthesis/limits/maxRounds"]);
+    expect(issuesOf({ ...base, synthesis: { intensity: "exhaustive" } }))
+      .toEqual([{ path: "/policy/synthesis/intensity", message: "must not exceed the policy intensity balanced" }]);
+    expect(issuesOf({ ...base, targets: { "final-output": { mode: "gauntlet", limits: { maxCostUsd: 10 } } } }))
+      .toEqual([{ path: "/policy/targets/final-output/mode", message: "synthesis mode comes from the scope; declare only intensity and limits" }]);
+    expect(issuesOf({ ...base, targets: { "final-output": { risk: "high" } } }))
+      .toEqual([{ path: "/policy/targets/final-output/risk", message: "synthesis accepts only intensity and limits" }]);
+    expect(issuesOf({ scope: "each-target", synthesis: { limits: { maxCostUsd: 10 } } }))
+      .toEqual([{ path: "/policy/synthesis", message: "requires policy.synthesisNodeId" }]);
+    expect(issuesOf({ ...base, synthesis: { limits: { maxCostUsd: 10 } }, targets: { "final-output": { limits: { maxCostUsd: 10 } } } }))
+      .toEqual([{ path: "/policy/targets/final-output", message: "synthesis is already configured by policy.synthesis" }]);
+    // A deliverable that is not the declared synthesis is still not a target.
+    expect(issuesOf({ scope: "each-target", targets: { "final-output": { limits: { maxCostUsd: 10 } } } }))
+      .toEqual([{ path: "/policy/targets/final-output", message: "deliverable final-output is not the declared synthesis; set policy.synthesisNodeId" }]);
+  });
+});


### PR DESCRIPTION
## Why

Under `each-target-and-final` and `adaptive`, `reserveAggregateGauntletBudget` completes the synthesis first with `min(cap, synthesis limit)`, and the synthesis had no limit of its own: `compileMultiTargetGauntletPolicy` refused `policy.targets[<synthesisNodeId>]` with `target node not found`, because the `deliverable` node is not a target. The synthesis requested the whole cap and every other Gauntlet target stayed at its safe minimum. Real case, the `landing-clinica` plan: cap USD 32, squad `landing-page-nirvana` limited to USD 20, synthesis unlimited → synthesis USD 31, squad USD 1.

## What

- `policy.synthesis: { intensity?, limits? }`, and `policy.targets[<synthesisNodeId>]` as an alias with the same meaning. Both fold into `synthesis` in the policy snapshot, so the two spellings digest alike.
- Conservative inheritance for limits (min of global and synthesis). An intensity above the policy's is an issue at `/policy/synthesis/intensity`; a `mode` on the synthesis is refused explaining that the mode comes from the scope; any other key is refused. `policy.synthesis` without `synthesisNodeId`, or the same override in both spellings, is an issue with its path.
- The compiled synthesis decision carries the effective limits with `source: "target-override"`. The reservation module is unchanged: the synthesis request is now `min(cap, its limit)` through the decision, the safe minimum still applies, and what it does not ask for goes to the targets.
- The zod schema already hands `policy` to the compiler untouched; the CLI test proves `policy.synthesis` validates and `nrv multi-target plan` prints the new allocation.
- Docs: `gauntlet-multi-target-policy.md` (new "Limites da síntese", reservation rule step 3 with the numeric example), `gauntlet-multi-target-cli.md` (policy snippet with `synthesis`), changelog in both locales.

## Reservation rule, with numbers

1. Safe floor per Gauntlet decision (USD 1 light, 2 balanced, 5 exhaustive); reject everything if the cap or an individual request cannot cover the floors.
2. Synthesis completes to `min(cap, synthesis.limits.maxCostUsd)`, or to the whole cap without a synthesis limit.
3. The balance is shared by the targets in proportion to their unmet requests; a grant never exceeds its request, and what nobody asks for stays as balance.

Cap USD 32, `light`, squad limited to USD 20, synthesis limited to USD 10: floors 1 + 1, synthesis completes to 10, squad completes to 20, balance USD 2 held back. Same plan without the synthesis limit: synthesis 31, squad 1 (unchanged behaviour).

## Tests

`multi-target-gauntlet-policy.test.ts` (override, alias with equal digest, digest changes with the limit, inheritance, standard under a non-selecting scope, every validation path), `gauntlet-aggregate-budget.test.ts` (the landing-clinica shape with and without the synthesis limit, clamp to the cap, proportional balance, rejection below the floor), `multi-target-cli.test.ts` (`plan` prints the allocation and refuses `targets[<synthesis>].mode`).

Gates run locally: `check-english-source --strict`, `check-engine-purity`, `check-dispatch-contract`, `check-audit-parity --strict`, `check-changelog-parity --strict`, `check-scope-guard --strict`, `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
