### PR TITLE
feat(graph): squad→squad composition becomes edges, and a plan's order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Squad composition becomes an edge, and a plan's order
+
+`capabilities[].requires[]` and `capabilities[].consumes[]` have parsed since the
+v6 fields landed, and no reader touched them. They are edges now.
+`readSquadComposition()` in `skills/_shared/lib/entity-graph.ts` reads every
+installed `squad.yaml`: a `requires` entry resolves to the squad declaring that
+capability id and becomes `depends_on` consumer to provider, a `consumes` entry
+resolves through `produces` and becomes `feeds` provider to consumer. Both pass
+through `dependencyPair()` as "the provider exists first", so `nrv graph order`
+and the install order pick the composition up without a second rule.
+
+An edge exists only where the provider is unambiguous. Sharing a capability id
+is the design, not a defect: ten squads carry `media.video.compose` and the
+router is meant to choose among them by brief. Choosing one of them here would
+invent an execution order nobody declared, so two providers yield no edge and a
+report row. A `slug:` prefix on the reference (`brand-forge:design.brand.identity`)
+names the provider and settles it.
+
+| Finding | `nrv graph check` |
+|---|---|
+| `requires` nothing provides | `x_requires_unresolved`, fails `--strict` |
+| `requires` two squads provide | `x_requires_ambiguous`, reported |
+| `consumes` nothing produces | `x_consumes_unresolved`, reported |
+| `consumes` two squads produce | `x_consumes_ambiguous`, reported |
+
+Ambiguity stops short of an error deliberately. The capability exists, twice, and
+failing the library over a duplicate id would punish the shape the router was
+built for. An unresolved `requires` is the other case: the library does not carry
+that capability, and no ordering can supply it.
+
+`compileManifest()` accepts the derived graph as `opts.composition` and inherits
+the order between two `squad` nodes of one plan when the author declared none.
+The author still wins, always: a pair already joined by an edge, in either
+direction, stays exactly as written. Without the option the compilation is
+bit-for-bit the one that shipped before, and a regression test holds it there.
+
 ### The workflow reader: one canonical graph, every legacy dialect normalized
 
 A squad's workflow was the only artifact of the protocol with no single shape.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,43 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A composição de squads vira aresta, e ordem de plano
+
+`capabilities[].requires[]` e `capabilities[].consumes[]` parseavam desde que os
+campos v6 entraram, e nenhum leitor os tocava. Agora são arestas.
+`readSquadComposition()`, em `skills/_shared/lib/entity-graph.ts`, lê cada
+`squad.yaml` instalado: uma entrada de `requires` resolve para o squad que
+declara aquele id de capability e vira `depends_on` do consumidor para o
+provedor; uma entrada de `consumes` resolve pelo `produces` e vira `feeds` do
+provedor para o consumidor. As duas passam pelo `dependencyPair()` como "o
+provedor existe primeiro", então `nrv graph order` e a ordem de instalação
+absorvem a composição sem uma segunda regra.
+
+A aresta só existe onde o provedor é inequívoco. Compartilhar um id de
+capability é o desenho, não um defeito: dez squads carregam `media.video.compose`
+e o roteador deve escolher entre eles pelo briefing. Escolher um deles aqui
+inventaria uma ordem de execução que ninguém declarou, então dois provedores não
+geram aresta e sim uma linha de reporte. Um prefixo `slug:` na referência
+(`brand-forge:design.brand.identity`) nomeia o provedor e resolve a questão.
+
+| Achado | `nrv graph check` |
+|---|---|
+| `requires` que ninguém provê | `x_requires_unresolved`, reprova no `--strict` |
+| `requires` que dois squads provêem | `x_requires_ambiguous`, reportado |
+| `consumes` que ninguém produz | `x_consumes_unresolved`, reportado |
+| `consumes` que dois squads produzem | `x_consumes_ambiguous`, reportado |
+
+A ambiguidade fica aquém do erro de propósito. A capability existe, duas vezes, e
+reprovar a biblioteca por um id repetido puniria justamente a forma para a qual o
+roteador foi feito. Um `requires` não resolvido é outro caso: a biblioteca não
+tem aquela capability, e nenhuma ordenação a fabrica.
+
+`compileManifest()` aceita o grafo derivado em `opts.composition` e herda a ordem
+entre dois nós `squad` de um mesmo plano quando o autor não declarou nenhuma. O
+autor continua vencendo, sempre: um par já ligado por uma aresta, em qualquer
+direção, fica exatamente como foi escrito. Sem a opção, a compilação é bit a bit
+a que já era publicada, e um teste de regressão a mantém assim.
+
 ### O leitor de workflow: um grafo canônico, todo dialeto legado normalizado
 
 O workflow de um squad era o único artefato do protocolo sem forma única.

--- a/skills/_shared/lib/dependency-graph.ts
+++ b/skills/_shared/lib/dependency-graph.ts
@@ -67,7 +67,10 @@ export function isCompatibleEdge(type: EdgeType, from: NodeType, to: NodeType): 
     case "staffs": return from === "employee" && to === "squad";
     case "embodies": return ["employee", "company"].includes(from) && to === "mind_clone";
     case "covers": return from === "squad" && to === "company";
-    case "feeds": return from === "material" && ["mind_clone", "company", "squad"].includes(to);
+    // A squad is a legal `feeds` source since Squad Protocol v6 §31: a
+    // capability's `consumes[]` names a `produces` slug, and what produces it
+    // is another squad, not a material.
+    case "feeds": return ["material", "squad"].includes(from) && ["mind_clone", "company", "squad"].includes(to);
     case "depends_on": return true;
     case "yields": return ["company", "squad", "agent"].includes(from) && to === "deliverable";
   }

--- a/skills/_shared/lib/entity-graph.ts
+++ b/skills/_shared/lib/entity-graph.ts
@@ -16,9 +16,11 @@
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 import {
   dependencyPair,
   type DependencyGraph,
+  type GraphEdge,
   type GraphNode,
 } from "./dependency-graph.ts";
 
@@ -150,14 +152,153 @@ export function readCloneBindings(roots: EntityRoots): CloneBindingScan {
   return { bindings, businesses, availableClones };
 }
 
