### PR TITLE
feat(protocol): extension-agnostic workflow readers and contract surface schema 3; validators accept 6.0 and 2.0 without semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The contract surface stops depending on the workflow file extension
+
+Squad Protocol v6 moves workflows to Markdown: a frontmatter graph plus a prose
+body. Under surface schema 2 the workflow key was `workflow:workflows/x.yaml`
+and the capability binding carried the same extension, so converting one file
+to `.md` produced `removed` + `added` + `rebound`: two breaks per workflow,
+about six hundred phantom breaks across the library for a change no invoker
+can observe. `SURFACE_SCHEMA` is now 3. Workflows are keyed by stem
+(`workflow:workflows/x`, lowercased, literal `/`), `.md` files are listed next
+to `.yaml`/`.yml`, and a `workflow:` binding drops its extension. When two
+files share a stem the `.md` wins the entry and the others are flagged in
+`collision` (metadata, never part of the surface hash) for the v6 lint to
+reject. `readSurface` normalizes a schema-2 file to the same key form without
+touching its schema number, so `diffSurfaces` still re-establishes the
+baseline across the transition (zero changes) while a `.yaml → .md` rename
+with an identical graph, compared under one schema, is `content_changed`, a
+patch. `contractBreaks(installed v5, incoming Markdown twin)` is `[]`; proof in
+`surface.test.ts` and `workflow-readers-v6.test.ts`.
+
+Every reader that assumed `workflows/*.yaml` now accepts `.md` and returns for
+YAML exactly what it returned before. `body-index.js` resolves a bare ref
+through `['', '.md', '.yaml', '.yml']` and unwraps the frontmatter, so
+`bodyTextFor(yaml) === bodyTextFor(md)` for one graph with no new prose;
+`asset-meta.js` types `workflows/*.md` as a workflow; `capability-validator.js`
+resolves a bare component to `.md`, `.yaml` or `.yml`; the audit's c7 lists
+`.md` workflows and parses their frontmatter; `components_files_stub` leaves an
+existing `.md` or `.yml` alone and only ever creates `.yaml`; the v4 inferrer
+accepts the three encodings and keeps emitting `.yaml` where that is what
+exists; `squad-doctor` scans `.yaml` and `.md` under `workflows/` (its filter
+on `.md` had made that scan a no-op); `init-squad` points at
+`workflows/<ref>.(yaml|md)`. Frontmatter with CRLF parses everywhere.
+
+The executed validators accept the next versions before any content declares
+them. `protocol: "6.0"` on a squad takes the v5 capabilities branch in
+`validate-squad`, the capability validator, audit criterion c1 and the
+registry, with no "unknown protocol" warning; `protocol: "2.0"` on a business
+passes the manifest and registry schemas. The fields the following cuts will
+author are accepted as optional and bounded, and nothing reads them yet:
+capability `acceptance[]` (max 12), `evaluator{}`, `requires[]` (max 8,
+optional `slug:` prefix) and `consumes[]` (max 20); business
+`squads_preferred[]`, `not_for[]` and `run_budget_usd`; employee
+`pinned_mind_clones[]` (max 2), `squads_preferred[]` and `acceptance[]`. No
+squad or business changes behavior: a v5 manifest parses to the same object as
+before (`validators-protocol-versions.test.ts`), the 47 genesis squads still
+print `[PASS]`, and the fixtures (v5 `steps`, v5 `agent_sequence`, minimal v6,
+stem collision, business v1 and v2, a mind-clone) are generated in `mkdtemp`
+by `tests/fixtures/protocol-entities.ts`, never committed as files.
+
 ### The Message receipt is immediate again, and a question never becomes a Gauntlet
 
 Since #113 `AgentXCanaryQueue.submit()` awaited the agentic router before

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,58 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A superfície de contrato deixa de depender da extensão do arquivo de workflow
+
+O Squad Protocol v6 leva os workflows para Markdown: um grafo no frontmatter e
+um corpo em prosa. No schema 2 da superfície a chave do workflow era
+`workflow:workflows/x.yaml` e o binding da capability carregava a mesma
+extensão, então converter um arquivo para `.md` produzia `removed` + `added` +
+`rebound`: duas quebras por workflow, cerca de seiscentas quebras fantasmas na
+biblioteca por uma mudança que nenhum invocador consegue observar. O
+`SURFACE_SCHEMA` agora é 3. Os workflows são chaveados pelo stem
+(`workflow:workflows/x`, em minúsculas, `/` literal), os arquivos `.md` entram
+na lista ao lado de `.yaml`/`.yml`, e um binding `workflow:` perde a extensão.
+Quando dois arquivos dividem o mesmo stem, o `.md` vence a entrada e os demais
+ficam sinalizados em `collision` (metadado, nunca parte do hash da superfície)
+para o lint da v6 recusar. O `readSurface` normaliza um arquivo de schema 2
+para a mesma forma de chave sem mexer no número do schema, então o
+`diffSurfaces` continua reestabelecendo a base na transição (zero mudanças),
+enquanto um rename `.yaml → .md` com grafo idêntico, comparado sob um único
+schema, é `content_changed`, um patch. `contractBreaks(v5 instalado, gêmeo em
+Markdown chegando)` é `[]`; a prova está em `surface.test.ts` e em
+`workflow-readers-v6.test.ts`.
+
+Todo leitor que assumia `workflows/*.yaml` passa a aceitar `.md` e devolve
+para YAML exatamente o que devolvia antes. O `body-index.js` resolve uma
+referência sem extensão por `['', '.md', '.yaml', '.yml']` e desembrulha o
+frontmatter, de modo que `bodyTextFor(yaml) === bodyTextFor(md)` para um mesmo
+grafo sem prosa nova; o `asset-meta.js` tipa `workflows/*.md` como workflow; o
+`capability-validator.js` resolve um componente sem extensão para `.md`,
+`.yaml` ou `.yml`; o c7 da auditoria lista workflows `.md` e parseia o
+frontmatter; o `components_files_stub` deixa em paz um `.md` ou `.yml`
+existente e só cria `.yaml`; o inferidor v4 aceita as três codificações e
+continua emitindo `.yaml` onde é isso que existe; o `squad-doctor` varre
+`.yaml` e `.md` em `workflows/` (o filtro em `.md` tinha transformado essa
+varredura num no-op); o `init-squad` aponta para `workflows/<ref>.(yaml|md)`.
+Frontmatter com CRLF parseia em todo lugar.
+
+Os validadores executados aceitam as versões seguintes antes de qualquer
+conteúdo declará-las. `protocol: "6.0"` num squad segue o ramo de capabilities
+da v5 no `validate-squad`, no validador de capabilities, no critério c1 da
+auditoria e no registro, sem aviso de "unknown protocol"; `protocol: "2.0"`
+numa empresa passa nos schemas do manifesto e do registro. Os campos que os
+cortes seguintes vão autorar são aceitos como opcionais e limitados, e nada os
+lê ainda: capability `acceptance[]` (máx. 12), `evaluator{}`, `requires[]`
+(máx. 8, prefixo `slug:` opcional) e `consumes[]` (máx. 20); empresa
+`squads_preferred[]`, `not_for[]` e `run_budget_usd`; funcionário
+`pinned_mind_clones[]` (máx. 2), `squads_preferred[]` e `acceptance[]`.
+Nenhum squad ou empresa muda de comportamento: um manifesto v5 parseia para o
+mesmo objeto de antes (`validators-protocol-versions.test.ts`), os 47 squads
+do genesis continuam imprimindo `[PASS]`, e as fixtures (v5 `steps`, v5
+`agent_sequence`, v6 mínimo, colisão de stem, empresa v1 e v2, um mind-clone)
+são geradas em `mkdtemp` por `tests/fixtures/protocol-entities.ts`, nunca
+gravadas como arquivos.
+
 ### O recibo da Message volta a ser imediato, e uma pergunta nunca vira um Gauntlet
 
 Desde o #113 o `AgentXCanaryQueue.submit()` esperava o roteador agêntico antes

--- a/docs/architecture/contracts-and-schemas.md
+++ b/docs/architecture/contracts-and-schemas.md
@@ -209,3 +209,14 @@ Conversation guarda mensagens visíveis e referências a Runs. Provider session 
 - Duas versões anteriores permanecem legíveis.
 - Breaking changes exigem major version, migrator e rollback.
 - Descriptors e snapshots são imutáveis durante um Run.
+
+## 10. Superfície de contrato (`.nirvana-surface.json`)
+
+Gerada por `skills/_shared/lib/surface.ts` e comparada por `surface-diff.ts`. É o conjunto de identificadores estáveis a que um consumidor se vincula (id de capability, ref de invocação, nome de task, workflow e agente, slug de funcionário) mais o hash do corpo de cada um. Determinística: sem data de geração, chaves ordenadas, arquivo excluído da própria medição.
+
+- `schema: 3`. Chaves usam `/` literal, nunca `path.join`, para serem idênticas no Windows.
+- Workflow chaveado pelo stem, não pelo nome do arquivo: `workflow:workflows/<stem>`, stem em minúsculas, para `.md`, `.yaml` e `.yml`. A codificação não é contrato: um invocador não se vincula à extensão.
+- Binding de capability para workflow sem extensão: `workflow:workflows/<ref sem .md|.yaml|.yml>`. Tasks e agentes mantêm as chaves de sempre (`task:tasks/x.md`, `agent:agents/y.md`).
+- Colisão de stem (`x.md` + `x.yaml`): uma única entrada; o `.md` vence o hash, os demais entram em `collision: ["x.yaml"]`. A flag é metadado para o lint da v6 recusar; não entra no `surface_hash`.
+- `readSurface` normaliza um arquivo de schema ≤ 2 para a forma de chave do schema 3 (`normalizeSurface`) sem mudar o número do schema. Assim `diffSurfaces` continua reestabelecendo a base quando os schemas diferem (zero mudanças) e, sob um mesmo schema, um rename `.yaml → .md` com grafo idêntico é `content_changed` (patch), nunca `removed + added + rebound`.
+- O bump 2 → 3 é único no programa v6; uma republicação de packs só com superfícies regeneradas fica invisível ao diff, e a partir dela a migração de conteúdo para Markdown aparece como patch.

--- a/skills/_shared/lib/asset-meta.js
+++ b/skills/_shared/lib/asset-meta.js
@@ -121,10 +121,12 @@ function inferType(filePath, raw) {
   if (/\/research\//i.test(lower)) return 'research';
   if (/\/decisions\.md$/i.test(lower)) return 'decision';
   if (/\/brief\.md$/i.test(lower)) return 'brief';
+  // A workflow is `.yaml`/`.yml` (v5) or `.md` with frontmatter (v6). Checked
+  // before the `.md` rules so the encoding never turns a workflow into a task.
+  if (/\/workflows\/[^/]+\.(ya?ml|md)$/i.test(lower)) return 'workflow';
   if (/\/tasks\/[^/]+\.md$/i.test(lower)) return 'task';
   if (/\/agents\/[^/]+\.md$/i.test(lower)) return 'agent';
   if (/\/employees\/[^/]+\.md$/i.test(lower)) return 'employee';
-  if (/\/workflows\/[^/]+\.ya?ml$/i.test(lower)) return 'workflow';
   return null;
 }
 

--- a/skills/_shared/lib/body-index.js
+++ b/skills/_shared/lib/body-index.js
@@ -63,19 +63,35 @@ function readIfFile(p) {
   } catch { return ''; }
 }
 
