### PR TITLE
ci(smoke): one run per change — push triggers only on main

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,8 +10,11 @@
 # sobrevivem para checkouts parciais e para o tarball instalado.
 name: smoke
 on:
+  # Um run por mudança: `push` só em main (pós-merge); branches de trabalho
+  # recebem o CI pelo `pull_request` abaixo. Antes, um push numa `feat/**`
+  # com PR aberto disparava dois runs completos e o merge esperava pelos dois.
   push:
-    branches: [main, "feat/**"]
+    branches: [main]
   # PRs de fork: `pull_request` (nunca pull_request_target) — roda o código do
   # contribuidor SEM secrets e sem token de escrita. É o que dá feedback de CI
   # a quem contribui, e é seguro por construção.


### PR DESCRIPTION
A push to a `feat/**` branch with an open PR started two full smoke runs (`push` + `pull_request`) and the merge waited for both. Work branches now get their CI from the `pull_request` event alone; `main` keeps the post-merge run. First PR merged through the repository's auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)