+/** One capability's composition declarations, as read off a squad.yaml. */
+interface DeclaredCapability {
+  squad: string;
+  id: string;
+  produces: string[];
+  requires: string[];
+  consumes: string[];
+}
+
+export interface SquadCompositionIssue {
+  /** `x_requires_ambiguous`, `x_requires_unresolved`, `x_consumes_*`. */
+  code: string;
+  kind: "requires" | "consumes";
+  reason: "ambiguous" | "unresolved";
+  squad: string;
+  capability: string;
+  /** The declaration verbatim, prefix included. */
+  ref: string;
+  /** Provider slugs found, sorted; empty when nothing declares the ref. */
+  candidates: string[];
+}
+
+export interface SquadCompositionScan {
+  edges: GraphEdge[];
+  issues: SquadCompositionIssue[];
+}
+
+/** `produces` slugs are authored prose, so they match on case and padding. */
+const producesKey = (slug: string) => slug.trim().toLowerCase();
+
+function readDeclaredCapabilities(squadsDir: string): DeclaredCapability[] {
+  const out: DeclaredCapability[] = [];
+  for (const slug of readdirSync(squadsDir).sort()) {
+    const manifest = join(squadsDir, slug, "squad.yaml");
+    if (!existsSync(manifest)) continue;
+    let doc: unknown;
+    // A manifest that does not parse costs the graph nothing. Before v6 this
+    // reader only asked whether the file existed, and a squad nobody can read
+    // must not start breaking an install order it never took part in.
+    try { doc = parseYaml(readFileSync(manifest, "utf8")); } catch { continue; }
+    const caps = (doc as { capabilities?: unknown } | null)?.capabilities;
+    if (!Array.isArray(caps)) continue;
+    for (const cap of caps) {
+      if (!cap || typeof cap !== "object") continue;
+      const c = cap as Record<string, unknown>;
+      if (typeof c.id !== "string") continue;
+      const list = (key: string) =>
+        Array.isArray(c[key]) ? (c[key] as unknown[]).filter((v): v is string => typeof v === "string") : [];
+      out.push({
+        squad: slug,
+        id: c.id,
+        produces: list("produces"),
+        requires: list("requires"),
+        consumes: list("consumes"),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Squad Protocol v6 §31, read off disk. `capabilities[].requires[]` names
+ * capability ids (optionally `slug:`-prefixed) and becomes a `depends_on`
+ * edge consumer → provider; `capabilities[].consumes[]` names `produces`
+ * slugs and becomes a `feeds` edge provider → consumer. Both go through
+ * dependencyPair() as "the provider exists first".
+ *
+ * An edge is created ONLY when the provider is unambiguous. Across the
+ * installed library a capability id and a `produces` slug are both free to
+ * repeat, and picking one of two providers would invent an execution order
+ * nobody declared — so two providers yield no edge and an
+ * `x_requires_ambiguous` / `x_consumes_ambiguous` row, while none at all
+ * yields `x_..._unresolved`. A reference the declaring squad satisfies itself
+ * is neither: a self-edge would be a cycle, and an intra-squad reference is
+ * not a gap.
+ */
+export function readSquadComposition(roots: EntityRoots): SquadCompositionScan {
+  const edges: GraphEdge[] = [];
+  const issues: SquadCompositionIssue[] = [];
+  if (!roots.squadsDir || !existsSync(roots.squadsDir)) return { edges, issues };
+
+  const declared = readDeclaredCapabilities(roots.squadsDir);
+  const byCapability = new Map<string, Set<string>>();
+  const byProduces = new Map<string, Set<string>>();
+  const index = (map: Map<string, Set<string>>, key: string, slug: string) => {
+    const set = map.get(key) ?? new Set<string>();
+    set.add(slug);
+    map.set(key, set);
+  };
+  for (const cap of declared) {
+    index(byCapability, cap.id, cap.squad);
+    for (const p of cap.produces) index(byProduces, producesKey(p), cap.squad);
+  }
+
+  const seen = new Set<string>();
+  const link = (type: "depends_on" | "feeds", consumer: string, provider: string) => {
+    const edge: GraphEdge = type === "depends_on"
+      ? { id: `depends_on:${consumer}->${provider}`, source: `squad:${consumer}`, target: `squad:${provider}`, type }
+      : { id: `feeds:${provider}->${consumer}`, source: `squad:${provider}`, target: `squad:${consumer}`, type };
+    if (seen.has(edge.id)) return;
+    seen.add(edge.id);
+    edges.push(edge);
+  };
+  const report = (
+    kind: SquadCompositionIssue["kind"],
+    reason: SquadCompositionIssue["reason"],
+    cap: DeclaredCapability,
+    ref: string,
+    candidates: string[]
+  ) => issues.push({ code: `x_${kind}_${reason}`, kind, reason, squad: cap.squad, capability: cap.id, ref, candidates });
+
+  const providesItself = (slug: string, id: string) => byCapability.get(id)?.has(slug) ?? false;
+
+  for (const cap of declared) {
+    for (const ref of cap.requires) {
+      const sep = ref.indexOf(":");
+      const explicit = sep === -1 ? null : ref.slice(0, sep);
+      const id = sep === -1 ? ref : ref.slice(sep + 1);
+      const providers = [...(byCapability.get(id) ?? [])].filter((s) => s !== cap.squad).sort();
+      const resolved = explicit
+        ? (providesItself(explicit, id) ? explicit : null)
+        : (providers.length === 1 ? providers[0] : null);
+      if (resolved && resolved !== cap.squad) link("depends_on", cap.squad, resolved);
+      else if (resolved) continue;
+      else if (!explicit && providers.length > 1) report("requires", "ambiguous", cap, ref, providers);
+      else if (!explicit && providesItself(cap.squad, id)) continue;
+      else report("requires", "unresolved", cap, ref, []);
+    }
+    for (const slug of cap.consumes) {
+      const key = producesKey(slug);
+      const providers = [...(byProduces.get(key) ?? [])].filter((s) => s !== cap.squad).sort();
+      if (providers.length === 1) link("feeds", cap.squad, providers[0]);
+      else if (providers.length > 1) report("consumes", "ambiguous", cap, slug, providers);
+      else if (!byProduces.get(key)?.has(cap.squad)) report("consumes", "unresolved", cap, slug, []);
+    }
+  }
+  return { edges, issues };
+}
+
 /**
  * The derived entity graph. Nodes: one `company` per business dir, one
  * `employee` per declaring employee, one `mind_clone` per referenced clone —
  * present or not (missing ones carry payload.missing = true) — and one
- * `squad` per squad dir (dependency-free until a declaration form exists).
- * Edges: `owns` (company → employee) and `embodies` (employee → mind_clone;
- * company → mind_clone for dna/ bindings). Dangling-symlink rows do not add
- * edges — the binding they duplicate is already in the graph.
+ * `squad` per squad dir. Edges: `owns` (company → employee), `embodies`
+ * (employee → mind_clone; company → mind_clone for dna/ bindings) and the
+ * squad → squad composition of readSquadComposition(). Dangling-symlink rows
+ * do not add edges — the binding they duplicate is already in the graph.
  */
 export function buildEntityGraph(roots: EntityRoots): DependencyGraph {
   const scan = readCloneBindings(roots);
@@ -207,6 +348,7 @@ export function buildEntityGraph(roots: EntityRoots): DependencyGraph {
         pushNode({ id: `squad:${s}`, type: "squad", payload: { slug: s } });
       }
     }
+    edges.push(...readSquadComposition(roots).edges);
   }
   return { nodes, edges };
 }

--- a/skills/_shared/tests/dependency-graph.test.ts
+++ b/skills/_shared/tests/dependency-graph.test.ts
@@ -299,3 +299,28 @@ describe("agent nodes", () => {
     expect(issues.map((i) => i.message)).toEqual(['edge type "owns" is not allowed from company to agent']);
   });
 });
+
+describe("squad composition edges", () => {
+  // `consumes` compiles to `feeds`, and its provider is a squad, not a
+  // material: the compatibility table has to admit squad → squad or the
+  // derived edge would be rejected by validateGraph before anyone saw it.
+  test("feeds accepts a squad provider without losing the material one", () => {
+    expect(isCompatibleEdge("feeds", "squad", "squad")).toBeTrue();
+    expect(isCompatibleEdge("feeds", "material", "squad")).toBeTrue();
+    expect(isCompatibleEdge("feeds", "material", "company")).toBeTrue();
+    expect(isCompatibleEdge("feeds", "squad", "employee")).toBeFalse();
+    expect(isCompatibleEdge("feeds", "company", "squad")).toBeFalse();
+  });
+
+  test("both composition edges order the provider before the consumer", () => {
+    const g: DependencyGraph = {
+      nodes: [node("squad:consumer", "squad"), node("squad:provider", "squad")],
+      edges: [
+        edge("depends_on:consumer->provider", "squad:consumer", "squad:provider", "depends_on"),
+        edge("feeds:provider->consumer", "squad:provider", "squad:consumer", "feeds"),
+      ],
+    };
+    expect(validateGraph(g)).toEqual([]);
+    expect(buildOrder(g).order.map((n) => n.id)).toEqual(["squad:provider", "squad:consumer"]);
+  });
+});

--- a/skills/_shared/tests/entity-graph.test.ts
+++ b/skills/_shared/tests/entity-graph.test.ts
@@ -11,7 +11,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildEntityGraph, readCloneBindings, refToSlug, slugOf } from "../lib/entity-graph.ts";
+import { buildEntityGraph, readCloneBindings, readSquadComposition, refToSlug, slugOf } from "../lib/entity-graph.ts";
 import { buildOrderOrThrow, closure } from "../lib/dependency-graph.ts";
 
 const roots: string[] = [];
@@ -141,5 +141,142 @@ describe("buildEntityGraph", () => {
     });
     expect(g.nodes.map((n) => n.id)).toEqual(["squad:my-squad"]);
     expect(g.edges).toEqual([]);