-/** `ref` may carry an extension or not, and may name a dir-relative file. */
-function resolveRef(squadDir, ref, kind) {
+/** `ref` may carry an extension or not, and may name a dir-relative file.
+ *  Returns the path of the first readable candidate, or ''. A workflow lives
+ *  in `.md` (v6: frontmatter graph + prose body) or in `.yaml`/`.yml` (v5);
+ *  for a bare ref the `.md` wins, as it does in the contract surface. */
+function resolveRefPath(squadDir, ref, kind) {
   if (typeof ref !== 'string' || !ref) return '';
-  const exts = kind === 'workflow' ? ['', '.yaml', '.yml'] : ['', '.md'];
+  const exts = kind === 'workflow' ? ['', '.md', '.yaml', '.yml'] : ['', '.md'];
   const bases = [ref, path.join(kind === 'agent' ? 'agents' : kind === 'workflow' ? 'workflows' : 'tasks', ref)];
   for (const b of bases) {
     for (const e of exts) {
       const p = path.join(squadDir, b + e);
-      const t = readIfFile(p);
-      if (t) return t;
+      if (readIfFile(p)) return p;
     }
   }
   return '';
+}
+
+function resolveRef(squadDir, ref, kind) {
+  const p = resolveRefPath(squadDir, ref, kind);
+  return p ? readIfFile(p) : '';
+}
+
+/** A Markdown workflow is its frontmatter (the graph) plus its body (the
+ *  prose), and both are body text: only the delimiters go. That is what makes
+ *  one graph yield one text whether it sits in `.yaml` or in `.md` — `clean()`
+ *  would otherwise strip the frontmatter as noise. CRLF tolerant. */
+function unwrapFrontmatter(text) {
+  const m = /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)([\s\S]*)$/.exec(text);
+  return m ? `${m[1]}\n${m[2]}` : text;
 }
 
 /** A workflow expands to the union of what it runs — that is the material that
@@ -107,8 +123,9 @@ function bodyTextFor(manifestPath, invoke) {
     const ref = invoke.ref;
     let raw = '';
     if (type === 'workflow') {
-      const wf = resolveRef(squadDir, ref, 'workflow');
-      raw = wf ? expandWorkflow(squadDir, wf) : '';
+      const wfPath = resolveRefPath(squadDir, ref, 'workflow');
+      const wf = wfPath ? readIfFile(wfPath) : '';
+      raw = wf ? expandWorkflow(squadDir, /\.md$/i.test(wfPath) ? unwrapFrontmatter(wf) : wf) : '';
     } else if (type === 'agent') {
       raw = resolveRef(squadDir, ref, 'agent');
     } else {

--- a/skills/_shared/lib/surface.ts
+++ b/skills/_shared/lib/surface.ts
@@ -30,7 +30,9 @@ export const SURFACE_FILE = ".nirvana-surface.json";
  *  mind-clone surface walks the whole directory, so the defect was exclusive
  *  to it. */
 export const GENERATED_FILES = [SURFACE_FILE, "CHANGES.json", "CHANGELOG.md", ".nirvana-behavior.md"];
-export const SURFACE_SCHEMA = 2;
+/** 3: workflow keys and bindings drop the file extension (`workflow:workflows/x`),
+ *  `.md` workflows are listed, stem collisions are flagged. See `normalizeSurface`. */
+export const SURFACE_SCHEMA = 3;
 
 export type ArtifactKind = "squad" | "business" | "mind-clone";
 
@@ -48,9 +50,14 @@ export type EntryType =
 
 export interface SurfaceEntry {
   type: EntryType;
-  /** Binding target: `workflow:workflows/x.yaml`, `task:tasks/y.md`. Changing
-   *  this breaks invokers, even with the id intact. */
+  /** Binding target: `workflow:workflows/x` (no extension: the encoding of a
+   *  workflow is not contract), `task:tasks/y.md`. Changing this breaks
+   *  invokers, even with the id intact. */
   binding?: string;
+  /** Workflow entries only: other files in `workflows/` sharing this stem
+   *  (`x.md` + `x.yaml`). The `.md` wins the entry; the rest are listed here
+   *  for the lint to fail on. Metadata, never part of the surface hash. */
+  collision?: string[];
   /** Routing labels (the capability's domains/produces). */
   routing?: string[];
   /** Hash of the entry's own body (YAML node or file). */
@@ -104,6 +111,15 @@ function fileHash(file: string): string {
   try { return sha(fs.readFileSync(file)); } catch { return "missing"; }
 }
 
+/** Workflow encodings, in precedence order: the `.md` wins a stem collision. */
+const WORKFLOW_EXTS = [".md", ".yaml", ".yml"];
+const WORKFLOW_EXT_RE = /\.(ya?ml|md)$/i;
+function stripWorkflowExt(name: string): string { return name.replace(WORKFLOW_EXT_RE, ""); }
+function workflowRank(file: string): number {
+  const i = WORKFLOW_EXTS.findIndex((e) => file.toLowerCase().endsWith(e));
+  return i === -1 ? WORKFLOW_EXTS.length : i;
+}
+
 /** Discovery prose: changes semantic routing, never the binding. */
 const PROSE_KEYS = ["description", "examples", "example_briefs", "keywords", "not_for"];
 
@@ -145,7 +161,9 @@ function squadSurface(dir: string, slug: string): { entries: Record<string, Surf
     const invoke = cap?.invoke ?? {};
     entries[`capability:${id}`] = {
       type: "capability",
-      binding: invoke?.type && invoke?.ref ? `${invoke.type}:${invoke.ref}` : undefined,
+      binding: invoke?.type && invoke?.ref
+        ? `${invoke.type}:${invoke.type === "workflow" ? stripWorkflowExt(String(invoke.ref)) : invoke.ref}`
+        : undefined,
       routing: [
         ...((cap?.domains ?? []) as string[]).map((d) => `domain:${d}`),
         ...((cap?.produces ?? []) as string[]).map((d) => `produces:${d}`),
@@ -160,15 +178,30 @@ function squadSurface(dir: string, slug: string): { entries: Record<string, Surf
 
   // File components: the name is the identifier workflows and capabilities
   // reference, so renaming is a break even with identical content.
-  for (const [sub, type, exts] of [
-    ["tasks", "task", [".md"]],
-    ["workflows", "workflow", [".yaml", ".yml"]],
-    ["agents", "agent", [".md"]],
-  ] as const) {
+  for (const [sub, type] of [["tasks", "task"], ["agents", "agent"]] as const) {
     const subdir = path.join(dir, sub);
-    for (const f of listFiles(subdir, exts as unknown as string[])) {
+    for (const f of listFiles(subdir, [".md"])) {
       entries[`${type}:${sub}/${f}`] = { type, hash: fileHash(path.join(subdir, f)) };
     }
+  }
+
+  // Workflows are keyed by STEM, never by file name: `.yaml` and `.md` are two
+  // encodings of one graph, and an invoker does not bind to the encoding.
+  // Keys use a literal `/` (never path.join) so they are identical on Windows;
+  // stems are lowercased because the file systems that matter are
+  // case-insensitive. When two files share a stem, the `.md` wins the entry
+  // and the others are flagged in `collision` for the lint to reject.
+  const wfDir = path.join(dir, "workflows");
+  const byStem = new Map<string, string[]>();
+  for (const f of listFiles(wfDir, WORKFLOW_EXTS)) {
+    const stem = stripWorkflowExt(f).toLowerCase();
+    byStem.set(stem, [...(byStem.get(stem) ?? []), f]);
+  }
+  for (const [stem, files] of byStem) {
+    const ranked = [...files].sort((a, b) => workflowRank(a) - workflowRank(b) || a.localeCompare(b));
+    const entry: SurfaceEntry = { type: "workflow", hash: fileHash(path.join(wfDir, ranked[0])) };
+    if (ranked.length > 1) entry.collision = ranked.slice(1);
+    entries[`workflow:workflows/${stem}`] = entry;
   }
   return { entries, prose };
 }
@@ -232,11 +265,42 @@ function declaredVersion(dir: string, kind: ArtifactKind): string {
   return /^\d+\.\d+\.\d+$/.test(v) ? v : "1.0.0";
 }
 
+/**
+ * Brings a surface written under schema ≤ 2 to the schema-3 key form: workflow
+ * keys and `workflow:` bindings lose their extension, stems are lowercased.
+ * The schema number is NOT touched: `diffSurfaces` must still see the
+ * transition and re-establish the baseline (surface-diff.ts). What this buys
+ * is that whoever reads an old file sees the identifiers a fresh extraction
+ * produces, so a `.yaml → .md` migration compared under one schema is
+ * `content_changed`, never `removed + added + rebound`.
+ */
+export function normalizeSurface(s: Surface): Surface {
+  if (typeof s.schema !== "number" || s.schema > 2) return s;
+  const entries: Record<string, SurfaceEntry> = {};
+  for (const k of Object.keys(s.entries).sort()) {
+    const e: SurfaceEntry = { ...s.entries[k] };
+    if (e.binding?.startsWith("workflow:")) e.binding = `workflow:${stripWorkflowExt(e.binding.slice("workflow:".length))}`;
+    let key = k;
+    if (e.type === "workflow" && k.startsWith("workflow:workflows/")) {
+      const file = k.slice("workflow:workflows/".length);
+      key = `workflow:workflows/${stripWorkflowExt(file).toLowerCase()}`;
+      if (key in entries) {
+        entries[key].collision = [...(entries[key].collision ?? []), file].sort();
+        continue;
+      }
+    }
+    entries[key] = e;
+  }
+  const ordered: Record<string, SurfaceEntry> = {};
+  for (const k of Object.keys(entries).sort()) ordered[k] = entries[k];
+  return { ...s, entries: ordered };
+}
+
 export function readSurface(dir: string): Surface | null {
   const file = path.join(dir, SURFACE_FILE);
   try {
     const s = JSON.parse(fs.readFileSync(file, "utf8")) as Surface;
-    return s && typeof s === "object" && s.entries ? s : null;
+    return s && typeof s === "object" && s.entries ? normalizeSurface(s) : null;
   } catch { return null; }
 }
 

--- a/skills/_shared/schemas/core-schemas.json
+++ b/skills/_shared/schemas/core-schemas.json
@@ -429,7 +429,7 @@
       "properties": {
         "schema_version": { "type": "string", "default": "1.0.0" },
         "generated_at": { "type": "string", "format": "date-time" },
-        "host_protocol_version": { "type": "string", "enum": ["5.0", "4.0"] },
+        "host_protocol_version": { "type": "string", "enum": ["6.0", "5.0", "4.0"] },
         "squads_root_dirs": { "type": "array", "items": { "type": "string" } },
         "squads": {
           "type": "object",
@@ -498,7 +498,7 @@
               "required": ["version", "protocol", "manifest_path", "manifest_hash", "domains", "capabilities"],
               "properties": {
                 "version": { "type": "string" },
-                "protocol": { "type": "string", "enum": ["1.0"] },
+                "protocol": { "type": "string", "enum": ["1.0", "2.0"] },
                 "manifest_path": { "type": "string" },
                 "manifest_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
                 "domains": { "type": "array", "items": { "type": "string" } },

--- a/skills/_shared/tests/fixtures/protocol-entities.ts
+++ b/skills/_shared/tests/fixtures/protocol-entities.ts
@@ -1,0 +1,352 @@
+/**
+ * Protocol fixtures, generated on demand in a temp dir.
+ *
+ * They live here as code, never as files: `check-engine-purity` forbids a
+ * `squad.yaml` / `business.yaml` / mind-clone manifest anywhere outside
+ * `templates/**`, `schemas/**` and `examples/**`, and the pattern the admission
+ * test already uses (`entity-admission.test.ts`) is to plant the entity in
+ * `mkdtemp` and delete it after the run.
+ *
+ * One graph, two encodings. `ALPHA_GRAPH` is the workflow used by the v5 squad
+ * (as `workflows/alpha.yaml`) and by its migrated twin (as the frontmatter of
+ * `workflows/alpha.md`). Keeping the bytes identical is what lets the tests
+ * state invariants ("same graph, same body text", "rename is a patch") instead
+ * of examples.
+ */
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { extractSurface, type Surface, type SurfaceEntry } from "../../lib/surface.ts";
+
+export function tmpRoot(prefix = "nrv-protocol-"): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** The `api-development` shape: `steps[]` with `depends_on`, `creates`, `on_failure`. */
+export const ALPHA_GRAPH = [
+  "name: alpha",
+  "description: Plan the alpha artifact, then build it",
+  "steps:",
+  "  - id: plan",
+  "    agent: planner",
+  "    task: plan",
+  "    creates: [plan.md]",
+  "  - id: build",
+  "    agent: builder",
+  "    task: build",
+  "    depends_on: [plan]",
+  "    on_failure: abort",
+  "success_indicators:",
+  "  - the alpha artifact exists and the build step reports success",
+  "",
+].join("\n");
+
+/** The `adaptive-tutor-k12` shape: a bare list of agent names. */
+export const SEQ_GRAPH = [
+  "workflow_name: seq",
+  "agent_sequence:",
+  "  - planner",
+  "  - builder",
+  "",
+].join("\n");
+
+export const ALPHA_BODY = [
+  "## plan",
+  "",
+  "Read the brief and write the plan before anything is built.",
+  "",
+  "## build",
+  "",
+  "Assemble the deliverable from the plan, one artifact per step.",
+  "",
+].join("\n");
+
+const agentDoc = (name: string) => [
+  "---",
+  `name: ${name}`,
+  `description: ${name} persona of the protocol fixture`,
+  "maxTurns: 12",
+  "---",
+  "",
+  `# ${name}`,
+  "",
+  `The ${name} owns one step of the alpha workflow and nothing else.`,
+  "",
+].join("\n");
+
+const taskDoc = (name: string) => [
+  "---",
+  `name: ${name}`,
+  `description: ${name} step of the alpha workflow`,
+  "---",
+  "",
+  `# ${name}`,
+  "",
+  `Perform the ${name} step. Distinctive token: quokka-${name}.`,
+  "",
+  "## Acceptance Criteria",
+  "",
+  `- [ ] the ${name} output exists`,
+  "",
+].join("\n");
+
+interface SquadSpec {
+  slug: string;
+  protocol: string;
+  /** file name inside workflows/ → content */
+  workflows: Record<string, string>;
+  /** entries of components.workflows as authored */
+  workflowComponents: string[];
+  /** capability invoke.ref as authored */
+  invokeRef: string;
+  /** extra YAML lines appended under the capability (already indented by 4) */
+  capabilityExtra?: string[];
+  /** extra top-level YAML lines */
+  manifestExtra?: string[];
+}
+
+function writeSquad(root: string, spec: SquadSpec): string {
+  const dir = join(root, spec.slug);
+  for (const sub of ["agents", "tasks", "workflows"]) mkdirSync(join(dir, sub), { recursive: true });
+  for (const a of ["planner", "builder"]) writeFileSync(join(dir, "agents", `${a}.md`), agentDoc(a), "utf8");
+  for (const t of ["plan", "build"]) writeFileSync(join(dir, "tasks", `${t}.md`), taskDoc(t), "utf8");
+  for (const [file, content] of Object.entries(spec.workflows)) {
+    writeFileSync(join(dir, "workflows", file), content, "utf8");
+  }
+  const manifest = [
+    `name: ${spec.slug}`,
+    "version: 1.2.3",
+    `protocol: "${spec.protocol}"`,
+    "description: Fixture squad that plans and builds one artifact",
+    "experimental_domains: true",
+    "components:",
+    "  agents: [planner, builder]",
+    "  tasks: [plan, build]",
+    `  workflows: [${spec.workflowComponents.join(", ")}]`,
+    "capabilities:",
+    "  - id: fixture.alpha.run",
+    "    description: Plans and builds the alpha artifact end to end",
+    "    domains: [fixture_domain]",
+    "    produces: [alpha_artifact]",
+    '    examples: ["build the alpha artifact from a brief"]',
+    "    invoke:",
+    "      type: workflow",
+    `      ref: ${spec.invokeRef}`,
+    ...(spec.capabilityExtra ?? []),
+    ...(spec.manifestExtra ?? []),
+    "",
+  ].join("\n");
+  writeFileSync(join(dir, "squad.yaml"), manifest, "utf8");
+  return dir;
+}
+
+/** v5, `steps` + `depends_on`, workflow in YAML, refs carry the extension. */
+export function v5StepsSquad(root: string, slug = "fixture-alpha"): string {
+  return writeSquad(root, {
+    slug, protocol: "5.0",
+    workflows: { "alpha.yaml": ALPHA_GRAPH },
+    workflowComponents: ["alpha.yaml"],
+    invokeRef: "workflows/alpha.yaml",
+  });
+}
+
+/** v5, `agent_sequence` dialect. */
+export function v5AgentSequenceSquad(root: string, slug = "fixture-seq"): string {
+  return writeSquad(root, {
+    slug, protocol: "5.0",
+    workflows: { "seq.yaml": SEQ_GRAPH },
+    workflowComponents: ["seq.yaml"],
+    invokeRef: "workflows/seq.yaml",
+  });
+}
+
+export function markdownWorkflow(graph: string, body: string, opts: { crlf?: boolean } = {}): string {
+  const text = `---\n${graph}---\n${body ? `\n${body}` : ""}`;
+  return opts.crlf ? text.replace(/\n/g, "\r\n") : text;
+}
+
+/**
+ * The v5 steps squad after a pure migration: the same graph as frontmatter of
+ * `workflows/alpha.md`, no prose added, refs without the extension where the
+ * component list allows it. `body` and `crlf` exist for the tests that need
+ * prose or Windows line endings; the default is the byte-faithful rename.
+ */
+export function migratedToMarkdown(root: string, slug = "fixture-alpha", opts: { body?: string; crlf?: boolean; protocol?: string } = {}): string {
+  return writeSquad(root, {
+    slug, protocol: opts.protocol ?? "6.0",
+    workflows: { "alpha.md": markdownWorkflow(ALPHA_GRAPH, opts.body ?? "", { crlf: opts.crlf }) },
+    workflowComponents: ["alpha"],
+    invokeRef: "workflows/alpha.md",
+  });
+}
+
+/** Minimal v6: markdown workflow with prose, and the optional v6 capability fields. */
+export function v6MarkdownSquad(root: string, slug = "fixture-v6"): string {
+  return writeSquad(root, {
+    slug, protocol: "6.0",
+    workflows: { "alpha.md": markdownWorkflow(ALPHA_GRAPH, ALPHA_BODY) },
+    workflowComponents: ["alpha"],
+    invokeRef: "workflows/alpha.md",
+    capabilityExtra: [
+      "    acceptance:",
+      "      - id: artifact_built",
+      "        description: the alpha artifact exists after the build step",
+      "        blocking: true",
+      "        minimumScore: 0.8",
+      "    requires: [other-squad:fixture.beta.run]",
+      "    consumes: [beta_artifact]",
+    ],
+  });
+}
+
+/** Mixed: `x.md` and `x.yaml` share a stem (the la-bottega case), plus a capitalised stem. */
+export function collisionSquad(root: string, slug = "fixture-twins"): string {
+  return writeSquad(root, {
+    slug, protocol: "5.0",
+    workflows: {
+      "x.yaml": ALPHA_GRAPH.replace("name: alpha", "name: x"),
+      "x.md": markdownWorkflow(ALPHA_GRAPH.replace("name: alpha", "name: x"), ALPHA_BODY),
+      "Beta.yaml": SEQ_GRAPH.replace("workflow_name: seq", "workflow_name: beta"),
+    },
+    workflowComponents: ["x.yaml"],
+    invokeRef: "workflows/x.yaml",
+  });
+}
+
+/** v4 manifest with no capabilities: what the inferrer reads. */
+export function v4Squad(root: string, workflowFile: string, slug = "fixture-v4"): string {
+  const dir = join(root, slug);
+  mkdirSync(join(dir, "workflows"), { recursive: true });
+  mkdirSync(join(dir, "agents"), { recursive: true });
+  writeFileSync(join(dir, "agents", "planner.md"), agentDoc("planner"), "utf8");
+  const content = workflowFile.endsWith(".md") ? markdownWorkflow(ALPHA_GRAPH, ALPHA_BODY) : ALPHA_GRAPH;
+  writeFileSync(join(dir, "workflows", workflowFile), content, "utf8");
+  writeFileSync(join(dir, "squad.yaml"), [
+    `name: ${slug}`,
+    "version: 1.0.0",
+    'protocol: "4.0"',
+    "description: Legacy fixture squad without capabilities",
+    "components:",
+    "  agents: [planner]",
+    "  workflows: [alpha]",
+    "",
+  ].join("\n"), "utf8");
+  return dir;
+}
+
+// ── businesses ───────────────────────────────────────────────────────────────
+
+function writeBusiness(root: string, slug: string, manifestLines: string[], employeeLines: string[]): string {
+  const dir = join(root, slug);
+  mkdirSync(join(dir, "employees"), { recursive: true });
+  writeFileSync(join(dir, "business.yaml"), manifestLines.join("\n") + "\n", "utf8");
+  writeFileSync(join(dir, "employees", "intake.md"), [
+    "---",
+    ...employeeLines,
+    "---",
+    "",
+    "# Intake",
+    "",
+    "Receives every brief of the fixture business and answers it.",
+    "",
+  ].join("\n"), "utf8");
+  writeFileSync(join(dir, "org-chart.yaml"), "chart:\n  - id: intake\n    reports_to: null\n", "utf8");
+  return dir;
+}
+
+const BUSINESS_BASE = (slug: string, protocol: string) => [
+  `name: ${slug}`,
+  "version: 1.0.0",
+  `protocol: "${protocol}"`,
+  "description: Fixture business with a single intake employee",
+  "domains: [fixture_domain]",
+  "produces: [fixture_report]",
+  "runtime_requirements:",
+  "  policy: declared",
+  "  minimum:",
+  "    - runtime: claude-code",
+];
+
+const EMPLOYEE_BASE = [
+  "name: intake",
+  "role: Intake",
+  "description: Receives the brief and answers it with the fixture report",
+  "is_brief_intake: true",
+];
+
+export function businessV1(root: string, slug = "fixture-biz-v1"): string {
+  return writeBusiness(root, slug, BUSINESS_BASE(slug, "1.0"), EMPLOYEE_BASE);
+}
+
+/** Minimal v2: the new optional fields, all of them without semantics in this cut. */
+export function businessV2(root: string, slug = "fixture-biz-v2"): string {
+  return writeBusiness(root, slug, [
+    ...BUSINESS_BASE(slug, "2.0"),
+    "squads_preferred: [fixture-alpha]",
+    "not_for: [legal advice, tax filing]",
+    "run_budget_usd: 5",
+  ], [
+    ...EMPLOYEE_BASE,
+    "pinned_mind_clones: [jane-doe]",
+    "squads_preferred: [fixture-alpha]",
+    "acceptance:",
+    "  - id: report_delivered",
+    "    description: the fixture report exists and is longer than a stub",
+    "    blocking: true",
+    "    minimum_score: 0.8",
+    "    path: outputs/report.md",
+    "    min_bytes: 200",
+  ]);
+}
+
+// ── mind-clone ───────────────────────────────────────────────────────────────
+
+export function mindClone(root: string, slug = "jane-doe"): string {
+  const dir = join(root, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "MANIFEST.yaml"), [
+    `name: ${slug}`,
+    "category: storytelling-narrative",
+    "validation_verdict: APPROVED",
+    "source_material:",
+    "  primary: [a-book]",
+    "routing:",
+    '  one_liner: "Jane Doe — the choice for planted-fixture storytelling"',
+    "",
+  ].join("\n"), "utf8");
+  writeFileSync(join(dir, "AGENT.md"), "# Jane Doe\n\n## Voice\n\nShort sentences.\n", "utf8");
+  writeFileSync(join(dir, "SOUL.md"), "# Soul\n\nCuriosity first.\n", "utf8");
+  return dir;
+}
+
+// ── legacy surface ───────────────────────────────────────────────────────────
+
+/**
+ * What the schema-2 extractor wrote for this directory: workflow keys and
+ * capability bindings carrying the file extension, `.md` workflows unlisted.
+ * Hashes are copied from the schema-3 extraction because the per-file hash
+ * function did not change; only the keys did.
+ */
+export function schema2Surface(dir: string): Surface {
+  const current = extractSurface(dir);
+  const manifest = parseYaml(readFileSync(join(dir, "squad.yaml"), "utf8")) as any;
+  const bindings = new Map<string, string>();
+  for (const cap of manifest.capabilities ?? []) bindings.set(`capability:${cap.id}`, `${cap.invoke.type}:${cap.invoke.ref}`);
+  const yamlFiles = readdirSync(join(dir, "workflows")).filter((f) => /\.ya?ml$/.test(f)).sort();
+  const entries: Record<string, SurfaceEntry> = {};
+  for (const [key, entry] of Object.entries(current.entries)) {
+    if (entry.type === "workflow") continue;
+    const e: SurfaceEntry = { ...entry };
+    if (bindings.has(key)) e.binding = bindings.get(key);
+    entries[key] = e;
+  }
+  for (const f of yamlFiles) {
+    const stem = f.replace(/\.ya?ml$/, "").toLowerCase();
+    const e = current.entries[`workflow:workflows/${stem}`];
+    entries[`workflow:workflows/${f}`] = { type: "workflow", hash: e?.hash ?? "missing" };
+  }
+  const ordered: Record<string, SurfaceEntry> = {};
+  for (const k of Object.keys(entries).sort()) ordered[k] = entries[k];
+  return { ...current, schema: 2, entries: ordered };
+}

--- a/skills/_shared/tests/surface.test.ts
+++ b/skills/_shared/tests/surface.test.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { extractSurface, serializeSurface, writeSurface, readSurface } from "../lib/surface.ts";
 import { diffSurfaces, mergeBehaviorNotes } from "../lib/surface-diff.ts";
+import { collisionSquad, migratedToMarkdown, schema2Surface, tmpRoot, v5StepsSquad } from "./fixtures/protocol-entities.ts";
 
 function tmpSquad(capabilities: string, extra?: { tasks?: string[]; workflows?: string[] }): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-surface-"));
@@ -189,4 +190,76 @@ test("saídas do gerador não entram na medição (senão o gen nunca converge)"
   fs.writeFileSync(path.join(dir, "CHANGELOG.md"), "# Changelog\n");
   const depois = extractSurface(dir);
   expect(diffSurfaces(antes, depois).changes).toHaveLength(0);
+});
+
+// ── schema 3: the workflow key stops carrying the file extension ─────────────
+//
+// Under schema 2 the key was `workflow:workflows/x.yaml` and the binding
+// `workflow:workflows/x.yaml`, so converting one workflow to Markdown produced
+// `removed` + `added` + `rebound`: two breaks per file, six hundred phantom
+// breaks across the library for a change no invoker can observe. These cases
+// pin the schema-3 behavior: same graph in another encoding is a patch.
+
+test("renomear workflow .yaml → .md com grafo idêntico é patch, nunca removed + added + rebound", () => {
+  const before = extractSurface(v5StepsSquad(tmpRoot()));
+  const after = extractSurface(migratedToMarkdown(tmpRoot()));
+  const r = diffSurfaces(before, after);
+  const types = r.changes.map((c) => c.type);
+  expect(types).not.toContain("removed");
+  expect(types).not.toContain("added");
+  expect(types).not.toContain("rebound");
+  expect(r.changes.some((c) => c.type === "content_changed" && c.id === "workflow:workflows/alpha")).toBe(true);
+  expect(r.breaking).toBe(0);
+  expect(r.bump).toBe("patch");
+  // The binding is the ref without its extension, in both encodings.
+  expect(before.entries["capability:fixture.alpha.run"].binding).toBe("workflow:workflows/alpha");
+  expect(after.entries["capability:fixture.alpha.run"].binding).toBe("workflow:workflows/alpha");
+});
+
+test("colisão de stem: x.md + x.yaml viram uma entrada, .md vence e a colisão fica sinalizada", () => {
+  const dir = collisionSquad(tmpRoot());
+  const s = extractSurface(dir);
+  const workflowKeys = Object.keys(s.entries).filter((k) => k.startsWith("workflow:"));
+  // Stems are lowercased: `Beta.yaml` lists as `beta`.
+  expect(workflowKeys).toEqual(["workflow:workflows/beta", "workflow:workflows/x"]);
+  const twin = s.entries["workflow:workflows/x"];
+  expect(twin.collision).toEqual(["x.yaml"]);
+  expect(s.entries["workflow:workflows/beta"].collision).toBeUndefined();
+  // The hash is the winner's: the `.md` body, not the `.yaml`.
+  const mdOnly = extractSurface((() => {
+    const d = collisionSquad(tmpRoot(), "fixture-md-only");
+    fs.rmSync(path.join(d, "workflows", "x.yaml"));
+    return d;
+  })());
+  expect(twin.hash).toBe(mdOnly.entries["workflow:workflows/x"].hash);
+  // The flag is lint metadata, not contract: it never enters the surface hash.
+  expect(s.surface_hash).toBe(mdOnly.surface_hash);
+  // Determinism holds with twins on disk.
+  expect(serializeSurface(extractSurface(dir))).toBe(serializeSurface(s));
+});
+
+test("arquivo em disco schema 2 × extração schema 3 = zero mudanças, e a leitura normaliza chaves e bindings", () => {
+  const dir = v5StepsSquad(tmpRoot());
+  writeSurface(dir, schema2Surface(dir));
+  const raw = JSON.parse(fs.readFileSync(path.join(dir, ".nirvana-surface.json"), "utf8"));
+  expect(Object.keys(raw.entries)).toContain("workflow:workflows/alpha.yaml");
+
+  const read = readSurface(dir)!;
+  // The schema number is kept: the diff must still see the transition.
+  expect(read.schema).toBe(2);
+  expect(Object.keys(read.entries)).toContain("workflow:workflows/alpha");
+  expect(Object.keys(read.entries)).not.toContain("workflow:workflows/alpha.yaml");
+  expect(read.entries["capability:fixture.alpha.run"].binding).toBe("workflow:workflows/alpha");
+
+  // Across schemas the baseline is re-established: nothing is invented.
+  const cross = diffSurfaces(read, extractSurface(dir));
+  expect(cross.changes).toHaveLength(0);
+  expect(cross.bump).toBe("none");
+
+  // Once comparable, the normalized old surface meets its Markdown twin as a
+  // patch — which is what the normalization exists for.
+  const migrated = extractSurface(migratedToMarkdown(tmpRoot()));
+  const r = diffSurfaces({ ...read, schema: migrated.schema }, migrated);
+  expect(r.breaking).toBe(0);
+  expect(r.bump).toBe("patch");
 });

--- a/skills/_shared/tests/validators-protocol-versions.test.ts
+++ b/skills/_shared/tests/validators-protocol-versions.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The executed validators accept Squad Protocol 6.0 and Business Protocol 2.0
+ * before any content declares them.
+ *
+ * `validators.ts` is the only validator that runs (`capability-validator.js`
+ * requires it; `validate-squad` spawns that). Until this cut a manifest with
+ * `protocol: "6.0"` failed there, so `build-all-packs.sh` would go FATAL on
+ * the first v6 squad. The fields the following cuts will author are accepted
+ * as optional and bounded, and nothing reads them yet: a v5 manifest parses to
+ * the same object it parsed to before, with no new key injected.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import {
+  BusinessManifestSchema, CapabilitySchema, EmployeeFrontmatterSchema,
+  RegistryBusinessesSchema, RegistrySquadsSchema, SquadManifestSchema,
+} from "../validators/validators.ts";
+import { businessV1, businessV2, tmpRoot, v5StepsSquad, v6MarkdownSquad } from "./fixtures/protocol-entities.ts";
+
+const ROOTS: string[] = [];
+function root(): string { const r = tmpRoot(); ROOTS.push(r); return r; }
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch {} });
+
+const manifest = (dir: string, file: string) => parseYaml(readFileSync(join(dir, file), "utf8"));
+const frontmatter = (file: string) => parseYaml(/^---\r?\n([\s\S]*?)\r?\n---/.exec(readFileSync(file, "utf8"))![1]);
+const issues = (r: { success: boolean; error?: any }) =>
+  r.success ? [] : r.error.issues.map((i: any) => `${i.path.join(".")}: ${i.message}`);
+
+describe("squad manifests", () => {
+  test("protocol 6.0 passes; 4.0, 4.1 and 5.0 keep passing; 7.0 fails", () => {
+    const v6 = manifest(v6MarkdownSquad(root()), "squad.yaml");
+    expect(issues(SquadManifestSchema.safeParse(v6))).toEqual([]);
+    const v5 = manifest(v5StepsSquad(root()), "squad.yaml");
+    for (const p of ["4.0", "4.1", "5.0"]) expect(SquadManifestSchema.safeParse({ ...v5, protocol: p }).success).toBe(true);
+    expect(SquadManifestSchema.safeParse({ ...v5, protocol: "7.0" }).success).toBe(false);
+  });
+
+  test("a v5 capability parses to the same object as before: no v6 key is injected", () => {
+    const cap = manifest(v5StepsSquad(root()), "squad.yaml").capabilities[0];
+    const parsed = CapabilitySchema.parse(cap);
+    for (const k of ["acceptance", "evaluator", "requires", "consumes"]) expect(k in parsed).toBe(false);
+  });
+
+  test("the v6 capability fields are optional and bounded, and mean nothing yet", () => {
+    const base = manifest(v6MarkdownSquad(root()), "squad.yaml").capabilities[0];
+    expect(issues(CapabilitySchema.safeParse(base))).toEqual([]);
+    const ok = (patch: Record<string, unknown>) => CapabilitySchema.safeParse({ ...base, ...patch }).success;
+    const acceptance = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `req_${i}`, description: `requirement ${i}` }));
+    expect(ok({ acceptance: acceptance(12) })).toBe(true);
+    expect(ok({ acceptance: acceptance(13) })).toBe(false);
+    expect(ok({ acceptance: [{ id: "Bad Id", description: "x" }] })).toBe(false);
+    expect(ok({ acceptance: [{ id: "ok", description: "x", minimumScore: 1.5 }] })).toBe(false);
+    expect(ok({ evaluator: { scorecard: "scorecards/x.json", rubric: "rubrics/x.md", dimensions: ["a"], max_cost_usd: 2 } })).toBe(true);
+    expect(ok({ evaluator: { scorecard: "s", rubric: "r", unknown: 1 } })).toBe(false);
+    expect(ok({ evaluator: { scorecard: "s", rubric: "r", max_cost_usd: -1 } })).toBe(false);
+    expect(ok({ requires: ["fixture.beta.run", "other-squad:fixture.beta.run"] })).toBe(true);
+    expect(ok({ requires: ["not an id"] })).toBe(false);
+    expect(ok({ requires: Array.from({ length: 9 }, (_, i) => `fixture.beta.run_${i}`) })).toBe(false);
+    expect(ok({ consumes: ["beta_artifact"] })).toBe(true);
+    expect(ok({ consumes: Array.from({ length: 21 }, (_, i) => `artifact_${i}`) })).toBe(false);
+  });
+});
+
+describe("business manifests and employees", () => {
+  test("protocol 1.0 fixture passes; 2.0 with its new fields passes; 3.0 fails", () => {
+    const v1 = manifest(businessV1(root()), "business.yaml");
+    expect(issues(BusinessManifestSchema.safeParse(v1))).toEqual([]);
+    const v2 = manifest(businessV2(root()), "business.yaml");
+    expect(issues(BusinessManifestSchema.safeParse(v2))).toEqual([]);
+    expect(BusinessManifestSchema.safeParse({ ...v2, protocol: "3.0" }).success).toBe(false);
+    expect(BusinessManifestSchema.safeParse({ ...v2, run_budget_usd: -1 }).success).toBe(false);
+    expect(BusinessManifestSchema.safeParse({ ...v2, squads_preferred: ["Not Kebab"] }).success).toBe(false);
+  });
+
+  test("employee v2: pinned_mind_clones (max 2), squads_preferred and acceptance; a v1 employee gains no key", () => {
+    const v2 = frontmatter(join(businessV2(root()), "employees", "intake.md"));
+    expect(issues(EmployeeFrontmatterSchema.safeParse(v2))).toEqual([]);
+    expect(EmployeeFrontmatterSchema.safeParse({ ...v2, pinned_mind_clones: ["a", "b", "c"] }).success).toBe(false);
+    expect(EmployeeFrontmatterSchema.safeParse({ ...v2, acceptance: [{ id: "Bad Id", description: "x" }] }).success).toBe(false);
+    expect(EmployeeFrontmatterSchema.safeParse({ ...v2, acceptance: [{ id: "ok", description: "x", min_bytes: -1 }] }).success).toBe(false);
+    const v1 = EmployeeFrontmatterSchema.parse(frontmatter(join(businessV1(root()), "employees", "intake.md")));
+    for (const k of ["pinned_mind_clones", "squads_preferred", "acceptance"]) expect(k in v1).toBe(false);
+  });
+});
+
+describe("registries", () => {
+  const HASH = `sha256:${"a".repeat(64)}`;
+
+  test("the businesses registry accepts protocol 2.0 and still rejects 3.0", () => {
+    const registry = (protocol: string) => ({
+      generated_at: "2026-08-26T00:00:00.000Z",
+      businesses: { "fixture-biz": { version: "1.0.0", protocol, manifest_path: "/x/business.yaml", manifest_hash: HASH, domains: ["fixture_domain"], capabilities: [] } },
+    });
+    expect(issues(RegistryBusinessesSchema.safeParse(registry("1.0")))).toEqual([]);
+    expect(issues(RegistryBusinessesSchema.safeParse(registry("2.0")))).toEqual([]);
+    expect(RegistryBusinessesSchema.safeParse(registry("3.0")).success).toBe(false);
+  });
+
+  test("the squads registry accepts host_protocol_version 6.0", () => {
+    const registry = (host: string) => ({
+      generated_at: "2026-08-26T00:00:00.000Z", host_protocol_version: host, squads_root_dirs: [], squads: {}, capabilities: {},
+    });
+    expect(issues(RegistrySquadsSchema.safeParse(registry("5.0")))).toEqual([]);
+    expect(issues(RegistrySquadsSchema.safeParse(registry("6.0")))).toEqual([]);
+  });
+
+  test("core-schemas.json mirrors the enums", () => {
+    const schema = JSON.parse(readFileSync(join(import.meta.dir, "..", "schemas", "core-schemas.json"), "utf8"));
+    const enums: Record<string, string[][]> = { host_protocol_version: [], protocol: [] };
+    const walk = (node: any) => {
+      if (!node || typeof node !== "object") return;
+      for (const [k, v] of Object.entries(node)) {
+        if (k in enums && v && typeof v === "object" && Array.isArray((v as any).enum)) enums[k].push((v as any).enum);
+        walk(v);
+      }
+    };
+    walk(schema);
+    expect(enums.host_protocol_version.some((e) => e.includes("6.0"))).toBe(true);
+    expect(enums.protocol.some((e) => e.includes("1.0") && e.includes("2.0"))).toBe(true);
+  });
+});

--- a/skills/_shared/tests/workflow-readers-v6.test.ts
+++ b/skills/_shared/tests/workflow-readers-v6.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Readers stop depending on the workflow file extension.
+ *
+ * Squad Protocol v6 moves workflows to Markdown (frontmatter graph + prose
+ * body). Before any content can move, every engine reader that assumed
+ * `workflows/*.yaml` has to accept `.md` and keep returning exactly what it
+ * returned for `.yaml`. The cases here state that as invariants over one graph
+ * written in both encodings (see fixtures/protocol-entities.ts), so a v5 squad
+ * cannot change behavior without a test changing result.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { contractBreaks } from "../lib/contract-breaks.ts";
+import { extractSurface, writeSurface } from "../lib/surface.ts";
+import { diffSurfaces } from "../lib/surface-diff.ts";
+import { checkPortability } from "../../squads/lib/squad-doctor.ts";
+import {
+  collisionSquad, markdownWorkflow, ALPHA_GRAPH, migratedToMarkdown, schema2Surface, tmpRoot,
+  v4Squad, v5AgentSequenceSquad, v5StepsSquad, v6MarkdownSquad,
+} from "./fixtures/protocol-entities.ts";
+
+const require_ = createRequire(import.meta.url);
+const REPO = join(import.meta.dir, "..", "..", "..");
+const SKILLS = join(REPO, "skills");
+const bodyIndex = require_(join(SKILLS, "_shared", "lib", "body-index.js"));
+const assetMeta = require_(join(SKILLS, "_shared", "lib", "asset-meta.js"));
+const criteria = require_(join(SKILLS, "squads", "lib", "squad-audit-criteria.js"));
+const fixers = require_(join(SKILLS, "squads", "lib", "mechanical-fixers.js"));
+const inferrer = require_(join(SKILLS, "squads", "lib", "v4-capability-inferrer.js"));
+
+const ROOTS: string[] = [];
+function root(): string { const r = tmpRoot(); ROOTS.push(r); return r; }
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch {} });
+
+/**
+ * The squads libs resolve `validators.ts` from NIRVANA_SKILLS_DIR when they are
+ * loaded, and `bun test` loads every file into one process. A child process is
+ * the only way to point them at this checkout without leaking the variable into
+ * whichever test file loads next.
+ */
+function runBun(script: string, args: string[], extraEnv: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [script, ...args], {
+    cwd: REPO, encoding: "utf8",
+    env: { ...process.env, NIRVANA_SKILLS_DIR: SKILLS, ...extraEnv },
+  });
+  return { code: r.status ?? 1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+const manifestOf = (dir: string) => join(dir, "squad.yaml");
+const workflowInvoke = (ref: string) => ({ type: "workflow", ref });
+
+describe("body-index: one graph, one body text, whatever the encoding", () => {
+  test("bodyTextFor(yaml) === bodyTextFor(md) for an identical graph with no new prose", () => {
+    const r = root();
+    const fromYaml = bodyIndex.bodyTextFor(manifestOf(v5StepsSquad(r)), workflowInvoke("workflows/alpha.yaml"));
+    const fromMd = bodyIndex.bodyTextFor(manifestOf(migratedToMarkdown(r)), workflowInvoke("workflows/alpha.md"));
+    expect(fromYaml.length).toBeGreaterThan(0);
+    expect(fromMd).toBe(fromYaml);
+    // The expansion still reaches the tasks and agents behind the graph.
+    expect(fromMd).toContain("quokka-plan");
+    expect(fromMd).toContain("quokka-build");
+    // The graph itself is retained for a Markdown file exactly as for YAML:
+    // the frontmatter is unwrapped, not stripped as front matter noise.
+    expect(fromMd).toContain("Plan the alpha artifact");
+  });
+
+  test("an extensionless ref resolves; with twins on disk, .md wins the bare ref and an explicit ref stays explicit", () => {
+    const dir = collisionSquad(root());
+    const explicit = bodyIndex.bodyTextFor(manifestOf(dir), workflowInvoke("workflows/x.yaml"));
+    const bare = bodyIndex.bodyTextFor(manifestOf(dir), workflowInvoke("workflows/x"));
+    expect(explicit).not.toContain("Assemble the deliverable");
+    expect(bare).toContain("Assemble the deliverable");
+  });
+
+  test("prose in the Markdown body enters the body text", () => {
+    const text = bodyIndex.bodyTextFor(manifestOf(v6MarkdownSquad(root())), workflowInvoke("workflows/alpha.md"));
+    expect(text).toContain("Assemble the deliverable from the plan");
+  });
+
+  test("CRLF frontmatter yields the same body text as its LF twin", () => {
+    const r = root();
+    const lf = bodyIndex.bodyTextFor(manifestOf(migratedToMarkdown(r, "fixture-lf")), workflowInvoke("workflows/alpha"));
+    const crlf = bodyIndex.bodyTextFor(manifestOf(migratedToMarkdown(r, "fixture-crlf", { crlf: true })), workflowInvoke("workflows/alpha"));
+    expect(crlf).toBe(lf);
+  });
+
+  test("the agent_sequence dialect keeps its (regex-only) expansion", () => {
+    const text = bodyIndex.bodyTextFor(manifestOf(v5AgentSequenceSquad(root())), workflowInvoke("workflows/seq.yaml"));
+    expect(text).toContain("planner");
+    expect(text).toContain("builder");
+  });
+});
+
+describe("asset-meta: a workflow is a workflow in either encoding", () => {
+  test("workflows/*.md is typed workflow, frontmatter parsed, body kept", () => {
+    const meta = assetMeta.loadMeta(join(v6MarkdownSquad(root()), "workflows", "alpha.md"));
+    expect(meta.error).toBeNull();
+    expect(meta.type).toBe("workflow");
+    expect(meta.format).toBe("frontmatter");
+    expect(meta.raw.name).toBe("alpha");
+    expect(meta.raw.steps).toHaveLength(2);
+    expect(meta.body).toContain("## plan");
+  });
+
+  test("workflows/*.yaml keeps its type; tasks and agents keep theirs", () => {
+    const dir = v5StepsSquad(root());
+    const wf = assetMeta.loadMeta(join(dir, "workflows", "alpha.yaml"));
+    expect(wf.type).toBe("workflow");
+    expect(wf.format).toBe("yaml");
+    expect(wf.raw.steps).toHaveLength(2);
+    expect(assetMeta.loadMeta(join(dir, "tasks", "plan.md")).type).toBe("task");
+    expect(assetMeta.loadMeta(join(dir, "agents", "planner.md")).type).toBe("agent");
+  });
+
+  test("CRLF frontmatter parses", () => {
+    const dir = migratedToMarkdown(root(), "fixture-crlf", { crlf: true, body: "## plan\r\n\r\nWindows prose.\r\n" });
+    const meta = assetMeta.loadMeta(join(dir, "workflows", "alpha.md"));
+    expect(meta.error).toBeNull();
+    expect(meta.type).toBe("workflow");
+    expect(meta.raw.name).toBe("alpha");
+    expect(meta.raw.steps.map((s: any) => s.id)).toEqual(["plan", "build"]);
+    expect(meta.body).toContain("Windows prose.");
+  });
+});
+
+describe("capability-validator: components and refs resolve to .md", () => {
+  const validator = join(SKILLS, "squads", "lib", "capability-validator.js");
+
+  test("a v6 squad with workflows/alpha.md and a bare component name is valid, with no unknown-protocol warning", () => {
+    const r = runBun(validator, ["squad", v6MarkdownSquad(root())]);
+    const out = JSON.parse(r.stdout);
+    expect(out.errors).toEqual([]);
+    expect(out.valid).toBe(true);
+    expect(out.warnings.filter((w: string) => /unknown protocol/i.test(w))).toEqual([]);
+    expect(out.warnings.filter((w: string) => /does not resolve on disk/i.test(w))).toEqual([]);
+    expect(out.referenced_files.workflows[0].exists).toBe(true);
+    expect(out.referenced_files.workflows[0].path.endsWith("alpha.md")).toBe(true);
+    expect(r.code).toBe(0);
+  });
+
+  test("the v5 squad validates as before, resolving to alpha.yaml", () => {
+    const r = runBun(validator, ["squad", v5StepsSquad(root())]);
+    const out = JSON.parse(r.stdout);
+    expect(out.valid).toBe(true);
+    expect(out.referenced_files.workflows[0].path.endsWith("alpha.yaml")).toBe(true);
+  });
+
+  test("a bare component with twins on disk resolves to the .md", () => {
+    const dir = collisionSquad(root());
+    const manifest = readFileSync(manifestOf(dir), "utf8").replace("workflows: [x.yaml]", "workflows: [x]");
+    writeFileSync(manifestOf(dir), manifest, "utf8");
+    const out = JSON.parse(runBun(validator, ["squad", dir]).stdout);
+    expect(out.referenced_files.workflows[0].exists).toBe(true);
+    expect(out.referenced_files.workflows[0].path.endsWith("x.md")).toBe(true);
+  });
+});
+
+describe("squad-doctor: portability scans workflows in YAML and in Markdown", () => {
+  test("a leak in workflows/alpha.yaml is found (it used to be skipped), and one in a .md too", () => {
+    const dir = v5StepsSquad(root());
+    appendFileSync(join(dir, "workflows", "alpha.yaml"), "# see ~/.claude/skills for the runner\n", "utf8");
+    writeFileSync(join(dir, "workflows", "leak.md"), markdownWorkflow(ALPHA_GRAPH, "## plan\n\nRead CLAUDE.md first.\n"), "utf8");
+    const where = checkPortability(dir).map((f) => f.where);
+    expect(where).toContain("workflows/alpha.yaml");
+    expect(where).toContain("workflows/leak.md");
+  });
+
+  test("a clean squad has no portability findings in either encoding", () => {
+    const r = root();
+    expect(checkPortability(v5StepsSquad(r))).toEqual([]);
+    expect(checkPortability(v6MarkdownSquad(r))).toEqual([]);
+  });
+});
+
+describe("contract surface: a v5 install meets its Markdown twin without a single break", () => {
+  test("contractBreaks(installed with schema 2 surface, incoming with schema 3 surface) === []", () => {
+    const installed = v5StepsSquad(root());
+    writeSurface(installed, schema2Surface(installed));
+    const incoming = migratedToMarkdown(root());
+    writeSurface(incoming, extractSurface(incoming));
+    expect(contractBreaks(installed, incoming, "squads/fixture-alpha")).toEqual([]);
+  });
+
+  test("with both surfaces on schema 3 the migration is a patch, still no break", () => {
+    const installed = v5StepsSquad(root());
+    writeSurface(installed, extractSurface(installed));
+    const incoming = migratedToMarkdown(root());
+    writeSurface(incoming, extractSurface(incoming));
+    expect(contractBreaks(installed, incoming, "squads/fixture-alpha")).toEqual([]);
+    expect(diffSurfaces(extractSurface(installed), extractSurface(incoming)).bump).toBe("patch");
+  });
+});
+
+describe("audit criteria, fixers and the v4 inferrer see .md workflows", () => {
+  const criterion = (dir: string, id: number) => criteria.scoreSquad(dir).breakdown.find((b: any) => b.id === id);
+
+  test("c1 scores protocol 6.0 as 5.0 and proposes no protocol patch", () => {
+    const c1 = criterion(v6MarkdownSquad(root()), 1);
+    expect(c1.score).toBe(c1.max);
+    expect(c1.evidence).toContain("protocol=6.0");
+    expect(c1.fixable_diff).toBeNull();
+    expect(criterion(v5StepsSquad(root()), 1).score).toBe(8);
+  });
+
+  test("c7 lists .md workflows and resolves their refs; .yaml scores as before", () => {
+    const md = criterion(v6MarkdownSquad(root()), 7);
+    expect(md.evidence).toContain("1/1 workflows resolve");
+    expect(md.score).toBe(md.max);
+    const yaml = criterion(v5StepsSquad(root()), 7);
+    expect(yaml.evidence).toContain("1/1 workflows resolve");
+    expect(yaml.score).toBe(yaml.max);
+    expect(criterion(collisionSquad(root()), 7).evidence).toContain("3/3 workflows resolve");
+  });
+
+  test("components_files_stub leaves an existing .md or .yml alone and only ever creates .yaml", () => {
+    const dir = migratedToMarkdown(root());
+    writeFileSync(join(dir, "workflows", "delta.yml"), ALPHA_GRAPH.replace("name: alpha", "name: delta"), "utf8");
+    const manifest = readFileSync(manifestOf(dir), "utf8").replace("workflows: [alpha]", "workflows: [alpha, delta, gamma]");
+    writeFileSync(manifestOf(dir), manifest, "utf8");
+    const results = fixers.applyMechanicalFixes(dir, { patches: [{ kind: "components_files_stub" }] });
+    expect(results[0].result.created).toEqual(["workflows/gamma.yaml"]);
+    expect(existsSync(join(dir, "workflows", "alpha.yaml"))).toBe(false);
+    expect(existsSync(join(dir, "workflows", "delta.yaml"))).toBe(false);
+    expect(existsSync(join(dir, "workflows", "gamma.yaml"))).toBe(true);
+  });
+
+  test("the inferrer accepts .md and .yml on disk and keeps emitting .yaml when that is what exists", () => {
+    const r = root();
+    const md = v4Squad(r, "alpha.md", "fixture-v4-md");
+    const mdCaps = inferrer.inferCapabilities(parseYaml(readFileSync(manifestOf(md), "utf8")), md);
+    expect(mdCaps[0].invoke).toEqual({ type: "workflow", ref: "workflows/alpha.md" });
+    expect(mdCaps[0].description).toContain("Plan the alpha artifact");
+    const yaml = v4Squad(r, "alpha.yaml", "fixture-v4-yaml");
+    const yamlCaps = inferrer.inferCapabilities(parseYaml(readFileSync(manifestOf(yaml), "utf8")), yaml);
+    expect(yamlCaps[0].invoke).toEqual({ type: "workflow", ref: "workflows/alpha.yaml" });
+    // The namespace comes from the squad slug; the workflow-derived tail is what the encoding must not change.
+    for (const caps of [mdCaps, yamlCaps]) expect(caps[0].capability_id.endsWith(".alpha.execute")).toBe(true);
+    expect(inferrer.slugifyWorkflowId("alpha.md")).toBe("alpha");
+    expect(inferrer.slugifyWorkflowId("alpha.yaml")).toBe("alpha");
+  });
+});
+
+describe("validate-squad: protocol 6.0 takes the capabilities branch", () => {
+  const script = join(SKILLS, "squads", "scripts", "validate-squad.ts");
+
+  test("a v6 squad passes through the capability validator", () => {
+    const r = runBun(script, [v6MarkdownSquad(root())], { NIRVANA_PROJECT_ROOT: root() });
+    expect(r.stdout).toContain("Protocol: 6.0");
+    expect(r.stdout).toContain("[PASS] v6 manifest valid");
+    expect(r.code).toBe(0);
+  });
+
+  test("a v5 squad prints exactly what it printed before", () => {
+    const r = runBun(script, [v5StepsSquad(root())], { NIRVANA_PROJECT_ROOT: root() });
+    expect(r.stdout).toContain("[PASS] v5 manifest valid");
+    expect(r.code).toBe(0);
+  });
+});

--- a/skills/_shared/validators/validators.ts
+++ b/skills/_shared/validators/validators.ts
@@ -1,7 +1,7 @@
 /**
  * Nirvana Protocol Validators (TypeScript / Zod)
  *
- * Fail-closed validators for Squad Protocol v5, Business Protocol v1, and Harness Protocol v1.
+ * Fail-closed validators for Squad Protocol v5/v6, Business Protocol v1/v2, and Harness Protocol v1.
  *
  * Used by:
  * - skills/squads (squad.yaml validation, capability validation)
@@ -35,6 +35,9 @@ const TICKET_ID = /^TKT-\d{4}-\d{2}-\d{2}-\d+$/
 const SHA256 = /^sha256:[a-f0-9]{64}$/
 const ENV_VAR = /^[A-Z][A-Z0-9_]*$/
 const MENTION = /^@[a-z][a-z0-9-]+$/
+const ACCEPTANCE_ID = /^[a-z][a-z0-9_-]*$/
+/** A capability id, optionally qualified by the providing squad: `slug:ns.cap.verb`. */
+const REQUIRES_REF = /^(?:[a-z][a-z0-9-]{1,63}:)?[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$/
 
 const Runtime = z.enum([
   'claude-code', 'codex', 'gemini-cli', 'cursor', 'antigravity', 'antigravity-cli',
@@ -126,12 +129,29 @@ export const CapabilitySchema = z.object({
     produces: z.array(z.string()).max(8).optional(),
     consumes: z.array(z.string()).max(8).optional(),
   }).strict()).max(8).optional(),
+  // Squad Protocol v6 (accepted, not yet read). Optional, so a v5 manifest
+  // parses to the same object as before; bounded, so the shapes the next cuts
+  // author are the shapes the validator already knows. No reader consumes them.
+  acceptance: z.array(z.object({
+    id: z.string().regex(ACCEPTANCE_ID),
+    description: z.string().min(1),
+    blocking: z.boolean().optional(),
+    minimumScore: z.number().min(0).max(1).optional(),
+  }).strict()).max(12).optional(),
+  evaluator: z.object({
+    scorecard: z.string().min(1),
+    rubric: z.string().min(1),
+    dimensions: z.array(z.string()).optional(),
+    max_cost_usd: z.number().min(0).optional(),
+  }).strict().optional(),
+  requires: z.array(z.string().regex(REQUIRES_REF)).max(8).optional(),
+  consumes: z.array(z.string().min(3).max(80)).max(20).optional(),
 }).strict()
 
 export const SquadManifestSchema = z.object({
   name: z.string().regex(KEBAB_CASE),
   version: z.string().regex(SEMVER),
-  protocol: z.enum(['4.0', '4.1', '5.0']),
+  protocol: z.enum(['4.0', '4.1', '5.0', '6.0']),
   description: z.string().min(20).optional(),
   author: z.string().optional(),
   license: z.string().default('MIT'),
@@ -234,6 +254,19 @@ export const EmployeeFrontmatterSchema = z.object({
   is_brief_intake: z.boolean().default(false),
   antagonizes: z.array(z.string()).optional(),
   squads_authorized: z.array(z.string().regex(KEBAB_CASE)).optional().nullable(),
+  // Business Protocol v2 (accepted, not yet read): pinned clones (max 2 — the
+  // prompt injects three at most), open squad preference, acceptance per role.
+  pinned_mind_clones: z.array(z.string()).max(2).optional(),
+  squads_preferred: z.array(z.string().regex(KEBAB_CASE)).optional(),
+  acceptance: z.array(z.object({
+    id: z.string().regex(ACCEPTANCE_ID),
+    description: z.string().min(1),
+    blocking: z.boolean().optional(),
+    minimum_score: z.number().min(0).max(1).optional(),
+    capability: z.string().optional(),
+    path: z.string().optional(),
+    min_bytes: z.number().int().min(0).optional(),
+  }).strict()).optional(),
   draws_from: z.array(z.object({
     source: z.string(),
     weight: z.number().min(0).max(1).optional(),
@@ -273,7 +306,7 @@ export const EmployeeFrontmatterSchema = z.object({
 export const BusinessManifestSchema = z.object({
   name: z.string().regex(KEBAB_CASE),
   version: z.string().regex(SEMVER),
-  protocol: z.literal('1.0'),
+  protocol: z.enum(['1.0', '2.0']),
   description: z.string().min(20).max(LIMITS.business_description_max!),
   author: z.string().optional(),
   license: z.string().default('MIT'),
@@ -285,6 +318,12 @@ export const BusinessManifestSchema = z.object({
   example_briefs: z.array(z.string().min(20).max(LIMITS.business_example_briefs_item_max!)).max(LIMITS.business_example_briefs_max!).optional(),
   keywords: z.array(z.string().min(2).max(60)).max(LIMITS.business_keywords_max!).optional(),
   squads_authorized: z.array(z.string().regex(KEBAB_CASE)).optional().nullable(),
+  // Business Protocol v2 (accepted, not yet read): open preference list, routing
+  // fences and a per-run budget. The manifest is passthrough, so `not_for`
+  // stays as loose as it already was; the others are new keys.
+  squads_preferred: z.array(z.string().regex(KEBAB_CASE)).optional(),
+  not_for: z.array(z.string()).optional(),
+  run_budget_usd: z.number().min(0).optional(),
   operation_mode: z.enum(['zero_human', 'hybrid', 'human_in_loop']).default('zero_human'),
   output: z.object({
     base_dir: z.string().default('default'),
@@ -587,7 +626,7 @@ export const ApprovalChainSchema = z.object({
 export const RegistrySquadsSchema = z.object({
   schema_version: z.string().default('1.0.0'),
   generated_at: z.string().datetime(),
-  host_protocol_version: z.enum(['5.0', '4.0']),
+  host_protocol_version: z.enum(['6.0', '5.0', '4.0']),
   squads_root_dirs: z.array(z.string()),
   squads: z.record(
     z.string().regex(/^[a-z][a-z0-9-]+$/),
@@ -635,7 +674,7 @@ export const RegistryBusinessesSchema = z.object({
     z.string().regex(/^[a-z][a-z0-9-]+$/),
     z.object({
       version: z.string(),
-      protocol: z.literal('1.0'),
+      protocol: z.enum(['1.0', '2.0']),
       manifest_path: z.string(),
       manifest_hash: z.string().regex(SHA256),
       // Routing signal (routing-360 Phase 2.1): manifest name + description are

--- a/skills/squads/lib/capability-validator.js
+++ b/skills/squads/lib/capability-validator.js
@@ -201,7 +201,7 @@ function validateSquadV5Manifest(manifest) {
   const errors = [];
   const warnings = [];
 
-  if (manifest.protocol === '5.0') {
+  if (manifest.protocol === '5.0' || manifest.protocol === '6.0') {
     if (!Array.isArray(manifest.capabilities) || manifest.capabilities.length === 0) {
       errors.push("v5 squads must declare capabilities[] (else they are invisible to discovery)");
     } else {
@@ -281,9 +281,10 @@ function validateAll(squadDir) {
 
   // Component file existence (relative to squad dir).
   // Accepts: full relative path, bare filename with extension, or bare filename
-  // without extension (default: .md for agents/tasks, .yaml or .yml for workflows).
+  // without extension (default: .md for agents/tasks; .md, .yaml or .yml for
+  // workflows — the .md wins a bare ref, as it does in the contract surface).
   const components = manifest.components || {};
-  const defaultExt = (bucket) => bucket === 'workflows' ? ['.yaml', '.yml'] : ['.md'];
+  const defaultExt = (bucket) => bucket === 'workflows' ? ['.md', '.yaml', '.yml'] : ['.md'];
   const checkBucket = (bucket, subdir) => {
     if (!Array.isArray(components[bucket])) return;
     for (const file of components[bucket]) {

--- a/skills/squads/lib/mechanical-fixers.js
+++ b/skills/squads/lib/mechanical-fixers.js
@@ -596,8 +596,11 @@ function fix_components_files_stub(squadDir) {
     // Strip any extension already present in the ref so we don't end up
     // with foo.md.md or foo.yaml.yaml.
     const baseName = name.replace(/\.(md|ya?ml)$/i, '');
+    // A workflow already on disk in any encoding (.md for v6, .yaml/.yml for
+    // v5) is not missing; the stub itself is only ever a .yaml in this cut.
+    const present = sub === 'workflows' ? ['.md', '.yaml', '.yml'] : [ext];
+    if (present.some(e => fs.existsSync(path.join(dir, `${baseName}${e}`)))) return;
     const fp = path.join(dir, `${baseName}${ext}`);
-    if (fs.existsSync(fp)) return;
     fs.writeFileSync(fp, body, 'utf8');
     created.push(`${sub}/${baseName}${ext}`);
   };

--- a/skills/squads/lib/squad-audit-criteria.js
+++ b/skills/squads/lib/squad-audit-criteria.js
@@ -49,7 +49,7 @@ const SEMVER_RE = /^\d+\.\d+\.\d+([+\-].*)?$/;
 const CAP_ID_RE = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$/;
 
 // ─────────────────────────────────────────────────────────────────────
-// Criterion 1 — protocol "5.0" + valid semver version  (8 pts)
+// Criterion 1 — protocol "5.0" or "6.0" + valid semver version  (8 pts)
 // ─────────────────────────────────────────────────────────────────────
 function c1_protocol_version({ manifest }) {
   const max = 8;
@@ -58,14 +58,17 @@ function c1_protocol_version({ manifest }) {
   const ver = String(manifest.version || '').trim();
   let score = 0;
   const ev = [];
-  if (proto === '5.0') { score += 4; ev.push('protocol=5.0'); }
+  // 6.0 scores as 5.0: the capabilities contract is the same, and the fixer
+  // must never downgrade a v6 manifest to 5.0.
+  const protoOk = proto === '5.0' || proto === '6.0';
+  if (protoOk) { score += 4; ev.push(`protocol=${proto}`); }
   else { ev.push(`protocol=${proto || '(missing)'}`); }
   if (SEMVER_RE.test(ver)) { score += 4; ev.push(`version=${ver}`); }
   else { ev.push(`version=${ver || '(missing)'} (not semver)`); }
   let fix = null;
-  if (proto !== '5.0' || !SEMVER_RE.test(ver)) {
+  if (!protoOk || !SEMVER_RE.test(ver)) {
     fix = { kind: 'manifest_patch', patches: [] };
-    if (proto !== '5.0') fix.patches.push({ op: 'set', path: 'protocol', value: '5.0' });
+    if (!protoOk) fix.patches.push({ op: 'set', path: 'protocol', value: '5.0' });
     if (!SEMVER_RE.test(ver)) fix.patches.push({ op: 'set', path: 'version', value: '5.0.0' });
   }
   return { score, max, evidence: ev.join(' · '), fixable_diff: fix };
@@ -210,20 +213,30 @@ function c6_tasks({ squadDir }) {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Criterion 7 — workflows/*.yaml DAG-valid, refs resolve  (8 pts)
+// Criterion 7 — workflows/*.{yaml,md} DAG-valid, refs resolve  (8 pts)
 // ─────────────────────────────────────────────────────────────────────
+/** A workflow document: the whole file for YAML, the frontmatter for Markdown
+ *  (v6: frontmatter graph + prose body). CRLF tolerant. */
+function readWorkflowDoc(p) {
+  if (!/\.md$/i.test(p)) return readYaml(p);
+  if (!exists(p) || !YAML) return null;
+  try {
+    const m = /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(fs.readFileSync(p, 'utf8'));
+    return m ? YAML.parse(m[1]) : null;
+  } catch { return null; }
+}
 function c7_workflows({ squadDir, manifest }) {
   const max = 8;
   const dir = path.join(squadDir, 'workflows');
   if (!exists(dir)) return { score: 0, max, evidence: 'workflows/ missing', fixable_diff: { kind: 'create_workflows_dir' } };
-  const files = listDir(dir).filter(f => /\.ya?ml$/.test(f));
+  const files = listDir(dir).filter(f => /\.(ya?ml|md)$/.test(f));
   if (files.length === 0) return { score: 0, max, evidence: 'no workflow files', fixable_diff: null };
   const knownAgents = new Set(listDir(path.join(squadDir, 'agents')).filter(f => f.endsWith('.md')).map(f => f.replace(/\.md$/, '')));
   const knownTasks = new Set(listDir(path.join(squadDir, 'tasks')).filter(f => f.endsWith('.md')).map(f => f.replace(/\.md$/, '')));
   let valid = 0;
   const issues = [];
   for (const f of files) {
-    const wf = readYaml(path.join(dir, f));
+    const wf = readWorkflowDoc(path.join(dir, f));
     if (!wf || typeof wf !== 'object') { issues.push(`${f}: parse-fail`); continue; }
     // v5 protocol allows multiple workflow shapes (real-world variance):
     //   top-level `steps:`            (Squad Protocol V5 canonical DAG)

--- a/skills/squads/lib/squad-doctor.ts
+++ b/skills/squads/lib/squad-doctor.ts
@@ -80,7 +80,10 @@ export function checkPortability(squadDir: string): Finding[] {
     const dir = path.join(squadDir, sub);
     if (!fs.existsSync(dir)) continue;
     let names: string[] = [];
-    try { names = fs.readdirSync(dir).filter((n) => n.endsWith(".md")); } catch { continue; }
+    // Workflows live in .yaml/.yml (v5) or .md (v6); agents and tasks in .md.
+    // Filtering every dir on .md made the workflow scan a no-op.
+    const isDoc = sub === "workflows" ? (n: string) => /\.(md|ya?ml)$/i.test(n) : (n: string) => n.endsWith(".md");
+    try { names = fs.readdirSync(dir).filter(isDoc); } catch { continue; }
     for (const f of names) {
       let txt = "";
       try { txt = fs.readFileSync(path.join(dir, f), "utf8"); } catch { continue; }

--- a/skills/squads/lib/v4-capability-inferrer.js
+++ b/skills/squads/lib/v4-capability-inferrer.js
@@ -18,7 +18,7 @@
  *     description: workflow.description ∪ workflow_name + squad summary (≥20 chars)
  *     domains:     heuristic match of squad.name + workflow.name vs catalog
  *     examples:    derived from workflow_name + squad.description chunks
- *     invoke:      {type: "workflow", ref: "workflows/<file>.yaml"}
+ *     invoke:      {type: "workflow", ref: "workflows/<file>.(yaml|yml|md)"}
  *     score_boost: 1.2 for premium-marker squads (awwwards, nirvana, master, elite, premium)
  */
 
@@ -109,7 +109,7 @@ const KEYWORD_DOMAINS = [
 function slugifyWorkflowId(name) {
   if (typeof name !== 'string') return 'execute';
   return name
-    .replace(/\.ya?ml$/i, '')
+    .replace(/\.(ya?ml|md)$/i, '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/_+/g, '_')
@@ -246,8 +246,13 @@ function inferCapabilities(manifest, manifestDir) {
   // Strategy A: 1 capability per workflow file.
   for (const wfRef of workflows) {
     if (typeof wfRef !== 'string') continue;
-    const wfFile = wfRef.endsWith('.yaml') || wfRef.endsWith('.yml') ? wfRef : `${wfRef}.yaml`;
-    const wfBaseName = path.basename(wfFile).replace(/\.ya?ml$/i, '');
+    // A bare ref resolves to whatever encoding exists — .yaml first, so a v4
+    // squad keeps emitting exactly what it emitted; then .yml; then .md for a
+    // v6 workflow. Nothing on disk keeps the historical `.yaml` emission.
+    const wfFile = /\.(ya?ml|md)$/i.test(wfRef)
+      ? wfRef
+      : (['.yaml', '.yml', '.md'].map((e) => `${wfRef}${e}`).find((f) => fs.existsSync(path.join(manifestDir, 'workflows', f))) || `${wfRef}.yaml`);
+    const wfBaseName = path.basename(wfFile).replace(/\.(ya?ml|md)$/i, '');
     const wfPath = path.join(manifestDir, 'workflows', wfFile);
     const summary = readWorkflowSummary(wfPath);
     const wfName = summary.workflowName || wfBaseName;

--- a/skills/squads/scripts/init-squad.ts
+++ b/skills/squads/scripts/init-squad.ts
@@ -148,7 +148,7 @@ console.log("");
 console.log("Next steps:");
 console.log(`  1. Fill in agents/${state.AGENT_1}.md and agents/${state.AGENT_2}.md (use templates/agent.md.tmpl)`);
 console.log(`  2. Fill in tasks/${state.TASK_1}.md and tasks/${state.TASK_2}.md`);
-console.log(`  3. Fill in workflows/${state.WORKFLOW_REF}.yaml`);
+console.log(`  3. Fill in workflows/${state.WORKFLOW_REF}.(yaml|md)`);
 console.log(`  4. Validate: bun ${path.join(skillDir, "scripts", "validate-squad.ts")} ${targetDir}`);
 console.log(`  5. Index:    bun ${path.join(skillDir, "scripts", "index-squads.ts")}`);
 

--- a/skills/squads/scripts/validate-squad.ts
+++ b/skills/squads/scripts/validate-squad.ts
@@ -3,7 +3,7 @@
  * validate-squad.ts — Squad Protocol Engine v5 validator (pure Bun port).
  *
  * Replaces validate-squad.sh. Branches by manifest protocol:
- *   protocol: 5.0  → capability-validator.js (Pydantic via _shared/validators)
+ *   protocol: 5.0 / 6.0 → capability-validator.js (Zod via _shared/validators)
  *   protocol: 4.0  → legacy B1-B8 + A-block checks in TS
  *
  * Usage:
@@ -68,9 +68,9 @@ console.log(`Protocol: ${protocol || "unknown"}`);
 console.log("================================");
 
 // ─────────────────────────────────────────────────────────────────────
-// Branch: protocol 5.0 → capability-validator.js
+// Branch: protocol 5.0 / 6.0 → capability-validator.js
 // ─────────────────────────────────────────────────────────────────────
-if (protocol === "5.0") {
+if (protocol === "5.0" || protocol === "6.0") {
   const capValidator = path.join(paths.CLAUDE_SKILLS_DIR, "squads", "lib", "capability-validator.js");
   if (!fs.existsSync(capValidator)) {
     console.error(`[FAIL] capability-validator.js missing at ${capValidator}`);
@@ -91,10 +91,11 @@ if (protocol === "5.0") {
 
   const errs: string[] = result.errors || [];
   const warns: string[] = result.warnings || [];
+  const label = protocol === "6.0" ? "v6" : "v5";
   if (errs.length === 0) {
-    console.log("[PASS] v5 manifest valid");
+    console.log(`[PASS] ${label} manifest valid`);
   } else {
-    console.log(`[FAIL] v5 manifest has ${errs.length} error(s):`);
+    console.log(`[FAIL] ${label} manifest has ${errs.length} error(s):`);
     errs.forEach((e, i) => console.log(`  ${i + 1}. ${e}`));
   }
   if (warns.length > 0) {


### PR DESCRIPTION
PR0 of the Squad Protocol v6 + Business Protocol v2 program. Engine only, no content, zero behavior change for v5 squads and v1 businesses. Plan: `~/.claude/plans/scalable-jumping-badger.md` ("Programa: cortes em ordem", PR0).

## What changes

- **Contract surface schema 3** (`skills/_shared/lib/surface.ts`): workflow entries keyed by stem (`workflow:workflows/<stem>`, lowercased, literal `/`), `.md` listed next to `.yaml`/`.yml`, capability `workflow:` bindings without extension, stem collision (`x.md` + `x.yaml`) flagged as `collision: ["x.yaml"]` (metadata, outside `surface_hash`; `.md` wins), and `normalizeSurface()` applied by `readSurface()` to schema <= 2 files without touching their schema number, so `diffSurfaces` still re-establishes the baseline across the transition.
- **Readers accept `.md` without changing the `.yaml` result**: `body-index.js` (`['', '.md', '.yaml', '.yml']`, frontmatter unwrapped so the graph is body text in both encodings), `asset-meta.js` (`workflows/*.md` typed workflow, rule placed before the task rule), `capability-validator.js` (bare components resolve to `.md`/`.yaml`/`.yml`; 6.0 takes the capabilities branch, no "unknown protocol"), `squad-audit-criteria.js` (c1 scores 6.0 as 5.0 and never patches it down; c7 lists `.md` and parses its frontmatter), `mechanical-fixers.js` (`components_files_stub` leaves an existing `.md`/`.yml` alone, still creates only `.yaml`), `v4-capability-inferrer.js` (accepts the three encodings, keeps emitting `.yaml` where that is what exists), `squad-doctor.ts` (portability scan covers `.yaml` and `.md` under `workflows/`; it was a no-op), `init-squad.ts` (message cites `workflows/<ref>.(yaml|md)`), `validate-squad.ts` (6.0 through the v5 branch, label `v6`).
- **Validators accept the next versions without semantics**: `validators.ts` `protocol` enums `6.0` (squads) and `1.0|2.0` (business manifest and registry), `host_protocol_version` `6.0`; optional bounded fields nothing reads yet: capability `acceptance[]` (max 12), `evaluator{}`, `requires[]` (max 8, optional `slug:` prefix), `consumes[]` (max 20); business `squads_preferred[]`, `not_for[]`, `run_budget_usd`; employee `pinned_mind_clones[]` (max 2), `squads_preferred[]`, `acceptance[]`. `core-schemas.json` mirrors both enums.
- Changelog EN + PT-BR (one section each, in parity); `docs/architecture/contracts-and-schemas.md` section 10 documents the key form and the collision rule.

## Invariants proven by tests

Fixtures are generated in `mkdtemp` by `skills/_shared/tests/fixtures/protocol-entities.ts` (v5 `steps`+`depends_on`, v5 `agent_sequence`, minimal v6 with `workflows/x.md`, stem collision, business v1 and v2, a mind-clone). One graph, two encodings.

- `bodyTextFor(yaml) === bodyTextFor(md)` for an identical graph with no new prose (LF and CRLF).
- `contractBreaks(<v5 dir with schema-2 surface>, <same squad migrated to .md with schema-3 surface>) === []`; with both on schema 3 the diff is `patch`.
- `diffSurfaces` of a pure `.yaml -> .md` rename: `content_changed` only, no `removed`/`added`/`rebound`, bump `patch`.
- Stem collision flagged; `Beta.yaml` keys as `beta`; determinism and `surface_hash` unaffected by the flag.
- Schema-2 file on disk x schema-3 extraction: zero changes; `readSurface` returns normalized keys/bindings with `schema` still 2.
- CRLF frontmatter parses in `asset-meta`, `body-index` and c7.
- A v5 capability/employee parses to the same object as before (no v6/v2 key injected).
- `validate-squad` prints `[PASS] v6 manifest valid` for the v6 fixture and `[PASS] v5 manifest valid` for the v5 one.

## Verification

- `bun test skills`: 1560 pass, 16 skip, 1 fail (`skills/harness/tests/buyer-path.test.ts`, `setup.ts failed`: the known environmental failure in worktrees).
- `bun run check:all`: 13/14 green; `check-not-for-fires --strict` fails in the worktree (exit 0 on the main checkout: the gate scores the machine's library against untracked baseline state, unrelated to this diff).
- Pack loop with `NIRVANA_SKILLS_DIR` pointing at this checkout: `~/nirvana-packs/genesis-content/squads/*` 47/47 `[PASS]`, 47/47 exit 0; squads with doctor findings 8 before and 8 after.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