+  });
+});
+
+// ── squad composition (Squad Protocol v6 §31) ────────────────────────────────
+// `requires[]` names capability ids, `consumes[]` names `produces` slugs. Both
+// become edges only when the provider is UNAMBIGUOUS: with 3.024 capability
+// entries across 204 installed squads, guessing a provider would silently
+// invent an execution order nobody declared.
+
+function squad(dir: string, slug: string, capabilities: unknown[]) {
+  const s = join(dir, "squads", slug);
+  mkdirSync(s, { recursive: true });
+  const caps = capabilities
+    .map((c) => {
+      const cap = c as Record<string, string[] | string>;
+      const list = (key: string) =>
+        Array.isArray(cap[key]) ? `\n    ${key}:\n${(cap[key] as string[]).map((v) => `      - ${v}`).join("\n")}` : "";
+      return `  - id: ${cap.id}${list("produces")}${list("requires")}${list("consumes")}`;
+    })
+    .join("\n");
+  writeFileSync(join(s, "squad.yaml"), `name: ${slug}\nversion: 1.0.0\nprotocol: "6.0"\ncapabilities:\n${caps}\n`);
+  return s;
+}
+const squadRoots = (pack: string) => ({
+  businessesDir: join(pack, "businesses"),
+  clonesDir: join(pack, "mind-clones"),
+  squadsDir: join(pack, "squads"),
+});
+
+describe("readSquadComposition", () => {
+  test("a single provider becomes a depends_on edge, provider first", () => {
+    const pack = packFixture();
+    squad(pack, "provider", [{ id: "design.brand.identity", produces: ["brand_kit"] }]);
+    squad(pack, "consumer", [{ id: "content.social.plan", requires: ["design.brand.identity"] }]);
+
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.issues).toEqual([]);
+    expect(scan.edges.map((e) => [e.type, e.source, e.target])).toEqual([
+      ["depends_on", "squad:consumer", "squad:provider"],
+    ]);
+
+    const g = buildEntityGraph(squadRoots(pack));
+    expect(g.edges.length).toBe(1);
+    const order = buildOrderOrThrow(g).map((n) => n.id);
+    expect(order.indexOf("squad:provider")).toBeLessThan(order.indexOf("squad:consumer"));
+  });
+
+  test("two providers of the same capability id yield no edge and x_requires_ambiguous", () => {
+    const pack = packFixture();
+    squad(pack, "zeta-provider", [{ id: "design.brand.identity" }]);
+    squad(pack, "alpha-provider", [{ id: "design.brand.identity" }]);
+    squad(pack, "consumer", [{ id: "content.social.plan", requires: ["design.brand.identity"] }]);
+
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.edges).toEqual([]);
+    expect(scan.issues).toEqual([{
+      code: "x_requires_ambiguous",
+      kind: "requires",
+      reason: "ambiguous",
+      squad: "consumer",
+      capability: "content.social.plan",
+      ref: "design.brand.identity",
+      candidates: ["alpha-provider", "zeta-provider"],
+    }]);
+  });
+
+  test("an explicit slug: prefix picks the provider the ambiguity hid", () => {
+    const pack = packFixture();
+    squad(pack, "zeta-provider", [{ id: "design.brand.identity" }]);
+    squad(pack, "alpha-provider", [{ id: "design.brand.identity" }]);
+    squad(pack, "consumer", [{ id: "content.social.plan", requires: ["zeta-provider:design.brand.identity"] }]);
+
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.issues).toEqual([]);
+    expect(scan.edges.map((e) => [e.source, e.target])).toEqual([["squad:consumer", "squad:zeta-provider"]]);
+  });
+
+  test("an explicit prefix naming a squad that is not installed is unresolved", () => {
+    const pack = packFixture();
+    squad(pack, "consumer", [{ id: "content.social.plan", requires: ["ghost-squad:design.brand.identity"] }]);
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.edges).toEqual([]);
+    expect(scan.issues.map((i) => [i.code, i.ref])).toEqual([["x_requires_unresolved", "ghost-squad:design.brand.identity"]]);
+    expect(scan.issues[0].candidates).toEqual([]);
+  });
+
+  test("a requires nobody provides is unresolved; a squad's own capability is not", () => {
+    const pack = packFixture();
+    squad(pack, "lonely", [
+      { id: "content.social.plan", requires: ["design.brand.identity", "content.social.audit"] },
+      { id: "content.social.audit" },
+    ]);
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.edges).toEqual([]);
+    expect(scan.issues.map((i) => [i.code, i.ref])).toEqual([["x_requires_unresolved", "design.brand.identity"]]);
+  });
+
+  test("consumes becomes feeds with one provider of the slug, nothing with two", () => {
+    const pack = packFixture();
+    squad(pack, "maker", [{ id: "design.brand.identity", produces: ["brand_kit"] }]);
+    squad(pack, "rival", [{ id: "design.brand.rebuild", produces: ["style_guide"] }]);
+    squad(pack, "twin", [{ id: "design.brand.copy", produces: ["style_guide"] }]);
+    squad(pack, "consumer", [{ id: "content.social.plan", consumes: ["brand_kit", "style_guide"] }]);
+
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.edges.map((e) => [e.type, e.source, e.target])).toEqual([
+      ["feeds", "squad:maker", "squad:consumer"],
+    ]);
+    expect(scan.issues.map((i) => [i.code, i.ref, i.candidates])).toEqual([
+      ["x_consumes_ambiguous", "style_guide", ["rival", "twin"]],
+    ]);
+  });
+
+  test("two capabilities of one squad requiring the same provider yield one edge", () => {
+    const pack = packFixture();
+    squad(pack, "provider", [{ id: "design.brand.identity", produces: ["brand_kit"] }]);
+    squad(pack, "consumer", [
+      { id: "content.social.plan", requires: ["design.brand.identity"] },
+      { id: "content.social.audit", requires: ["design.brand.identity"], consumes: ["brand_kit"] },
+    ]);
+    const scan = readSquadComposition(squadRoots(pack));
+    expect(scan.edges.map((e) => e.id)).toEqual([
+      "depends_on:consumer->provider",
+      "feeds:provider->consumer",
+    ]);
+  });
+
+  test("a squad.yaml that does not parse costs the graph nothing", () => {
+    const pack = packFixture();
+    mkdirSync(join(pack, "squads", "broken"), { recursive: true });
+    writeFileSync(join(pack, "squads", "broken", "squad.yaml"), "name: broken\ncapabilities: [ unterminated\n");
+    squad(pack, "provider", [{ id: "design.brand.identity" }]);
+    squad(pack, "consumer", [{ id: "content.social.plan", requires: ["design.brand.identity"] }]);
+
+    const g = buildEntityGraph(squadRoots(pack));
+    expect(g.nodes.map((n) => n.id).sort()).toEqual(["squad:broken", "squad:consumer", "squad:provider"]);
+    expect(g.edges.length).toBe(1);
   });
 });

--- a/skills/_shared/tests/verify-backup.test.ts
+++ b/skills/_shared/tests/verify-backup.test.ts
@@ -7,6 +7,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { BACKUP_KEEP, createBackup, listBackups, mindCloneModule, verifyEntity, type KindModule } from "../lib/verify/index.ts";
 import { cloneFixture, rmrf, runCli, tempRoot, treeDigest } from "./helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const ROOTS: string[] = [];
 afterAll(() => { for (const r of ROOTS) rmrf(r); });
@@ -33,7 +34,7 @@ describe("backup", () => {
     expect(treeDigest(backups[0])).toEqual(before);
     expect(treeDigest(dir)).not.toEqual(before);
     expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).not.toContain("delegates_to");
-  });
+  }, spawnBudgetMs(2));
 
   test("no fixer to run → no backup", async () => {
     const r = root();
@@ -41,7 +42,7 @@ describe("backup", () => {
     const report = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical" });
     expect(report.fix_outcome).toMatchObject({ mode: "mechanical", backup: null, rolled_back: false });
     expect(listBackups("mind-clone", "jane-doe", path.join(r, "backups"))).toEqual([]);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("rollback", () => {
@@ -52,7 +53,7 @@ describe("rollback", () => {
     const module = sabotaged("delegates_to_strip", ({ dir: d }) => {
       fs.writeFileSync(path.join(d, "agent", "SOUL.md"), "", "utf8");
       throw new Error("boom");
-    });
+    }, spawnBudgetMs(2));
     const report = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module });
     expect(report.fix_outcome?.rolled_back).toBe(true);
     expect(report.fix_outcome?.rollback_reason).toContain("boom");
@@ -67,7 +68,7 @@ describe("rollback", () => {
     const module = sabotaged("delegates_to_strip", ({ dir: d, finding }) => {
       fs.writeFileSync(path.join(d, "MANIFEST.yaml"), "manifest: [unclosed\n", "utf8");
       return { fixer: "delegates_to_strip", finding: finding.id, applied: true, changed_files: ["MANIFEST.yaml"] };
-    });
+    }, spawnBudgetMs(2));
     const report = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module });
     expect(report.fix_outcome?.rolled_back).toBe(true);
     expect(report.fix_outcome?.rollback_reason).toContain("manifest");
@@ -82,7 +83,7 @@ describe("rollback", () => {
     const deletesSoul = sabotaged("delegates_to_strip", ({ dir: d, finding }) => {
       fs.rmSync(path.join(d, "agent", "SOUL.md"));
       return { fixer: "delegates_to_strip", finding: finding.id, applied: true, changed_files: ["agent/SOUL.md"] };
-    });
+    }, spawnBudgetMs(2));
     const rolled = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module: deletesSoul });
     expect(rolled.fix_outcome?.rolled_back).toBe(true);
     expect(rolled.fix_outcome?.rollback_reason).toContain("artifact_missing:agent/SOUL.md");
@@ -118,7 +119,7 @@ describe("idempotence and retention", () => {
     expect(second.json.fixes.filter((f: any) => f.applied)).toEqual([]);
     expect(second.json.fix_outcome.backup).toBeNull();
     expect(treeDigest(dir)).toEqual(after);
-  });
+  }, spawnBudgetMs(2));
 
   test(`only the newest ${BACKUP_KEEP} backups of an entity are kept`, () => {
     const r = root();
@@ -129,7 +130,7 @@ describe("idempotence and retention", () => {
     expect(kept.length).toBe(BACKUP_KEEP);
     expect(kept).toEqual(made.slice(-BACKUP_KEEP));
     expect(fs.existsSync(made[0])).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 
   test("a same-millisecond collision keeps listing order equal to creation order", () => {
     // The retention rule is "the newest BACKUP_KEEP", and it reads that order off
@@ -146,5 +147,5 @@ describe("idempotence and retention", () => {
     expect(listed.length).toBe(2);
     expect(listed).toEqual([first, second]);
     expect(fs.existsSync(parent)).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/verify-baseline.test.ts
+++ b/skills/_shared/tests/verify-baseline.test.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { applyBaseline, importLegacy, loadBaseline, recordBaseline, verifyEntity, type Finding } from "../lib/verify/index.ts";
 import { cloneFixture, rmrf, runCli, tempRoot } from "./helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const ROOTS: string[] = [];
 afterAll(() => { for (const r of ROOTS) rmrf(r); });
@@ -26,7 +27,7 @@ describe("merge and regression", () => {
     expect(read(file).entities).toEqual({ "mind-clone:a": ["validation_verdict_missing"], "mind-clone:b": ["source_material_missing"] });
     expect(recordBaseline(file, [{ kind: "mind-clone", slug: "a", debt: [] }]).ok).toBe(true);
     expect(read(file).entities).toEqual({ "mind-clone:b": ["source_material_missing"] });
-  });
+  }, spawnBudgetMs(2));
 
   test("growth is refused without allowRegression, and named", () => {
     const r = root();
@@ -39,12 +40,12 @@ describe("merge and regression", () => {
     const allowed = recordBaseline(file, [{ kind: "mind-clone", slug: "a", debt: ["validation_verdict_missing", "source_material_missing"] }], { allowRegression: true });
     expect(allowed.ok).toBe(true);
     expect(read(file).entities["mind-clone:a"]).toEqual(["source_material_missing", "validation_verdict_missing"]);
-  });
+  }, spawnBudgetMs(2));
 
   test("a first record with no baseline is never a regression", () => {
     const r = root();
     expect(recordBaseline(bl(r), [{ kind: "business", slug: "x", debt: ["seat_thin:employees/ceo.md"] }]).ok).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("applyBaseline", () => {
@@ -54,7 +55,7 @@ describe("applyBaseline", () => {
     const baseline = { recorded_at: "t", entities: { "business:acme": ["validation_verdict_missing", "seat_thin:employees/ceo.md", "one_liner_too_long"] } };
     applyBaseline("business", "acme", findings, new Set(["validation_verdict_missing", "seat_thin"]), baseline);
     expect(findings.map((f) => f.baselined)).toEqual([true, true, false, false]);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("legacy import", () => {
@@ -71,7 +72,7 @@ describe("legacy import", () => {
       "business:acme": ["seat_thin:employees/ceo.md", "seat_thin:employees/cto.md"],
       "business:beta": ["seat_thin:employees/ops.md"],
       "mind-clone:jane": ["source_material_missing", "validation_verdict_missing"],
-    });
+    }, spawnBudgetMs(2));
     expect(b?.imported_from?.length).toBe(2);
     expect(fs.existsSync(bl(r))).toBe(true);
     // second load reads the written file: the legacy files are not consulted again
@@ -84,7 +85,7 @@ describe("legacy import", () => {
     const r = root();
     expect(loadBaseline(bl(r))).toBeNull();
     expect(fs.existsSync(bl(r))).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("grandfathering", () => {
@@ -109,7 +110,7 @@ describe("grandfathering", () => {
     cloneFixture(r2, "jane-doe", { verdict: null });
     expect(runCli(r2, ["mind-clone", "jane-doe", "--strict", "--no-retrieval"]).code).toBe(2);
     expect(fs.existsSync(bl(r2))).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 
   test("--all --record then --all --strict: recorded debt no longer rejects; growth is refused", () => {
     const r = root();
@@ -134,5 +135,5 @@ describe("grandfathering", () => {
     const other = path.join(r, "other-baseline.json");
     expect(runCli(r, ["mind-clone", "--all", "--record", "--baseline", other, ...rootArg]).code).toBe(0);
     expect(fs.existsSync(other)).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/verify-runner.test.ts
+++ b/skills/_shared/tests/verify-runner.test.ts
@@ -7,6 +7,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { businessFixture, cloneFixture, rmrf, runCli, squadFixture, tempRoot } from "./helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const ROOTS: string[] = [];
 afterAll(() => { for (const r of ROOTS) rmrf(r); });
@@ -23,7 +24,7 @@ describe("exit codes", () => {
     const bySlug = runCli(r, ["mind-clone", "jane-doe", "--no-retrieval"]);
     expect(bySlug.code).toBe(0);
     for (const alias of ["clone", "mc"]) expect(runCli(r, [alias, "jane-doe", "--no-retrieval"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("an error rejects (1)", () => {
     const r = root();
@@ -33,7 +34,7 @@ describe("exit codes", () => {
     expect(out.code).toBe(1);
     expect(out.stdout).toContain("artifact_missing:agent/SOUL.md");
     expect(out.stdout).toContain("REJECTED");
-  });
+  }, spawnBudgetMs(2));
 
   test("warnings only: 0 by default, 2 under --strict", () => {
     const r = root();
@@ -42,7 +43,7 @@ describe("exit codes", () => {
     const strict = runCli(r, ["mind-clone", "jane-doe", "--no-retrieval", "--strict"]);
     expect(strict.code).toBe(2);
     expect(strict.stdout).toContain("one_liner_too_long");
-  });
+  }, spawnBudgetMs(2));
 
   test("usage errors and unknown entities exit 64", () => {
     const r = root();
@@ -55,7 +56,7 @@ describe("exit codes", () => {
     expect(agentic.code).toBe(64);
     expect(agentic.stderr).toContain("not available yet");
     expect(runCli(r, ["--help"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("--json", () => {
@@ -81,7 +82,7 @@ describe("--json", () => {
     expect(j.fix_outcome).toBeNull();
     expect(j.baseline).toEqual({ present: false, debt: 0 });
     expect(j.exit_code).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("registry_absent is an info finding that never changes the verdict", () => {
     const r = root();
@@ -91,7 +92,7 @@ describe("--json", () => {
     const info = out.json.findings.find((x: any) => x.id === "registry_absent");
     expect(info?.severity).toBe("info");
     expect(out.json.summary.warnings).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("--all and --pack", () => {
@@ -111,7 +112,7 @@ describe("--all and --pack", () => {
     const text = runCli(r, ["mind-clone", "--all", "--root", path.join(r, "dna"), "--no-retrieval", "--quiet"]);
     expect(text.stdout).toContain("beta");
     expect(text.stdout).not.toContain("alpha");
-  });
+  }, spawnBudgetMs(2));
 
   test("--all uses the installed root when no --root is given", () => {
     const r = root();
@@ -119,7 +120,7 @@ describe("--all and --pack", () => {
     const out = runCli(r, ["mind-clone", "--all", "--json", "--no-retrieval"]);
     expect(out.code).toBe(0);
     expect(out.json.entities).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("--pack walks <dir>/{squads,businesses,mind-clones}", () => {
     const r = root();
@@ -138,7 +139,7 @@ describe("--all and --pack", () => {
     expect(out.json.reports.find((x: any) => x.slug === "one-squad").findings.map((f: any) => f.id)).toContain("surface_missing");
     expect(runCli(r, ["--pack", pack, "mind-clone", "--json"]).json.entities).toBe(1);
     expect(fs.existsSync(path.join(r, "state", "gamma"))).toBe(false); // pack entities are not installed: no state
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("kinds", () => {
@@ -158,7 +159,7 @@ describe("kinds", () => {
     expect(runCli(r, ["squad", "one-squad", "--json"]).json.verdict).toBe("ADMITTED");
     expect(runCli(r, ["biz", "one-biz"]).code).toBe(0);
     expect(runCli(r, ["business", "one-biz", "--strict"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("a manifest that does not parse is manifest_parse", () => {
     const r = root();
@@ -168,7 +169,7 @@ describe("kinds", () => {
     expect(out.json.findings.map((f: any) => f.id)).toContain("manifest_parse");
     // a squad path the kind does not own is unknown, not a crash
     expect(runCli(r, ["business", squad]).code).toBe(64);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("side effects", () => {
@@ -183,5 +184,5 @@ describe("side effects", () => {
     const log = fs.readFileSync(path.join(r, "logs", day, "audit.jsonl"), "utf8");
     const ev = log.split("\n").filter(Boolean).map((l) => JSON.parse(l)).find((e) => e.event === "x_verify_mind_clone");
     expect(ev).toMatchObject({ slug: "jane-doe", verdict: "ADMITTED", exit_code: 0 });
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/verify-squad.test.ts
+++ b/skills/_shared/tests/verify-squad.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { createRequire } from "node:module";
 import { parse as parseYaml } from "yaml";
 import { CANONICAL_WORKFLOW, rmrf, runCli, squadFixture, tempRoot, treeDigest, writeSurfaceFor } from "./helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 import { criteria as squadCriteria, squadModule } from "../lib/verify/kinds/squad.ts";
 import { WORKFLOW_LINT_IDS } from "../../squads/lib/workflow-reader.ts";
 
@@ -70,7 +71,7 @@ describe("catalog integrity", () => {
     // The surface is always regenerated last: a fixer that rewrote the
     // manifest after it would leave the entity reporting surface_stale.
     expect(squadModule.fixOrder[squadModule.fixOrder.length - 1]).toBe("surface_regen");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the dialect corpus, judged by protocol", () => {
@@ -92,7 +93,7 @@ describe("the dialect corpus, judged by protocol", () => {
         const code = runCli(r, ["squad", slug, "--no-retrieval"]).code;
         expect(code).toBe(protocol === "6.0" ? 1 : 0);
       }
-    });
+    }, spawnBudgetMs(2));
   }
 
   test("a v6 Markdown workflow with a canonical graph is admitted with no workflow finding", () => {
@@ -106,7 +107,7 @@ describe("the dialect corpus, judged by protocol", () => {
         "        description: the artifact exists after the build step",
         "        blocking: true",
       ],
-    });
+    }, spawnBudgetMs(2));
     const f = findings(r, "clean-v6");
     expect(idsOf(f).filter((id) => id.startsWith("workflow_"))).toEqual([]);
     expect(idsOf(f)).not.toContain("protocol_below_6");
@@ -123,7 +124,7 @@ describe("the dialect corpus, judged by protocol", () => {
       expect(severityOf(f, "workflow_unnormalizable")).toBe("warning");
       expect(runCli(r, ["squad", slug, "--no-retrieval"]).code).toBe(0);
     }
-  });
+  }, spawnBudgetMs(2));
 
   test("a twin, an orphan and an over-long body each get their own finding", () => {
     const r = root();
@@ -133,7 +134,7 @@ describe("the dialect corpus, judged by protocol", () => {
         "main.md": `---\nname: main\n---\n\n## plan\n\n${"word ".repeat(3000)}\n`,
         "spare.yaml": CANONICAL_WORKFLOW.replace("name: main", "name: spare"),
       },
-    });
+    }, spawnBudgetMs(2));
     const f = findings(r, "twins");
     expect(idsOf(f)).toContain("workflow_twin");
     expect(f.find((x) => x.id === "workflow_twin")!.where).toBe("main.md");
@@ -148,7 +149,7 @@ describe("the dialect corpus, judged by protocol", () => {
     expect(severityOf(findings(r, "case-v6"), "workflow_stem_case")).toBe("error");
     squadFixture(r, "case-v5", { workflows: { "Main.yaml": CANONICAL_WORKFLOW }, workflowComponent: "Main.yaml", invokeRef: "workflows/Main.yaml" });
     expect(severityOf(findings(r, "case-v5"), "workflow_stem_case")).toBe("warning");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("exit codes", () => {
@@ -159,7 +160,7 @@ describe("exit codes", () => {
     const strict = runCli(r, ["squad", "clean", "--no-retrieval", "--strict"]);
     expect(strict.code).toBe(2);
     expect(strict.stdout).toContain("protocol_below_6");
-  });
+  }, spawnBudgetMs(2));
 
   test("an error rejects (1): a manifest the schema refuses", () => {
     const r = root();
@@ -167,14 +168,14 @@ describe("exit codes", () => {
     const out = runCli(r, ["squad", "no-components", "--no-retrieval"]);
     expect(out.code).toBe(1);
     expect(out.stdout).toContain("manifest_schema");
-  });
+  }, spawnBudgetMs(2));
 
   test("a capability invoking a workflow that is not on disk is an error under either protocol", () => {
     const r = root();
     squadFixture(r, "no-workflow", { invokeRef: "workflows/absent.yaml" });
     const f = findings(r, "no-workflow");
     expect(severityOf(f, "invoke_ref_unresolved")).toBe("error");
-  });
+  }, spawnBudgetMs(2));
 
   test("a declared component that is not on disk is an error", () => {
     const r = root();
@@ -182,7 +183,7 @@ describe("exit codes", () => {
     fs.writeFileSync(path.join(dir, "squad.yaml"), fs.readFileSync(path.join(dir, "squad.yaml"), "utf8").replace("tasks: [plan, build]", "tasks: [plan, build, ghost]"), "utf8");
     writeSurfaceFor(dir, "squad");
     expect(severityOf(findings(r, "ghost-component"), "components_missing")).toBe("error");
-  });
+  }, spawnBudgetMs(2));
 
   test("a run-output directory inside the squad is an error", () => {
     const r = root();
@@ -190,7 +191,7 @@ describe("exit codes", () => {
     fs.mkdirSync(path.join(dir, "outputs"));
     fs.writeFileSync(path.join(dir, "outputs", "run.md"), "leftover\n", "utf8");
     expect(severityOf(findings(r, "polluted"), "outputs_pollution")).toBe("error");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the advisory catalog", () => {
@@ -205,7 +206,7 @@ describe("the advisory catalog", () => {
     const f = findings(r, "thin-routing");
     expect(severityOf(f, "routing_metadata_incomplete")).toBe("warning");
     expect(f.find((x) => x.id === "routing_metadata_incomplete")!.where).toBe("fixture.artifact.build");
-  });
+  }, spawnBudgetMs(2));
 
   test("a not_for entry longer than 25 chars: warning under 5.0, error under 6.0", () => {
     const r = root();
@@ -220,13 +221,13 @@ describe("the advisory catalog", () => {
       expect(severityOf(f, "not_for_too_long")).toBe(protocol === "6.0" ? "error" : "warning");
       expect(idsOf(f)).toContain("not_for_dead");
     }
-  });
+  }, spawnBudgetMs(2));
 
   test("fidelity validated with no ground truth on disk", () => {
     const r = root();
     squadFixture(r, "unproven", { capabilityExtra: ["    fidelity:", "      status: validated", "      ground_truth_dir: eval/ground-truth"] });
     expect(severityOf(findings(r, "unproven"), "fidelity_validated_unproven")).toBe("warning");
-  });
+  }, spawnBudgetMs(2));
 
   test("requires and consumes with no provider in reach", () => {
     const r = root();
@@ -234,7 +235,7 @@ describe("the advisory catalog", () => {
     const f = findings(r, "composer").filter((x) => x.id === "requires_no_provider");
     expect(f).toHaveLength(2);
     expect(severityOf(f, "requires_no_provider")).toBe("warning");
-  });
+  }, spawnBudgetMs(2));
 
   test("component quality: a thin agent, a task with no acceptance criteria, no README, no dependency manifest", () => {
     const r = root();
@@ -249,7 +250,7 @@ describe("the advisory catalog", () => {
       expect(ids).toContain(id);
     }
     expect(runCli(r, ["squad", "thin-components", "--no-retrieval"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("per-buyer distribution artifacts are reported, never rejected: an installed copy is legitimate", () => {
     const r = root();
@@ -260,7 +261,7 @@ describe("the advisory catalog", () => {
     const f = findings(r, "installed-copy").find((x) => x.id === "distribution_artifacts")!;
     expect(f.severity).toBe("warning");
     expect(runCli(r, ["squad", "installed-copy", "--no-retrieval"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("the evaluator capability without its block: warning under 5.0, error under 6.0", () => {
     const r = root();
@@ -272,7 +273,7 @@ describe("the advisory catalog", () => {
       writeSurfaceFor(dir, "squad");
       expect(severityOf(findings(r, slug), "evaluator_missing")).toBe(protocol === "6.0" ? "error" : "warning");
     }
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("--fix", () => {
@@ -282,7 +283,7 @@ describe("--fix", () => {
       protocol: "6.0",
       workflows: { "main.md": `---\n${INLINE_PROSE}---\n\n## intro\n\nExisting prose.\n` },
       workflowComponent: "main.md", invokeRef: "workflows/main.md",
-    });
+    }, spawnBudgetMs(2));
     fs.writeFileSync(path.join(dir, "agents", "planner.md"), "---\nname: planner\ndescription: planner\n---\n\n# planner\n", "utf8");
     fs.writeFileSync(path.join(dir, "tasks", "plan.md"), "# plan\n\nJust prose.\n", "utf8");
     fs.rmSync(path.join(dir, "README.md"));
@@ -305,7 +306,7 @@ describe("--fix", () => {
       protocol: "6.0",
       workflows: { "main.md": `---\n${INLINE_PROSE}---\n\n## intro\n\nExisting prose.\n` },
       workflowComponent: "main.md", invokeRef: "workflows/main.md",
-    });
+    }, spawnBudgetMs(2));
     runCli(r, ["squad", "prose", "--no-retrieval", "--fix"]);
     const text = fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8");
     expect(text).toContain("## intro");
@@ -327,13 +328,13 @@ describe("--fix", () => {
     expect(manifest.capabilities[0].invoke.ref).toBe("workflows/main");
     expect(manifest.components.workflows).toEqual(["main"]);
     expect(idsOf(findings(r, "extension"))).not.toContain("invoke_ref_extension");
-  });
+  }, spawnBudgetMs(2));
 
   test("outputs_shape_repair promotes a singular `output` and drops the keys the schema refuses", () => {
     const r = root();
     const dir = squadFixture(r, "outputs", {
       capabilityExtra: ["    output:", "      name: report", "      type: markdown", "      humanize: true"],
-    });
+    }, spawnBudgetMs(2));
     writeSurfaceFor(dir, "squad");
     expect(idsOf(findings(r, "outputs"))).toContain("capability_outputs_shape");
     runCli(r, ["squad", "outputs", "--no-retrieval", "--fix"]);
@@ -347,7 +348,7 @@ describe("--fix", () => {
     const r = root();
     const dir = squadFixture(r, "merge", {
       workflows: { "main.yaml": CANONICAL_WORKFLOW, "main.md": "---\nname: main\n---\n\n## plan\n\nThe body that survives.\n" },
-    });
+    }, spawnBudgetMs(2));
     runCli(r, ["squad", "merge", "--no-retrieval", "--fix"]);
     expect(fs.existsSync(path.join(dir, "workflows", "main.yaml"))).toBe(false);
     const merged = fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8");
@@ -367,7 +368,7 @@ describe("--fix", () => {
     const r = root();
     const dir = squadFixture(r, "renames", {
       workflows: { "main.yaml": "name: main\nsteps:\n  - id: plan\n    agent: planner\n    task: PLAN\n  - id: build\n    agent: Builder\n    task: nowhere\n" },
-    });
+    }, spawnBudgetMs(2));
     runCli(r, ["squad", "renames", "--no-retrieval", "--fix"]);
     const text = fs.readFileSync(path.join(dir, "workflows", "main.yaml"), "utf8");
     expect(text).toContain("task: plan");
@@ -384,7 +385,7 @@ describe("--fix", () => {
     const dir = squadFixture(r, "byoutput", {
       protocol: "6.0", workflows: { "main.md": `---\n${graph}---\n` },
       workflowComponent: "main", invokeRef: "workflows/main",
-    });
+    }, spawnBudgetMs(2));
     expect(idsOf(findings(r, "byoutput"))).toContain("workflow_requires_by_output");
     runCli(r, ["squad", "byoutput", "--no-retrieval", "--fix"]);
     const graphAfter = parseYaml(fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8").split("---")[1]);
@@ -399,7 +400,7 @@ describe("--fix", () => {
     const note = out.json.fixes.find((x: any) => x.fixer === "workflow_normalize_shape").note;
     expect(note).toContain("nrv migrate --to 6");
     expect(fs.readFileSync(path.join(dir, "workflows", "main.yaml"), "utf8")).toBe(AGENT_SEQUENCE);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the audit scorer after `humanize`", () => {
@@ -408,7 +409,7 @@ describe("the audit scorer after `humanize`", () => {
     expect(criteria.CRITERIA).toHaveLength(13);
     expect(criteria.CRITERIA.find((c: any) => c.id === 9).name).toBe("acceptance");
     expect(criteria.CRITERIA.some((c: any) => c.name === "humanize")).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 
   test("c9 scores acceptance[] and the acceptance criteria of an invoked task", () => {
     const r = root();
@@ -417,7 +418,7 @@ describe("the audit scorer after `humanize`", () => {
 
     const declared = squadFixture(r, "c9-acceptance", {
       capabilityExtra: ["    acceptance:", "      - id: built", "        description: the artifact exists"],
-    });
+    }, spawnBudgetMs(2));
     const c9 = criteria.scoreSquad(declared).breakdown.find((b: any) => b.id === 9);
     expect(c9.score).toBe(6);
     expect(c9.evidence).toContain("1/1");
@@ -432,7 +433,7 @@ describe("the audit scorer after `humanize`", () => {
     const r = root();
     const dir = squadFixture(r, "retired-fixer", {
       capabilityExtra: ["    output:", "      name: report", "      type: markdown", "      humanize: true"],
-    });
+    }, spawnBudgetMs(2));
     const results = fixers.applyMechanicalFixes(dir, { patches: [{ kind: "humanize_default_true" }, { kind: "outputs_shape_repair" }] });
     expect(results[0].result.ok).toBe(false);
     expect(results[0].result.reason).toBe("unknown patch kind");
@@ -452,5 +453,5 @@ describe("the audit scorer after `humanize`", () => {
     const front = /^---\n([\s\S]*?)\n---/.exec(text)![1];
     expect(parseYaml(front).tools).toEqual(["Read", "Write", "Edit", "Bash", "Grep", "Glob"]);
     expect(parseYaml(front).maxTurns).toBe(12);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/lib/plan-compiler.ts
+++ b/skills/harness/lib/plan-compiler.ts
@@ -18,6 +18,7 @@ import {
   toDagNodes,
   validateGraph,
   type DependencyGraph,
+  type GraphEdge,
   type GraphIssue,
   type GraphNode,
 } from "../../_shared/lib/dependency-graph.ts";
@@ -195,9 +196,10 @@ function dependentCounts(manifest: CompiledManifest): Map<string, number> {
  */
 export function compileMultiTargetGauntletPolicy(
   graph: DependencyGraph,
-  policy?: MultiTargetGauntletPolicy
+  policy?: MultiTargetGauntletPolicy,
+  opts: CompileManifestOptions = {}
 ): { plan: CompiledMultiTargetPlan | null; issues: MultiTargetPolicyIssue[] } {
-  const compiled = compileManifest(graph);
+  const compiled = compileManifest(graph, opts);
   if (!compiled.manifest) return { plan: null, issues: compiled.issues };
   const manifest = compiled.manifest;
   const issues: MultiTargetPolicyIssue[] = [];
@@ -340,6 +342,54 @@ export function compileMultiTargetGauntletPolicy(
   return { plan: { ...snapshot, digest }, issues: [] };
 }
 
+export interface CompileManifestOptions {
+  parallelSafe?: (n: GraphNode) => boolean;
+  /**
+   * The derived entity graph (skills/_shared/lib/entity-graph.ts). Supplying
+   * it lets the plan read the composition the squads already declare instead
+   * of demanding the author restate it. Omitted — which is every caller
+   * today — the compilation is bit-for-bit the one that shipped before.
+   */
+  composition?: DependencyGraph;
+}
+
+/** A plan node's squad slug: what its payload says, else its id unprefixed. */
+function squadSlug(nodes: GraphNode[], id: string): string {
+  const node = nodes.find((n) => n.id === id);
+  return String(node?.payload?.slug ?? id.replace(/^squad:/, ""));
+}
+
+/**
+ * Squad Protocol v6 §31 order, inherited. When two `squad` nodes of the plan
+ * are the endpoints of a `depends_on` edge of the composition graph, the plan
+ * gets that order without the author writing it. Two rules keep it honest:
+ * the author always wins (a pair already joined by an edge, in EITHER
+ * direction, is left exactly as declared), and nothing is inherited for a
+ * squad the plan does not name.
+ */
+function inheritedCompositionEdges(graph: DependencyGraph, composition: DependencyGraph): GraphEdge[] {
+  const planned = new Map<string, string>();
+  for (const node of graph.nodes) {
+    if (node.type === "squad") planned.set(squadSlug(graph.nodes, node.id), node.id);
+  }
+  if (planned.size < 2) return [];
+  const authored = new Set(graph.edges.flatMap((e) => [`${e.source} ${e.target}`, `${e.target} ${e.source}`]));
+  const inherited: GraphEdge[] = [];
+  const seen = new Set<string>();
+  for (const edge of composition.edges) {
+    if (edge.type !== "depends_on") continue;
+    const consumer = planned.get(squadSlug(composition.nodes, edge.source));
+    const provider = planned.get(squadSlug(composition.nodes, edge.target));
+    if (!consumer || !provider || consumer === provider) continue;
+    if (authored.has(`${consumer} ${provider}`)) continue;
+    const id = `inherited:depends_on:${consumer}->${provider}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    inherited.push({ id, source: consumer, target: provider, type: "depends_on", meta: { inherited_from: edge.id } });
+  }
+  return inherited;
+}
+
 /**
  * One phase per graph node, dependencies from the effective dependency
  * direction (dependencyPair — `employee embodies mind_clone` compiles to the
@@ -349,8 +399,11 @@ export function compileMultiTargetGauntletPolicy(
  */
 export function compileManifest(
   graph: DependencyGraph,
-  opts: { parallelSafe?: (n: GraphNode) => boolean } = {}
+  opts: CompileManifestOptions = {}
 ): { manifest: CompiledManifest | null; issues: GraphIssue[] } {
+  const inherited = opts.composition ? inheritedCompositionEdges(graph, opts.composition) : [];
+  if (inherited.length) graph = { nodes: graph.nodes, edges: [...graph.edges, ...inherited] };
+
   const issues = validateGraph(graph);
   if (issues.length) return { manifest: null, issues };
 

--- a/skills/harness/scripts/graph.ts
+++ b/skills/harness/scripts/graph.ts
@@ -21,7 +21,7 @@ import {
   validateGraph,
   type GraphNode,
 } from "../../_shared/lib/dependency-graph.ts";
-import { buildEntityGraph, installKindOrder, readCloneBindings, resolveRoots } from "../../_shared/lib/entity-graph.ts";
+import { buildEntityGraph, installKindOrder, readCloneBindings, readSquadComposition, resolveRoots } from "../../_shared/lib/entity-graph.ts";
 
 const RED = "\x1b[31m", GRN = "\x1b[32m", YEL = "\x1b[33m", DIM = "\x1b[2m", BOLD = "\x1b[1m", RST = "\x1b[0m";
 
@@ -92,14 +92,26 @@ if (sub === "closure") {
   const issues = validateGraph(graph);
   const scan = readCloneBindings(roots);
   const missing = scan.bindings.filter((b) => !b.dangling && !scan.availableClones.has(b.clone));
+  // Composition (Squad Protocol v6 §31). A `requires` that resolves to nothing
+  // is a broken declaration — the capability is not in the library and no
+  // ordering can supply it — so --strict fails on it. Ambiguity is a different
+  // finding: the capability exists, twice, and the library already carries
+  // duplicate ids, so it is reported and never fatal.
+  const composition = readSquadComposition(roots).issues;
+  const orphans = composition.filter((c) => c.kind === "requires" && c.reason === "unresolved");
   if (asJson) {
-    console.log(JSON.stringify({ issues, missing }, null, 2));
+    console.log(JSON.stringify({ issues, missing, composition }, null, 2));
   } else {
     console.log(`\n${BOLD}GRAPH CHECK${RST}`);
-    console.log(`  ${graph.nodes.length} nodes · ${graph.edges.length} edges · ${issues.length} structural issue(s) · ${missing.length} unresolved binding(s)`);
+    console.log(`  ${graph.nodes.length} nodes · ${graph.edges.length} edges · ${issues.length} structural issue(s) · ${missing.length} unresolved binding(s) · ${composition.length} composition finding(s)`);
     for (const i of issues.slice(0, 12)) console.log(`  ${RED}✗${RST} ${i.path} — ${i.message}`);
     for (const m of missing.slice(0, 12)) console.log(`  ${YEL}?${RST} ${m.clone} ${DIM}← ${m.business}/${m.employee}${RST}`);
+    for (const c of composition.slice(0, 12)) {
+      const where = `${DIM}← ${c.squad}/${c.capability}${RST}`;
+      const hint = c.candidates.length ? ` ${DIM}(${c.candidates.join(", ")})${RST}` : "";
+      console.log(`  ${c.reason === "unresolved" && c.kind === "requires" ? `${RED}✗${RST}` : `${YEL}?${RST}`} ${c.code} ${c.ref} ${where}${hint}`);
+    }
     console.log("");
   }
-  process.exitCode = strict && (issues.length || missing.length) ? 1 : 0;
+  process.exitCode = strict && (issues.length || missing.length || orphans.length) ? 1 : 0;
 }

--- a/skills/harness/tests/graph-command.test.ts
+++ b/skills/harness/tests/graph-command.test.ts
@@ -105,3 +105,69 @@ describe("the graph layer stays off the dispatch hot path", () => {
     }
   });
 });
+
+// ── squad composition reporting ─────────────────────────────────────────────
+// `requires` that resolves to nothing is a broken declaration: the squad says
+// it needs a capability the library does not carry, and no ordering can fix it,
+// so --strict fails. Ambiguity is a different animal — the capability EXISTS,
+// twice — and it stays a report: erroring would fail the whole library on the
+// duplicate ids it already carries.
+
+function squadFixture(capabilities: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "graph-comp-"));
+  for (const [slug, body] of Object.entries(capabilities)) {
+    mkdirSync(join(dir, "squads", slug), { recursive: true });
+    writeFileSync(join(dir, "squads", slug, "squad.yaml"), `name: ${slug}\nversion: 1.0.0\nprotocol: "6.0"\n${body}`);
+  }
+  return dir;
+}
+
+describe("nrv graph check reports squad composition", () => {
+  test("an unresolved requires fails --strict and names the ref", () => {
+    const pack = squadFixture({
+      consumer: "capabilities:\n  - id: content.social.plan\n    requires:\n      - design.brand.identity\n",
+    });
+    try {
+      const { out, code } = run(["check", "--pack", pack, "--strict", "--json"]);
+      expect(code).toBe(1);
+      const j = JSON.parse(out);
+      expect(j.composition.map((c: { code: string; ref: string }) => [c.code, c.ref]))
+        .toEqual([["x_requires_unresolved", "design.brand.identity"]]);
+    } finally {
+      rmSync(pack, { recursive: true, force: true });
+    }
+  });
+
+  test("an ambiguous requires is reported, never fatal, and creates no edge", () => {
+    const pack = squadFixture({
+      "provider-a": "capabilities:\n  - id: design.brand.identity\n",
+      "provider-b": "capabilities:\n  - id: design.brand.identity\n",
+      consumer: "capabilities:\n  - id: content.social.plan\n    requires:\n      - design.brand.identity\n",
+    });
+    try {
+      const { out, code } = run(["check", "--pack", pack, "--strict", "--json"]);
+      expect(code).toBe(0);
+      const j = JSON.parse(out);
+      expect(j.issues).toEqual([]);
+      expect(j.composition.map((c: { code: string; candidates: string[] }) => [c.code, c.candidates]))
+        .toEqual([["x_requires_ambiguous", ["provider-a", "provider-b"]]]);
+    } finally {
+      rmSync(pack, { recursive: true, force: true });
+    }
+  });
+
+  test("a resolved composition is silent and shows up in the order", () => {
+    const pack = squadFixture({
+      provider: "capabilities:\n  - id: design.brand.identity\n    produces:\n      - brand_kit\n",
+      consumer: "capabilities:\n  - id: content.social.plan\n    consumes:\n      - brand_kit\n",
+    });
+    try {
+      expect(run(["check", "--pack", pack, "--strict", "--json"]).code).toBe(0);
+      expect(JSON.parse(run(["check", "--pack", pack, "--json"]).out).composition).toEqual([]);
+      const order = JSON.parse(run(["order", "--pack", pack, "--json"]).out);
+      expect(order.order).toEqual(["squad:provider", "squad:consumer"]);
+    } finally {
+      rmSync(pack, { recursive: true, force: true });
+    }
+  });
+});

--- a/skills/harness/tests/plan-compiler.test.ts
+++ b/skills/harness/tests/plan-compiler.test.ts
@@ -91,3 +91,78 @@ describe("compileManifest with agent nodes", () => {
     expect(manifest!.parallel_waves).toEqual([["brief-1"], ["squad-a"], ["role-writer"], ["squad-b"], ["deliv-1"]]);
   });
 });
+
+// ── inherited squad composition (Squad Protocol v6 §31) ──────────────────────
+// The plan reads the protocol instead of demanding manual authorship: when the
+// entity graph already says squad A requires a capability squad B provides, a
+// plan naming both gets that order for free. It never overrides the author, and
+// a plan whose squads declare no composition compiles exactly as before.
+
+const composition = (...pairs: [string, string][]): DependencyGraph => ({
+  nodes: [...new Set(pairs.flat())].map((slug) => ({ id: `squad:${slug}`, type: "squad" as const, payload: { slug } })),
+  edges: pairs.map(([consumer, provider]) => ({
+    id: `depends_on:${consumer}->${provider}`,
+    source: `squad:${consumer}`,
+    target: `squad:${provider}`,
+    type: "depends_on" as const,
+  })),
+});
+
+describe("compileManifest inherits squad→squad composition", () => {
+  const plan: DependencyGraph = {
+    nodes: [n("brief-1", "brief"), n("squad:consumer", "squad"), n("squad:provider", "squad")],
+    edges: [e("e1", "brief-1", "squad:consumer", "briefs"), e("e2", "brief-1", "squad:provider", "briefs")],
+  };
+
+  test("an undeclared pair inherits the order the protocol already knows", () => {
+    const { manifest, issues } = compileManifest(plan, { composition: composition(["consumer", "provider"]) });
+    expect(issues).toEqual([]);
+    const byId = Object.fromEntries(manifest!.phases.map((p) => [p.id, p]));
+    expect(byId["squad:consumer"].depends_on).toEqual(["brief-1", "squad:provider"]);
+    expect(byId["squad:provider"].consumed_by).toEqual(["squad:consumer"]);
+    expect(manifest!.parallel_waves).toEqual([["brief-1"], ["squad:provider"], ["squad:consumer"]]);
+  });
+
+  test("a node id without the squad: prefix matches by payload slug", () => {
+    const bySlug: DependencyGraph = {
+      nodes: [
+        { id: "phase-a", type: "squad", payload: { slug: "consumer" } },
+        { id: "phase-b", type: "squad", payload: { slug: "provider" } },
+      ],
+      edges: [],
+    };
+    const { manifest } = compileManifest(bySlug, { composition: composition(["consumer", "provider"]) });
+    expect(manifest!.phases.map((p) => p.id)).toEqual(["phase-b", "phase-a"]);
+  });
+
+  test("the author wins: a declared edge is never duplicated nor reversed", () => {
+    const authored: DependencyGraph = {
+      nodes: plan.nodes,
+      edges: [...plan.edges, e("e3", "squad:provider", "squad:consumer", "depends_on")],
+    };
+    // the composition says the opposite direction; the plan keeps its own.
+    const { manifest, issues } = compileManifest(authored, { composition: composition(["consumer", "provider"]) });
+    expect(issues).toEqual([]);
+    const byId = Object.fromEntries(manifest!.phases.map((p) => [p.id, p]));
+    expect(byId["squad:provider"].depends_on).toEqual(["brief-1", "squad:consumer"]);
+    expect(byId["squad:consumer"].depends_on).toEqual(["brief-1"]);
+  });
+
+  test("a plan whose squads declare no composition compiles byte-identically", () => {
+    const before = compileManifest(plan);
+    const withGraph = compileManifest(plan, { composition: composition(["other-a", "other-b"]) });
+    expect(withGraph.issues).toEqual(before.issues);
+    expect(JSON.stringify(withGraph.manifest)).toBe(JSON.stringify(before.manifest));
+    // and with no composition option at all, which is every caller today
+    expect(JSON.stringify(compileManifest(plan, {}).manifest)).toBe(JSON.stringify(before.manifest));
+  });
+
+  test("only squad nodes inherit: a company pair with the same slugs is untouched", () => {
+    const companies: DependencyGraph = {
+      nodes: [n("squad:consumer", "company"), n("squad:provider", "company")],
+      edges: [],
+    };
+    const { manifest } = compileManifest(companies, { composition: composition(["consumer", "provider"]) });
+    expect(manifest!.phases.every((p) => p.depends_on.length === 0)).toBeTrue();
+  });
+});


### PR DESCRIPTION
## What

`capabilities[].requires[]` and `capabilities[].consumes[]` have parsed since the v6 fields landed, and no reader touched them. This cut turns them into graph edges and into plan order.

**`skills/_shared/lib/entity-graph.ts` — `readSquadComposition()`.** Reads every installed `squad.yaml`. A `requires` entry resolves to the squad declaring that capability id and becomes `depends_on` consumer → provider; a `consumes` entry resolves through `produces` and becomes `feeds` provider → consumer. Both pass through `dependencyPair()` as "the provider exists first", so `nrv graph order` and the install order pick the composition up without a second rule. `buildEntityGraph()` appends the edges; squads stop being dependency-free nodes.

**The ambiguity rule.** An edge exists only where the provider is unambiguous. Sharing a capability id is the design, not a defect — `media.video.compose` lives in ten squads and the router is meant to choose among them by brief — so choosing one here would invent an execution order nobody declared. Two providers yield no edge and a report row. A `slug:` prefix on the reference (`brand-forge:design.brand.identity`) names the provider and settles it. A reference the declaring squad satisfies itself is neither an edge nor a finding: a self-edge would be a cycle.

| Finding | `nrv graph check` |
|---|---|
| `requires` nothing provides | `x_requires_unresolved`, fails `--strict` |
| `requires` two squads provide | `x_requires_ambiguous`, reported |
| `consumes` nothing produces | `x_consumes_unresolved`, reported |
| `consumes` two squads produce | `x_consumes_ambiguous`, reported |

Ambiguity stops short of an error deliberately: the capability exists, twice. An unresolved `requires` is the other case — the library does not carry that capability, and no ordering can supply it.

**`skills/_shared/lib/dependency-graph.ts`.** `isCompatibleEdge` admits a squad as a `feeds` source. `consumes` needs it and only a material had it before; every other row of the table is untouched.

**`skills/harness/lib/plan-compiler.ts`.** `compileManifest()` takes the derived graph as `opts.composition` and inherits the order between two `squad` nodes of one plan when the author declared none. The author always wins: a pair already joined by an edge, in either direction, stays exactly as written. `compileMultiTargetGauntletPolicy()` forwards the same options.

**Non-regression.** Without `opts.composition` — which is every caller today — compilation is bit-for-bit the one that shipped before, held by a test that compares the serialized manifest with and without the option. A `squad.yaml` that does not parse costs the graph nothing, as before, when the reader only asked whether the file existed.

## Not in this cut

No new CLI verb and no new flag: `nrv graph check` gained a `composition` array in `--json` and rows in the human output. No `parallel_safe` wiring into `plan-compiler.ts` — `parallelSafe` still defaults to `() => true`, and `registry.js` does not emit the field yet, so there is nothing to keep flowing. Only `depends_on` edges of the composition graph are inherited by a plan; a `feeds` edge orders the entity graph but is not inherited.

## Tests

- `skills/_shared/tests/entity-graph.test.ts` — single provider, ambiguous provider, explicit `slug:` prefix, explicit prefix naming an uninstalled squad, orphan `requires`, a squad's own capability, `consumes` with one and with two providers, per-squad edge dedupe, unparseable manifest.
- `skills/_shared/tests/dependency-graph.test.ts` — `feeds` from a squad, and both edge types ordering the provider first.
- `skills/harness/tests/plan-compiler.test.ts` — inheritance, slug matching by payload, author-wins, the byte-identical regression, company nodes untouched.
- `skills/harness/tests/graph-command.test.ts` — `--strict` exit 1 on the orphan, exit 0 with the ambiguity reported, and a resolved composition showing up in `nrv graph order`.

`bun test skills`: 1777 pass, 16 skip, 1 fail (`buyer-path.test.ts`, which fails identically on the base commit — the temp home has no `node_modules`, so `_shared/lib` cannot resolve `yaml`; `surface.ts` is the first import to hit it there today).

Every gate of `bun run check:all` passes except `check-not-for-fires --strict`, which fails identically on the base commit (it compares the live `~/squads` library against `~/.nirvana/.not-for-baseline.json`).

Run against the live library — 204 squads, 61 businesses — `nrv graph check` reports 0 structural issues, 0 missing bindings and 0 composition findings in 0.6s: nothing authored the v6 fields yet, so no installed squad changes shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)