### PR TITLE
feat(validate): the business catalog of the admission gate, and the fixers that repair it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,85 @@ The author still wins, always: a pair already joined by an edge, in either
 direction, stays exactly as written. Without the option the compilation is
 bit-for-bit the one that shipped before, and a regression test holds it there.
 
+### `nrv validate business` gets its catalog, and the business fixers exist
+
+The business half of the admission gate carried three structural criteria while
+§16.2 of `BUSINESS_PROTOCOL_V2.md` declared thirty-nine, and the thirteen
+`fixable_diff` kinds the audit scorer emitted named repairs no code performed.
+`skills/_shared/lib/verify/kinds/business.ts` is the whole catalog now, and
+`skills/businesses/lib/business-fixers.js` is the applier both the gate and the
+scorer call — the same twenty-one handlers, one dispatch table, no LLM.
+
+Measured over the 61 installed businesses (against a copy; the library was not
+written to): 0 errors of shape — every manifest and all 581 seats already pass
+Zod — and 31 errors of semantics, all of them routes: 7 businesses keep
+`auto_routes` in `business.yaml` and 5 route to a seat that does not exist. The
+1,262 warnings are the surface v2 retired: 61 businesses declare
+`employee_count`, 61 declare no `acceptance` on the intake seat, 302 fields are
+retired by §22, 562 patterns fire against none of the business's own example
+briefs, and 38 ship no README.
+
+`--fix` over that copy applied 578 repairs in 3.2 s, rolled back nothing, left
+all 61 loading, and cleared 537 warnings and the 7 misplaced route blocks.
+`protocol: "2.0"` rose on 56 of the 61 — the five with an open error keep 1.0,
+which is the rule §18.4 asks for. A second `--fix` run over the same 61
+businesses changed zero bytes.
+
+| Fixer | What it repairs |
+|---|---|
+| `employee_frontmatter_repair` | a seat with no `---` block gets one derived from its own heading and first paragraph |
+| `intake_from_chart_root` | zero intake seats and one org-chart root: the root receives the brief |
+| `type_flag_sync` | `type: antagonist_gate` gains the `is_antagonist: true` it implies (§7.8) |
+| `acceptance_from_self_score` | `self_score_contract.criteria[]` → `acceptance[]`, ids prefixed by seat on collision (§11) |
+| `acceptance_normalize` | acceptance ids to `^[a-z][a-z0-9_-]*$`, unique in the business, scores back into 0..1 |
+| `heartbeat_strip` | the block BP10 retired, removed from every seat |
+| `draws_from_to_assigned` | `draws_from` sources that resolve to an installed clone become `assigned_mind_clones` |
+| `dna_reference_to_pin` | `dna_reference` becomes `pinned_mind_clones` when the path resolves (§7.7) |
+| `deprecated_field_strip` | one retired field of §22, wherever it is declared, from an allowlist |
+| `squads_authorized_empty_strip` | `squads_authorized: []` removed: empty means every squad (§6.10) |
+| `employee_count_strip` | the count §6.12 derives from disk |
+| `manifest_schema_repair` | `name`, `version`, `protocol` and `license` when the directory already answers them |
+| `runtime_requirements_business_default` | a manifest with no runtime floor follows the active runtime |
+| `org_chart_repair` | the chart recomputed from `reports_to` / `manages`, bidirectional by construction |
+| `auto_routes_relocate` | `business.yaml.auto_routes` → `routing.yaml`, deduplicated, nothing dropped (§13.2) |
+| `routing_scaffold` | `brief_intake.default_employee` for a business that declares none |
+| `catch_all_to_default_employee` | a `.*` route becomes the default employee, and only when nothing is lost |
+| `dna_dir_to_bindings` | `dna/` symlinks become the intake seat's `assigned_mind_clones` (§5.3) |
+| `readme_business_scaffold` | a README derived from the manifest and the seats, never overwriting one |
+| `memory_seed` | `memory/permanent.md` |
+| `protocol_bump_2` | `protocol: "2.0"`, last, and only while no error is open (§18.4) |
+
+Three rules hold across all of them. **The seat's body is never touched**:
+`skills/_shared/lib/frontmatter-edit.ts` rewrites the `---` block through the
+`yaml` Document API and reassembles the file around the original body slice, so
+comments, key order, line endings and every byte below the header survive.
+**Nothing authored is deleted**: a retired *file* is reported and left where it
+is, and a route is converted into the field that implements it, never dropped.
+**Nothing is invented**: no fixer writes a `not_for`, an `example_brief`, a
+description or an acceptance criterion, and a `draws_from` source that resolves
+to no installed clone keeps its field instead of becoming a broken binding.
+
+`skills/businesses/scripts/validate-business.ts` stopped being forty lines that
+spawned the loader: it delegates to the runner, so the script and
+`nrv validate business` are one code path with the same exit codes, and
+`--report` writes `nirvana.verify-report/v1` under `.audit-state/<slug>/`.
+
+The audit scorer moved with the protocol. Criterion 2 stopped scoring the
+author's `employee_count` arithmetic (§6.12 derives it) and now asks whether the
+seats are there and their headers parse; criterion 3 redirects the six points it
+used to pay for declaring a `heartbeat` no scheduler ever ran to `acceptance`,
+the contract the judge reads; criterion 5 asks routing for a `brief_intake` and
+for patterns that fire against the business's own example briefs. The rubric now
+sums to exactly 100 — it had summed 104 since `seat_sufficiency` was added while
+the header still said 100 — and every `fixable_diff` names a handler that exists
+plus the class that can apply it (`mechanical`, `agentic`, `none`).
+
+The spec table and the module are now equal in both directions:
+`protocol-v2-spec-parity.test.ts` compares ids, severity, autofix class and the
+baselineable flag row by row, so a criterion added to one side without the other
+is a red test.
+
+
 ### The workflow reader: one canonical graph, every legacy dialect normalized
 
 A squad's workflow was the only artifact of the protocol with no single shape.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -45,6 +45,88 @@ autor continua vencendo, sempre: um par já ligado por uma aresta, em qualquer
 direção, fica exatamente como foi escrito. Sem a opção, a compilação é bit a bit
 a que já era publicada, e um teste de regressão a mantém assim.
 
+### `nrv validate business` ganha o catálogo, e os fixers de empresa existem
+
+A metade de empresa do portão de admissão carregava três critérios estruturais
+enquanto a §16.2 do `BUSINESS_PROTOCOL_V2.md` declarava trinta e nove, e os treze
+`fixable_diff` que o scorer de auditoria emitia nomeavam reparos que código
+nenhum executava. `skills/_shared/lib/verify/kinds/business.ts` é o catálogo
+inteiro agora, e `skills/businesses/lib/business-fixers.js` é o aplicador que o
+portão e o scorer chamam — os mesmos vinte e um handlers, uma tabela de
+despacho, nenhum LLM.
+
+Medido sobre as 61 empresas instaladas (contra uma cópia; a biblioteca não foi
+escrita): 0 erros de forma — todo manifesto e os 581 cargos já passam no Zod — e
+31 erros de semântica, todos de rota: 7 empresas mantêm `auto_routes` em
+`business.yaml` e 5 roteiam para um cargo que não existe. Os 1.262 avisos são a
+superfície que a v2 aposentou: 61 empresas declaram `employee_count`, 61 não
+declaram `acceptance` no cargo de intake, 302 campos estão aposentados pela §22,
+562 padrões não disparam em nenhum `example_brief` da própria empresa e 38 não
+trazem README.
+
+O `--fix` sobre essa cópia aplicou 578 reparos em 3,2 s, não fez rollback nenhum,
+deixou as 61 carregando e limpou 537 avisos e os 7 blocos de rota fora de lugar.
+`protocol: "2.0"` subiu em 56 das 61 — as cinco com erro aberto ficam em 1.0, que
+é a regra da §18.4. Uma segunda rodada de `--fix` sobre as mesmas 61 empresas
+mudou zero bytes.
+
+| Fixer | O que repara |
+|---|---|
+| `employee_frontmatter_repair` | um cargo sem bloco `---` ganha um derivado do próprio título e do primeiro parágrafo |
+| `intake_from_chart_root` | zero cargos de intake e uma raiz no org-chart: a raiz recebe o brief |
+| `type_flag_sync` | `type: antagonist_gate` ganha o `is_antagonist: true` que ele implica (§7.8) |
+| `acceptance_from_self_score` | `self_score_contract.criteria[]` → `acceptance[]`, ids prefixados pelo cargo quando colidem (§11) |
+| `acceptance_normalize` | ids de acceptance para `^[a-z][a-z0-9_-]*$`, únicos na empresa, notas de volta a 0..1 |
+| `heartbeat_strip` | o bloco que o BP10 aposentou, removido de todo cargo |
+| `draws_from_to_assigned` | fontes de `draws_from` que resolvem para um clone instalado viram `assigned_mind_clones` |
+| `dna_reference_to_pin` | `dna_reference` vira `pinned_mind_clones` quando o caminho resolve (§7.7) |
+| `deprecated_field_strip` | um campo aposentado da §22, onde quer que esteja declarado, a partir de uma allowlist |
+| `squads_authorized_empty_strip` | `squads_authorized: []` removido: vazio significa todos os squads (§6.10) |
+| `employee_count_strip` | a contagem que a §6.12 deriva do disco |
+| `manifest_schema_repair` | `name`, `version`, `protocol` e `license` quando o diretório já responde por eles |
+| `runtime_requirements_business_default` | um manifesto sem piso de runtime passa a seguir o runtime ativo |
+| `org_chart_repair` | o chart recomputado de `reports_to` / `manages`, bidirecional por construção |
+| `auto_routes_relocate` | `business.yaml.auto_routes` → `routing.yaml`, deduplicado, sem perder nenhuma (§13.2) |
+| `routing_scaffold` | `brief_intake.default_employee` para uma empresa que não declara nenhum |
+| `catch_all_to_default_employee` | uma rota `.*` vira o funcionário padrão, e só quando nada se perde |
+| `dna_dir_to_bindings` | symlinks de `dna/` viram `assigned_mind_clones` do cargo de intake (§5.3) |
+| `readme_business_scaffold` | um README derivado do manifesto e dos cargos, nunca sobrescrevendo um existente |
+| `memory_seed` | `memory/permanent.md` |
+| `protocol_bump_2` | `protocol: "2.0"`, por último, e só enquanto nenhum erro estiver aberto (§18.4) |
+
+Três regras valem para todos eles. **O corpo do cargo nunca é tocado**:
+`skills/_shared/lib/frontmatter-edit.ts` reescreve o bloco `---` pela API de
+documento da `yaml` e remonta o arquivo em volta da fatia original do corpo, de
+modo que comentários, ordem das chaves, fim de linha e todo byte abaixo do
+cabeçalho sobrevivem. **Nada autoral é apagado**: um *arquivo* aposentado é
+relatado e fica onde está, e uma rota é convertida no campo que a implementa,
+nunca descartada. **Nada é inventado**: nenhum fixer escreve um `not_for`, um
+`example_brief`, uma descrição ou um critério de aceitação, e uma fonte de
+`draws_from` que não resolve para um clone instalado mantém o campo em vez de
+virar um vínculo quebrado.
+
+`skills/businesses/scripts/validate-business.ts` deixou de ser quarenta linhas
+que davam spawn no loader: ele delega ao runner, então o script e o
+`nrv validate business` são um caminho de código só, com os mesmos códigos de
+saída, e `--report` grava `nirvana.verify-report/v1` em `.audit-state/<slug>/`.
+
+O scorer de auditoria andou junto com o protocolo. O critério 2 parou de pontuar
+a aritmética de `employee_count` do autor (a §6.12 a deriva) e passa a perguntar
+se os cargos estão lá e se os cabeçalhos parseiam; o critério 3 redireciona os
+seis pontos que pagava por declarar um `heartbeat` que agendador nenhum rodou
+para `acceptance`, o contrato que o juiz lê; o critério 5 pede à routing um
+`brief_intake` e padrões que disparem nos `example_briefs` da própria empresa. A
+rubrica soma exatamente 100 agora — somava 104 desde que `seat_sufficiency` foi
+acrescentado com o cabeçalho ainda dizendo 100 — e todo `fixable_diff` nomeia um
+handler que existe mais a classe que pode aplicá-lo (`mechanical`, `agentic`,
+`none`).
+
+A tabela da spec e o módulo agora são iguais nas duas direções: o
+`protocol-v2-spec-parity.test.ts` compara ids, severidade, classe de autofix e a
+marca de baselinável linha a linha, então um critério acrescentado de um lado
+sem o outro é teste vermelho.
+
+
 ### O leitor de workflow: um grafo canônico, todo dialeto legado normalizado
 
 O workflow de um squad era o único artefato do protocolo sem forma única.

--- a/docs/architecture/validate-gate.md
+++ b/docs/architecture/validate-gate.md
@@ -61,7 +61,7 @@ O relatório de cada entidade também é gravado em `SQUADS_STATE_DIR/<slug>/ver
 
 Três severidades. **Erro** é o que uma edição de texto conserta em um minuto: o manifesto não parseia, um artefato canônico falta, a superfície de contrato não existe. **Aviso** é o que degrada a entidade sem inviabilizá-la. **Info** nunca muda o veredito; existe para dizer que uma checagem não pôde rodar — `registry_absent` é o caso: sem registro indexado, o eixo de auto-recuperação é pulado em vez de reprovar.
 
-Um subconjunto dos critérios é `baselineable`: os fatos que o pipeline de validação produz e que nenhum fixer pode inventar — `validation_verdict_missing`, `source_material_missing`, `fonte_density_low`, `dna_layers_missing`, `routing_block_missing`, `self_retrieval_miss`. Um finding baselineável que o baseline já registra conta como **débito**: aparece no relatório como `DEBT` e não reprova. Erro duro nunca vira débito.
+Um subconjunto dos critérios é `baselineable`: os fatos que o pipeline de validação produz e que nenhum fixer pode inventar — `validation_verdict_missing`, `source_material_missing`, `fonte_density_low`, `dna_layers_missing`, `routing_block_missing`, `self_retrieval_miss` e, do lado de empresa, `seat_thin`. Um finding baselineável que o baseline já registra conta como **débito**: aparece no relatório como `DEBT` e não reprova. Erro duro nunca vira débito.
 
 O arquivo é `$NIRVANA_HOME/.nirvana/.verify-baseline.json`:
 
@@ -84,7 +84,7 @@ Porte de `skills/squads/scripts/improve-squad.ts:98-134` sem a etapa de consenso
 
 1. `check` → os findings com `autofix: "mechanical"` e fixer declarado são os alvos.
 2. Backup com `fs.cpSync` para `$NIRVANA_HOME/.nirvana/verify-backups/<kind>/<slug>.<ts>/`; os cinco mais recentes por entidade ficam. Nunca `rsync`: a matriz de CI roda Windows, onde ele não existe.
-3. Os fixers rodam na ordem fixa do módulo — estrutura, manifesto, routing, arquivos — e `surface_regen` sempre por último, porque qualquer reescrita de manifesto muda a superfície.
+3. Os fixers rodam na ordem fixa do módulo — estrutura, manifesto, routing, arquivos — e `surface_regen` por último, porque qualquer reescrita de manifesto muda a superfície. Empresa tem um passo depois dele: `protocol_bump_2`, que declara `2.0` só quando não resta erro (§18.4) e não altera a superfície, porque `protocol` não entra nem nas entradas nem na prosa extraída.
 4. `check` de novo.
 5. **Rollback** — `rm` + `cpSync`, byte a byte — quando um fixer lançou, quando o manifesto parou de parsear, ou quando surgiu um erro que não existia antes. O motivo entra em `fix_outcome.rollback_reason`.
 6. O relatório mostra `before` e `after`.
@@ -188,9 +188,21 @@ Quem for estender o catálogo precisa de quatro detalhes:
 
 O `humanize` saiu junto. Era a contradição documentada no inventário: os docs mandavam declarar, o schema estrito rejeitava, e o fixer **escrevia** o campo — de modo que `fix-squad --apply` podia transformar um manifesto válido em inválido. Os seis pontos do critério 9 da auditoria passam a medir o contrato que o juiz de fato lê (`c9_acceptance`: parcela de capabilities com `acceptance[]` ou com task invocada declarando `## Acceptance Criteria`), o total continua 100, e a metade útil do fixer virou `outputs_shape_repair`.
 
-## Empresas
+## Catálogo de empresa
 
-Neste corte o módulo de empresa existe com os critérios triviais — o manifesto parseia, `.nirvana-surface.json` existe e bate com os arquivos em disco. O catálogo do Business Protocol v2 entra no corte próprio do programa.
+A tabela da §16.2 do `skills/businesses/BUSINESS_PROTOCOL_V2.md` **é** este catálogo: 16 erros e 23 avisos, mesmos ids, mesma severidade, mesma classe de autofix, mesma marca de baselinável. O `skills/businesses/tests/protocol-v2-spec-parity.test.ts` compara os dois conjuntos linha a linha, nas duas direções — a spec é o documento, o módulo é a execução, e um critério só de um lado é teste vermelho. Por isso o módulo de empresa não declara nenhum critério `info`: a §16.2 só tem erro e aviso, então o eixo de auto-recuperação é pulado em silêncio quando a empresa não está no registro, em vez de emitir `registry_absent` como o módulo de clone faz.
+
+Os números que moldaram os critérios (61 empresas, 581 cargos, 26/08/2026): nenhum manifesto e nenhum cargo falha no Zod, então nada aqui é sobre YAML malformado. 566 cargos declaram um `self_score_contract` que código nenhum lê, 475 um `heartbeat` que agendador nenhum rodou, 30 manifestos e 201 cargos uma `squads_authorized` vazia que a spec lia como "todos" e o prompt lia como "nenhum", 61 um `employee_count` que o registro recomputa, 7 manifestos guardam `auto_routes` no arquivo errado e 38 empresas não trazem README.
+
+**Erros**: `manifest_parse`, `manifest_schema` (`manifest_schema_repair`), `protocol_unsupported`, `employees_present`, `employee_frontmatter_invalid` (`employee_frontmatter_repair`, só quando o bloco falta inteiro — reescrever um cabeçalho que um humano escreveu é autoria), `intake_exactly_one` (`intake_from_chart_root`, só com zero intakes), `org_chart_missing` e `org_chart_inconsistent` (`org_chart_repair`), `antagonist_bp7`, `auto_route_unknown_employee`, `auto_route_in_manifest` (`auto_routes_relocate`), `pinned_clone_unresolved`, `acceptance_invalid` (`acceptance_normalize`), `surface_missing` (`surface_regen`), `dna_symlink_dangling`, `outputs_pollution`.
+
+**Avisos**: `protocol_v1` (`protocol_bump_2`), `employee_count_authored` (`employee_count_strip`), `deprecated_field:<campo>` (o fixer varia por campo: `heartbeat_strip`, `acceptance_from_self_score`, `draws_from_to_assigned`, `dna_reference_to_pin` ou `deprecated_field_strip`), `deprecated_file:<arquivo>` (relatado, nunca apagado), `squads_authorized_empty` (`squads_authorized_empty_strip`), `squads_ref_unknown`, `acceptance_missing` (agêntico), `routing_metadata_incomplete` (agêntico), `description_short` (agêntico), `auto_route_never_fires`, `auto_route_catch_all` (`catch_all_to_default_employee`), `seat_thin` (débito), `self_retrieval_miss` (débito), `readme_missing` (`readme_business_scaffold`), `readme_thin` (agêntico), `memory_missing` (`memory_seed`), `runtime_requirements_default` (`runtime_requirements_business_default`), `type_mind_clone_without_pin`, `type_flag_mismatch` (`type_flag_sync`), `dna_dir_present` (`dna_dir_to_bindings`), `surface_stale` (`surface_regen`), `operation_mode_unsupported`, `legacy_partial`.
+
+Os fixers moram em `skills/businesses/lib/business-fixers.js` — CJS com tabela de despacho, como o `mechanical-fixers.js` dos squads — e o scorer de auditoria (`business-audit-criteria.js`) emite os mesmos nomes em `fixable_diff.kind`, mais `fixable_diff.class` dizendo quem pode aplicar (`mechanical`, `agentic`, `none`). Um `fixable_diff` que nomeia um reparo sem aplicador era o defeito anterior; agora as duas superfícies chamam a mesma tabela.
+
+O frontmatter de cargo é editado por `skills/_shared/lib/frontmatter-edit.ts`, que reescreve **só** o bloco `---` e remonta o arquivo em volta da fatia original do corpo. `business.yaml`, `org-chart.yaml` e `routing.yaml` são reescritos inteiros pela API de documento da `yaml`: comentários e ordem de chaves sobrevivem, exceto o comentário grudado numa chave que o fixer remove, que sai com ela.
+
+Medição de `nrv validate business --all` sobre uma cópia da biblioteca instalada (26/08/2026, 61 empresas, 0,8 s sem auto-recuperação e 4,3 s com ela): 53 admitidas, 8 reprovadas, 31 erros (7 `auto_route_in_manifest` e 24 `auto_route_unknown_employee`), 1.262 avisos, 15 empresas com `self_retrieval_miss`. Um `--fix` sobre a mesma cópia aplicou 578 reparos em 3,2 s, sem rollback, com as 61 ainda carregando pelo loader, e a segunda rodada mudou zero bytes.
 
 ## Tudo em processo
 

--- a/skills/_shared/lib/frontmatter-edit.ts
+++ b/skills/_shared/lib/frontmatter-edit.ts
@@ -1,0 +1,152 @@
+// frontmatter-edit.ts — edit the `---` block of a Markdown file and nothing else.
+//
+// An employee is a seat's method written as prose with a YAML header. The
+// mechanical fixers of Business Protocol 2.0 rewrite the header — strip
+// `heartbeat`, convert `self_score_contract` into `acceptance[]`, add a pin —
+// and must not touch a single byte of what the author wrote below it. Reading
+// the file, re-serializing the whole document and writing it back is how a
+// fixer silently reflows 581 seats: trailing spaces, tab indentation, the blank
+// line before a heading, the exact bytes the writer chose.
+//
+// So the edit is surgical. The frontmatter block is parsed through the `yaml`
+// Document API (comments, key order and the formatting of untouched nodes
+// survive), and the file is reassembled as
+//
+//   <BOM?> --- <eol> <new frontmatter> <eol> --- <tail> <body verbatim>
+//
+// where the body is the original slice, never re-encoded. Line endings are
+// preserved: a CRLF checkout stays CRLF.
+//
+// `business.yaml`, `org-chart.yaml` and `routing.yaml` are plain YAML documents
+// and use `editYaml` in verify/common.ts instead — same Document API, whole
+// file.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseDocument, type Document } from "yaml";
+
+/**
+ * The opening fence, the block, the closing fence. Both the block and its
+ * trailing newline are optional so an empty header (`---\n---\n`) parses.
+ * Captures: 1 BOM · 2 opening EOL · 3 block · 4 block EOL · 5 closing tail.
+ */
+const FENCE = /^(\uFEFF)?---[ \t]*(\r?\n)(?:([\s\S]*?)(\r?\n))?---[ \t]*(\r?\n|$)/;
+
+export interface SplitFrontmatter {
+  /** Byte-order mark, when the file carries one. */
+  bom: string;
+  /** The YAML text between the fences, without its trailing newline. */
+  block: string;
+  /** Everything after the closing fence, byte for byte. */
+  body: string;
+  /** The line ending the header uses. */
+  eol: "\n" | "\r\n";
+  /** What follows the closing `---`: a newline, or nothing at end of file. */
+  tail: string;
+}
+
+/** Splits the header from the body, or null when the file has no header. */
+export function splitFrontmatter(text: string): SplitFrontmatter | null {
+  const m = FENCE.exec(text);
+  if (!m) return null;
+  const [whole, bom = "", openEol, block = "", blockEol, tail = ""] = m;
+  return {
+    bom,
+    block,
+    body: text.slice(whole.length),
+    eol: (blockEol ?? openEol) === "\r\n" ? "\r\n" : "\n",
+    tail,
+  };
+}
+
+/** Reassembles a file from a split and a new frontmatter block. */
+export function joinFrontmatter(s: SplitFrontmatter, block: string): string {
+  const normalized = block.replace(/\r\n/g, "\n").replace(/\n+$/, "");
+  const withEol = s.eol === "\r\n" ? normalized.replace(/\n/g, "\r\n") : normalized;
+  const head = withEol === "" || withEol === "{}"
+    ? `${s.bom}---${s.eol}---${s.tail}`
+    : `${s.bom}---${s.eol}${withEol}${s.eol}---${s.tail}`;
+  return head + s.body;
+}
+
+export interface ReadFrontmatter extends SplitFrontmatter {
+  /** The parsed header. Null when it does not parse as YAML. */
+  doc: Document.Parsed | null;
+  /** The header as plain data; `{}` when it is empty or not a mapping. */
+  data: Record<string, unknown>;
+  parseError: string | null;
+}
+
+/** Reads a file's header without touching the body. Null when there is none. */
+export function readFrontmatter(file: string): ReadFrontmatter | null {
+  const s = splitFrontmatter(fs.readFileSync(file, "utf8"));
+  if (!s) return null;
+  let doc: Document.Parsed | null = null;
+  let parseError: string | null = null;
+  try {
+    // Duplicate keys are what yaml.safe_load tolerated and 581 installed seats
+    // were written against: the loader accepts them, so the gate reads them.
+    const d = parseDocument(s.block, { uniqueKeys: false });
+    if (d.errors.length) parseError = d.errors[0].message;
+    else doc = d;
+  } catch (e: any) {
+    parseError = String(e?.message ?? e).split("\n")[0];
+  }
+  const raw = doc ? doc.toJS() : null;
+  const data = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  return { ...s, doc, data, parseError };
+}
+
+export function hasFrontmatter(file: string): boolean {
+  try { return splitFrontmatter(fs.readFileSync(file, "utf8")) !== null; } catch { return false; }
+}
+
+/**
+ * Edits one file's frontmatter through the Document API. `mutate` returns true
+ * when it changed something; nothing is written otherwise, so a second run over
+ * an already-fixed file writes zero bytes (the idempotence every fixer
+ * promises). Returns whether the file changed on disk.
+ *
+ * A file with no header, or a header that does not parse, is left alone — a
+ * fixer that cannot read what it is about to rewrite must not rewrite it.
+ */
+export function editFrontmatter(file: string, mutate: (doc: Document.Parsed) => boolean): boolean {
+  const text = fs.readFileSync(file, "utf8");
+  const s = splitFrontmatter(text);
+  if (!s) return false;
+  let doc: Document.Parsed;
+  try {
+    doc = parseDocument(s.block, { uniqueKeys: false });
+    if (doc.errors.length) return false;
+  } catch { return false; }
+  if (!mutate(doc)) return false;
+  // lineWidth 0: a header rewritten at the default 80 columns re-wraps every
+  // long `description` in the library, which is a diff nobody asked for.
+  const out = joinFrontmatter(s, doc.toString({ lineWidth: 0 }));
+  if (out === text) return false;
+  fs.writeFileSync(file, out, "utf8");
+  return true;
+}
+
+/**
+ * Writes a header onto a file that has none, keeping the body verbatim. Used
+ * by the seat-skeleton fixer; never overwrites an existing header.
+ */
+export function prependFrontmatter(file: string, block: string, eol: "\n" | "\r\n" = "\n"): boolean {
+  const text = fs.readFileSync(file, "utf8");
+  if (splitFrontmatter(text) !== null) return false;
+  const bom = text.startsWith("\uFEFF") ? "\uFEFF" : "";
+  const body = bom ? text.slice(1) : text;
+  const detected = /\r\n/.test(text) ? "\r\n" : eol;
+  const out = joinFrontmatter({ bom, block: "", body, eol: detected, tail: detected }, block);
+  fs.writeFileSync(file, out, "utf8");
+  return true;
+}
+
+/** Every `<dir>/employees/*.md`, sorted — the order every fixer iterates in. */
+export function employeeFiles(businessDir: string): string[] {
+  const dir = path.join(businessDir, "employees");
+  let names: string[];
+  try { names = fs.readdirSync(dir); } catch { return []; }
+  return names.filter((f) => f.endsWith(".md")).sort().map((f) => path.join(dir, f));
+}

--- a/skills/_shared/lib/verify/kinds/business.ts
+++ b/skills/_shared/lib/verify/kinds/business.ts
@@ -1,39 +1,672 @@
-// kinds/business.ts — the business module of the admission gate, trivial for now.
+// kinds/business.ts — the business catalog of the admission gate.
 //
-// Only the criteria every kind shares live here (the manifest parses,
-// the contract surface exists and is fresh), so the CLI works end to end for all three
-// kinds. The full business catalog lands in PR8 of the program plan.
+// The table in §16.2 of `skills/businesses/BUSINESS_PROTOCOL_V2.md` IS this
+// catalog: same ids, same severities, same autofix classes, same baselineable
+// flags, checked by `skills/businesses/tests/protocol-v2-spec-parity.test.ts`.
+// A criterion here without a row there — or a row there without a criterion
+// here — fails that test. Write the row and the criterion in the same commit.
+//
+// Facts that shaped it (installed library, 61 businesses and 581 seats,
+// 2026-08-26): every manifest and every seat already passes the Zod schema, so
+// nothing in the catalog is about malformed YAML — the findings are about
+// surface the protocol retired and semantics nobody implemented. 566 seats
+// declare a `self_score_contract` no code reads, 475 a `heartbeat` no scheduler
+// ever ran, 30 manifests and 201 seats an empty `squads_authorized` that the
+// spec read as "every squad" and the prompt read as "no squad", 61 an
+// `employee_count` the registry recomputes anyway, 7 manifests keep
+// `auto_routes` in the wrong file, and 38 businesses ship no README at all.
+//
+// **The gate reads; the fixers write.** Every mechanical repair lives in
+// `skills/businesses/lib/business-fixers.js` (CJS, like the squad side), so the
+// audit scorer's `fixable_diff` kinds and the gate's `--fix` loop apply the
+// same code. What a fixer cannot derive from the files stays a finding: no
+// fixer writes a `not_for`, an `example_brief` or an acceptance criterion.
+//
+// **No `info` criterion.** The mind-clone module signals a skipped
+// self-retrieval axis with severity `info`; here the axis is simply skipped
+// when the business is not in the registry, because §16.2 declares errors and
+// warnings only and this module must equal it.
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 import { parse as parseYaml } from "yaml";
-import { listEntities, resolveEntityDir, surfaceFindings, surfaceRegenFixer } from "../common.ts";
-import type { CheckContext, Criterion, Finding, KindModule } from "../types.ts";
+import { BusinessManifestSchema, EmployeeFrontmatterSchema, OrgChartSchema } from "../../../validators/validators.ts";
+import { readFrontmatter, employeeFiles } from "../../frontmatter-edit.ts";
+import { refToSlug, slugOf } from "../../entity-graph.ts";
+import { classify } from "../../corpus-language.ts";
+import { fixResult, listEntities, resolveEntityDir, surfaceFindings, surfaceRegenFixer } from "../common.ts";
+import type { CheckContext, Criterion, Finding, FixResult, Fixer, KindModule } from "../types.ts";
+
+const require_ = createRequire(import.meta.url);
+const BUSINESS_LIB = path.join(import.meta.dir, "..", "..", "..", "..", "businesses", "lib");
+const fixers = require_(path.join(BUSINESS_LIB, "business-fixers.js")) as {
+  applyBusinessFixes(dir: string, diff: { patches: Array<Record<string, unknown>> }): Array<{ kind: string; result: any }>;
+  FIX_ORDER: string[];
+  DEPRECATED_FIELDS: Record<string, string[]>;
+};
+const outputsLint = require_(path.join(import.meta.dir, "..", "..", "outputs-lint.js")) as {
+  lintDir(dir: string): { errors: string[]; warnings: string[] };
+};
+const seatSufficiency = require_(path.join(import.meta.dir, "..", "..", "seat-sufficiency.js")) as {
+  sufficiencyOfFile(content: string): { verdict: "sufficient" | "thin" };
+};
+
+/** A description shorter than this carries no routing signal (audit c6). */
+const DESCRIPTION_MIN_CHARS = 100;
+/** A README under this many lines is the scaffold, not the document (audit c9). */
+const README_MIN_LINES = 40;
+/** §6.9: three example briefs, at least one EN and one PT. */
+const EXAMPLE_BRIEFS_MIN = 3;
+/** BP7: above this many seats a business needs an antagonist. */
+const ANTAGONIST_FLOOR = 5;
+
+/** §13.2: a pattern that matches every brief turns routing off. */
+const CATCH_ALL = new Set([".*", ".+", "(?i).*", "(?i).+", "^.*$", "^.+$", "(?i)^.*$", "(?i)^.+$", ".*?"]);
+
+/** §22, with the destination each one has. `null` = removed, no conversion. */
+const RETIRED_EMPLOYEE_FIELDS: Record<string, string | null> = {
+  heartbeat: "heartbeat_strip",
+  self_score_contract: "acceptance_from_self_score",
+  draws_from: "draws_from_to_assigned",
+  dna_reference: "dna_reference_to_pin",
+  budget_monthly_usd: null, mentions: null, escalation_triggers: null,
+  disclosure_template: null, default_tools: null, project_tool_overrides: null,
+};
+const RETIRED_MANIFEST_FIELDS = ["capabilities_required", "default_tools", "project_tool_overrides", "tickets", "ticket_intake", "disclosure_template"];
+const RETIRED_ROUTING_FIELDS = ["mention_routing", "ticket_intake"];
+const RETIRED_ROUTE_FIELDS = ["confidence_threshold", "requires_escalation_to"];
+/** §5.3 / §22: reported, never deleted. */
+const RETIRED_FILES = ["culture.md", "budgets.yaml", "secrets-manifest.yaml", "escalation-triggers.yaml", "approval-chains.yaml", "tickets", "processes"];
 
 export const criteria: Criterion[] = [
-  { id: "manifest_parse", severity: "error", autofix: "none", baselineable: false, title: "business.yaml parses" },
+  // ── errors ────────────────────────────────────────────────────────────────
+  { id: "manifest_parse", severity: "error", autofix: "none", baselineable: false, title: "business.yaml exists and is valid YAML" },
+  { id: "manifest_schema", severity: "error", autofix: "mechanical", baselineable: false, title: "the manifest passes BusinessManifestSchema", fixer: "manifest_schema_repair" },
+  { id: "protocol_unsupported", severity: "error", autofix: "none", baselineable: false, title: "protocol is 1.0 or 2.0" },
+  { id: "employees_present", severity: "error", autofix: "none", baselineable: false, title: "employees/ exists with at least one .md" },
+  { id: "employee_frontmatter_invalid", severity: "error", autofix: "mechanical", baselineable: false, title: "every frontmatter passes EmployeeFrontmatterSchema", fixer: "employee_frontmatter_repair" },
+  { id: "intake_exactly_one", severity: "error", autofix: "mechanical", baselineable: false, title: "exactly one employee declares is_brief_intake", fixer: "intake_from_chart_root" },
+  { id: "org_chart_missing", severity: "error", autofix: "mechanical", baselineable: false, title: "org-chart.yaml exists", fixer: "org_chart_repair" },
+  { id: "org_chart_inconsistent", severity: "error", autofix: "mechanical", baselineable: false, title: "every node exists in employees/, reporting is bidirectional, no cycle", fixer: "org_chart_repair" },
+  { id: "antagonist_bp7", severity: "error", autofix: "none", baselineable: false, title: `BP7: more than ${ANTAGONIST_FLOOR} employees require an antagonist` },
+  { id: "auto_route_unknown_employee", severity: "error", autofix: "none", baselineable: false, title: "every route_to names an existing employee" },
+  { id: "auto_route_in_manifest", severity: "error", autofix: "mechanical", baselineable: false, title: "auto_routes is not in business.yaml", fixer: "auto_routes_relocate" },
+  { id: "pinned_clone_unresolved", severity: "error", autofix: "none", baselineable: false, title: "every pinned_mind_clones entry resolves in the library" },
+  { id: "acceptance_invalid", severity: "error", autofix: "mechanical", baselineable: false, title: "acceptance ids are valid and unique in the business; minimum_score in 0..1", fixer: "acceptance_normalize" },
   { id: "surface_missing", severity: "error", autofix: "mechanical", baselineable: false, title: ".nirvana-surface.json present", fixer: "surface_regen" },
-  { id: "surface_stale", severity: "warning", autofix: "mechanical", baselineable: false, title: ".nirvana-surface.json matches the files on disk", fixer: "surface_regen" },
+  { id: "dna_symlink_dangling", severity: "error", autofix: "none", baselineable: false, title: "no dna/ symlink points at a target that is gone" },
+  { id: "outputs_pollution", severity: "error", autofix: "none", baselineable: false, title: "no run-output directory inside the business" },
+
+  // ── warnings ──────────────────────────────────────────────────────────────
+  { id: "protocol_v1", severity: "warning", autofix: "mechanical", baselineable: false, title: "the business still declares protocol 1.0", fixer: "protocol_bump_2" },
+  { id: "employee_count_authored", severity: "warning", autofix: "mechanical", baselineable: false, title: "employee_count declared in the manifest (§6.12)", fixer: "employee_count_strip" },
+  { id: "deprecated_field", severity: "warning", autofix: "mechanical", baselineable: false, title: "a retired field is declared (`:<name>` says which)", fixer: "deprecated_field_strip" },
+  { id: "deprecated_file", severity: "warning", autofix: "none", baselineable: false, title: "a retired file is present (`:<name>` says which)" },
+  { id: "squads_authorized_empty", severity: "warning", autofix: "mechanical", baselineable: false, title: "squads_authorized: [] declared (§6.10)", fixer: "squads_authorized_empty_strip" },
+  { id: "squads_ref_unknown", severity: "warning", autofix: "none", baselineable: false, title: "a squad named in preferred/authorized is not in the library" },
+  { id: "acceptance_missing", severity: "warning", autofix: "agentic", baselineable: false, title: "the intake seat declares no acceptance" },
+  { id: "routing_metadata_incomplete", severity: "warning", autofix: "agentic", baselineable: false, title: "one of the four §6.9 fields is missing or truncated" },
+  { id: "description_short", severity: "warning", autofix: "agentic", baselineable: false, title: "description too short to carry routing signal" },
+  { id: "auto_route_never_fires", severity: "warning", autofix: "none", baselineable: false, title: "a pattern fires against no example_brief of the business" },
+  { id: "auto_route_catch_all", severity: "warning", autofix: "mechanical", baselineable: false, title: "a pattern matches everything (§13.2)", fixer: "catch_all_to_default_employee" },
+  { id: "seat_thin", severity: "warning", autofix: "agentic", baselineable: true, title: "a seat carries too little method of its own" },
+  { id: "self_retrieval_miss", severity: "warning", autofix: "agentic", baselineable: true, title: "an example_brief does not return the business in top-1" },
+  { id: "readme_missing", severity: "warning", autofix: "mechanical", baselineable: false, title: "README.md absent", fixer: "readme_business_scaffold" },
+  { id: "readme_thin", severity: "warning", autofix: "agentic", baselineable: false, title: "README.md holds nothing beyond the skeleton" },
+  { id: "memory_missing", severity: "warning", autofix: "mechanical", baselineable: false, title: "memory/permanent.md absent", fixer: "memory_seed" },
+  { id: "runtime_requirements_default", severity: "warning", autofix: "mechanical", baselineable: false, title: "runtime_requirements is still the template skeleton", fixer: "runtime_requirements_business_default" },
+  { id: "type_mind_clone_without_pin", severity: "warning", autofix: "none", baselineable: false, title: "type: mind_clone without pinned_mind_clones (§7.8)" },
+  { id: "type_flag_mismatch", severity: "warning", autofix: "mechanical", baselineable: false, title: "type: antagonist_gate without is_antagonist: true (§7.8)", fixer: "type_flag_sync" },
+  { id: "dna_dir_present", severity: "warning", autofix: "mechanical", baselineable: false, title: "a dna/ directory is present (§5.3)", fixer: "dna_dir_to_bindings" },
+  { id: "surface_stale", severity: "warning", autofix: "mechanical", baselineable: false, title: ".nirvana-surface.json differs from the extraction", fixer: "surface_regen" },
+  { id: "operation_mode_unsupported", severity: "warning", autofix: "none", baselineable: false, title: "operation_mode other than zero_human, not honored this cycle" },
+  { id: "legacy_partial", severity: "warning", autofix: "none", baselineable: false, title: "the legacy block is present and incomplete" },
 ];
+
 const BY_ID = new Map(criteria.map((c) => [c.id, c]));
 
-function mk(id: string, message: string, evidence: string): Finding {
-  const c = BY_ID.get(id)!;
-  return { id, severity: c.severity, autofix: c.autofix, message, evidence, baselined: false, ...(c.fixer ? { fixer: c.fixer } : {}) };
+/** A finding of one criterion. `fixer` overrides the criterion's default —
+ *  `deprecated_field:heartbeat` and `deprecated_field:mentions` are the same
+ *  criterion repaired by two different handlers. */
+function mk(id: string, message: string, evidence: string, where?: string, fixer?: string | null): Finding {
+  const c = BY_ID.get(id);
+  if (!c) throw new Error(`unknown business criterion: ${id}`);
+  const chosen = fixer === undefined ? c.fixer : fixer;
+  return {
+    id, severity: c.severity, autofix: c.autofix, message, evidence,
+    ...(where ? { where } : {}), baselined: false, ...(chosen ? { fixer: chosen } : {}),
+  };
+}
+
+// ── measurements ────────────────────────────────────────────────────────────
+
+const isMapping = (v: unknown): v is Record<string, unknown> => !!v && typeof v === "object" && !Array.isArray(v);
+const manifestOf = (dir: string) => path.join(dir, "business.yaml");
+const strings = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []);
+
+export interface SeatRead {
+  file: string;
+  stem: string;
+  name: string;
+  /** null when the file carries no frontmatter block at all. */
+  data: Record<string, unknown> | null;
+  frontmatterMissing: boolean;
+  parseError: string | null;
+  body: string;
+}
+
+export interface BusinessRead {
+  manifest: Record<string, unknown> | null;
+  parseError: string | null;
+  /** `protocol` as declared, with an unquoted YAML number rendered as `x.0`. */
+  protocol: string;
+  seats: SeatRead[];
+  employeesDirMissing: boolean;
+  chart: Record<string, unknown> | null;
+  chartMissing: boolean;
+  chartParseError: string | null;
+  routing: Record<string, unknown> | null;
+  routingParseError: string | null;
+}
+
+function readYamlFile(file: string): { data: Record<string, unknown> | null; error: string | null; missing: boolean } {
+  if (!fs.existsSync(file)) return { data: null, error: null, missing: true };
+  try {
+    const doc = parseYaml(fs.readFileSync(file, "utf8"), { uniqueKeys: false });
+    if (!isMapping(doc)) return { data: null, error: `not a YAML mapping (${Array.isArray(doc) ? "array" : typeof doc})`, missing: false };
+    return { data: doc, error: null, missing: false };
+  } catch (e: any) {
+    return { data: null, error: String(e?.message ?? e).split("\n")[0], missing: false };
+  }
+}
+
+export function readBusiness(dir: string): BusinessRead {
+  const m = readYamlFile(manifestOf(dir));
+  const chart = readYamlFile(path.join(dir, "org-chart.yaml"));
+  const routing = readYamlFile(path.join(dir, "routing.yaml"));
+  const files = employeeFiles(dir);
+  const seats: SeatRead[] = files.map((file) => {
+    const stem = path.basename(file).replace(/\.md$/, "");
+    const fm = readFrontmatter(file);
+    return {
+      file, stem,
+      name: fm && typeof fm.data.name === "string" ? fm.data.name : stem,
+      data: fm && fm.doc ? fm.data : null,
+      frontmatterMissing: fm === null,
+      parseError: fm ? fm.parseError : null,
+      body: fm ? fm.body : (() => { try { return fs.readFileSync(file, "utf8"); } catch { return ""; } })(),
+    };
+  });
+  const rawProtocol = m.data?.protocol;
+  return {
+    manifest: m.data,
+    parseError: m.missing ? "business.yaml is absent" : m.error,
+    protocol: typeof rawProtocol === "number" ? rawProtocol.toFixed(1) : String(rawProtocol ?? "").trim(),
+    seats,
+    employeesDirMissing: !fs.existsSync(path.join(dir, "employees")),
+    chart: chart.data,
+    chartMissing: chart.missing,
+    chartParseError: chart.error,
+    routing: routing.data,
+    routingParseError: routing.error,
+  };
+}
+
+/** Every auto_route the business declares, from both files (§13.2). */
+function autoRoutes(b: BusinessRead): Array<{ pattern: string; route_to: string; source: "routing.yaml" | "business.yaml"; raw: Record<string, unknown> }> {
+  const out: Array<{ pattern: string; route_to: string; source: "routing.yaml" | "business.yaml"; raw: Record<string, unknown> }> = [];
+  for (const [source, holder] of [["routing.yaml", b.routing], ["business.yaml", b.manifest]] as const) {
+    for (const r of (Array.isArray(holder?.auto_routes) ? holder!.auto_routes : []) as unknown[]) {
+      if (!isMapping(r)) continue;
+      out.push({ pattern: String(r.pattern ?? ""), route_to: String(r.route_to ?? ""), source, raw: r });
+    }
+  }
+  return out;
+}
+
+/** Compiles a router pattern the way router.js does: `(?i)` becomes the flag. */
+function compilePattern(pattern: string): RegExp | null {
+  try {
+    const ci = pattern.startsWith("(?i)");
+    return new RegExp(ci ? pattern.slice(4) : pattern, ci ? "i" : "");
+  } catch { return null; }
+}
+
+function cloneSlugOf(ref: string): string | null {
+  const viaLibrary = refToSlug(ref);
+  const last = slugOf(ref.replace(/\/+$/, "")).replace(/\.(md|markdown)$/i, "");
+  const slug = /(^|\/)dna\//.test(ref) && viaLibrary ? viaLibrary : last;
+  return slug && !/\.(md|ya?ml|json)$/i.test(slug) ? slug : null;
+}
+
+function installedSlugs(kind: "squad" | "mind-clone"): Set<string> {
+  try { return new Set(listEntities(kind).map((e) => e.slug)); } catch { return new Set(); }
+}
+
+// ── the check ───────────────────────────────────────────────────────────────
+
+/**
+ * Everything the gate can decide from the files alone. `check` adds the one
+ * axis that needs the registry (self-retrieval); `protocol_bump_2` consults
+ * this function to refuse a version bump while an error is still open.
+ */
+export function checkSync(dir: string): Finding[] {
+  const out: Finding[] = [];
+  const b = readBusiness(dir);
+
+  // ── the manifest ──────────────────────────────────────────────────────────
+  if (!b.manifest) {
+    out.push(mk("manifest_parse", `business.yaml does not load: ${b.parseError ?? "unknown reason"}`, manifestOf(dir)));
+  } else {
+    const parsed = BusinessManifestSchema.safeParse(b.manifest);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`);
+      out.push(mk("manifest_schema", `the manifest fails BusinessManifestSchema (${issues.length} issue${issues.length === 1 ? "" : "s"})`, issues.slice(0, 3).join(" · ")));
+    }
+    if (b.protocol && b.protocol !== "1.0" && b.protocol !== "2.0") {
+      out.push(mk("protocol_unsupported", `protocol ${b.protocol} is not a version this engine loads`, "expected 1.0 or 2.0"));
+    }
+    if (b.protocol === "1.0") out.push(mk("protocol_v1", "still Business Protocol 1.0 — the v2 rules apply as advice until the version rises", "protocol: \"1.0\""));
+    if ("employee_count" in b.manifest) {
+      out.push(mk("employee_count_authored", `employee_count is derived from employees/*.md (§6.12); the declared ${String(b.manifest.employee_count)} is decoration`, `${b.seats.length} file(s) on disk`));
+    }
+    if ("auto_routes" in b.manifest) {
+      const n = Array.isArray(b.manifest.auto_routes) ? b.manifest.auto_routes.length : 0;
+      out.push(mk("auto_route_in_manifest", `${n} auto_route(s) live in business.yaml; §13.2 puts them in routing.yaml`, "business.yaml.auto_routes"));
+    }
+    const description = String(b.manifest.description ?? "").trim();
+    if (description.length < DESCRIPTION_MIN_CHARS) {
+      out.push(mk("description_short", `description is ${description.length} chars — under ${DESCRIPTION_MIN_CHARS} it carries almost no BM25 signal`, description.slice(0, 60)));
+    }
+    const rr = b.manifest.runtime_requirements;
+    const hasFloor = isMapping(rr) && (rr.policy === "active" || (Array.isArray(rr.minimum) && rr.minimum.length > 0));
+    if (!hasFloor) out.push(mk("runtime_requirements_default", "runtime_requirements declares no minimum and does not follow the active runtime", isMapping(rr) ? `policy: ${String(rr.policy)}` : "absent"));
+    if (b.manifest.operation_mode !== undefined && b.manifest.operation_mode !== "zero_human") {
+      out.push(mk("operation_mode_unsupported", `operation_mode ${String(b.manifest.operation_mode)} is declared but not honored this cycle — the engine runs zero_human`, "business.yaml.operation_mode"));
+    }
+    if (isMapping(b.manifest.legacy)) {
+      const l = b.manifest.legacy;
+      if (typeof l.paperclip_instance !== "string" || typeof l.paperclip_data_dir !== "string") {
+        out.push(mk("legacy_partial", "the legacy block names no instance or no data dir, so the migration cannot be traced", Object.keys(l).join(", ") || "(empty)"));
+      }
+    }
+    out.push(...routingMetadata(b.manifest));
+  }
+
+  // ── the seats ─────────────────────────────────────────────────────────────
+  if (b.employeesDirMissing) out.push(mk("employees_present", "employees/ is absent — a business with no seat cannot receive a brief", path.join(dir, "employees")));
+  else if (b.seats.length === 0) out.push(mk("employees_present", "employees/ holds no .md file", path.join(dir, "employees")));
+
+  const names = new Set(b.seats.map((s) => s.name));
+  for (const seat of b.seats) {
+    if (seat.frontmatterMissing) {
+      out.push(mk("employee_frontmatter_invalid", `${seat.stem}.md has no frontmatter block`, seat.file, seat.stem));
+      continue;
+    }
+    if (!seat.data) {
+      out.push(mk("employee_frontmatter_invalid", `${seat.stem}.md frontmatter does not parse: ${seat.parseError ?? "unknown reason"}`, seat.file, seat.stem, null));
+      continue;
+    }
+    const parsed = EmployeeFrontmatterSchema.safeParse(seat.data);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`);
+      out.push(mk("employee_frontmatter_invalid", `${seat.stem}.md fails EmployeeFrontmatterSchema`, issues.slice(0, 2).join(" · "), seat.stem, null));
+    }
+    if (seat.data.type === "mind_clone" && strings(seat.data.pinned_mind_clones).length === 0) {
+      out.push(mk("type_mind_clone_without_pin", `${seat.name} is typed mind_clone and pins no clone — the seat promises a voice it cannot guarantee`, "pinned_mind_clones", seat.stem));
+    }
+    if (seat.data.type === "antagonist_gate" && seat.data.is_antagonist !== true) {
+      out.push(mk("type_flag_mismatch", `${seat.name} is typed antagonist_gate without is_antagonist: true`, "is_antagonist", seat.stem));
+    }
+    if (seatSufficiency.sufficiencyOfFile(fs.readFileSync(seat.file, "utf8")).verdict === "thin") {
+      // `employees/<file>.md`, not the seat name: this is the key
+      // `baseline.importLegacy` writes when it converts a `.seat-sufficiency-
+      // baseline.json` entry, and recorded debt must survive the import.
+      out.push(mk("seat_thin", `${seat.name} carries too little method of its own to stand without a clone`, `${seat.body.trim().length} chars of body`, `employees/${path.basename(seat.file)}`));
+    }
+  }
+
+  const intakes = b.seats.filter((s) => s.data?.is_brief_intake === true);
+  if (b.seats.length > 0 && intakes.length !== 1) {
+    out.push(mk("intake_exactly_one", `${intakes.length} seat(s) declare is_brief_intake: true; a business receives a brief at exactly one`,
+      intakes.map((s) => s.name).join(", ") || "(none)", undefined, intakes.length === 0 ? "intake_from_chart_root" : null));
+  }
+  if (intakes.length === 1 && !(Array.isArray(intakes[0].data!.acceptance) && (intakes[0].data!.acceptance as unknown[]).length > 0)) {
+    out.push(mk("acceptance_missing", `the intake seat ${intakes[0].name} declares no acceptance — nothing tells the judge what the deliverable must satisfy`, "employees/" + intakes[0].stem + ".md"));
+  }
+  if (b.seats.length > ANTAGONIST_FLOOR && !b.seats.some((s) => s.data?.is_antagonist === true)) {
+    out.push(mk("antagonist_bp7", `${b.seats.length} seats and no antagonist: BP7 requires adversarial review above ${ANTAGONIST_FLOOR}`, "is_antagonist"));
+  }
+
+  out.push(...acceptanceFindings(b));
+  out.push(...deprecatedFindings(dir, b));
+  out.push(...chartFindings(b));
+  out.push(...routeFindings(b, names));
+  out.push(...squadRefFindings(b));
+  out.push(...cloneFindings(dir, b));
+  out.push(...fileFindings(dir, b));
+
+  out.push(...surfaceFindings(dir, "business", (id, message, evidence) => mk(id, message, evidence)));
+  for (const e of outputsLint.lintDir(dir).errors) out.push(mk("outputs_pollution", e, dir));
+  return out;
+}
+
+/** §6.9: the four fields the router reads off the manifest. */
+function routingMetadata(manifest: Record<string, unknown>): Finding[] {
+  const missing: string[] = [];
+  if (strings(manifest.produces).length === 0) missing.push("produces");
+  if (strings(manifest.keywords).length === 0) missing.push("keywords");
+  const briefs = strings(manifest.example_briefs);
+  if (briefs.length < EXAMPLE_BRIEFS_MIN) missing.push(`example_briefs (${briefs.length}/${EXAMPLE_BRIEFS_MIN})`);
+  else {
+    const langs = new Set(briefs.map(classify));
+    if (!langs.has("en") || !langs.has("pt")) missing.push(`example_briefs in both EN and PT (found ${[...langs].sort().join("+") || "none"})`);
+  }
+  if (strings(manifest.not_for).length === 0) missing.push("not_for");
+  return missing.length ? [mk("routing_metadata_incomplete", "the business is missing routing metadata the router reads (§6.9)", missing.join(" · "))] : [];
+}
+
+/** §11: ids match the pattern, are unique in the business, scores are in 0..1. */
+function acceptanceFindings(b: BusinessRead): Finding[] {
+  const out: Finding[] = [];
+  const seen = new Map<string, string>();
+  const ID = /^[a-z][a-z0-9_-]*$/;
+  for (const seat of b.seats) {
+    for (const entry of (Array.isArray(seat.data?.acceptance) ? seat.data!.acceptance : []) as unknown[]) {
+      if (!isMapping(entry)) { out.push(mk("acceptance_invalid", `${seat.name}: an acceptance entry is not a mapping`, String(entry).slice(0, 40), seat.stem)); continue; }
+      const id = typeof entry.id === "string" ? entry.id : "";
+      if (!ID.test(id)) out.push(mk("acceptance_invalid", `${seat.name}: acceptance id ${JSON.stringify(id)} does not match ^[a-z][a-z0-9_-]*$`, "id", `${seat.stem}:${id || "(unnamed)"}`));
+      else if (seen.has(id)) out.push(mk("acceptance_invalid", `${seat.name}: acceptance id ${id} is already declared by ${seen.get(id)} — ids are unique inside the business`, "id", `${seat.stem}:${id}`));
+      else seen.set(id, seat.name);
+      if (entry.minimum_score !== undefined) {
+        const n = typeof entry.minimum_score === "number" ? entry.minimum_score : Number(entry.minimum_score);
+        if (!Number.isFinite(n) || n < 0 || n > 1) out.push(mk("acceptance_invalid", `${seat.name}: minimum_score ${String(entry.minimum_score)} is outside 0..1`, "minimum_score", `${seat.stem}:${id || "(unnamed)"}`));
+      }
+    }
+  }
+  return out;
+}
+
+/** §22: every retired field, wherever it is declared, with its destination. */
+function deprecatedFindings(dir: string, b: BusinessRead): Finding[] {
+  const out: Finding[] = [];
+  const seats = new Map<string, string[]>();
+  for (const seat of b.seats) {
+    for (const field of Object.keys(RETIRED_EMPLOYEE_FIELDS)) {
+      if (seat.data && field in seat.data) seats.set(field, [...(seats.get(field) ?? []), seat.name]);
+    }
+    if (seat.data && (seat.data.squads_authorized === null || (Array.isArray(seat.data.squads_authorized) && seat.data.squads_authorized.length === 0))) {
+      seats.set("__empty_authorized", [...(seats.get("__empty_authorized") ?? []), seat.name]);
+    }
+  }
+  for (const [field, where] of seats) {
+    if (field === "__empty_authorized") continue;
+    const fixer = RETIRED_EMPLOYEE_FIELDS[field] ?? "deprecated_field_strip";
+    const destination = RETIRED_EMPLOYEE_FIELDS[field] ? "converted by --fix" : "removed by --fix";
+    out.push(mk("deprecated_field", `${where.length} seat(s) declare ${field}, retired in v2 (§22) — ${destination}`, where.slice(0, 4).join(", "), field, fixer));
+  }
+  for (const field of RETIRED_MANIFEST_FIELDS) {
+    if (b.manifest && field in b.manifest) out.push(mk("deprecated_field", `business.yaml declares ${field}, retired in v2 (§22)`, "business.yaml", field, "deprecated_field_strip"));
+  }
+  for (const field of RETIRED_ROUTING_FIELDS) {
+    if (b.routing && field in b.routing) out.push(mk("deprecated_field", `routing.yaml declares ${field}, retired in v2 (§22)`, "routing.yaml", field, "deprecated_field_strip"));
+  }
+  for (const field of RETIRED_ROUTE_FIELDS) {
+    const hits = autoRoutes(b).filter((r) => field in r.raw);
+    if (hits.length) out.push(mk("deprecated_field", `${hits.length} auto_route(s) declare ${field}, retired in v2 (§13.2) — nothing ever read it`, hits[0].pattern.slice(0, 40), field, "deprecated_field_strip"));
+  }
+
+  // §6.10: the empty list the spec and the prompt read in opposite directions.
+  const manifestEmpty = b.manifest && (b.manifest.squads_authorized === null || (Array.isArray(b.manifest.squads_authorized) && b.manifest.squads_authorized.length === 0));
+  const seatsEmpty = seats.get("__empty_authorized") ?? [];
+  if (manifestEmpty || seatsEmpty.length) {
+    const where = [...(manifestEmpty ? ["business.yaml"] : []), ...seatsEmpty];
+    out.push(mk("squads_authorized_empty", `${where.length} declaration(s) of squads_authorized: [] — empty means every squad (§6.10), and --fix removes the line`, where.slice(0, 4).join(", ")));
+  }
+  for (const file of RETIRED_FILES) {
+    if (fs.existsSync(path.join(dir, file))) out.push(mk("deprecated_file", `${file} is retired in v2 (§22) — reported, never deleted`, path.join(dir, file), file));
+  }
+  return out;
+}
+
+/** §5.3: the chart is a graph over the seats, consistent in both directions. */
+function chartFindings(b: BusinessRead): Finding[] {
+  const out: Finding[] = [];
+  if (b.chartMissing) return [mk("org_chart_missing", "org-chart.yaml is absent — the hierarchy the team mode walks has no file", "org-chart.yaml")];
+  if (!b.chart) return [mk("org_chart_inconsistent", `org-chart.yaml does not load: ${b.chartParseError ?? "unknown reason"}`, "org-chart.yaml")];
+  const parsed = OrgChartSchema.safeParse(b.chart);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`);
+    out.push(mk("org_chart_inconsistent", "org-chart.yaml fails OrgChartSchema", issues.slice(0, 2).join(" · ")));
+  }
+  const chart = (Array.isArray(b.chart.chart) ? b.chart.chart : []).filter(isMapping);
+  if (chart.length === 0) return out;                                  // the `org:` layout exposes no graph
+  const names = new Set(b.seats.map((s) => s.name));
+  const nodeOf = new Map(chart.map((n) => [String(n.employee), n]));
+  const problems: string[] = [];
+  for (const node of chart) {
+    const who = String(node.employee);
+    if (!names.has(who)) problems.push(`${who} has no employees/*.md`);
+    for (const up of strings(node.reports)) if (!names.has(up)) problems.push(`${who} reports to unknown ${up}`);
+    for (const down of strings(node.direct_reports)) {
+      if (!names.has(down)) { problems.push(`${who} manages unknown ${down}`); continue; }
+      const child = nodeOf.get(down);
+      if (child && !strings(child.reports).includes(who)) problems.push(`${who} manages ${down} but ${down} does not report back`);
+    }
+  }
+  const seen = new Set<string>(), stack = new Set<string>();
+  const cycles = (who: string): boolean => {
+    if (stack.has(who)) return true;
+    if (seen.has(who)) return false;
+    seen.add(who); stack.add(who);
+    for (const down of strings(nodeOf.get(who)?.direct_reports)) if (cycles(down)) return true;
+    stack.delete(who);
+    return false;
+  };
+  for (const node of chart) if (cycles(String(node.employee))) { problems.push(`the chart cycles through ${String(node.employee)}`); break; }
+  if (problems.length) out.push(mk("org_chart_inconsistent", `${problems.length} inconsistenc${problems.length === 1 ? "y" : "ies"} between org-chart.yaml and employees/`, problems.slice(0, 3).join(" · ")));
+  return out;
+}
+
+/** §13.2: routes name a seat, fire against a real brief, and never match all. */
+function routeFindings(b: BusinessRead, names: Set<string>): Finding[] {
+  const out: Finding[] = [];
+  const routes = autoRoutes(b);
+  if (routes.length === 0) return out;
+  const briefs = strings(b.manifest?.example_briefs);
+  for (const r of routes) {
+    const label = r.pattern.slice(0, 48) || "(empty)";
+    if (!names.has(r.route_to)) {
+      out.push(mk("auto_route_unknown_employee", `route_to ${r.route_to || "(empty)"} names no seat of this business`, `${r.source}: ${label}`, r.route_to || label));
+      continue;
+    }
+    if (CATCH_ALL.has(r.pattern.trim())) {
+      out.push(mk("auto_route_catch_all", `pattern ${label} matches every brief, so it is ignored and every specific route below it never runs`, `${r.source} → ${r.route_to}`, label));
+      continue;
+    }
+    const re = compilePattern(r.pattern);
+    if (!re) { out.push(mk("auto_route_never_fires", `pattern ${label} is not a regex this engine compiles`, r.source, label)); continue; }
+    if (briefs.length && !briefs.some((brief) => re.test(brief))) {
+      out.push(mk("auto_route_never_fires", `pattern ${label} fires against none of the ${briefs.length} example_briefs of the business`, `${r.source} → ${r.route_to}`, label));
+    }
+  }
+  return out;
+}
+
+/** §6.10: a squad named in a preference or a fence has to exist. */
+function squadRefFindings(b: BusinessRead): Finding[] {
+  const declared = new Map<string, string[]>();
+  const add = (slug: string, where: string) => declared.set(slug, [...(declared.get(slug) ?? []), where]);
+  for (const key of ["squads_preferred", "squads_authorized"]) {
+    for (const s of strings(b.manifest?.[key])) add(s, `business.yaml.${key}`);
+    for (const seat of b.seats) for (const s of strings(seat.data?.[key])) add(s, `${seat.name}.${key}`);
+  }
+  if (declared.size === 0) return [];
+  const installed = installedSlugs("squad");
+  if (installed.size === 0) return [];        // no library to compare against
+  const out: Finding[] = [];
+  for (const [slug, where] of declared) {
+    if (installed.has(slug)) continue;
+    out.push(mk("squads_ref_unknown", `${slug} is named by ${where.length} declaration(s) and is not installed`, where.slice(0, 3).join(", "), slug));
+  }
+  return out;
+}
+
+/** §7.7 / §5.3: pins resolve, and a dna/ symlink that broke is an error. */
+function cloneFindings(dir: string, b: BusinessRead): Finding[] {
+  const out: Finding[] = [];
+  const pins = new Map<string, string[]>();
+  for (const seat of b.seats) for (const p of strings(seat.data?.pinned_mind_clones)) {
+    const slug = cloneSlugOf(p) ?? p;
+    pins.set(slug, [...(pins.get(slug) ?? []), seat.name]);
+  }
+  if (pins.size) {
+    const installed = installedSlugs("mind-clone");
+    for (const [slug, seats] of pins) {
+      if (installed.has(slug)) continue;
+      out.push(mk("pinned_clone_unresolved", `${seats.join(", ")} pins ${slug}, which is not in the library — a seat that promises a voice must have it`, "pinned_mind_clones", slug));
+    }
+  }
+  const dnaDir = path.join(dir, "dna");
+  if (!fs.existsSync(dnaDir)) return out;
+  const entries = (() => { try { return fs.readdirSync(dnaDir); } catch { return []; } })();
+  for (const name of entries) {
+    const full = path.join(dnaDir, name);
+    let st; try { st = fs.lstatSync(full); } catch { continue; }
+    if (st.isSymbolicLink() && !fs.existsSync(full)) {
+      out.push(mk("dna_symlink_dangling", `dna/${name} points at a target that is gone — the binding already broke`, (() => { try { return fs.readlinkSync(full); } catch { return full; } })(), name));
+    }
+  }
+  out.push(mk("dna_dir_present", `dna/ holds ${entries.length} entr${entries.length === 1 ? "y" : "ies"}; symlinks do not travel in a pack, so §5.3 moves the binding into the frontmatter`, dnaDir));
+  return out;
+}
+
+/** README and memory: the two files a business is expected to carry. */
+function fileFindings(dir: string, b: BusinessRead): Finding[] {
+  const out: Finding[] = [];
+  const readme = ["README.md", "README.pt-BR.md"].map((f) => path.join(dir, f)).find((f) => fs.existsSync(f));
+  if (!readme) out.push(mk("readme_missing", "no README.md — the one document a human opens first", path.join(dir, "README.md")));
+  else {
+    const text = fs.readFileSync(readme, "utf8");
+    const lines = text.split("\n").length;
+    const lower = text.toLowerCase();
+    const groups = [["## "], ["employee", "funcionário", "cargo", "role"], ["usage", "uso", "como", "getting started"], ["domain", "domínio", "description", "descrição", "sobre"]];
+    const covered = groups.filter((g) => g.some((kw) => lower.includes(kw))).length;
+    if (lines < README_MIN_LINES || covered < 3) {
+      out.push(mk("readme_thin", `${path.basename(readme)} is ${lines} line(s) and covers ${covered}/4 of the sections a reader looks for`, path.basename(readme)));
+    }
+  }
+  if (!fs.existsSync(path.join(dir, "memory", "permanent.md"))) {
+    out.push(mk("memory_missing", "memory/permanent.md is absent — every seat starts each run with no curated facts", path.join(dir, "memory", "permanent.md")));
+  }
+  return out;
+}
+
+// ── self-retrieval ──────────────────────────────────────────────────────────
+
+const MATCH_INDEX = new WeakMap<object, unknown>();
+let REGISTRIES: any;
+
+/**
+ * ROUTING_METADATA_CONTRACT §9, one entity at a time: the business's own
+ * `example_briefs` are put through the router with amplification off, and the
+ * business has to come back first. The match index is built once per registry
+ * object, so `--all` over 61 businesses builds one corpus, not 61.
+ *
+ * The axis is skipped — silently, §16.2 declares no `info` severity — when
+ * retrieval is off, the registry is absent, or the business is not in it.
+ */
+async function selfRetrieval(ctx: CheckContext): Promise<Finding[]> {
+  let registries: any = ctx.registries;
+  if (!registries) {
+    if (REGISTRIES === undefined) {
+      try {
+        const loader = require_(path.join(import.meta.dir, "..", "..", "..", "..", "harness", "lib", "registry-loader.js"));
+        REGISTRIES = loader.loadAll();
+      } catch { REGISTRIES = null; }
+    }
+    registries = REGISTRIES;
+  }
+  if (!registries?.businesses?.businesses?.[ctx.slug]) return [];
+  const briefs = strings(readBusiness(ctx.dir).manifest?.example_briefs);
+  if (briefs.length === 0) return [];
+
+  const router = require_(path.join(import.meta.dir, "..", "..", "..", "..", "harness", "lib", "router.js"));
+  let prepared = MATCH_INDEX.get(registries as object);
+  if (!prepared) { prepared = router.prepareMatchIndex(registries); MATCH_INDEX.set(registries as object, prepared); }
+
+  for (const brief of briefs) {
+    const result = await router.route(brief, { registries, amplify: false, preparedMatchIndex: prepared });
+    const s3 = result?.stage3 ?? {};
+    const ranked = s3.signal === "HIGH" ? [s3.target, ...(s3.alternatives ?? [])].filter(Boolean)
+      : s3.signal === "AMBIGUOUS" ? (s3.alternatives ?? []).filter(Boolean) : [];
+    const hit = ranked.findIndex((c: any) => {
+      const meta = c?.meta ?? {};
+      return (meta.type === "business" || meta.type === "business_route") && meta.slug === ctx.slug;
+    });
+    if (hit === 0) continue;
+    const top = ranked.slice(0, 3).map((c: any) => `${c?.meta?.slug ?? c?.id ?? "?"} (${typeof c?.normalized === "number" ? c.normalized.toFixed(2) : "-"})`).join(", ") || "no candidates";
+    return [mk("self_retrieval_miss", `example_brief ${JSON.stringify(brief.slice(0, 48))} does not return this business first (rank ${hit === -1 ? "-" : hit + 1})`, `top: ${top}`)];
+  }
+  return [];
 }
 
 export async function check(ctx: CheckContext): Promise<Finding[]> {
-  const out: Finding[] = [];
-  const file = path.join(ctx.dir, "business.yaml");
-  try {
-    const doc = parseYaml(fs.readFileSync(file, "utf8"));
-    if (!doc || typeof doc !== "object" || Array.isArray(doc)) out.push(mk("manifest_parse", "business.yaml is not a YAML mapping", typeof doc));
-  } catch (e: any) {
-    out.push(mk("manifest_parse", "business.yaml does not parse", String(e?.message ?? e).split("\n")[0]));
-  }
-  out.push(...surfaceFindings(ctx.dir, "business", mk));
+  const out = checkSync(ctx.dir);
+  if (ctx.retrieval) out.push(...await selfRetrieval(ctx));
   return out;
 }
+
+// ── fixers ──────────────────────────────────────────────────────────────────
+
+/** Contract-surface paths a fixer touches; the digest that names changed files. */
+const TRACKED = ["business.yaml", "org-chart.yaml", "routing.yaml", "README.md", "employees", "memory", "dna"];
+
+function trackedDigest(dir: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const add = (rel: string) => {
+    const full = path.join(dir, rel);
+    let st: fs.Stats;
+    try { st = fs.lstatSync(full); } catch { return; }
+    if (st.isSymbolicLink()) { out[rel] = "symlink"; return; }
+    if (st.isFile()) { try { out[rel] = String(Bun.hash(fs.readFileSync(full))); } catch { /* unreadable */ } return; }
+    if (!st.isDirectory()) return;
+    for (const name of (() => { try { return fs.readdirSync(full); } catch { return []; } })()) add(path.posix.join(rel, name));
+  };
+  for (const rel of TRACKED) add(rel);
+  return out;
+}
+
+/**
+ * Runs one handler of `business-fixers.js` and reports which tracked files it
+ * changed. A handler that declines (`ok: false`) is a note in the report, never
+ * a thrown error: declining is how the gate says "this one needs a human".
+ */
+function delegate(kind: string, patchOf?: (f: Finding) => Record<string, unknown>): Fixer {
+  return ({ dir, finding }): FixResult => {
+    const before = trackedDigest(dir);
+    const r = fixers.applyBusinessFixes(dir, { patches: [{ kind, criterion: finding.id, ...(patchOf ? patchOf(finding) : {}) }] })[0];
+    const after = trackedDigest(dir);
+    const changed = [...new Set([...Object.keys(before), ...Object.keys(after)])].filter((k) => before[k] !== after[k]).sort();
+    const note = r?.result?.ok === false ? `declined: ${r.result.reason ?? "no reason given"}` : r?.result?.note ?? undefined;
+    return { ...fixResult(kind, finding, changed.length > 0, changed), ...(note ? { note } : {}) };
+  };
+}
+
+/**
+ * §18.4: the version is an assertion about everything else, so it rises last
+ * and only over a business with no error left. The guard re-runs the file-based
+ * half of the catalog — the half a fixer can have changed — and declines while
+ * anything is still an error.
+ */
+const protocolBump: Fixer = (ctx) => {
+  const remaining = checkSync(ctx.dir).filter((f) => f.severity === "error");
+  if (remaining.length) {
+    return { ...fixResult("protocol_bump_2", ctx.finding, false, []), note: `declined: ${remaining.length} error(s) still open (${remaining.slice(0, 3).map((f) => f.id).join(", ")})` };
+  }
+  return delegate("protocol_bump_2")(ctx);
+};
 
 export const businessModule: KindModule = {
   kind: "business",
@@ -42,6 +675,37 @@ export const businessModule: KindModule = {
   listAll: (roots) => listEntities("business", roots),
   criteria,
   check,
-  fixers: { surface_regen: surfaceRegenFixer("business") },
-  fixOrder: ["surface_regen"],
+  fixers: {
+    employee_frontmatter_repair: delegate("employee_frontmatter_repair"),
+    intake_from_chart_root: delegate("intake_from_chart_root"),
+    type_flag_sync: delegate("type_flag_sync"),
+    acceptance_from_self_score: delegate("acceptance_from_self_score"),
+    acceptance_normalize: delegate("acceptance_normalize"),
+    heartbeat_strip: delegate("heartbeat_strip"),
+    // Both conversions bind a seat to a clone, so both are told which clones
+    // the gate can see — the same set `pinned_clone_unresolved` judges against.
+    draws_from_to_assigned: delegate("draws_from_to_assigned", () => ({ available_clones: [...installedSlugs("mind-clone")] })),
+    dna_reference_to_pin: delegate("dna_reference_to_pin", () => ({ available_clones: [...installedSlugs("mind-clone")] })),
+    deprecated_field_strip: delegate("deprecated_field_strip", (f) => ({ field: f.where })),
+    squads_authorized_empty_strip: delegate("squads_authorized_empty_strip"),
+    manifest_schema_repair: delegate("manifest_schema_repair"),
+    employee_count_strip: delegate("employee_count_strip"),
+    runtime_requirements_business_default: delegate("runtime_requirements_business_default"),
+    org_chart_repair: delegate("org_chart_repair"),
+    auto_routes_relocate: delegate("auto_routes_relocate"),
+    catch_all_to_default_employee: delegate("catch_all_to_default_employee"),
+    dna_dir_to_bindings: delegate("dna_dir_to_bindings"),
+    readme_business_scaffold: delegate("readme_business_scaffold"),
+    memory_seed: delegate("memory_seed"),
+    surface_regen: surfaceRegenFixer("business"),
+    protocol_bump_2: protocolBump,
+  },
+  // Seats first (the chart is derived from their frontmatter), then the
+  // manifest, then routing, then the files, then the surface, and the version
+  // last: `protocol_bump_2` reads the state every handler before it left.
+  fixOrder: [
+    ...fixers.FIX_ORDER.filter((k) => k !== "protocol_bump_2" && k !== "routing_scaffold"),
+    "surface_regen",
+    "protocol_bump_2",
+  ],
 };

--- a/skills/_shared/tests/helpers/verify-fixture.ts
+++ b/skills/_shared/tests/helpers/verify-fixture.ts
@@ -263,11 +263,159 @@ export function squadFixture(root: string, slug: string, o: SquadOpts = {}): str
   return dir;
 }
 
-export function businessFixture(root: string, slug: string, o: { surface?: boolean; manifest?: string } = {}): string {
+export interface BusinessOpts {
+  surface?: boolean;
+  /** Replaces business.yaml wholesale (the malformed-manifest cases). */
+  manifest?: string;
+  /** Extra YAML appended to business.yaml, already at column 0. */
+  manifestExtra?: string;
+  protocol?: string;
+  /** Seat file name → content. Default: one intake seat, `ceo.md`. */
+  employees?: Record<string, string>;
+  /** Written when given; a business needs no routing.yaml to be admitted. */
+  routing?: string;
+  /** Replaces the derived org-chart.yaml; `null` leaves the file out. */
+  orgChart?: string | null;
+  readme?: string | null;
+  memory?: boolean;
+}
+
+/**
+ * A seat body the sufficiency scorer accepts: headings plus decision lines.
+ * `seat_thin` fires on a body without them, which is a different test.
+ */
+export const SEAT_BODY = [
+  "## Method",
+  "",
+  "- Read the brief twice before writing anything, and name what is missing.",
+  "- Decide the artifact type first; the format follows the decision, never leads it.",
+  "- When two readings of the brief are possible, state both and pick one out loud.",
+  "",
+  "## Thresholds",
+  "",
+  "- Reject a draft whose sources are not named and dated in the text itself.",
+  "- Escalate when the run would cost more than the budget the brief declared.",
+  "- Hand off only when every acceptance criterion of this seat is satisfied.",
+  "",
+].join("\n");
+
+/** The intake seat of the fixture: acceptance, a real body, protocol 2.0 shape. */
+export const INTAKE_SEAT = [
+  "---",
+  "name: ceo",
+  "role: Chief executive of the fixture business",
+  "description: Receives every brief, decides the artifact and hands the work to the seat that owns it.",
+  "type: orchestrator",
+  "is_brief_intake: true",
+  "acceptance:",
+  "  - id: brief_understood",
+  "    description: the deliverable answers the brief that was actually written",
+  "    blocking: true",
+  "    minimum_score: 0.8",
+  "---",
+  "",
+  `# CEO`,
+  "",
+  SEAT_BODY,
+].join("\n");
+
+/** A complete, admitted business at <root>/businesses/<slug>. */
+export function businessFixture(root: string, slug: string, o: BusinessOpts = {}): string {
   const dir = path.join(root, "businesses", slug);
   fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
-  fs.writeFileSync(path.join(dir, "business.yaml"), o.manifest ?? `name: ${slug}\nversion: 1.0.0\nprotocol: "1.0"\n`, "utf8");
-  fs.writeFileSync(path.join(dir, "employees", "ceo.md"), "---\nname: ceo\nrole: CEO\n---\n\n# CEO\n", "utf8");
+  const employees = o.employees ?? { "ceo.md": INTAKE_SEAT };
+  for (const [file, content] of Object.entries(employees)) fs.writeFileSync(path.join(dir, "employees", file), content, "utf8");
+
+  fs.writeFileSync(path.join(dir, "business.yaml"), o.manifest ?? [
+    `name: ${slug}`,
+    "version: 1.0.0",
+    `protocol: "${o.protocol ?? "2.0"}"`,
+    "description: Fixture business that turns a written brief into one artifact, decides the format from the brief and hands it back reviewed.",
+    "domains: [fixture_domain]",
+    "produces: [fixture-report]",
+    "keywords: [fixture, report, relatorio, relatório, brief]",
+    "example_briefs:",
+    '  - "turn this brief into the fixture report our team can read"',
+    '  - "preciso do relatório de fixture a partir deste brief"',
+    '  - "write the fixture report and review it before delivery"',
+    'not_for: ["logo design", "tax filing"]',
+    "run_budget_usd: 0",
+    "operation_mode: zero_human",
+    "runtime_requirements:",
+    "  policy: active",
+    ...(o.manifestExtra ? [o.manifestExtra] : []),
+    "",
+  ].join("\n"), "utf8");
+
+  if (o.orgChart !== null) {
+    fs.writeFileSync(path.join(dir, "org-chart.yaml"), o.orgChart ?? [
+      "chart:",
+      ...Object.keys(employees).flatMap((f, i) => {
+        const name = /^name:\s*(\S+)/m.exec(employees[f])?.[1] ?? f.replace(/\.md$/, "");
+        const root_ = i === 0;
+        const children = Object.keys(employees).slice(1).map((c) => /^name:\s*(\S+)/m.exec(employees[c])?.[1] ?? c.replace(/\.md$/, ""));
+        return [
+          `  - employee: ${name}`,
+          `    reports: [${root_ ? "" : (/^name:\s*(\S+)/m.exec(employees[Object.keys(employees)[0]])?.[1] ?? "ceo")}]`,
+          `    direct_reports: [${root_ ? children.join(", ") : ""}]`,
+          "    is_antagonist: false",
+        ];
+      }),
+      "",
+    ].join("\n"), "utf8");
+  }
+  if (o.routing) fs.writeFileSync(path.join(dir, "routing.yaml"), o.routing, "utf8");
+  if (o.readme !== null) {
+    fs.writeFileSync(path.join(dir, "README.md"), o.readme ?? [
+      `# ${slug}`,
+      "",
+      "Fixture business. It exists so the admission gate has something complete to",
+      "compare a broken business against.",
+      "",
+      "## Description",
+      "",
+      "Turns a written brief into one artifact and hands it back reviewed.",
+      "",
+      "## Employees",
+      "",
+      ...Object.keys(employees).map((f) => `- \`${f.replace(/\.md$/, "")}\``),
+      "",
+      "## Usage",
+      "",
+      "```bash",
+      `nrv validate business ${slug} --strict`,
+      "```",
+      "",
+      "## Domain",
+      "",
+      "One fixture domain, one produces slug, three example briefs.",
+      "",
+      "## Memory",
+      "",
+      "`memory/permanent.md` holds the curated facts every seat reads.",
+      "",
+      "## Notes",
+      "",
+      "Everything here is deliberately boring: the tests break one thing at a time.",
+      "",
+      "## History",
+      "",
+      "Created by the fixture builder, never by hand.",
+      "",
+      "## Contact",
+      "",
+      "Nobody: this business has no owner outside the test run.",
+      "",
+      "## License",
+      "",
+      "MIT, like the engine.",
+      "",
+    ].join("\n"), "utf8");
+  }
+  if (o.memory !== false) {
+    fs.mkdirSync(path.join(dir, "memory"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "memory", "permanent.md"), "# Permanent memory\n\n- The fixture business delivers one artifact per brief.\n", "utf8");
+  }
   if (o.surface !== false) writeSurfaceFor(dir, "business");
   return dir;
 }

--- a/skills/_shared/tests/verify-business.test.ts
+++ b/skills/_shared/tests/verify-business.test.ts
@@ -1,0 +1,422 @@
+/**
+ * verify-business.test.ts — the business catalog of `nrv validate`.
+ *
+ * One fixture per criterion. The builder in `helpers/verify-fixture.ts` writes
+ * a business that is ADMITTED with zero warnings under `--strict`; every test
+ * below breaks exactly one thing and asserts that exactly that id fires. A
+ * catalog whose criteria are only checked in aggregate is a catalog where a
+ * criterion can silently stop firing, which is the failure mode this cut exists
+ * to remove.
+ *
+ * Everything runs under mkdtemp with the CLI env redirected there; the
+ * installed library at ~/businesses is never read and never written.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { businessFixture, INTAKE_SEAT, rmrf, runCli, squadFixture, tempRoot, writeSurfaceFor, type BusinessOpts } from "./helpers/verify-fixture.ts";
+import { businessModule, criteria as businessCriteria } from "../lib/verify/kinds/business.ts";
+import { verifyEntity } from "../lib/verify/index.ts";
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) rmrf(r); });
+function root(): string { const r = tempRoot(); ROOTS.push(r); return r; }
+
+/** The gate's findings for one fixture, by id. */
+function findings(r: string, slug: string, extra: string[] = []): Array<{ id: string; severity: string; where?: string; fixer?: string; message: string }> {
+  const out = runCli(r, ["business", slug, "--no-retrieval", "--json", ...extra]);
+  expect(out.json).not.toBeNull();
+  return out.json.findings;
+}
+const idsOf = (f: Array<{ id: string }>) => f.map((x) => x.id);
+
+/** Builds one business and returns what the gate says about it. */
+function check(slug: string, o: BusinessOpts = {}, extra: string[] = []) {
+  const r = root();
+  businessFixture(r, slug, o);
+  return { root: r, findings: findings(r, slug, extra) };
+}
+
+const SEAT = (name: string, extra: string[] = [], body = "\n## Method\n\n- One decision line that is long enough to count as method for the seat.\n") =>
+  ["---", `name: ${name}`, `role: ${name} of the fixture business`,
+    `description: The ${name} seat exists so the gate has a second employee to reason about.`,
+    ...extra, "---", "", `# ${name}`, body].join("\n");
+
+describe("catalog integrity", () => {
+  test("ids are unique, every fixer exists and is in fixOrder, protocol rises last", () => {
+    const ids = businessCriteria.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const fixers = new Set(Object.keys(businessModule.fixers));
+    for (const c of businessCriteria) if (c.fixer) expect(fixers.has(c.fixer)).toBe(true);
+    for (const f of fixers) expect(businessModule.fixOrder).toContain(f);
+    // §18.4: the version is an assertion about everything else, so it rises
+    // after every other handler had its turn.
+    expect(businessModule.fixOrder[businessModule.fixOrder.length - 1]).toBe("protocol_bump_2");
+    expect(businessModule.fixOrder).toContain("surface_regen");
+  });
+
+  test("only seat_thin and self_retrieval_miss are baselineable, and no error is", () => {
+    expect(businessCriteria.filter((c) => c.baselineable).map((c) => c.id).sort()).toEqual(["seat_thin", "self_retrieval_miss"]);
+    for (const c of businessCriteria) if (c.severity === "error") expect(c.baselineable).toBe(false);
+  });
+
+  test("every criterion declares error or warning — §16.2 has no third severity", () => {
+    for (const c of businessCriteria) expect(["error", "warning"]).toContain(c.severity);
+  });
+});
+
+describe("a complete business is admitted", () => {
+  test("the fixture passes every criterion, warnings included", () => {
+    const r = root();
+    businessFixture(r, "whole-biz");
+    const out = runCli(r, ["business", "whole-biz", "--strict", "--no-retrieval", "--json"]);
+    expect(out.json.findings).toEqual([]);
+    expect(out.json.summary).toMatchObject({ errors: 0, warnings: 0, debt: 0, passed: businessCriteria.length });
+    expect(out.code).toBe(0);
+  });
+
+  test("a warning rejects only under --strict", () => {
+    const r = root();
+    businessFixture(r, "v1-biz", { protocol: "1.0" });
+    expect(runCli(r, ["business", "v1-biz", "--no-retrieval"]).code).toBe(0);
+    expect(runCli(r, ["business", "v1-biz", "--no-retrieval", "--strict"]).code).toBe(2);
+  });
+});
+
+// ── errors ──────────────────────────────────────────────────────────────────
+
+describe("errors", () => {
+  test("manifest_parse: business.yaml is not YAML", () => {
+    expect(idsOf(check("bad-yaml", { manifest: "name: [unclosed\n" }).findings)).toContain("manifest_parse");
+  });
+
+  test("manifest_schema: a required key the schema names is absent", () => {
+    const f = check("no-domains", { manifest: 'name: no-domains\nversion: 1.0.0\nprotocol: "2.0"\ndescription: A manifest that declares no domains at all, which the schema requires it to.\n' }).findings;
+    expect(idsOf(f)).toContain("manifest_schema");
+    expect(f.find((x) => x.id === "manifest_schema")!.severity).toBe("error");
+  });
+
+  test("protocol_unsupported: a version this engine does not load", () => {
+    expect(idsOf(check("v3-biz", { protocol: "3.0" }).findings)).toContain("protocol_unsupported");
+  });
+
+  test("employees_present: employees/ is empty", () => {
+    expect(idsOf(check("no-seats", { employees: {}, orgChart: "chart: []\n" }).findings)).toContain("employees_present");
+  });
+
+  test("employee_frontmatter_invalid: no frontmatter at all, and the fixer is the skeleton", () => {
+    const f = check("no-fm", { employees: { "ceo.md": INTAKE_SEAT, "ghost.md": "# ghost\n\nNo frontmatter here.\n" } }).findings;
+    const hit = f.find((x) => x.id === "employee_frontmatter_invalid");
+    expect(hit).toBeDefined();
+    expect(hit!.where).toBe("ghost");
+    expect(hit!.fixer).toBe("employee_frontmatter_repair");
+  });
+
+  test("employee_frontmatter_invalid: a header that fails the schema carries no fixer", () => {
+    const f = check("bad-fm", { employees: { "ceo.md": INTAKE_SEAT.replace("role: Chief executive of the fixture business", "role: X") } }).findings;
+    const hit = f.find((x) => x.id === "employee_frontmatter_invalid");
+    expect(hit).toBeDefined();
+    expect(hit!.fixer).toBeUndefined();
+  });
+
+  test("intake_exactly_one: zero intakes get the chart-root fixer, two get none", () => {
+    const none = check("no-intake", { employees: { "ceo.md": INTAKE_SEAT.replace("is_brief_intake: true", "is_brief_intake: false") } }).findings;
+    expect(none.find((x) => x.id === "intake_exactly_one")!.fixer).toBe("intake_from_chart_root");
+    const two = check("two-intakes", { employees: { "ceo.md": INTAKE_SEAT, "second.md": SEAT("second", ["is_brief_intake: true"]) } }).findings;
+    expect(two.find((x) => x.id === "intake_exactly_one")!.fixer).toBeUndefined();
+  });
+
+  test("org_chart_missing / org_chart_inconsistent", () => {
+    expect(idsOf(check("no-chart", { orgChart: null }).findings)).toContain("org_chart_missing");
+    const f = check("ghost-chart", { orgChart: "chart:\n  - employee: ghost\n    reports: []\n    direct_reports: []\n" }).findings;
+    expect(idsOf(f)).toContain("org_chart_inconsistent");
+    expect(f.find((x) => x.id === "org_chart_inconsistent")!.message).toMatch(/inconsistenc/);
+  });
+
+  test("org_chart_inconsistent: reporting that is not bidirectional", () => {
+    const employees = { "ceo.md": INTAKE_SEAT, "second.md": SEAT("second") };
+    const chart = "chart:\n  - employee: ceo\n    reports: []\n    direct_reports: [second]\n  - employee: second\n    reports: []\n    direct_reports: []\n";
+    expect(idsOf(check("one-way", { employees, orgChart: chart }).findings)).toContain("org_chart_inconsistent");
+  });
+
+  test("antagonist_bp7: six seats and no adversarial review", () => {
+    const employees: Record<string, string> = { "ceo.md": INTAKE_SEAT };
+    for (let i = 1; i <= 5; i++) employees[`seat${i}.md`] = SEAT(`seat${i}`, ["reports_to: ceo"]);
+    const chart = ["chart:", "  - employee: ceo", "    reports: []", `    direct_reports: [${[1, 2, 3, 4, 5].map((i) => `seat${i}`).join(", ")}]`,
+      ...[1, 2, 3, 4, 5].flatMap((i) => [`  - employee: seat${i}`, "    reports: [ceo]", "    direct_reports: []"]), ""].join("\n");
+    expect(idsOf(check("bp7-biz", { employees, orgChart: chart }).findings)).toContain("antagonist_bp7");
+  });
+
+  test("auto_route_unknown_employee: route_to names nobody", () => {
+    const f = check("ghost-route", { routing: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ghost\n' }).findings;
+    expect(idsOf(f)).toContain("auto_route_unknown_employee");
+    expect(f.find((x) => x.id === "auto_route_unknown_employee")!.where).toBe("ghost");
+  });
+
+  test("auto_route_in_manifest: the routes are in the wrong file", () => {
+    const f = check("manifest-routes", { manifestExtra: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n' }).findings;
+    expect(idsOf(f)).toContain("auto_route_in_manifest");
+    expect(f.find((x) => x.id === "auto_route_in_manifest")!.fixer).toBe("auto_routes_relocate");
+  });
+
+  test("pinned_clone_unresolved: a seat promises a voice the library does not have", () => {
+    const f = check("ghost-pin", { employees: { "ceo.md": INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\npinned_mind_clones: [nobody-at-all]") } }).findings;
+    expect(idsOf(f)).toContain("pinned_clone_unresolved");
+    expect(f.find((x) => x.id === "pinned_clone_unresolved")!.where).toBe("nobody-at-all");
+  });
+
+  test("acceptance_invalid: a malformed id, a duplicate id and a score outside 0..1", () => {
+    const bad = INTAKE_SEAT.replace("  - id: brief_understood", "  - id: Brief Understood");
+    expect(idsOf(check("bad-acc-id", { employees: { "ceo.md": bad } }).findings)).toContain("acceptance_invalid");
+
+    const dup = SEAT("second", ["acceptance:", "  - id: brief_understood", "    description: the same id as the intake seat"]);
+    const f = check("dup-acc", { employees: { "ceo.md": INTAKE_SEAT, "second.md": dup } }).findings;
+    expect(f.filter((x) => x.id === "acceptance_invalid").some((x) => /already declared/.test(x.message))).toBe(true);
+
+    const score = INTAKE_SEAT.replace("minimum_score: 0.8", "minimum_score: 80");
+    expect(check("bad-score", { employees: { "ceo.md": score } }).findings.filter((x) => x.id === "acceptance_invalid").some((x) => /0\.\.1/.test(x.message))).toBe(true);
+  });
+
+  test("surface_missing", () => {
+    expect(idsOf(check("no-surface", { surface: false }).findings)).toContain("surface_missing");
+  });
+
+  test("dna_symlink_dangling: the binding already broke", () => {
+    const r = root();
+    const dir = businessFixture(r, "dangling-biz");
+    fs.mkdirSync(path.join(dir, "dna"));
+    fs.symlinkSync(path.join(r, "dna", "gone-clone"), path.join(dir, "dna", "gone-clone"));
+    writeSurfaceFor(dir, "business");
+    const f = findings(r, "dangling-biz");
+    expect(idsOf(f)).toContain("dna_symlink_dangling");
+    expect(idsOf(f)).toContain("dna_dir_present");
+  });
+
+  test("outputs_pollution: a run-output dir inside the business", () => {
+    const r = root();
+    const dir = businessFixture(r, "polluted-biz");
+    fs.mkdirSync(path.join(dir, "outputs"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "outputs", "report.md"), "# run output\n", "utf8");
+    expect(idsOf(findings(r, "polluted-biz"))).toContain("outputs_pollution");
+  });
+});
+
+// ── warnings ────────────────────────────────────────────────────────────────
+
+describe("warnings", () => {
+  test("protocol_v1 carries the bump fixer", () => {
+    const f = check("still-v1", { protocol: "1.0" }).findings;
+    expect(f.find((x) => x.id === "protocol_v1")!.fixer).toBe("protocol_bump_2");
+  });
+
+  test("employee_count_authored", () => {
+    expect(idsOf(check("counted", { manifestExtra: "employee_count: 1" }).findings)).toContain("employee_count_authored");
+  });
+
+  test("deprecated_field: the conversions and the removals reach different fixers", () => {
+    const seat = INTAKE_SEAT.replace("type: orchestrator", [
+      "type: orchestrator",
+      "budget_monthly_usd: 10",
+      "heartbeat:",
+      "  cadence: daily",
+      "  enabled: true",
+      "self_score_contract:",
+      "  required_before_handoff: true",
+      "  criteria:",
+      "    - id: quality",
+      "      description: the deliverable is worth handing over",
+      "      threshold: 0.8",
+    ].join("\n"));
+    const f = check("deprecated-biz", { employees: { "ceo.md": seat } }).findings.filter((x) => x.id === "deprecated_field");
+    const byField = Object.fromEntries(f.map((x) => [x.where, x.fixer]));
+    expect(byField.heartbeat).toBe("heartbeat_strip");
+    expect(byField.self_score_contract).toBe("acceptance_from_self_score");
+    expect(byField.budget_monthly_usd).toBe("deprecated_field_strip");
+  });
+
+  test("deprecated_file: reported, never deleted", () => {
+    const r = root();
+    const dir = businessFixture(r, "culture-biz");
+    fs.writeFileSync(path.join(dir, "culture.md"), "# Culture\n\nWe ship.\n", "utf8");
+    const f = findings(r, "culture-biz");
+    expect(f.find((x) => x.id === "deprecated_file")!.where).toBe("culture.md");
+    expect(runCli(r, ["business", "culture-biz", "--no-retrieval", "--fix"]).code).toBe(0);
+    expect(fs.existsSync(path.join(dir, "culture.md"))).toBe(true);
+  });
+
+  test("squads_authorized_empty: the manifest and the seat both count", () => {
+    const f = check("empty-authorized", {
+      manifestExtra: "squads_authorized: []",
+      employees: { "ceo.md": INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\nsquads_authorized: []") },
+    }).findings;
+    const hit = f.find((x) => x.id === "squads_authorized_empty")!;
+    expect(hit.message).toMatch(/2 declaration/);
+    expect(hit.fixer).toBe("squads_authorized_empty_strip");
+  });
+
+  test("squads_ref_unknown: a fence naming a squad that is not installed", () => {
+    const r = root();
+    squadFixture(r, "real-squad");
+    businessFixture(r, "fenced-biz", { manifestExtra: "squads_authorized: [real-squad, ghost-squad]" });
+    const f = findings(r, "fenced-biz");
+    const hits = f.filter((x) => x.id === "squads_ref_unknown");
+    expect(hits.map((x) => x.where)).toEqual(["ghost-squad"]);
+  });
+
+  test("acceptance_missing: the intake seat declares nothing for the judge", () => {
+    const seat = INTAKE_SEAT.split("acceptance:")[0] + "---\n\n# CEO\n\n## Method\n\n- A decision line long enough to keep this seat out of seat_thin.\n- A second decision line so the seat has method of its own.\n";
+    expect(idsOf(check("no-acceptance", { employees: { "ceo.md": seat } }).findings)).toContain("acceptance_missing");
+  });
+
+  test("routing_metadata_incomplete names the field that is missing", () => {
+    const r = root();
+    const dir = businessFixture(r, "no-fence");
+    const manifest = fs.readFileSync(path.join(dir, "business.yaml"), "utf8").replace(/^not_for:.*$/m, "");
+    fs.writeFileSync(path.join(dir, "business.yaml"), manifest, "utf8");
+    writeSurfaceFor(dir, "business");
+    const hit = findings(r, "no-fence").find((x) => x.id === "routing_metadata_incomplete")!;
+    expect(hit.message).toMatch(/§6\.9/);
+  });
+
+  test("routing_metadata_incomplete: three briefs in one language only", () => {
+    const r = root();
+    const dir = businessFixture(r, "one-language");
+    const manifest = fs.readFileSync(path.join(dir, "business.yaml"), "utf8")
+      .replace('  - "preciso do relatório de fixture a partir deste brief"', '  - "produce the fixture report for the team that asked"');
+    fs.writeFileSync(path.join(dir, "business.yaml"), manifest, "utf8");
+    writeSurfaceFor(dir, "business");
+    expect(idsOf(findings(r, "one-language"))).toContain("routing_metadata_incomplete");
+  });
+
+  test("description_short", () => {
+    const manifest = [
+      "name: terse-biz", "version: 1.0.0", 'protocol: "2.0"',
+      "description: Does things for people sometimes.",
+      "domains: [fixture_domain]", "produces: [fixture-report]", "keywords: [fixture, relatorio]",
+      "example_briefs:", '  - "turn this brief into the fixture report our team can read"',
+      '  - "preciso do relatório de fixture a partir deste brief"', '  - "write the fixture report and review it"',
+      'not_for: ["logo design"]', "runtime_requirements:", "  policy: active", "",
+    ].join("\n");
+    expect(idsOf(check("terse-biz", { manifest }).findings)).toContain("description_short");
+  });
+
+  test("auto_route_never_fires and auto_route_catch_all", () => {
+    const never = check("dead-route", { routing: 'auto_routes:\n  - pattern: "(?i)\\\\bcryogenics\\\\b"\n    route_to: ceo\n' }).findings;
+    expect(idsOf(never)).toContain("auto_route_never_fires");
+    const all = check("catch-all", { routing: 'auto_routes:\n  - pattern: ".*"\n    route_to: ceo\n' }).findings;
+    const hit = all.find((x) => x.id === "auto_route_catch_all")!;
+    expect(hit.fixer).toBe("catch_all_to_default_employee");
+    // A catch-all is judged before "does it fire": it fires against everything.
+    expect(idsOf(all)).not.toContain("auto_route_never_fires");
+  });
+
+  test("seat_thin is baselineable debt, not a verdict", () => {
+    const thin = ["---", "name: second", "role: Second seat", "description: A seat whose body says nothing about how it works at all.", "---", "", "# second", ""].join("\n");
+    const r = root();
+    businessFixture(r, "thin-biz", { employees: { "ceo.md": INTAKE_SEAT, "second.md": thin } });
+    const f = findings(r, "thin-biz");
+    // The key the legacy seat-sufficiency baseline imports as.
+    expect(f.find((x) => x.id === "seat_thin")!.where).toBe("employees/second.md");
+    // Recorded once, it stops counting as a warning.
+    expect(runCli(r, ["business", "--all", "--no-retrieval", "--record", "--json"]).json.baseline.recorded).toBe(true);
+    const after = runCli(r, ["business", "thin-biz", "--no-retrieval", "--strict", "--json"]);
+    expect(after.json.findings.find((x: any) => x.id === "seat_thin").baselined).toBe(true);
+    expect(after.code).toBe(0);
+  });
+
+  test("readme_missing / readme_thin / memory_missing", () => {
+    expect(idsOf(check("no-readme", { readme: null }).findings)).toContain("readme_missing");
+    expect(idsOf(check("thin-readme", { readme: "# thin\n\nNothing here.\n" }).findings)).toContain("readme_thin");
+    expect(idsOf(check("no-memory", { memory: false }).findings)).toContain("memory_missing");
+  });
+
+  test("runtime_requirements_default: the template skeleton never got a floor", () => {
+    const manifest = [
+      "name: skeleton-biz", "version: 1.0.0", 'protocol: "2.0"',
+      "description: Fixture business that turns a written brief into one artifact and hands it back reviewed, twice over.",
+      "domains: [fixture_domain]", "produces: [fixture-report]", "keywords: [fixture, relatorio]",
+      "example_briefs:", '  - "turn this brief into the fixture report our team can read"',
+      '  - "preciso do relatório de fixture a partir deste brief"', '  - "write the fixture report and review it"',
+      'not_for: ["logo design"]', "runtime_requirements:", "  policy: declared", "",
+    ].join("\n");
+    expect(idsOf(check("skeleton-biz", { manifest }).findings)).toContain("runtime_requirements_default");
+  });
+
+  test("type_mind_clone_without_pin and type_flag_mismatch", () => {
+    const clone = SEAT("second", ["type: mind_clone", "disclosure_required: true"]);
+    expect(idsOf(check("unpinned", { employees: { "ceo.md": INTAKE_SEAT, "second.md": clone } }).findings)).toContain("type_mind_clone_without_pin");
+    const gate = SEAT("second", ["type: antagonist_gate"]);
+    const f = check("flagless", { employees: { "ceo.md": INTAKE_SEAT, "second.md": gate } }).findings;
+    expect(f.find((x) => x.id === "type_flag_mismatch")!.fixer).toBe("type_flag_sync");
+  });
+
+  test("surface_stale: a file changed after the surface was written", () => {
+    const r = root();
+    const dir = businessFixture(r, "stale-biz");
+    fs.appendFileSync(path.join(dir, "employees", "ceo.md"), "\n- One more decision line, written after the surface was frozen.\n");
+    expect(idsOf(findings(r, "stale-biz"))).toContain("surface_stale");
+  });
+
+  test("operation_mode_unsupported and legacy_partial", () => {
+    expect(idsOf(check("hybrid-biz", { manifestExtra: "operation_mode: hybrid" }).findings)).toContain("operation_mode_unsupported");
+    expect(idsOf(check("half-legacy", { manifestExtra: "legacy:\n  paperclip_instance: prod" }).findings)).toContain("legacy_partial");
+  });
+
+  test("dna_dir_present carries the bindings fixer", () => {
+    const r = root();
+    const dir = businessFixture(r, "dna-biz");
+    fs.mkdirSync(path.join(dir, "dna", "some-clone"), { recursive: true });
+    writeSurfaceFor(dir, "business");
+    expect(findings(r, "dna-biz").find((x) => x.id === "dna_dir_present")!.fixer).toBe("dna_dir_to_bindings");
+  });
+});
+
+// ── self-retrieval ──────────────────────────────────────────────────────────
+
+describe("the self-retrieval axis", () => {
+  const registryEntry = (o: Record<string, unknown>) => ({
+    description: "", domains: [], capabilities: [], produces: [], keywords: [], example_briefs: [], not_for: [], ...o,
+  });
+
+  test("no registry means no finding — the axis is skipped, never guessed", async () => {
+    const r = root();
+    const dir = businessFixture(r, "unindexed-biz");
+    const report = await verifyEntity("business", dir, { stateDir: null, emit: null, baselinePath: null });
+    expect(report.findings.map((f) => f.id)).not.toContain("self_retrieval_miss");
+    expect(report.verdict).toBe("ADMITTED");
+  });
+
+  test("an example_brief that returns another business first is a miss", async () => {
+    const r = root();
+    const dir = businessFixture(r, "misdeclared-biz", {
+      manifestExtra: undefined,
+      manifest: [
+        "name: misdeclared-biz", "version: 1.0.0", 'protocol: "2.0"',
+        "description: Bookkeeping, tax filing and payroll reconciliation for small companies, month after month.",
+        "domains: [accounting]", "produces: [tax-return]", "keywords: [bookkeeping, tax, payroll, contabilidade]",
+        "example_briefs:",
+        '  - "design a new logo and a full brand book for our company"',
+        '  - "preciso de um logotipo novo e de um manual de marca completo"',
+        '  - "create the brand identity, logo and visual system"',
+        'not_for: ["logo design"]', "runtime_requirements:", "  policy: active", "",
+      ].join("\n"),
+    });
+    const registries = {
+      squads: { squads: {}, domains: {}, _v4_inferred_capabilities: {}, capabilities: {} },
+      businesses: {
+        businesses: {
+          "misdeclared-biz": registryEntry({ description: "Bookkeeping, tax filing and payroll reconciliation for small companies.", domains: ["accounting"], keywords: ["bookkeeping", "tax", "payroll"] }),
+          "brand-studio": registryEntry({ description: "Logo design, brand book and the whole visual identity system.", domains: ["branding"], keywords: ["logo", "brand", "identity", "logotipo", "marca"] }),
+        },
+        _business_routing: {},
+      },
+      warnings: [],
+    };
+    const report = await verifyEntity("business", dir, { stateDir: null, emit: null, baselinePath: null, registries });
+    const hit = report.findings.find((f) => f.id === "self_retrieval_miss");
+    expect(hit).toBeDefined();
+    expect(hit!.baselined).toBe(false);
+    expect(report.summary.warnings).toBeGreaterThan(0);
+    expect(report.verdict).toBe("ADMITTED");            // a warning never rejects on its own
+  });
+});

--- a/skills/businesses/CONFIGURATION.md
+++ b/skills/businesses/CONFIGURATION.md
@@ -54,14 +54,24 @@ Creates a new business via interactive wizard.
 | `--domain <slug>,...` | (interactive) | Override domains (skips the user prompt) |
 | `--employee-count <n>` | (interactive) | Pre-sets the wizard's employee count |
 
-### `validate-business.ts <path-or-slug>`
+### `validate-business.ts <path-or-slug>|--all`
 
-Validates manifest + integrity.
+The admission gate. Delegates to the shared runner, so this script and
+`nrv validate business` are the same code path and the same catalog
+(`BUSINESS_PROTOCOL_V2.md` §16: 16 errors, 23 warnings).
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `<path-or-slug>` (positional) | required | Absolute path or slug (resolved against `BUSINESSES_DIR`) |
-| `--strict` | (off) | Promotes warnings to errors (BP7 antagonist, intake unique, schema strict) |
+| `<path-or-slug>` (positional) | required unless `--all` | Absolute path or slug (resolved against the scope, then `BUSINESSES_DIR`) |
+| `--all` | (off) | Every business the scope resolves, one batch report |
+| `--fix` | (off) | Applies the mechanical fixers with backup, re-check and rollback |
+| `--strict` | (off) | Warnings reject too (exit 2) |
+| `--json` | (off) | `nirvana.verify-report/v1`, or `nirvana.verify-batch/v1` with `--all` |
+| `--report` | (off) | Also writes the JSON to `.audit-state/<slug>/verify.json` |
+| `--no-retrieval` | (off) | Skips the self-retrieval axis |
+
+Exit: `0` admitted · `1` an error the baseline does not cover · `2` only
+warnings, under `--strict` · `64` usage error or unknown business.
 
 ### `index-businesses.ts [options]`
 

--- a/skills/businesses/README.md
+++ b/skills/businesses/README.md
@@ -214,7 +214,7 @@ Validators in `~/.nirvana/skills/_shared/validators/validators.{ts,py}` (Zod + P
 | Script | Purpose |
 |---|---|
 | `init-business.ts <name> [--template solo\|council\|agency]` | Interactive wizard |
-| `validate-business.ts <path>` | Manifest + integrity validation |
+| `validate-business.ts <slug\|path>\|--all [--fix] [--strict] [--json] [--report]` | Admission gate (Protocol 2.0 §16) |
 | `index-businesses.ts [--roots <dir>...]` | Rebuild registry |
 | `list-businesses.ts [--format json\|table]` | Enumerate registry |
 | `inspect-business.ts <slug>` | Detailed view |

--- a/skills/businesses/SKILL.md
+++ b/skills/businesses/SKILL.md
@@ -173,7 +173,7 @@ Multi-intent: process in dependency order. Always lazy-load (never load the full
 | Command | Implementation | Description |
 |---|---|---|
 | `*business init <name>` | `bun ~/.nirvana/skills/businesses/scripts/init-business.ts <name>` + wizard via AskUserQuestion | Scaffold new business in `~/businesses/<slug>/` |
-| `nrv validate business <slug>` | `bun ~/.nirvana/skills/businesses/scripts/validate-business.ts <slug>` | Admission gate: manifest + employees + org-chart + integrity (`--strict` also fails on warnings) |
+| `nrv validate business <slug>` | `bun ~/.nirvana/skills/businesses/scripts/validate-business.ts <slug>` | Admission gate: the 39 criteria of `BUSINESS_PROTOCOL_V2.md` §16 (`--fix` applies the mechanical repairs, `--strict` also fails on warnings, `--all` walks the library, `--report` writes the JSON under `.audit-state/<slug>/`) |
 | `*business index` | `bun ~/.nirvana/skills/businesses/scripts/index-businesses.ts` | Regenerates `~/.businesses-registry.json` |
 | `*business list` | `bun ~/.nirvana/skills/businesses/scripts/list-businesses.ts` | Table of businesses from the registry |
 | `*business inspect <slug>` | `bun ~/.nirvana/skills/businesses/scripts/inspect-business.ts <slug>` | Manifest + employees + org-chart formatted |

--- a/skills/businesses/lib/business-audit-criteria.js
+++ b/skills/businesses/lib/business-audit-criteria.js
@@ -1,9 +1,27 @@
 /**
- * business-audit-criteria.js — Business Protocol v1 Nirvana scorer.
+ * business-audit-criteria.js — the Business Protocol Nirvana scorer.
  *
- * 11 dimensions, 100 points. Tiers: red <60, yellow 60-79, green ≥80.
+ * 11 dimensions, 100 points. Tiers: red <60, yellow 60-79, green >=80.
  *
- * Each function returns { score, max, evidence, fixable_diff? }.
+ * Each function returns { score, max, evidence, fixable_diff? }, where
+ * `fixable_diff.kind` names a handler of `business-fixers.js` and
+ * `fixable_diff.class` says who can apply it:
+ *
+ *   mechanical — `nrv validate business <slug> --fix` applies it, no LLM
+ *   agentic    — needs a model to write what the fixer must not invent
+ *   none       — a human decision the tooling has no honest default for
+ *
+ * Until this cut the kinds named repairs no code performed. They are the
+ * gate's fixer names now, so the scorer's suggestion and `--fix` are the same
+ * table.
+ *
+ * Business Protocol 2.0 moved three of the dimensions (§6.12, §11, §13.2):
+ * `employee_count` is derived, so c2 stopped scoring the author's arithmetic;
+ * `heartbeat` is retired, so the six points c3 paid for declaring one now go to
+ * `acceptance`, the contract the judge actually reads; and c5 asks routing for
+ * a `brief_intake` and for patterns that fire against the business's own
+ * example briefs, instead of counting keys.
+ *
  * Pure: only filesystem reads, no side effects.
  */
 
@@ -19,6 +37,8 @@ const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), '.nirvana', 'skills')) ? path.join(os.homedir(), '.nirvana', 'skills') : path.join(os.homedir(), '.claude', 'skills'));
 const YAML = require('yaml');
 const LOADER_TS = path.join(SKILLS_ROOT, 'businesses', 'lib', 'loader.ts');
+/** §13.2: patterns that match every brief, so they never select anything. */
+const CATCH_ALL = new Set(['.*', '.+', '(?i).*', '(?i).+', '^.*$', '^.+$', '(?i)^.*$', '(?i)^.+$', '.*?']);
 
 function exists(p) { try { return fs.existsSync(p); } catch { return false; } }
 function listDir(p) { try { return fs.readdirSync(p); } catch { return []; } }
@@ -33,46 +53,80 @@ function c1_manifest_valid({ businessDir }) {
   return {
     score: ok ? max : 0, max,
     evidence: ok ? 'manifest valid' : `validation failed: ${(r.stderr || r.stdout || '').slice(-200)}`,
-    fixable_diff: ok ? null : { kind: 'manifest_validation', stderr: (r.stderr || r.stdout || '').slice(-500) },
+    fixable_diff: ok ? null : { kind: 'manifest_schema_repair', class: 'mechanical', stderr: (r.stderr || r.stdout || '').slice(-500) },
   };
 }
 
-// ─── Criterion 2 — employee_count matches disk — 10 pts ─────────────────
-function c2_employee_count({ businessDir, manifest }) {
-  const max = 10;
-  const declared = manifest?.employee_count;
+// ─── Criterion 2 — the seats exist and their headers parse — 6 pts ─────
+// Business Protocol 2.0 §6.12: `employee_count` is derived from disk, so what
+// is worth scoring is whether the seats are there and readable — not whether
+// the author kept a number in sync that the registry recomputes anyway.
+function c2_employees_present({ businessDir, manifest }) {
+  const max = 6;
   const dir = path.join(businessDir, 'employees');
-  if (!exists(dir)) return { score: 0, max, evidence: 'employees/ missing', fixable_diff: { kind: 'create_employees_dir' } };
-  const actual = listDir(dir).filter(f => f.endsWith('.md')).length;
-  if (declared == null) return { score: 5, max, evidence: `${actual} on disk (no employee_count declared)`, fixable_diff: { kind: 'declare_employee_count', count: actual } };
-  if (declared === actual) return { score: max, max, evidence: `${actual} match` };
-  return { score: 4, max, evidence: `declared ${declared} but disk has ${actual}`, fixable_diff: { kind: 'sync_employee_count', actual } };
+  if (!exists(dir)) return { score: 0, max, evidence: 'employees/ missing', fixable_diff: { kind: 'create_employees_dir', class: 'none' } };
+  const files = listDir(dir).filter(f => f.endsWith('.md'));
+  if (files.length === 0) return { score: 0, max, evidence: 'employees/ holds no .md', fixable_diff: { kind: 'create_employees_dir', class: 'none' } };
+  let parsed = 0;
+  const offenders = [];
+  for (const f of files) {
+    const raw = fs.readFileSync(path.join(dir, f), 'utf8');
+    const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fm) { offenders.push(`${f}: no frontmatter`); continue; }
+    try { const d = YAML.parse(fm[1]); if (d && typeof d === 'object') parsed++; else offenders.push(`${f}: header is not a mapping`); }
+    catch { offenders.push(`${f}: header does not parse`); }
+  }
+  const authored = manifest && manifest.employee_count != null;
+  const score = Math.round((parsed / files.length) * max);
+  const evidence = `${parsed}/${files.length} header(s) parse${offenders.length ? ' · ' + offenders.slice(0, 2).join('; ') : ''}${authored ? ' · employee_count declared (derived since §6.12)' : ''}`;
+  return {
+    score, max, evidence,
+    fixable_diff: parsed < files.length ? { kind: 'employee_frontmatter_repair', class: 'mechanical' }
+      : authored ? { kind: 'employee_count_strip', class: 'mechanical' } : null,
+  };
 }
 
-// ─── Criterion 3 — Employees have frontmatter + heartbeat — 14 pts ──────
-function c3_employees_frontmatter({ businessDir }) {
+// ─── Criterion 3 — headers complete + acceptance declared — 14 pts ──────
+// §11 (BP4 redefined): the six points this criterion used to pay for declaring
+// a `heartbeat` no scheduler ever ran now go to `acceptance`, the requirement
+// the Gauntlet judge and `verify-deliverable` actually read.
+function c3_employees_contract({ businessDir }) {
   const max = 14;
   const dir = path.join(businessDir, 'employees');
   if (!exists(dir)) return { score: 0, max, evidence: 'employees/ missing', fixable_diff: null };
   const files = listDir(dir).filter(f => f.endsWith('.md'));
   if (files.length === 0) return { score: 0, max, evidence: 'no employees', fixable_diff: null };
-  let withFrontmatter = 0;
-  let withHeartbeat = 0;
+  let complete = 0;
+  let intakeWithAcceptance = 0;
+  let intakes = 0;
+  let withSelfScore = 0;
   const offenders = [];
   for (const f of files) {
     const raw = fs.readFileSync(path.join(dir, f), 'utf8');
-    const fm = raw.match(/^---\r?\n([\s\S]+?)\r?\n---/);
+    const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!fm) { offenders.push(`${f}: no frontmatter`); continue; }
-    withFrontmatter++;
-    if (/^\s*heartbeat\s*:/m.test(fm[1])) withHeartbeat++;
+    let d = null;
+    try { d = YAML.parse(fm[1]); } catch { offenders.push(`${f}: header does not parse`); continue; }
+    if (!d || typeof d !== 'object') { offenders.push(`${f}: header is not a mapping`); continue; }
+    if (typeof d.name === 'string' && typeof d.role === 'string' && typeof d.description === 'string') complete++;
+    else offenders.push(`${f}: name, role or description missing`);
+    if (d.self_score_contract) withSelfScore++;
+    if (d.is_brief_intake === true) {
+      intakes++;
+      if (Array.isArray(d.acceptance) && d.acceptance.length > 0) intakeWithAcceptance++;
+    }
   }
-  const fmRatio = withFrontmatter / files.length;
-  const hbRatio = withHeartbeat / files.length;
-  const score = Math.round(fmRatio * 8 + hbRatio * 6);
+  const completeRatio = complete / files.length;
+  const acceptanceRatio = intakes > 0 ? intakeWithAcceptance / intakes : 0;
+  const score = Math.round(completeRatio * 8 + acceptanceRatio * 6);
   return {
     score, max,
-    evidence: `${withFrontmatter}/${files.length} frontmatter · ${withHeartbeat}/${files.length} heartbeat${offenders.length ? ' · ' + offenders.slice(0, 2).join('; ') : ''}`,
-    fixable_diff: (withFrontmatter < files.length || withHeartbeat < files.length) ? { kind: 'employee_frontmatter_repair' } : null,
+    evidence: `${complete}/${files.length} complete header(s) · ${intakeWithAcceptance}/${intakes || 0} intake seat(s) declare acceptance${offenders.length ? ' · ' + offenders.slice(0, 2).join('; ') : ''}`,
+    fixable_diff: complete < files.length ? { kind: 'employee_frontmatter_repair', class: 'mechanical' }
+      : acceptanceRatio < 1 ? (withSelfScore > 0
+        ? { kind: 'acceptance_from_self_score', class: 'mechanical' }
+        : { kind: 'acceptance_author', class: 'agentic' })
+      : null,
   };
 }
 
@@ -80,7 +134,7 @@ function c3_employees_frontmatter({ businessDir }) {
 function c4_org_chart({ businessDir }) {
   const max = 12;
   const file = path.join(businessDir, 'org-chart.yaml');
-  if (!exists(file)) return { score: 0, max, evidence: 'org-chart.yaml missing', fixable_diff: { kind: 'org_chart_scaffold' } };
+  if (!exists(file)) return { score: 0, max, evidence: 'org-chart.yaml missing', fixable_diff: { kind: 'org_chart_repair', class: 'mechanical' } };
   const oc = readYaml(file);
   if (!oc) return { score: 4, max, evidence: 'org-chart.yaml unparseable', fixable_diff: null };
   // Accept multiple shapes: nodes[], chart[], or nested orgchart.nodes
@@ -99,24 +153,45 @@ function c4_org_chart({ businessDir }) {
   return {
     score, max,
     evidence: `nodes=${nodes.length} · ceo=${hasCEO ? 'yes' : 'no'}`,
-    fixable_diff: score < max ? { kind: 'org_chart_repair' } : null,
+    fixable_diff: score < max ? { kind: 'org_chart_repair', class: 'mechanical' } : null,
   };
 }
 
-// ─── Criterion 5 — routing.yaml exists + valid — 10 pts ─────────────────
-function c5_routing({ businessDir }) {
+// ─── Criterion 5 — brief_intake declared + routes that fire — 10 pts ────
+// §13.2: an `auto_route` does two things — it makes the business a routing
+// candidate and it picks the seat that receives the brief. A pattern that
+// matches none of the business's own example briefs does neither, and a
+// catch-all matches everything before any specific rule is evaluated. So the
+// points follow both: half for declaring where a brief lands by default, half
+// for patterns that can actually fire.
+function c5_routing({ businessDir, manifest }) {
   const max = 10;
   const file = path.join(businessDir, 'routing.yaml');
-  if (!exists(file)) return { score: 0, max, evidence: 'routing.yaml missing', fixable_diff: { kind: 'routing_scaffold' } };
+  if (!exists(file)) return { score: 0, max, evidence: 'routing.yaml missing', fixable_diff: { kind: 'routing_scaffold', class: 'mechanical' } };
   const r = readYaml(file);
   if (!r) return { score: 3, max, evidence: 'routing.yaml unparseable', fixable_diff: null };
-  const hasRoutes = (Array.isArray(r.routes) && r.routes.length > 0)
-    || (Array.isArray(r.auto_routes) && r.auto_routes.length > 0)
-    || (typeof r.brief_intake === 'string' && r.brief_intake.length > 0);
+
+  const intake = r.brief_intake && typeof r.brief_intake === 'object'
+    ? (typeof r.brief_intake.default_employee === 'string' && r.brief_intake.default_employee.length > 0)
+    : typeof r.brief_intake === 'string' && r.brief_intake.length > 0;
+  const routes = (Array.isArray(r.auto_routes) ? r.auto_routes : []).filter(x => x && typeof x.pattern === 'string');
+  const briefs = Array.isArray(manifest && manifest.example_briefs) ? manifest.example_briefs.filter(b => typeof b === 'string') : [];
+  let firing = 0;
+  const dead = [];
+  for (const route of routes) {
+    if (CATCH_ALL.has(route.pattern.trim())) { dead.push(route.pattern); continue; }
+    let re = null;
+    try { const ci = route.pattern.startsWith('(?i)'); re = new RegExp(ci ? route.pattern.slice(4) : route.pattern, ci ? 'i' : ''); } catch { re = null; }
+    if (re && briefs.some(b => re.test(b))) firing++;
+    else dead.push(route.pattern);
+  }
+  const routeShare = routes.length === 0 ? 0 : firing / routes.length;
+  const score = Math.round((intake ? 5 : 0) + routeShare * 5);
   return {
-    score: hasRoutes ? max : 6, max,
-    evidence: hasRoutes ? 'routes declared' : 'routing.yaml lacks routes/auto_routes/brief_intake',
-    fixable_diff: hasRoutes ? null : { kind: 'routing_default_routes' },
+    score, max,
+    evidence: `brief_intake ${intake ? 'declared' : 'absent'} · ${firing}/${routes.length} route(s) fire against the ${briefs.length} example brief(s)${dead.length ? ' · dead: ' + dead.slice(0, 2).join(', ') : ''}`,
+    fixable_diff: !intake ? { kind: 'routing_scaffold', class: 'mechanical' }
+      : dead.length ? { kind: 'routing_default_routes', class: 'agentic', dead } : null,
   };
 }
 
@@ -126,8 +201,8 @@ function c6_description({ manifest }) {
   const desc = (manifest?.description || '').trim();
   if (desc.length >= 100) return { score: max, max, evidence: `${desc.length} chars` };
   if (desc.length >= 50) return { score: 4, max, evidence: `${desc.length} chars (good, could be richer)` };
-  if (desc.length >= 20) return { score: 2, max, evidence: `${desc.length} chars (minimum only)`, fixable_diff: { kind: 'description_expand' } };
-  return { score: 0, max, evidence: `${desc.length} chars (below minimum)`, fixable_diff: { kind: 'description_expand' } };
+  if (desc.length >= 20) return { score: 2, max, evidence: `${desc.length} chars (minimum only)`, fixable_diff: { kind: 'description_expand', class: 'agentic' } };
+  return { score: 0, max, evidence: `${desc.length} chars (below minimum)`, fixable_diff: { kind: 'description_expand', class: 'agentic' } };
 }
 
 // ─── Criterion 7 — runtime_requirements + features_required — 8 pts ────
@@ -143,7 +218,11 @@ function c7_runtime_requirements({ manifest }) {
   return {
     score, max,
     evidence: `policy=${rr?.policy || 'declared'} · min=${hasMin ? rr.minimum.length : 0} · features=${hasFeats ? manifest.features_required.length : 0}`,
-    fixable_diff: score < max ? { kind: 'runtime_requirements_business_default', missing_min: !usesActiveRuntime && !hasMin, missing_feats: !hasFeats } : null,
+    // Only the runtime floor is mechanical. `features_required` is a claim
+    // about what the host must support, and no fixer can guess it.
+    fixable_diff: (!usesActiveRuntime && !hasMin)
+      ? { kind: 'runtime_requirements_business_default', class: 'mechanical', missing_min: true, missing_feats: !hasFeats }
+      : !hasFeats ? { kind: 'features_required_author', class: 'none', missing_feats: true } : null,
   };
 }
 
@@ -153,7 +232,7 @@ function c9_readme({ businessDir }) {
   const candidates = ['README.md', 'README.pt-BR.md'];
   let chosen = null;
   for (const c of candidates) if (exists(path.join(businessDir, c))) { chosen = path.join(businessDir, c); break; }
-  if (!chosen) return { score: 0, max, evidence: 'README.md missing', fixable_diff: { kind: 'readme_business_scaffold' } };
+  if (!chosen) return { score: 0, max, evidence: 'README.md missing', fixable_diff: { kind: 'readme_business_scaffold', class: 'mechanical' } };
   const text = fs.readFileSync(chosen, 'utf8');
   const lines = text.split('\n').length;
   const lower = text.toLowerCase();
@@ -175,7 +254,7 @@ function c9_readme({ businessDir }) {
   return {
     score: Math.min(score, max), max,
     evidence: `${lines} lines · ${hit} sections`,
-    fixable_diff: score < max ? { kind: 'readme_business_expand' } : null,
+    fixable_diff: score < max ? { kind: 'readme_business_expand', class: 'agentic' } : null,
   };
 }
 
@@ -183,9 +262,9 @@ function c9_readme({ businessDir }) {
 function c10_memory({ businessDir }) {
   const max = 6;
   const dir = path.join(businessDir, 'memory');
-  if (!exists(dir)) return { score: 0, max, evidence: 'memory/ missing', fixable_diff: { kind: 'memory_scaffold' } };
+  if (!exists(dir)) return { score: 0, max, evidence: 'memory/ missing', fixable_diff: { kind: 'memory_seed', class: 'mechanical' } };
   const files = listDir(dir).filter(f => !f.startsWith('.'));
-  if (files.length === 0) return { score: 2, max, evidence: 'memory/ empty', fixable_diff: { kind: 'memory_seed' } };
+  if (files.length === 0) return { score: 2, max, evidence: 'memory/ empty', fixable_diff: { kind: 'memory_seed', class: 'mechanical' } };
   return { score: max, max, evidence: `${files.length} memory file(s)` };
 }
 
@@ -212,7 +291,7 @@ function c12_seat_sufficiency({ businessDir }) {
   return {
     score: Math.round(ratio * max), max,
     evidence: thin.length ? `${thin.length}/${total} thin: ${thin.join(', ')}` : `${total}/${total} seats sufficient`,
-    fixable_diff: thin.length ? { kind: 'enrich_employee_method', slugs: thin } : null,
+    fixable_diff: thin.length ? { kind: 'enrich_employee_method', class: 'agentic', slugs: thin } : null,
   };
 }
 
@@ -225,7 +304,7 @@ function c11_legacy_tagged({ manifest }) {
   const hasInstance = typeof legacy.paperclip_instance === 'string';
   const hasDataDir = typeof legacy.paperclip_data_dir === 'string';
   if (hasInstance && hasDataDir) return { score: max, max, evidence: 'legacy migration tagged' };
-  return { score: 3, max, evidence: 'partial legacy block', fixable_diff: { kind: 'legacy_complete' } };
+  return { score: 3, max, evidence: 'partial legacy block', fixable_diff: { kind: 'legacy_complete', class: 'none' } };
 }
 
 // ─── orchestrator ───────────────────────────────────────────────────────
@@ -237,8 +316,8 @@ function scoreBusiness(businessDir) {
 
   const fns = [
     ['manifest_valid', c1_manifest_valid],
-    ['employee_count', c2_employee_count],
-    ['employees_frontmatter', c3_employees_frontmatter],
+    ['employees_present', c2_employees_present],
+    ['employees_contract', c3_employees_contract],
     ['org_chart', c4_org_chart],
     ['routing', c5_routing],
     ['description', c6_description],

--- a/skills/businesses/lib/business-fixers.js
+++ b/skills/businesses/lib/business-fixers.js
@@ -1,0 +1,809 @@
+/**
+ * business-fixers.js — the mechanical fixers of Business Protocol 2.0.
+ *
+ * The squad side of the house has had `mechanical-fixers.js` for a year: a
+ * dispatch table, one idempotent handler per patch kind, filesystem side
+ * effects and no LLM. Businesses had thirteen `fixable_diff` kinds that no code
+ * ever applied — the audit scorer named the repair and then nobody performed
+ * it. This is the applier, plus the conversions Business Protocol 2.0 added
+ * (§0, §6, §7, §11, §13, §22).
+ *
+ * Three rules the handlers never break:
+ *
+ * 1. **Idempotent.** Every handler compares before it writes, so a second run
+ *    produces zero bytes of change. `nrv validate business <slug> --fix` twice
+ *    in a row is a no-op the second time, and the gate's rollback logic depends
+ *    on that.
+ * 2. **Never deletes authored content.** Deprecated *fields* are removed or
+ *    converted (§0.3); deprecated *files* are reported and left where they are;
+ *    routes are never dropped, only converted into the field that implements
+ *    them; a `dna/` directory loses its symlinks after the bindings move into
+ *    the frontmatter, and keeps any real file it holds.
+ * 3. **Never invents prose.** No fixer writes a `not_for`, an `example_brief`,
+ *    a description or an acceptance criterion the author did not write. What
+ *    the author cannot be derived from stays a finding for a human — or for
+ *    `--fix=agentic`, which is a different tool with a ledger line.
+ *
+ * Employee frontmatter is edited through `_shared/lib/frontmatter-edit.ts`,
+ * which rewrites the `---` block and leaves the body byte for byte. YAML files
+ * are edited through the `yaml` Document API, so comments and key order survive.
+ *
+ * Entry point: `applyBusinessFixes(businessDir, { patches: [{ kind, ... }] })`,
+ * the same shape `applyMechanicalFixes` takes for squads.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const YAML = require('yaml');
+
+const SHARED_LIB = path.join(__dirname, '..', '..', '_shared', 'lib');
+const { editFrontmatter, employeeFiles, prependFrontmatter, readFrontmatter } = require(path.join(SHARED_LIB, 'frontmatter-edit.ts'));
+const { refToSlug, slugOf } = require(path.join(SHARED_LIB, 'entity-graph.ts'));
+
+// ─── file helpers ───────────────────────────────────────────────────────────
+
+function exists(p) { try { return fs.existsSync(p); } catch { return false; } }
+function listDir(p) { try { return fs.readdirSync(p); } catch { return []; } }
+const manifestOf = (dir) => path.join(dir, 'business.yaml');
+const chartOf = (dir) => path.join(dir, 'org-chart.yaml');
+const routingOf = (dir) => path.join(dir, 'routing.yaml');
+
+/** Parses a YAML file into a Document, or null when it is missing/broken. */
+function readDoc(file) {
+  if (!exists(file)) return null;
+  try {
+    const doc = YAML.parseDocument(fs.readFileSync(file, 'utf8'), { uniqueKeys: false });
+    return doc.errors.length ? null : doc;
+  } catch { return null; }
+}
+
+function readData(file) {
+  const doc = readDoc(file);
+  if (!doc) return null;
+  const js = doc.toJS();
+  return js && typeof js === 'object' && !Array.isArray(js) ? js : null;
+}
+
+/**
+ * Edits a YAML file through the Document API. `mutate` returns true when it
+ * changed something; nothing is written otherwise, which is where idempotence
+ * comes from.
+ */
+function editDoc(file, mutate) {
+  const text = exists(file) ? fs.readFileSync(file, 'utf8') : null;
+  if (text === null) return false;
+  let doc;
+  try {
+    doc = YAML.parseDocument(text, { uniqueKeys: false });
+    if (doc.errors.length) return false;
+  } catch { return false; }
+  if (!mutate(doc)) return false;
+  // lineWidth 0 keeps a long description on its own line instead of
+  // re-wrapping it at 80 columns. The Document API still re-renders the file,
+  // so a comment attached to a key this edit removes goes with it.
+  let out = doc.toString({ lineWidth: 0 });
+  if (text.endsWith('\n') && !out.endsWith('\n')) out += '\n';
+  if (out === text) return false;
+  fs.writeFileSync(file, out, 'utf8');
+  return true;
+}
+
+/** Creates a YAML file from plain data. Never overwrites. */
+function createYaml(file, data) {
+  if (exists(file)) return false;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, YAML.stringify(data, { lineWidth: 0 }), 'utf8');
+  return true;
+}
+
+/** Every employee, as `{ file, name, data }`, in file order. */
+function readEmployees(dir) {
+  const out = [];
+  for (const file of employeeFiles(dir)) {
+    const fm = readFrontmatter(file);
+    const data = fm && fm.doc ? fm.data : null;
+    out.push({
+      file,
+      stem: path.basename(file).replace(/\.md$/, ''),
+      name: data && typeof data.name === 'string' ? data.name : path.basename(file).replace(/\.md$/, ''),
+      data,
+    });
+  }
+  return out;
+}
+
+const isArray = Array.isArray;
+const isMapping = (v) => !!v && typeof v === 'object' && !isArray(v);
+/** A `yaml` sequence node already sitting in the document. */
+const isSeqNode = (n) => !!n && typeof n === 'object' && isArray(n.items);
+
+/** `Some Name` → `some-name`, the shape KEBAB_CASE accepts. */
+function kebab(s) {
+  const out = String(s).normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return /^[a-z]/.test(out) ? out : `seat-${out}`;
+}
+
+/** An acceptance id: `^[a-z][a-z0-9_-]*$`. */
+function acceptanceId(s) {
+  const out = String(s).normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase().replace(/[^a-z0-9_-]+/g, '_').replace(/^[_-]+/, '');
+  return /^[a-z]/.test(out) ? out : `c_${out}`;
+}
+
+/** The clone slug a reference names, or null when it names none. */
+function cloneSlug(ref) {
+  if (typeof ref !== 'string' || !ref.trim()) return null;
+  const viaLibrary = refToSlug(ref);
+  const last = slugOf(ref.replace(/\/+$/, '')).replace(/\.(md|markdown)$/i, '');
+  // `dna/<slug>/agent/AGENT.md` names the clone in the middle of the path;
+  // every other form names it in the last segment.
+  const slug = /(^|\/)dna\//.test(ref) && viaLibrary ? viaLibrary : last;
+  return slug && !/\.(md|ya?ml|json)$/i.test(slug) ? slug : null;
+}
+
+/** Clone slugs installed on this machine, or the set the caller measured. */
+function availableClones(patch) {
+  if (isArray(patch && patch.available_clones)) return new Set(patch.available_clones.map(String));
+  const root = process.env.DNA_LIBRARY || path.join(os.homedir(), 'businesses', '_library', 'dna');
+  const out = new Set();
+  for (const name of listDir(root)) {
+    if (name.startsWith('.')) continue;
+    const full = path.join(root, name);
+    let st; try { st = fs.statSync(full); } catch { continue; }
+    if (!st.isDirectory()) { out.add(name.replace(/\.md$/, '')); continue; }
+    out.add(name);
+    // A clone directory holds its own manifest; anything else at this level is
+    // a category of the legacy nested layout, and its children are the clones.
+    if (exists(path.join(full, 'MANIFEST.yaml'))) continue;
+    for (const sub of listDir(full)) if (!sub.startsWith('.')) out.add(sub);
+  }
+  return out;
+}
+
+// ─── §7 · employees ─────────────────────────────────────────────────────────
+
+/**
+ * A seat with no frontmatter at all gets the skeleton the schema requires and
+ * nothing more. `name` comes from the filename, `role` from the first heading,
+ * `description` from the first paragraph the author already wrote — the fixer
+ * derives, it does not compose. A seat whose frontmatter exists but fails the
+ * schema is left alone: rewriting a header a human wrote is authorship.
+ */
+function fix_employee_frontmatter_repair(dir) {
+  const repaired = [];
+  for (const file of employeeFiles(dir)) {
+    const text = fs.readFileSync(file, 'utf8');
+    const stem = path.basename(file).replace(/\.md$/, '');
+    if (readFrontmatter(file) !== null) continue;
+    const heading = /^#\s+(.+)$/m.exec(text);
+    const role = heading ? heading[1].trim().slice(0, 80) : stem.replace(/[-_]+/g, ' ');
+    const paragraph = text.replace(/^#.*$/gm, '').split(/\n\s*\n/).map((p) => p.replace(/\s+/g, ' ').trim()).find((p) => p.length >= 20);
+    const description = (paragraph || `Seat ${stem}: frontmatter scaffolded by the admission gate, method below.`).slice(0, 400);
+    const block = YAML.stringify({ name: kebab(stem), role, description }, { lineWidth: 0 }).replace(/\n+$/, '');
+    if (prependFrontmatter(file, block)) repaired.push(stem);
+  }
+  return repaired.length ? { ok: true, repaired } : { ok: true, changed: false, reason: 'every employee already declares frontmatter' };
+}
+
+/**
+ * Exactly one seat receives the brief. With zero declared, the root of the org
+ * chart is the only answer the files already contain; with more than one, the
+ * choice is the owner's and the gate keeps reporting it.
+ */
+function fix_intake_from_chart_root(dir) {
+  const employees = readEmployees(dir).filter((e) => e.data);
+  const declared = employees.filter((e) => e.data.is_brief_intake === true);
+  if (declared.length === 1) return { ok: true, changed: false, reason: 'the intake seat is already declared' };
+  if (declared.length > 1) return { ok: false, reason: `${declared.length} seats declare is_brief_intake: choosing between them is the owner's call` };
+  const names = new Set(employees.map((e) => e.name));
+
+  const chart = readData(chartOf(dir));
+  const roots = isArray(chart && chart.chart)
+    ? chart.chart.filter((n) => isMapping(n) && isArray(n.reports) && n.reports.length === 0 && names.has(n.employee)).map((n) => n.employee)
+    : [];
+  let target = roots.length === 1 ? roots[0] : null;
+  if (!target) {
+    const orphans = employees.filter((e) => !e.data.reports_to);
+    if (orphans.length === 1) target = orphans[0].name;
+  }
+  if (!target) return { ok: false, reason: 'no single root in org-chart.yaml and no single seat without reports_to' };
+  const seat = employees.find((e) => e.name === target);
+  if (!seat) return { ok: false, reason: `org-chart root ${target} has no employee file` };
+  const changed = editFrontmatter(seat.file, (doc) => { doc.set('is_brief_intake', true); return true; });
+  return { ok: true, intake: target, changed };
+}
+
+/** `type: antagonist_gate` implies `is_antagonist: true` (§7.8). */
+function fix_type_flag_sync(dir) {
+  const synced = [];
+  for (const e of readEmployees(dir)) {
+    if (!e.data || e.data.type !== 'antagonist_gate' || e.data.is_antagonist === true) continue;
+    if (editFrontmatter(e.file, (doc) => { doc.set('is_antagonist', true); return true; })) synced.push(e.name);
+  }
+  return synced.length ? { ok: true, synced } : { ok: true, changed: false, reason: 'no antagonist_gate seat is missing the flag' };
+}
+
+function fix_heartbeat_strip(dir) {
+  const stripped = stripEmployeeField(dir, 'heartbeat');
+  return stripped.length ? { ok: true, stripped } : { ok: true, changed: false, reason: 'no seat declares heartbeat' };
+}
+
+function stripEmployeeField(dir, field) {
+  const stripped = [];
+  for (const e of readEmployees(dir)) {
+    if (!e.data || !(field in e.data)) continue;
+    if (editFrontmatter(e.file, (doc) => { if (!doc.has(field)) return false; doc.delete(field); return true; })) stripped.push(e.name);
+  }
+  return stripped;
+}
+
+/**
+ * §11: `self_score_contract.criteria[]` already has the shape of an acceptance
+ * requirement — `{id, description, threshold}` → `{id, description,
+ * minimum_score}` — so 566 dead self-assessments become live requirements of
+ * the judge without one line of new authorship. `weight`, `on_below_threshold`
+ * and `max_revise_iterations` have no destination: the Gauntlet's revision loop
+ * already replaced them.
+ */
+function fix_acceptance_from_self_score(dir) {
+  const employees = readEmployees(dir).filter((e) => e.data);
+  const used = new Set();
+  for (const e of employees) for (const a of (isArray(e.data.acceptance) ? e.data.acceptance : [])) {
+    if (isMapping(a) && typeof a.id === 'string') used.add(a.id);
+  }
+  const converted = [];
+  for (const e of employees) {
+    const contract = e.data.self_score_contract;
+    if (!isMapping(contract)) continue;
+    const criteria = isArray(contract.criteria) ? contract.criteria.filter(isMapping) : [];
+    const existing = new Set((isArray(e.data.acceptance) ? e.data.acceptance : []).filter(isMapping).map((a) => a.id));
+    const entries = [];
+    for (const c of criteria) {
+      if (typeof c.id !== 'string' || !c.id.trim()) continue;
+      let id = acceptanceId(c.id);
+      if (used.has(id) && !existing.has(id)) id = acceptanceId(`${e.name}_${c.id}`);
+      if (existing.has(id)) continue;
+      const entry = { id, description: String(c.description || c.id).trim(), blocking: true };
+      const score = normalizeScore(c.threshold);
+      if (score !== null) entry.minimum_score = score;
+      entries.push(entry);
+      used.add(id);
+      existing.add(id);
+    }
+    const changed = editFrontmatter(e.file, (doc) => {
+      if (!doc.has('self_score_contract')) return false;
+      if (entries.length) {
+        if (isSeqNode(doc.get('acceptance'))) for (const entry of entries) doc.addIn(['acceptance'], entry);
+        else doc.set('acceptance', entries);
+      }
+      doc.delete('self_score_contract');
+      return true;
+    });
+    if (changed) converted.push({ employee: e.name, requirements: entries.length });
+  }
+  return converted.length
+    ? { ok: true, converted, note: 'weight, on_below_threshold and max_revise_iterations have no destination in §11 and were not carried over' }
+    : { ok: true, changed: false, reason: 'no seat declares self_score_contract' };
+}
+
+/** 0..1 as declared; a percentage (1 < n ≤ 100) read as one; anything else, null. */
+function normalizeScore(v) {
+  const n = typeof v === 'number' ? v : typeof v === 'string' && v.trim() !== '' ? Number(v) : NaN;
+  if (!Number.isFinite(n)) return null;
+  if (n >= 0 && n <= 1) return n;
+  if (n > 1 && n <= 100) return Math.round((n / 100) * 100) / 100;
+  return null;
+}
+
+/** §11: ids that match the pattern, unique inside the business, scores in 0..1. */
+function fix_acceptance_normalize(dir) {
+  const employees = readEmployees(dir).filter((e) => e.data);
+  const seen = new Set();
+  const fixed = [];
+  for (const e of employees) {
+    const list = isArray(e.data.acceptance) ? e.data.acceptance : null;
+    if (!list) continue;
+    const changed = editFrontmatter(e.file, (doc) => {
+      let touched = false;
+      list.forEach((entry, i) => {
+        if (!isMapping(entry)) return;
+        if (typeof entry.id === 'string') {
+          let id = acceptanceId(entry.id);
+          if (seen.has(id)) id = acceptanceId(`${e.name}_${entry.id}`);
+          let n = 2;
+          while (seen.has(id)) id = acceptanceId(`${e.name}_${entry.id}_${n++}`);
+          seen.add(id);
+          if (id !== entry.id) { doc.setIn(['acceptance', i, 'id'], id); touched = true; }
+        }
+        if ('minimum_score' in entry) {
+          const score = normalizeScore(entry.minimum_score);
+          if (score !== null && score !== entry.minimum_score) { doc.setIn(['acceptance', i, 'minimum_score'], score); touched = true; }
+        }
+      });
+      return touched;
+    });
+    if (changed) fixed.push(e.name);
+  }
+  return fixed.length ? { ok: true, normalized: fixed } : { ok: true, changed: false, reason: 'every acceptance id is already valid and unique' };
+}
+
+/** §22: `draws_from` was a hint with a path; `assigned_mind_clones` is the hint. */
+function fix_draws_from_to_assigned(dir, patch) {
+  const clones = availableClones(patch);
+  const converted = [];
+  const kept = [];
+  for (const e of readEmployees(dir)) {
+    if (!e.data || !isArray(e.data.draws_from)) continue;
+    const sources = e.data.draws_from.filter(isMapping).map((d) => d.source);
+    const slugs = sources.map(cloneSlug);
+    const resolved = slugs.filter((s) => s && clones.has(s));
+    const unresolved = sources.filter((_, i) => !slugs[i] || !clones.has(slugs[i]));
+    const already = new Set((isArray(e.data.assigned_mind_clones) ? e.data.assigned_mind_clones : []).map((x) => slugOf(String(x))));
+    const additions = [...new Set(resolved)].filter((s) => !already.has(s));
+    const changed = editFrontmatter(e.file, (doc) => {
+      let touched = false;
+      if (additions.length) {
+        if (isSeqNode(doc.get('assigned_mind_clones'))) for (const s of additions) doc.addIn(['assigned_mind_clones'], s);
+        else doc.set('assigned_mind_clones', additions);
+        touched = true;
+      }
+      // The field goes only when every source it carried arrived somewhere.
+      if (unresolved.length === 0 && doc.has('draws_from')) { doc.delete('draws_from'); touched = true; }
+      return touched;
+    });
+    if (changed) converted.push({ employee: e.name, clones: additions });
+    if (unresolved.length) kept.push({ employee: e.name, unresolved });
+  }
+  const result = converted.length ? { ok: true, converted } : { ok: true, changed: false, reason: 'no seat declares draws_from that resolves to an installed clone' };
+  if (kept.length) result.note = `draws_from kept on ${kept.length} seat(s): a source that resolves to no installed clone is not a binding to move`;
+  return result;
+}
+
+/** §7.7: `dna_reference` named the clone by path; the pin names it by slug. */
+function fix_dna_reference_to_pin(dir, patch) {
+  const clones = availableClones(patch);
+  const pinned = [];
+  const kept = [];
+  for (const e of readEmployees(dir)) {
+    if (!e.data || typeof e.data.dna_reference !== 'string') continue;
+    const slug = cloneSlug(e.data.dna_reference);
+    if (!slug || !clones.has(slug)) { kept.push({ employee: e.name, ref: e.data.dna_reference }); continue; }
+    const current = isArray(e.data.pinned_mind_clones) ? e.data.pinned_mind_clones.map(String) : [];
+    if (current.length >= 2 && !current.includes(slug)) { kept.push({ employee: e.name, ref: e.data.dna_reference }); continue; }
+    const changed = editFrontmatter(e.file, (doc) => {
+      if (!current.includes(slug)) {
+        if (isSeqNode(doc.get('pinned_mind_clones'))) doc.addIn(['pinned_mind_clones'], slug);
+        else doc.set('pinned_mind_clones', [slug]);
+      }
+      doc.delete('dna_reference');
+      return true;
+    });
+    if (changed) pinned.push({ employee: e.name, clone: slug });
+  }
+  const result = pinned.length ? { ok: true, pinned } : { ok: true, changed: false, reason: 'no dna_reference resolves to an installed clone' };
+  if (kept.length) result.note = `dna_reference kept on ${kept.length} seat(s): the path resolves to no installed clone, or the seat already carries two pins`;
+  return result;
+}
+
+// ─── §6 · the manifest ──────────────────────────────────────────────────────
+
+/** §6.12: the count is derived from `employees/*.md`; declaring it is a smell. */
+function fix_employee_count_strip(dir) {
+  const changed = editDoc(manifestOf(dir), (doc) => {
+    if (!doc.has('employee_count')) return false;
+    doc.delete('employee_count');
+    return true;
+  });
+  return changed ? { ok: true, changed: true } : { ok: true, changed: false, reason: 'the manifest declares no employee_count' };
+}
+
+/**
+ * §6.10: an empty `squads_authorized` meant "every squad" in the spec and "no
+ * squad" in the prompt. Removing it restores what the author who wrote `[]`
+ * against the spec intended. A non-empty list is a real fence and is never
+ * touched.
+ */
+function fix_squads_authorized_empty_strip(dir) {
+  const isEmpty = (v) => v === null || (isArray(v) && v.length === 0);
+  const stripped = [];
+  const manifest = readData(manifestOf(dir));
+  if (manifest && 'squads_authorized' in manifest && isEmpty(manifest.squads_authorized)) {
+    if (editDoc(manifestOf(dir), (doc) => { doc.delete('squads_authorized'); return true; })) stripped.push('business.yaml');
+  }
+  for (const e of readEmployees(dir)) {
+    if (!e.data || !('squads_authorized' in e.data) || !isEmpty(e.data.squads_authorized)) continue;
+    if (editFrontmatter(e.file, (doc) => { doc.delete('squads_authorized'); return true; })) stripped.push(e.name);
+  }
+  return stripped.length ? { ok: true, stripped } : { ok: true, changed: false, reason: 'no empty squads_authorized declared' };
+}
+
+/**
+ * Every field §22 retires without a conversion, removed wherever it is
+ * declared. The allowlist is the whole authority: a kind this table does not
+ * name is refused, so a typo can never strip a live field.
+ */
+const DEPRECATED_FIELDS = {
+  budget_monthly_usd: ['employee'],
+  mentions: ['employee'],
+  escalation_triggers: ['employee'],
+  disclosure_template: ['employee', 'manifest'],
+  capabilities_required: ['manifest'],
+  default_tools: ['manifest', 'employee'],
+  project_tool_overrides: ['manifest', 'employee'],
+  tickets: ['manifest'],
+  ticket_intake: ['manifest', 'routing'],
+  mention_routing: ['routing'],
+  confidence_threshold: ['route'],
+  requires_escalation_to: ['route'],
+};
+
+function fix_deprecated_field_strip(dir, patch) {
+  const field = patch && patch.field;
+  const scopes = DEPRECATED_FIELDS[field];
+  if (!scopes) return { ok: false, reason: `not a field Business Protocol 2.0 §22 retires: ${field}` };
+  const stripped = [];
+  if (scopes.includes('employee')) for (const name of stripEmployeeField(dir, field)) stripped.push(name);
+  if (scopes.includes('manifest') && editDoc(manifestOf(dir), (doc) => { if (!doc.has(field)) return false; doc.delete(field); return true; })) stripped.push('business.yaml');
+  if (scopes.includes('routing') && editDoc(routingOf(dir), (doc) => { if (!doc.has(field)) return false; doc.delete(field); return true; })) stripped.push('routing.yaml');
+  if (scopes.includes('route') && editDoc(routingOf(dir), (doc) => {
+    const routes = doc.get('auto_routes');
+    if (!routes || !isArray(routes.items)) return false;
+    let touched = false;
+    routes.items.forEach((_, i) => {
+      if (!doc.hasIn(['auto_routes', i, field])) return;
+      doc.deleteIn(['auto_routes', i, field]);
+      touched = true;
+    });
+    return touched;
+  })) stripped.push(`routing.yaml:auto_routes[].${field}`);
+  return stripped.length ? { ok: true, field, stripped } : { ok: true, changed: false, field, reason: `${field} is not declared anywhere in this business` };
+}
+
+/**
+ * The keys the schema requires and the directory already answers. Nothing here
+ * is prose: a name, a version, a protocol and a license are metadata whose
+ * absence blocks the load, and every other schema failure stays a finding.
+ */
+function fix_manifest_schema_repair(dir) {
+  const manifest = readData(manifestOf(dir));
+  if (!manifest) return { ok: false, reason: 'business.yaml is missing or does not parse' };
+  const slug = path.basename(dir);
+  const filled = [];
+  const changed = editDoc(manifestOf(dir), (doc) => {
+    let touched = false;
+    if (typeof manifest.name !== 'string' || !/^[a-z][a-z0-9-]+$/.test(manifest.name)) {
+      if (/^[a-z][a-z0-9-]+$/.test(slug)) { doc.set('name', slug); filled.push('name'); touched = true; }
+    }
+    if (typeof manifest.version !== 'string' || !/^\d+\.\d+\.\d+/.test(manifest.version)) { doc.set('version', '1.0.0'); filled.push('version'); touched = true; }
+    if (manifest.protocol !== '1.0' && manifest.protocol !== '2.0') { doc.set('protocol', '1.0'); filled.push('protocol'); touched = true; }
+    if (manifest.license !== undefined && typeof manifest.license !== 'string') { doc.set('license', 'MIT'); filled.push('license'); touched = true; }
+    return touched;
+  });
+  return changed
+    ? { ok: true, filled }
+    : { ok: true, changed: false, reason: 'the schema failure is not one of the derivable keys (name, version, protocol, license)' };
+}
+
+/** The manifest must declare a runtime floor, or say it follows the active one. */
+function fix_runtime_requirements_business_default(dir) {
+  const manifest = readData(manifestOf(dir));
+  if (!manifest) return { ok: false, reason: 'business.yaml is missing or does not parse' };
+  const rr = manifest.runtime_requirements;
+  const ok = isMapping(rr) && (rr.policy === 'active' || (isArray(rr.minimum) && rr.minimum.length > 0));
+  if (ok) return { ok: true, changed: false, reason: 'runtime_requirements already declares a floor or follows the active runtime' };
+  const changed = editDoc(manifestOf(dir), (doc) => {
+    if (isMapping(rr)) doc.setIn(['runtime_requirements', 'policy'], 'active');
+    else doc.set('runtime_requirements', { policy: 'active' });
+    return true;
+  });
+  return changed ? { ok: true, policy: 'active' } : { ok: false, reason: 'business.yaml could not be rewritten' };
+}
+
+/** §18.4: the version rises last, and only over a business with no error left. */
+function fix_protocol_bump_2(dir) {
+  const changed = editDoc(manifestOf(dir), (doc) => {
+    if (doc.get('protocol') === '2.0') return false;
+    doc.set('protocol', '2.0');
+    return true;
+  });
+  return changed ? { ok: true, protocol: '2.0' } : { ok: true, changed: false, reason: 'the manifest already declares protocol 2.0' };
+}
+
+// ─── §13 · routing ──────────────────────────────────────────────────────────
+
+const routeKey = (r) => `${String(r && r.pattern)} ${String(r && r.route_to)}`;
+
+/** §13.2: `auto_routes` lives in `routing.yaml`. The manifest copy moves there. */
+function fix_auto_routes_relocate(dir) {
+  const manifest = readData(manifestOf(dir));
+  if (!manifest) return { ok: false, reason: 'business.yaml is missing or does not parse' };
+  const routes = isArray(manifest.auto_routes) ? manifest.auto_routes.filter(isMapping) : [];
+  if (!('auto_routes' in manifest)) return { ok: true, changed: false, reason: 'the manifest declares no auto_routes' };
+
+  const routingFile = routingOf(dir);
+  const routing = readData(routingFile);
+  if (routing === null && exists(routingFile)) return { ok: false, reason: 'routing.yaml does not parse: the routes have nowhere safe to land' };
+  const existing = new Set(((routing && isArray(routing.auto_routes) ? routing.auto_routes : []).filter(isMapping)).map(routeKey));
+  const moving = routes.filter((r) => !existing.has(routeKey(r)));
+
+  if (moving.length && !exists(routingFile)) createYaml(routingFile, { auto_routes: moving });
+  else if (moving.length) editDoc(routingFile, (doc) => {
+    if (isSeqNode(doc.get('auto_routes'))) for (const r of moving) doc.addIn(['auto_routes'], r);
+    else doc.set('auto_routes', moving);
+    return true;
+  });
+  const changed = editDoc(manifestOf(dir), (doc) => { if (!doc.has('auto_routes')) return false; doc.delete('auto_routes'); return true; });
+  return {
+    ok: true, relocated: moving.length, deduplicated: routes.length - moving.length, changed,
+    note: moving.length ? 'comments written inside business.yaml auto_routes are not carried into routing.yaml' : undefined,
+  };
+}
+
+/** A business with no `routing.yaml` gets the one line the file needs: the seat
+ *  a brief reaches when no route fires. */
+function fix_routing_scaffold(dir) {
+  const routingFile = routingOf(dir);
+  if (exists(routingFile)) {
+    const routing = readData(routingFile);
+    if (routing === null) return { ok: false, reason: 'routing.yaml does not parse' };
+    if (isMapping(routing.brief_intake)) return { ok: true, changed: false, reason: 'routing.yaml already declares brief_intake' };
+  }
+  const intakes = readEmployees(dir).filter((e) => e.data && e.data.is_brief_intake === true);
+  if (intakes.length !== 1) return { ok: false, reason: `brief_intake needs exactly one intake seat (found ${intakes.length})` };
+  const target = intakes[0].name;
+  if (!exists(routingFile)) { createYaml(routingFile, { brief_intake: { default_employee: target } }); return { ok: true, default_employee: target, created: true }; }
+  const changed = editDoc(routingFile, (doc) => { doc.set('brief_intake', { default_employee: target }); return true; });
+  return changed ? { ok: true, default_employee: target } : { ok: false, reason: 'routing.yaml could not be rewritten' };
+}
+
+const CATCH_ALL = new Set(['.*', '.+', '(?i).*', '(?i).+', '^.*$', '^.+$', '(?i)^.*$', '(?i)^.+$', '.*?']);
+const isCatchAll = (p) => typeof p === 'string' && CATCH_ALL.has(p.trim());
+
+/**
+ * §13.2: a catch-all route matches every brief before any specific rule is
+ * evaluated, so it turns routing off while looking like routing. What it
+ * expresses — "when nothing else fits, this seat" — is exactly
+ * `brief_intake.default_employee`, so the route is converted into that field
+ * rather than removed: the destination survives, in the key that implements it.
+ * When the file already names a DIFFERENT default employee the conversion would
+ * lose one of the two, so the fixer declines and the finding stands.
+ */
+function fix_catch_all_to_default_employee(dir) {
+  const routingFile = routingOf(dir);
+  const routing = readData(routingFile);
+  if (!routing) return { ok: false, reason: 'routing.yaml is missing or does not parse' };
+  const routes = (isArray(routing.auto_routes) ? routing.auto_routes : []).filter(isMapping);
+  const catchAll = routes.filter((r) => isCatchAll(r.pattern));
+  if (!catchAll.length) return { ok: true, changed: false, reason: 'no catch-all pattern declared' };
+  const targets = [...new Set(catchAll.map((r) => String(r.route_to)))];
+  const current = isMapping(routing.brief_intake) ? routing.brief_intake.default_employee : undefined;
+  if (targets.length > 1) return { ok: false, reason: `catch-all routes name ${targets.length} different seats: the default employee is the owner's call` };
+  if (current !== undefined && current !== targets[0]) return { ok: false, reason: `brief_intake.default_employee is ${current} and the catch-all routes to ${targets[0]}: converting would drop one of them` };
+
+  const changed = editDoc(routingFile, (doc) => {
+    if (current === undefined) {
+      if (isMapping(routing.brief_intake)) doc.setIn(['brief_intake', 'default_employee'], targets[0]);
+      else doc.set('brief_intake', { default_employee: targets[0] });
+    }
+    const seq = doc.get('auto_routes');
+    if (!isSeqNode(seq)) return true;
+    for (let i = seq.items.length - 1; i >= 0; i--) {
+      if (isCatchAll(doc.getIn(['auto_routes', i, 'pattern']))) doc.deleteIn(['auto_routes', i]);
+    }
+    return true;
+  });
+  return changed
+    ? { ok: true, default_employee: targets[0], converted: catchAll.length, note: 'the catch-all route became brief_intake.default_employee: the destination is preserved, the dead pattern is not' }
+    : { ok: false, reason: 'routing.yaml could not be rewritten' };
+}
+
+// ─── §5 · files ─────────────────────────────────────────────────────────────
+
+/**
+ * §5.3: symlinks do not travel in a zip, so a `dna/` binding reaches the buyer
+ * broken. The link names become `assigned_mind_clones` on the intake seat and
+ * the links go; a real file inside `dna/` is authored content and stays, with
+ * the directory around it.
+ */
+function fix_dna_dir_to_bindings(dir) {
+  const dnaDir = path.join(dir, 'dna');
+  if (!exists(dnaDir)) return { ok: true, changed: false, reason: 'no dna/ directory' };
+  const links = [];
+  const others = [];
+  for (const name of listDir(dnaDir)) {
+    let st; try { st = fs.lstatSync(path.join(dnaDir, name)); } catch { continue; }
+    if (st.isSymbolicLink() || st.isDirectory()) links.push(name);
+    else others.push(name);
+  }
+  const slugs = [...new Set(links.map((n) => n.replace(/\.md$/, '')))];
+  const intakes = readEmployees(dir).filter((e) => e.data && e.data.is_brief_intake === true);
+  if (slugs.length && intakes.length !== 1) return { ok: false, reason: `the bindings need one intake seat to land on (found ${intakes.length})` };
+
+  if (slugs.length) {
+    const seat = intakes[0];
+    const already = new Set((isArray(seat.data.assigned_mind_clones) ? seat.data.assigned_mind_clones : []).map((x) => slugOf(String(x))));
+    const additions = slugs.filter((s) => !already.has(s));
+    if (additions.length) {
+      editFrontmatter(seat.file, (doc) => {
+        if (isSeqNode(doc.get('assigned_mind_clones'))) for (const s of additions) doc.addIn(['assigned_mind_clones'], s);
+        else doc.set('assigned_mind_clones', additions);
+        return true;
+      });
+    }
+  }
+  for (const name of links) fs.rmSync(path.join(dnaDir, name), { recursive: true, force: true });
+  if (others.length === 0) fs.rmdirSync(dnaDir);
+  return {
+    ok: true, clones: slugs, removed_links: links.length,
+    note: others.length ? `dna/ kept: it also holds ${others.join(', ')}, which the gate never deletes` : undefined,
+  };
+}
+
+function fix_readme_business_scaffold(dir) {
+  const file = path.join(dir, 'README.md');
+  if (exists(file) || exists(path.join(dir, 'README.pt-BR.md'))) return { ok: true, changed: false, reason: 'a README is already present' };
+  const manifest = readData(manifestOf(dir)) || {};
+  const slug = path.basename(dir);
+  const employees = readEmployees(dir);
+  const lines = [
+    `# ${manifest.name || slug}`,
+    '',
+    String(manifest.description || 'Describe what this business does and who it serves.').trim(),
+    '',
+    '## Employees',
+    '',
+    ...(employees.length ? employees.map((e) => `- \`${e.name}\`${e.data && e.data.role ? ` — ${e.data.role}` : ''}`) : ['- (none yet)']),
+    '',
+    '## Usage',
+    '',
+    '```bash',
+    `nrv validate business ${slug} --strict`,
+    `bun ~/.nirvana/skills/businesses/scripts/brief-business.ts ${slug} "<brief>"`,
+    '```',
+    '',
+    '> Scaffolded by `nrv validate business --fix`. Replace it with the real thing.',
+    '',
+  ];
+  fs.writeFileSync(file, lines.join('\n'), 'utf8');
+  return { ok: true, created: 'README.md' };
+}
+
+function fix_memory_seed(dir) {
+  const file = path.join(dir, 'memory', 'permanent.md');
+  if (exists(file)) return { ok: true, changed: false, reason: 'memory/permanent.md is already present' };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, [
+    `# Permanent memory — ${path.basename(dir)}`,
+    '',
+    'Curated facts every employee of this business reads before working. One fact',
+    'per line, each one true across runs. A pack update replaces this file;',
+    '`memory/learned.md` is the one that survives it.',
+    '',
+  ].join('\n'), 'utf8');
+  return { ok: true, created: 'memory/permanent.md' };
+}
+
+/**
+ * §5.3: `org-chart.yaml` is derived, not authored twice. The parent of a seat
+ * is its own `reports_to`; a seat that declares none is adopted by the single
+ * seat that lists it under `manages`. Deriving `direct_reports` from the
+ * children's side is what makes the chart bidirectionally consistent by
+ * construction — the inconsistency the loader rejects cannot be written here.
+ */
+function fix_org_chart_repair(dir) {
+  const employees = readEmployees(dir).filter((e) => e.data);
+  if (!employees.length) return { ok: false, reason: 'no employee frontmatter to derive the chart from' };
+  const names = employees.map((e) => e.name);
+  const known = new Set(names);
+  if (new Set(names).size !== names.length) return { ok: false, reason: 'two seats declare the same name' };
+
+  const parent = new Map();
+  for (const e of employees) {
+    const r = e.data.reports_to;
+    if (typeof r === 'string' && known.has(r) && r !== e.name) parent.set(e.name, r);
+  }
+  for (const e of employees) {
+    for (const child of (isArray(e.data.manages) ? e.data.manages : [])) {
+      if (typeof child !== 'string' || !known.has(child) || child === e.name || parent.has(child)) continue;
+      parent.set(child, e.name);
+    }
+  }
+  const roots = names.filter((n) => !parent.has(n));
+  if (roots.length !== 1) return { ok: false, reason: `the frontmatter yields ${roots.length} roots: exactly one seat must report to nobody` };
+  for (const start of names) {
+    const seen = new Set();
+    let cur = start;
+    while (parent.has(cur)) {
+      cur = parent.get(cur);
+      if (seen.has(cur)) return { ok: false, reason: `reports_to/manages form a cycle through ${cur}` };
+      seen.add(cur);
+    }
+  }
+
+  const chart = employees.map((e) => {
+    const node = {
+      employee: e.name,
+      reports: parent.has(e.name) ? [parent.get(e.name)] : [],
+      direct_reports: names.filter((n) => parent.get(n) === e.name).sort(),
+      is_antagonist: e.data.is_antagonist === true,
+    };
+    const antagonizes = isArray(e.data.antagonizes) ? e.data.antagonizes.filter((x) => typeof x === 'string') : [];
+    if (antagonizes.length) node.antagonizes = antagonizes;
+    return node;
+  });
+
+  const file = chartOf(dir);
+  if (!exists(file)) { createYaml(file, { chart }); return { ok: true, created: 'org-chart.yaml', nodes: chart.length }; }
+  const current = readData(file);
+  if (current === null) return { ok: false, reason: 'org-chart.yaml does not parse: rewriting it would drop what it holds' };
+  if (JSON.stringify(current.chart) === JSON.stringify(chart)) return { ok: true, changed: false, reason: 'org-chart.yaml already matches the frontmatter' };
+  const changed = editDoc(file, (doc) => { doc.set('chart', chart); return true; });
+  return changed ? { ok: true, nodes: chart.length, note: 'routing_rules and every other key of org-chart.yaml were left as they were' } : { ok: false, reason: 'org-chart.yaml could not be rewritten' };
+}
+
+// ─── apply orchestrator ─────────────────────────────────────────────────────
+
+const HANDLERS = {
+  employee_frontmatter_repair: fix_employee_frontmatter_repair,
+  intake_from_chart_root: fix_intake_from_chart_root,
+  org_chart_repair: fix_org_chart_repair,
+  type_flag_sync: fix_type_flag_sync,
+  acceptance_from_self_score: fix_acceptance_from_self_score,
+  acceptance_normalize: fix_acceptance_normalize,
+  heartbeat_strip: fix_heartbeat_strip,
+  draws_from_to_assigned: fix_draws_from_to_assigned,
+  dna_reference_to_pin: fix_dna_reference_to_pin,
+  deprecated_field_strip: fix_deprecated_field_strip,
+  employee_count_strip: fix_employee_count_strip,
+  squads_authorized_empty_strip: fix_squads_authorized_empty_strip,
+  manifest_schema_repair: fix_manifest_schema_repair,
+  runtime_requirements_business_default: fix_runtime_requirements_business_default,
+  auto_routes_relocate: fix_auto_routes_relocate,
+  routing_scaffold: fix_routing_scaffold,
+  catch_all_to_default_employee: fix_catch_all_to_default_employee,
+  dna_dir_to_bindings: fix_dna_dir_to_bindings,
+  readme_business_scaffold: fix_readme_business_scaffold,
+  memory_seed: fix_memory_seed,
+  protocol_bump_2: fix_protocol_bump_2,
+};
+
+/**
+ * The order `--fix` applies them in: seats first (the chart is derived from
+ * their frontmatter), then the manifest, then routing, then the files, and the
+ * version last — declaring 2.0 over a business that still fails a v2 rule is
+ * worse than declaring the old one. The gate regenerates `.nirvana-surface.json`
+ * after the last handler; nothing here writes it.
+ */
+const FIX_ORDER = [
+  'employee_frontmatter_repair', 'intake_from_chart_root', 'type_flag_sync',
+  'acceptance_from_self_score', 'acceptance_normalize',
+  'heartbeat_strip', 'draws_from_to_assigned', 'dna_reference_to_pin',
+  'deprecated_field_strip', 'squads_authorized_empty_strip',
+  'manifest_schema_repair', 'employee_count_strip', 'runtime_requirements_business_default',
+  'org_chart_repair',
+  'auto_routes_relocate', 'routing_scaffold', 'catch_all_to_default_employee',
+  'dna_dir_to_bindings', 'readme_business_scaffold', 'memory_seed',
+  'protocol_bump_2',
+];
+
+/** Applies a set of patches to one business directory. */
+function applyBusinessFixes(businessDir, diff) {
+  const results = [];
+  for (const patch of ((diff && diff.patches) || [])) {
+    let r;
+    try {
+      const handler = HANDLERS[patch.kind];
+      r = handler ? handler(businessDir, patch) : { ok: false, reason: 'unknown patch kind' };
+    } catch (e) {
+      r = { ok: false, reason: 'exception: ' + e.message };
+    }
+    results.push({ kind: patch.kind, criterion: patch.criterion, result: r });
+  }
+  return results;
+}
+
+module.exports = { applyBusinessFixes, FIX_ORDER, HANDLERS, DEPRECATED_FIELDS, cloneSlug, acceptanceId, normalizeScore };

--- a/skills/businesses/scripts/validate-business.ts
+++ b/skills/businesses/scripts/validate-business.ts
@@ -1,40 +1,123 @@
 #!/usr/bin/env bun
 /**
- * validate-business.ts — validate a single business manifest + integrity.
+ * validate-business.ts — the business entry point of the admission gate.
+ *
+ * Until Business Protocol 2.0 this script was forty lines that spawned
+ * `loader.ts` and printed whatever it said: no flags, no catalog, no repair,
+ * and a verdict that answered one question (does the manifest parse?) out of
+ * the thirty-nine §16.2 asks. It now delegates to the shared runner, so
+ * `nrv validate business <slug>` and this script are literally the same code
+ * path and cannot drift.
+ *
+ *   validate-business.ts <slug|path> [--fix] [--strict] [--json] [--report]
+ *   validate-business.ts --all [--fix] [--strict] [--json] [--report]
+ *
+ *   --fix        apply the mechanical fixers (backup, re-check, rollback)
+ *   --strict     warnings reject too (exit 2)
+ *   --json       nirvana.verify-report/v1 (one business) or -batch/v1 (--all)
+ *   --report     also write the JSON under .audit-state/<slug>/verify.json
+ *   --no-retrieval  skip the self-retrieval axis
+ *
+ * Exit: 0 admitted · 1 an error the baseline does not cover · 2 only warnings,
+ * under --strict · 64 usage error or unknown business.
+ *
+ * Criteria and contract: skills/businesses/BUSINESS_PROTOCOL_V2.md §16 and
+ * docs/architecture/validate-gate.md.
  */
 
-import * as path from "node:path";
 import * as fs from "node:fs";
-import { exec, paths, EXIT, BUN_BIN } from "../../_shared/lib/bun-helpers.ts";
-import { resolveScope, enumerate } from "../../_shared/lib/scope.ts";
+import * as path from "node:path";
+import { paths } from "../../_shared/lib/bun-helpers.ts";
+import { enumerate, resolveScope } from "../../_shared/lib/scope.ts";
+import {
+  VERIFY_EXIT, VerifyUsageError, renderBatch, renderReport, verifyAll, verifyEntity,
+  type BatchReport, type VerifyReport,
+} from "../../_shared/lib/verify/index.ts";
 
-const SKILL_DIR = path.join(paths.CLAUDE_SKILLS_DIR, "businesses");
-const outputsLint = require(path.join(paths.CLAUDE_SKILLS_DIR, "_shared", "lib", "outputs-lint.js"));
-const slug = process.argv[2];
-if (!slug) {
-  console.error("usage: validate-business <slug>");
-  process.exit(EXIT.INVALID_ARGS);
+const KNOWN = new Set(["fix", "strict", "json", "all", "report", "no-retrieval", "quiet", "help", "h"]);
+
+const argv = process.argv.slice(2);
+const flags = new Set<string>();
+const positional: string[] = [];
+for (const a of argv) {
+  if (!a.startsWith("-")) { positional.push(a); continue; }
+  const name = a.replace(/^--?/, "");
+  if (!KNOWN.has(name)) {
+    console.error(`validate-business: unknown option --${name}`);
+    console.error(USAGE);
+    process.exit(VERIFY_EXIT.USAGE);
+  }
+  flags.add(name);
 }
 
-const scopedDir = enumerate(resolveScope(), "businesses").find(e => e.slug === slug && !e.overridden)?.dir;
-const candidates = [
-  ...(scopedDir ? [scopedDir] : []),
-  path.join(paths.BUSINESSES_DIR, slug),
-  slug,
-];
-const target = candidates.find(p => fs.existsSync(p));
-if (!target) {
-  console.error(`ERROR: business not found (tried: ${candidates.join(", ")})`);
-  process.exit(EXIT.INVALID_ARGS);
+const USAGE = `usage: validate-business <slug|path>|--all [--fix] [--strict] [--json] [--report] [--no-retrieval]
+
+  Admission gate for a business (Business Protocol 2.0 §16). Same catalog,
+  same fixers and same exit codes as \`nrv validate business\`.
+
+  0 admitted · 1 error · 2 warnings under --strict · 64 usage / unknown business`;
+
+if (flags.has("help") || flags.has("h")) { console.log(USAGE); process.exit(VERIFY_EXIT.ADMITTED); }
+
+/**
+ * Where a report lands. Project scope keeps it inside the project (a business
+ * of one project must not leak its verdict into another); global scope uses the
+ * businesses skill dir, the same split `audit-businesses-score.ts` already made.
+ */
+function reportDir(slug: string): string {
+  const scope = resolveScope();
+  const base = scope.projectRoot
+    ? path.join(scope.projectRoot, ".nirvana", ".audit-state")
+    : path.join(paths.CLAUDE_SKILLS_DIR, "businesses", ".audit-state");
+  return path.join(base, slug);
 }
 
-// Outputs-pollution lint — block run-output dirs leaking into a portable business.
-const lintResult = outputsLint.lintDir(target);
-for (const w of lintResult.warnings) console.log(`[WARN] outputs-lint: ${w}`);
-if (lintResult.errors.length > 0) {
-  for (const e of lintResult.errors) console.error(`[FAIL] outputs-lint: ${e}`);
-  process.exit(EXIT.FAILURES);
+function writeReport(r: VerifyReport): void {
+  const dir = reportDir(r.slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "verify.json"), JSON.stringify(r, null, 2) + "\n", "utf8");
+  if (!flags.has("json")) console.log(`report: ${path.join(dir, "verify.json")}`);
 }
 
-const r = exec(`${JSON.stringify(BUN_BIN)} ${JSON.stringify(path.join(SKILL_DIR, "lib", "loader.ts"))} ${JSON.stringify(target)}`, { silent: false });
-process.exit(r.code ?? (r.ok ? EXIT.OK : EXIT.FAILURES));
+/** A slug the scope knows, a path, or nothing this machine can resolve. */
+function resolveTarget(target: string): string {
+  if (fs.existsSync(path.resolve(target))) return path.resolve(target);
+  const scoped = enumerate(resolveScope(), "businesses").find((e) => e.slug === target && !e.overridden)?.dir;
+  return scoped ?? target;
+}
+
+async function main(): Promise<number> {
+  const common = {
+    fix: flags.has("fix") ? ("mechanical" as const) : (false as const),
+    strict: flags.has("strict"),
+    retrieval: !flags.has("no-retrieval"),
+  };
+
+  if (flags.has("all")) {
+    if (positional.length) throw new VerifyUsageError(`--all takes no <slug> (got ${positional[0]})`);
+    const batch: BatchReport = await verifyAll("business", common);
+    console.log(flags.has("json") ? JSON.stringify(batch, null, 2) : renderBatch(batch, { quiet: flags.has("quiet") }));
+    if (flags.has("report")) for (const r of batch.reports) writeReport(r);
+    return batch.exit_code;
+  }
+
+  const target = positional[0];
+  if (!target) throw new VerifyUsageError("a <slug> or a path is required (or --all)");
+  if (positional.length > 1) throw new VerifyUsageError(`unexpected argument: ${positional[1]}`);
+  const report = await verifyEntity("business", resolveTarget(target), common);
+  console.log(flags.has("json") ? JSON.stringify(report, null, 2) : renderReport(report));
+  if (flags.has("report")) writeReport(report);
+  return report.exit_code;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    if (e instanceof VerifyUsageError) {
+      console.error(`validate-business: ${e.message}`);
+      console.error(USAGE);
+      process.exit(e.exit);
+    }
+    console.error(`validate-business: ${e?.stack ?? e}`);
+    process.exit(VERIFY_EXIT.REJECTED);
+  });

--- a/skills/businesses/tests/business-audit-criteria.test.ts
+++ b/skills/businesses/tests/business-audit-criteria.test.ts
@@ -1,0 +1,120 @@
+/**
+ * business-audit-criteria.test.ts — the scorer's scale and its suggestions.
+ *
+ * Two things drift silently and cost a release each time they do: the rubric's
+ * maximum (it read "100 points" in the header while summing 104 for as long as
+ * `seat_sufficiency` had been bolted on) and the `fixable_diff` kinds (they
+ * named repairs no applier implemented, so "fixable" meant nothing). Both are
+ * asserted here against the fixer table itself.
+ *
+ * Runs with: bun test skills/businesses/tests
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { businessFixture, INTAKE_SEAT, rmrf, tempRoot } from "../../_shared/tests/helpers/verify-fixture.ts";
+
+const require_ = createRequire(import.meta.url);
+const REPO = path.resolve(import.meta.dir, "..", "..", "..");
+const { scoreBusiness } = require_(path.join(REPO, "skills", "businesses", "lib", "business-audit-criteria.js"));
+const { HANDLERS } = require_(path.join(REPO, "skills", "businesses", "lib", "business-fixers.js"));
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) rmrf(r); });
+function root(): string { const r = tempRoot(); ROOTS.push(r); return r; }
+
+/** Every fixable_diff a corpus of businesses produces, dedup by kind. */
+function suggestions(dirs: string[]): Map<string, { kind: string; class?: string }> {
+  const out = new Map<string, { kind: string; class?: string }>();
+  for (const dir of dirs) for (const b of scoreBusiness(dir).breakdown) if (b.fixable_diff) out.set(b.fixable_diff.kind, b.fixable_diff);
+  return out;
+}
+
+describe("the rubric", () => {
+  test("eleven dimensions summing to exactly 100", () => {
+    const r = scoreBusiness(businessFixture(root(), "scored-biz"));
+    expect(r.breakdown).toHaveLength(11);
+    expect(r.breakdown.reduce((a: number, b: any) => a + b.max, 0)).toBe(100);
+    expect(r.max).toBe(100);
+    expect(r.breakdown.map((b: any) => b.name)).toContain("employees_present");
+    expect(r.breakdown.map((b: any) => b.name)).toContain("employees_contract");
+  });
+
+  test("a complete business scores green and suggests nothing mechanical", () => {
+    const r = scoreBusiness(businessFixture(root(), "green-biz", { routing: 'brief_intake:\n  default_employee: ceo\n' }));
+    expect(r.tier).toBe("green");
+    expect(r.breakdown.filter((b: any) => b.fixable_diff?.class === "mechanical")).toEqual([]);
+  });
+
+  test("employee_count no longer costs points, and is suggested for removal", () => {
+    const withCount = scoreBusiness(businessFixture(root(), "counted-biz", { manifestExtra: "employee_count: 1" }));
+    const without = scoreBusiness(businessFixture(root(), "uncounted-biz"));
+    const c2 = (r: any) => r.breakdown.find((b: any) => b.name === "employees_present");
+    expect(c2(withCount).score).toBe(c2(without).score);
+    expect(c2(withCount).fixable_diff).toMatchObject({ kind: "employee_count_strip", class: "mechanical" });
+  });
+
+  test("declaring a heartbeat earns nothing; declaring acceptance earns the six points", () => {
+    const noAcceptance = INTAKE_SEAT.split("acceptance:")[0] + "heartbeat:\n  cadence: daily\n  enabled: true\n---\n\n# CEO\n\n## Method\n\n- One decision line.\n";
+    const bare = scoreBusiness(businessFixture(root(), "hb-biz", { employees: { "ceo.md": noAcceptance } }));
+    const full = scoreBusiness(businessFixture(root(), "acc-biz"));
+    const c3 = (r: any) => r.breakdown.find((b: any) => b.name === "employees_contract");
+    expect(c3(bare).score).toBe(8);
+    expect(c3(full).score).toBe(14);
+    expect(c3(bare).evidence).toContain("0/1 intake seat(s) declare acceptance");
+  });
+
+  test("a self_score_contract is scored as convertible, an empty seat as authorship", () => {
+    const contract = INTAKE_SEAT.split("acceptance:")[0] + "self_score_contract:\n  criteria:\n    - id: quality\n      description: worth handing over\n---\n\n# CEO\n\n## Method\n\n- One decision line.\n";
+    const withContract = scoreBusiness(businessFixture(root(), "ssc-biz", { employees: { "ceo.md": contract } }));
+    expect(withContract.breakdown.find((b: any) => b.name === "employees_contract").fixable_diff)
+      .toMatchObject({ kind: "acceptance_from_self_score", class: "mechanical" });
+
+    const empty = INTAKE_SEAT.split("acceptance:")[0] + "---\n\n# CEO\n\n## Method\n\n- One decision line.\n";
+    const withoutContract = scoreBusiness(businessFixture(root(), "empty-acc", { employees: { "ceo.md": empty } }));
+    expect(withoutContract.breakdown.find((b: any) => b.name === "employees_contract").fixable_diff)
+      .toMatchObject({ kind: "acceptance_author", class: "agentic" });
+  });
+
+  test("routing scores the intake seat and the patterns that fire", () => {
+    const c5 = (r: any) => r.breakdown.find((b: any) => b.name === "routing");
+    const none = scoreBusiness(businessFixture(root(), "no-routing"));
+    expect(c5(none)).toMatchObject({ score: 0, fixable_diff: { kind: "routing_scaffold", class: "mechanical" } });
+
+    const intakeOnly = scoreBusiness(businessFixture(root(), "intake-only", { routing: "brief_intake:\n  default_employee: ceo\n" }));
+    expect(c5(intakeOnly).score).toBe(5);
+
+    const firing = scoreBusiness(businessFixture(root(), "firing", {
+      routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n',
+    }));
+    expect(c5(firing).score).toBe(10);
+
+    const dead = scoreBusiness(businessFixture(root(), "dead-routes", {
+      routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: "(?i)\\\\bcryogenics\\\\b"\n    route_to: ceo\n',
+    }));
+    expect(c5(dead).score).toBe(5);
+    expect(c5(dead).fixable_diff).toMatchObject({ kind: "routing_default_routes", class: "agentic" });
+  });
+});
+
+describe("every suggestion names something that exists", () => {
+  test("mechanical kinds are handlers of business-fixers.js; the others declare why not", () => {
+    const r = root();
+    const dirs = [
+      businessFixture(r, "a-biz", { manifestExtra: "employee_count: 1", readme: null, memory: false }),
+      businessFixture(r, "b-biz", { orgChart: null, employees: { "ceo.md": INTAKE_SEAT, "ghost.md": "# ghost\n" } }),
+      businessFixture(r, "c-biz", { manifest: "name: c-biz\nversion: 1.0.0\n" }),
+      businessFixture(r, "d-biz", { routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: ".*"\n    route_to: ceo\n' }),
+    ];
+    // A thin seat and a short description, to reach the two agentic kinds.
+    fs.writeFileSync(path.join(dirs[0], "employees", "thin.md"), "---\nname: thin\nrole: Thin seat\ndescription: A seat whose body carries no method of its own at all.\n---\n\n# thin\n", "utf8");
+
+    const found = suggestions(dirs);
+    expect(found.size).toBeGreaterThan(4);
+    for (const [kind, diff] of found) {
+      if (diff.class === "mechanical") expect(Object.keys(HANDLERS)).toContain(kind);
+      else expect(["agentic", "none"]).toContain(diff.class);
+    }
+  });
+});

--- a/skills/businesses/tests/business-fixers.test.ts
+++ b/skills/businesses/tests/business-fixers.test.ts
@@ -1,0 +1,562 @@
+/**
+ * business-fixers.test.ts — the mechanical fixers of Business Protocol 2.0,
+ * and the frontmatter primitive they all write through.
+ *
+ * Two promises are tested here more than anything else, because breaking either
+ * one damages 581 installed seats at once:
+ *
+ * 1. **The body is not touched.** `frontmatter-edit.ts` rewrites the `---`
+ *    block and reassembles the file around the original body slice. Every test
+ *    that edits a seat compares the body byte for byte afterwards.
+ * 2. **The second run writes nothing.** A fixer that is not idempotent turns
+ *    `--fix` into a source of diffs, and the gate's rollback logic assumes the
+ *    opposite. Each fixer runs twice; the tree digest after run two equals the
+ *    digest after run one.
+ *
+ * Everything is built under mkdtemp; ~/businesses is never read or written.
+ *
+ * Runs with: bun test skills/businesses/tests
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { parse as parseYaml } from "yaml";
+import {
+  businessFixture, cliEnv, crlf, INTAKE_SEAT, rmrf, runCli, tempRoot, treeDigest, writeSurfaceFor,
+} from "../../_shared/tests/helpers/verify-fixture.ts";
+import {
+  editFrontmatter, joinFrontmatter, prependFrontmatter, readFrontmatter, splitFrontmatter,
+} from "../../_shared/lib/frontmatter-edit.ts";
+import { businessModule, verifyEntity, type KindModule } from "../../_shared/lib/verify/index.ts";
+
+const require_ = createRequire(import.meta.url);
+const REPO = path.resolve(import.meta.dir, "..", "..", "..");
+const { applyBusinessFixes, acceptanceId, cloneSlug, normalizeScore } = require_(path.join(REPO, "skills", "businesses", "lib", "business-fixers.js"));
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) rmrf(r); });
+function root(): string { const r = tempRoot(); ROOTS.push(r); return r; }
+
+const apply = (dir: string, kind: string, patch: Record<string, unknown> = {}) =>
+  applyBusinessFixes(dir, { patches: [{ kind, ...patch }] })[0].result;
+
+const seatFile = (dir: string, name = "ceo") => path.join(dir, "employees", `${name}.md`);
+const bodyOf = (file: string) => readFrontmatter(file)!.body;
+const fmOf = (file: string) => readFrontmatter(file)!.data as Record<string, any>;
+const manifestOf = (dir: string) => parseYaml(fs.readFileSync(path.join(dir, "business.yaml"), "utf8")) as Record<string, any>;
+const routingOf = (dir: string) => parseYaml(fs.readFileSync(path.join(dir, "routing.yaml"), "utf8")) as Record<string, any>;
+
+/** Runs a fixer twice and asserts the second run changes nothing on disk. */
+function twice(dir: string, kind: string, patch: Record<string, unknown> = {}) {
+  const first = apply(dir, kind, patch);
+  const afterFirst = treeDigest(dir);
+  const second = apply(dir, kind, patch);
+  expect(treeDigest(dir)).toEqual(afterFirst);
+  return { first, second };
+}
+
+// ── the frontmatter primitive ───────────────────────────────────────────────
+
+describe("frontmatter-edit: the block changes, the body does not", () => {
+  test("splitFrontmatter keeps the body as a slice, LF and CRLF alike", () => {
+    const lfText = "---\nname: ceo\n---\n\n# CEO\n\nBody  with   spacing.\t\n";
+    const s = splitFrontmatter(lfText)!;
+    expect(s.block).toBe("name: ceo");
+    expect(s.body).toBe("\n# CEO\n\nBody  with   spacing.\t\n");
+    expect(s.eol).toBe("\n");
+    expect(joinFrontmatter(s, s.block)).toBe(lfText);
+
+    const c = splitFrontmatter(crlf(lfText))!;
+    expect(c.eol).toBe("\r\n");
+    expect(joinFrontmatter(c, c.block)).toBe(crlf(lfText));
+  });
+
+  test("an empty block, a BOM and a file that ends at the fence all round-trip", () => {
+    for (const text of ["---\n---\n# body\n", "﻿---\nname: x\n---\nbody\n", "---\nname: x\n---"]) {
+      const s = splitFrontmatter(text)!;
+      expect(joinFrontmatter(s, s.block)).toBe(text);
+    }
+    expect(splitFrontmatter("# no frontmatter\n")).toBeNull();
+  });
+
+  test("editFrontmatter preserves comments, key order and every byte of the body", () => {
+    const r = root();
+    const file = path.join(r, "cwd", "seat.md");
+    const body = "\n# CEO\n\n- One  line with  odd   spacing.\t\n\n\n## Trailing section\n";
+    fs.writeFileSync(file, ["---", "# a comment the fixer must not eat", "name: ceo", "heartbeat:", "  enabled: true", "role: CEO", "---", body].join("\n"), "utf8");
+    const before = bodyOf(file);
+    expect(editFrontmatter(file, (doc) => { doc.delete("heartbeat"); return true; })).toBe(true);
+    const text = fs.readFileSync(file, "utf8");
+    expect(text).toContain("# a comment the fixer must not eat");
+    expect(text).not.toContain("heartbeat");
+    expect(bodyOf(file)).toBe(before);
+    expect(Object.keys(fmOf(file))).toEqual(["name", "role"]);
+    // The second edit finds nothing to do and writes nothing.
+    expect(editFrontmatter(file, (doc) => { if (!doc.has("heartbeat")) return false; doc.delete("heartbeat"); return true; })).toBe(false);
+  });
+
+  test("a file with no block is left alone; prependFrontmatter writes one", () => {
+    const r = root();
+    const file = path.join(r, "cwd", "bare.md");
+    fs.writeFileSync(file, "# bare\n\nBody.\n", "utf8");
+    expect(editFrontmatter(file, () => true)).toBe(false);
+    expect(prependFrontmatter(file, "name: bare\nrole: Bare seat")).toBe(true);
+    expect(fs.readFileSync(file, "utf8")).toBe("---\nname: bare\nrole: Bare seat\n---\n# bare\n\nBody.\n");
+    expect(prependFrontmatter(file, "name: other")).toBe(false);
+  });
+});
+
+describe("helpers the conversions rely on", () => {
+  test("acceptanceId, normalizeScore and cloneSlug", () => {
+    expect(acceptanceId("Brief Understood")).toBe("brief_understood");
+    expect(acceptanceId("9-lives")).toBe("c_9-lives");
+    expect(normalizeScore(0.8)).toBe(0.8);
+    expect(normalizeScore(80)).toBe(0.8);
+    expect(normalizeScore("nope")).toBeNull();
+    expect(cloneSlug("dna/april-dunford/agent/AGENT.md")).toBe("april-dunford");
+    expect(cloneSlug("/Volumes/x/mindclones/26-research/philip-tetlock")).toBe("philip-tetlock");
+    expect(cloneSlug("~/businesses/_library/dna/edward-tufte.md")).toBe("edward-tufte");
+  });
+});
+
+// ── the seat fixers ─────────────────────────────────────────────────────────
+
+describe("seat fixers", () => {
+  test("heartbeat_strip removes the block and nothing else", () => {
+    const r = root();
+    const dir = businessFixture(r, "hb-biz", {
+      employees: { "ceo.md": INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\nheartbeat:\n  cadence: daily\n  enabled: true") },
+    });
+    const body = bodyOf(seatFile(dir));
+    const { first } = twice(dir, "heartbeat_strip");
+    expect(first.ok).toBe(true);
+    expect(fmOf(seatFile(dir)).heartbeat).toBeUndefined();
+    expect(fmOf(seatFile(dir)).is_brief_intake).toBe(true);
+    expect(bodyOf(seatFile(dir))).toBe(body);
+  });
+
+  test("acceptance_from_self_score converts the criteria and drops the contract", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.split("acceptance:")[0] + [
+      "self_score_contract:",
+      "  required_before_handoff: true",
+      "  max_revise_iterations: 3",
+      "  criteria:",
+      "    - id: brief_understood",
+      "      description: the deliverable answers the brief that was written",
+      "      threshold: 0.8",
+      "      weight: 1.5",
+      "    - id: sources_cited",
+      "      description: every factual claim names a dated source",
+      "      threshold: 90",
+      "---", "", "# CEO", "", "## Method", "", "- A decision line long enough to keep the seat sufficient.", "",
+    ].join("\n");
+    const dir = businessFixture(r, "ssc-biz", { employees: { "ceo.md": seat } });
+    const body = bodyOf(seatFile(dir));
+    const { first } = twice(dir, "acceptance_from_self_score");
+    expect(first.ok).toBe(true);
+    const fm = fmOf(seatFile(dir));
+    expect(fm.self_score_contract).toBeUndefined();
+    expect(fm.acceptance).toEqual([
+      { id: "brief_understood", description: "the deliverable answers the brief that was written", blocking: true, minimum_score: 0.8 },
+      { id: "sources_cited", description: "every factual claim names a dated source", blocking: true, minimum_score: 0.9 },
+    ]);
+    expect(bodyOf(seatFile(dir))).toBe(body);
+  });
+
+  test("acceptance_from_self_score prefixes an id another seat already holds", () => {
+    const r = root();
+    const second = ["---", "name: second", "role: Second seat", "description: The second seat of the fixture business, with its own contract.",
+      "reports_to: ceo", "self_score_contract:", "  criteria:", "    - id: brief_understood", "      description: the same id the intake seat declares",
+      "---", "", "# second", ""].join("\n");
+    const dir = businessFixture(r, "collide-biz", { employees: { "ceo.md": INTAKE_SEAT, "second.md": second } });
+    apply(dir, "acceptance_from_self_score");
+    expect(fmOf(seatFile(dir, "second")).acceptance[0].id).toBe("second_brief_understood");
+  });
+
+  test("acceptance_normalize repairs the id shape and a percentage score", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.replace("  - id: brief_understood", "  - id: Brief Understood").replace("minimum_score: 0.8", "minimum_score: 80");
+    const dir = businessFixture(r, "acc-biz", { employees: { "ceo.md": seat } });
+    twice(dir, "acceptance_normalize");
+    expect(fmOf(seatFile(dir)).acceptance[0]).toMatchObject({ id: "brief_understood", minimum_score: 0.8 });
+  });
+
+  test("draws_from becomes assigned_mind_clones only for clones that exist", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.replace("type: orchestrator", [
+      "type: orchestrator",
+      "draws_from:",
+      "  - source: /Volumes/x/mindclones/02-strategy/jim-collins",
+      "  - source: ~/businesses/_library/dna/nobody-here.md",
+    ].join("\n"));
+    const dir = businessFixture(r, "draws-biz", { employees: { "ceo.md": seat } });
+    const { first } = twice(dir, "draws_from_to_assigned", { available_clones: ["jim-collins"] });
+    expect(first.ok).toBe(true);
+    const fm = fmOf(seatFile(dir));
+    expect(fm.assigned_mind_clones).toEqual(["jim-collins"]);
+    // One source resolved to nothing, so the field that carried it stays.
+    expect(fm.draws_from).toHaveLength(2);
+    expect(first.note).toMatch(/kept/);
+  });
+
+  test("draws_from goes when every source landed", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\ndraws_from:\n  - source: dna/jim-collins/agent/AGENT.md");
+    const dir = businessFixture(r, "draws-clean", { employees: { "ceo.md": seat } });
+    twice(dir, "draws_from_to_assigned", { available_clones: ["jim-collins"] });
+    const fm = fmOf(seatFile(dir));
+    expect(fm.draws_from).toBeUndefined();
+    expect(fm.assigned_mind_clones).toEqual(["jim-collins"]);
+  });
+
+  test("dna_reference becomes a pin, and stays put when the clone is missing", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\ndna_reference: dna/april-dunford/agent/AGENT.md");
+    const dir = businessFixture(r, "pin-biz", { employees: { "ceo.md": seat } });
+    twice(dir, "dna_reference_to_pin", { available_clones: ["april-dunford"] });
+    expect(fmOf(seatFile(dir)).pinned_mind_clones).toEqual(["april-dunford"]);
+    expect(fmOf(seatFile(dir)).dna_reference).toBeUndefined();
+
+    const other = businessFixture(root(), "pin-miss", { employees: { "ceo.md": seat } });
+    const r2 = apply(other, "dna_reference_to_pin", { available_clones: [] });
+    expect(r2.note).toMatch(/kept/);
+    expect(fmOf(seatFile(other)).dna_reference).toBe("dna/april-dunford/agent/AGENT.md");
+  });
+
+  test("type_flag_sync gives an antagonist_gate seat its flag", () => {
+    const r = root();
+    const gate = ["---", "name: second", "role: Adversarial reviewer", "description: Reviews the deliverable before it leaves the business, against the brief.",
+      "type: antagonist_gate", "reports_to: ceo", "---", "", "# second", ""].join("\n");
+    const dir = businessFixture(r, "gate-biz", { employees: { "ceo.md": INTAKE_SEAT, "second.md": gate } });
+    twice(dir, "type_flag_sync");
+    expect(fmOf(seatFile(dir, "second")).is_antagonist).toBe(true);
+  });
+
+  test("employee_frontmatter_repair derives a header and keeps the prose", () => {
+    const r = root();
+    const bare = "# Growth lead\n\nOwns acquisition end to end, from the first ad to the activated account.\n";
+    const dir = businessFixture(r, "bare-biz", { employees: { "ceo.md": INTAKE_SEAT, "growth.md": bare } });
+    const { first } = twice(dir, "employee_frontmatter_repair");
+    expect(first.repaired).toEqual(["growth"]);
+    const fm = fmOf(seatFile(dir, "growth"));
+    expect(fm.name).toBe("growth");
+    expect(fm.role).toBe("Growth lead");
+    expect(fm.description).toContain("Owns acquisition end to end");
+    expect(fs.readFileSync(seatFile(dir, "growth"), "utf8")).toContain(bare);
+  });
+
+  test("intake_from_chart_root promotes the root, and refuses to choose between two", () => {
+    const r = root();
+    const noIntake = INTAKE_SEAT.replace("is_brief_intake: true", "is_brief_intake: false");
+    const dir = businessFixture(r, "root-biz", { employees: { "ceo.md": noIntake } });
+    twice(dir, "intake_from_chart_root");
+    expect(fmOf(seatFile(dir)).is_brief_intake).toBe(true);
+
+    const two = businessFixture(root(), "two-biz", {
+      employees: { "ceo.md": INTAKE_SEAT, "second.md": ["---", "name: second", "role: Second", "description: Another seat that also declares itself the intake of the business.", "is_brief_intake: true", "---", "", "# second", ""].join("\n") },
+    });
+    expect(apply(two, "intake_from_chart_root").ok).toBe(false);
+  });
+});
+
+// ── the manifest, routing and file fixers ───────────────────────────────────
+
+describe("manifest and routing fixers", () => {
+  test("employee_count_strip and squads_authorized_empty_strip keep every other key and comment", () => {
+    const r = root();
+    const dir = businessFixture(r, "strip-biz", {
+      manifestExtra: "# a comment about the whole business\nauthor: someone\nemployee_count: 1\nsquads_authorized: []",
+    });
+    twice(dir, "employee_count_strip");
+    twice(dir, "squads_authorized_empty_strip");
+    const text = fs.readFileSync(path.join(dir, "business.yaml"), "utf8");
+    // A comment that belongs to a surviving key survives with it; one attached
+    // to the removed key leaves with the key, which is what the author meant.
+    expect(text).toContain("# a comment about the whole business");
+    expect(manifestOf(dir).employee_count).toBeUndefined();
+    expect(manifestOf(dir).squads_authorized).toBeUndefined();
+    expect(manifestOf(dir).author).toBe("someone");
+    expect(manifestOf(dir).name).toBe("strip-biz");
+    // The description keeps its single line: the rewrite never re-wraps prose.
+    expect(text).toContain("description: Fixture business that turns a written brief into one artifact, decides the format from the brief and hands it back reviewed.");
+  });
+
+  test("squads_authorized_empty_strip never touches a fence that names a squad", () => {
+    const r = root();
+    const dir = businessFixture(r, "fenced-biz", { manifestExtra: "squads_authorized: [brandcraft]" });
+    apply(dir, "squads_authorized_empty_strip");
+    expect(manifestOf(dir).squads_authorized).toEqual(["brandcraft"]);
+  });
+
+  test("deprecated_field_strip only accepts a field §22 retires", () => {
+    const r = root();
+    const seat = INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\nbudget_monthly_usd: 40\nmentions:\n  receives: ['@ceo']");
+    const dir = businessFixture(r, "dep-biz", { employees: { "ceo.md": seat } });
+    twice(dir, "deprecated_field_strip", { field: "budget_monthly_usd" });
+    twice(dir, "deprecated_field_strip", { field: "mentions" });
+    expect(fmOf(seatFile(dir)).budget_monthly_usd).toBeUndefined();
+    expect(fmOf(seatFile(dir)).mentions).toBeUndefined();
+    expect(fmOf(seatFile(dir)).role).toBeTruthy();
+    expect(apply(dir, "deprecated_field_strip", { field: "description" })).toMatchObject({ ok: false });
+  });
+
+  test("auto_routes_relocate moves every route and drops none", () => {
+    const r = root();
+    const dir = businessFixture(r, "relocate-biz", {
+      manifestExtra: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n  - pattern: "(?i)relatorio"\n    route_to: ceo',
+      routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n',
+    });
+    const { first } = twice(dir, "auto_routes_relocate");
+    expect(first.relocated).toBe(1);
+    expect(first.deduplicated).toBe(1);
+    expect(manifestOf(dir).auto_routes).toBeUndefined();
+    expect(routingOf(dir).auto_routes.map((x: any) => x.pattern)).toEqual(["(?i)fixture report", "(?i)relatorio"]);
+    expect(routingOf(dir).brief_intake.default_employee).toBe("ceo");
+  });
+
+  test("auto_routes_relocate creates routing.yaml when the business has none", () => {
+    const r = root();
+    const dir = businessFixture(r, "no-routing-biz", { manifestExtra: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo' });
+    twice(dir, "auto_routes_relocate");
+    expect(routingOf(dir).auto_routes).toHaveLength(1);
+  });
+
+  test("catch_all_to_default_employee converts the destination, and declines when it would drop one", () => {
+    const r = root();
+    const dir = businessFixture(r, "catchall-biz", { routing: 'auto_routes:\n  - pattern: ".*"\n    route_to: ceo\n  - pattern: "(?i)fixture"\n    route_to: ceo\n' });
+    const { first } = twice(dir, "catch_all_to_default_employee");
+    expect(first.ok).toBe(true);
+    expect(routingOf(dir).brief_intake.default_employee).toBe("ceo");
+    expect(routingOf(dir).auto_routes.map((x: any) => x.pattern)).toEqual(["(?i)fixture"]);
+
+    const conflict = businessFixture(root(), "conflict-biz", {
+      employees: { "ceo.md": INTAKE_SEAT, "second.md": ["---", "name: second", "role: Second", "description: A second seat the catch-all route points at instead of the intake.", "reports_to: ceo", "---", "", "# second", ""].join("\n") },
+      routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: ".*"\n    route_to: second\n',
+    });
+    const declined = apply(conflict, "catch_all_to_default_employee");
+    expect(declined.ok).toBe(false);
+    expect(routingOf(conflict).auto_routes).toHaveLength(1);
+  });
+
+  test("manifest_schema_repair fills only what the directory already answers", () => {
+    const r = root();
+    const dir = businessFixture(r, "schema-biz", { manifest: 'description: A manifest with no name, no version and no protocol at all, which the schema requires.\ndomains: [fixture_domain]\n' });
+    const { first } = twice(dir, "manifest_schema_repair");
+    expect(first.filled.sort()).toEqual(["name", "protocol", "version"]);
+    expect(manifestOf(dir)).toMatchObject({ name: "schema-biz", version: "1.0.0", protocol: "1.0" });
+    // Nothing invented: the description the author wrote is still the one there.
+    expect(manifestOf(dir).description).toMatch(/^A manifest with no name/);
+  });
+
+  test("runtime_requirements_business_default declares the active-runtime policy", () => {
+    const r = root();
+    const dir = businessFixture(r, "rr-biz", { manifest: 'name: rr-biz\nversion: 1.0.0\nprotocol: "2.0"\ndescription: A manifest whose runtime_requirements never got a floor of its own, only a policy.\ndomains: [fixture_domain]\nruntime_requirements:\n  policy: declared\n' });
+    twice(dir, "runtime_requirements_business_default");
+    expect(manifestOf(dir).runtime_requirements).toEqual({ policy: "active" });
+  });
+
+  test("org_chart_repair derives a chart that is consistent in both directions", () => {
+    const r = root();
+    const second = ["---", "name: second", "role: Second seat", "description: Reports to the CEO and owns the delivery half of the business.", "reports_to: ceo", "---", "", "# second", ""].join("\n");
+    const third = ["---", "name: third", "role: Third seat", "description: Managed by the CEO through manages, with no reports_to of its own.", "---", "", "# third", ""].join("\n");
+    const dir = businessFixture(r, "chart-biz", {
+      employees: { "ceo.md": INTAKE_SEAT.replace("type: orchestrator", "type: orchestrator\nmanages: [third]"), "second.md": second, "third.md": third },
+      orgChart: "chart:\n  - employee: ceo\n    reports: []\n    direct_reports: []\nrouting_rules:\n  escalation_path:\n    second: ceo\n",
+    });
+    const { first } = twice(dir, "org_chart_repair");
+    expect(first.ok).toBe(true);
+    const chart = parseYaml(fs.readFileSync(path.join(dir, "org-chart.yaml"), "utf8")) as any;
+    expect(chart.chart).toEqual([
+      { employee: "ceo", reports: [], direct_reports: ["second", "third"], is_antagonist: false },
+      { employee: "second", reports: ["ceo"], direct_reports: [], is_antagonist: false },
+      { employee: "third", reports: ["ceo"], direct_reports: [], is_antagonist: false },
+    ]);
+    // Everything else the file held is still there.
+    expect(chart.routing_rules.escalation_path.second).toBe("ceo");
+  });
+
+  test("org_chart_repair refuses two roots rather than inventing a hierarchy", () => {
+    const r = root();
+    const orphan = ["---", "name: second", "role: Second seat", "description: A seat that reports to nobody, next to another seat that reports to nobody.", "---", "", "# second", ""].join("\n");
+    const dir = businessFixture(r, "two-roots", { employees: { "ceo.md": INTAKE_SEAT, "second.md": orphan } });
+    expect(apply(dir, "org_chart_repair")).toMatchObject({ ok: false });
+  });
+
+  test("dna_dir_to_bindings moves the links and keeps a real file", () => {
+    const r = root();
+    const dir = businessFixture(r, "dna-biz");
+    fs.mkdirSync(path.join(dir, "dna"), { recursive: true });
+    fs.mkdirSync(path.join(r, "dna", "rory-sutherland"), { recursive: true });
+    fs.symlinkSync(path.join(r, "dna", "rory-sutherland"), path.join(dir, "dna", "rory-sutherland"));
+    fs.writeFileSync(path.join(dir, "dna", "README.md"), "# why this directory exists\n", "utf8");
+    const { first } = twice(dir, "dna_dir_to_bindings");
+    expect(first.clones).toEqual(["rory-sutherland"]);
+    expect(fmOf(seatFile(dir)).assigned_mind_clones).toEqual(["rory-sutherland"]);
+    expect(fs.existsSync(path.join(dir, "dna", "rory-sutherland"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "dna", "README.md"))).toBe(true);
+    expect(first.note).toMatch(/README\.md/);
+  });
+
+  test("readme_business_scaffold and memory_seed create, never overwrite", () => {
+    const r = root();
+    const dir = businessFixture(r, "files-biz", { readme: null, memory: false });
+    twice(dir, "readme_business_scaffold");
+    twice(dir, "memory_seed");
+    expect(fs.readFileSync(path.join(dir, "README.md"), "utf8")).toContain("Fixture business that turns a written brief");
+    expect(fs.readFileSync(path.join(dir, "memory", "permanent.md"), "utf8")).toContain("Permanent memory");
+    fs.writeFileSync(path.join(dir, "README.md"), "# mine\n", "utf8");
+    apply(dir, "readme_business_scaffold");
+    expect(fs.readFileSync(path.join(dir, "README.md"), "utf8")).toBe("# mine\n");
+  });
+
+  test("an unknown patch kind is refused, an exception is caught", () => {
+    const r = root();
+    const dir = businessFixture(r, "unknown-biz");
+    expect(apply(dir, "no_such_fixer")).toEqual({ ok: false, reason: "unknown patch kind" });
+  });
+});
+
+// ── the --fix loop end to end ───────────────────────────────────────────────
+
+describe("nrv validate business --fix", () => {
+  /** A business that fires most of the mechanical catalog at once. */
+  function brokenBusiness(r: string, slug: string): string {
+    const seat = INTAKE_SEAT.replace("type: orchestrator", [
+      "type: orchestrator",
+      "squads_authorized: []",
+      "budget_monthly_usd: 40",
+      "heartbeat:",
+      "  cadence: daily",
+      "  enabled: true",
+    ].join("\n"));
+    const dir = businessFixture(r, slug, {
+      protocol: "1.0",
+      employees: { "ceo.md": seat },
+      manifestExtra: 'employee_count: 1\nauto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo',
+      readme: null,
+      memory: false,
+    });
+    return dir;
+  }
+
+  test("one run clears every mechanical finding; the second writes nothing", () => {
+    const r = root();
+    const dir = brokenBusiness(r, "broken-biz");
+    const before = runCli(r, ["business", "broken-biz", "--no-retrieval", "--json"]);
+    expect(before.json.summary.errors).toBeGreaterThan(0);
+
+    const fixed = runCli(r, ["business", "broken-biz", "--no-retrieval", "--fix", "--json"]);
+    expect(fixed.json.fix_outcome.rolled_back).toBe(false);
+    expect(fixed.json.fix_outcome.backup).toBeTruthy();
+    expect(fixed.json.summary.errors).toBe(0);
+    expect(fixed.json.findings.filter((f: any) => f.fixer).map((f: any) => f.id)).toEqual([]);
+
+    const digest = treeDigest(dir);
+    const again = runCli(r, ["business", "broken-biz", "--no-retrieval", "--fix", "--json"]);
+    expect(again.json.summary.errors).toBe(0);
+    expect(treeDigest(dir)).toEqual(digest);
+  });
+
+  test("the backup holds the business as it was before the fixers ran", () => {
+    const r = root();
+    const dir = brokenBusiness(r, "backup-biz");
+    const before = treeDigest(dir);
+    const out = runCli(r, ["business", "backup-biz", "--no-retrieval", "--fix", "--json"]);
+    const backup = out.json.fix_outcome.backup as string;
+    expect(fs.existsSync(backup)).toBe(true);
+    expect(treeDigest(backup)).toEqual(before);
+  });
+
+  test("protocol rises only once nothing is an error any more", () => {
+    const r = root();
+    // A schema failure no fixer can derive: `domains` is required and empty.
+    const dir = businessFixture(r, "still-broken", {
+      protocol: "1.0",
+      manifest: 'name: still-broken\nversion: 1.0.0\nprotocol: "1.0"\ndescription: A manifest whose domains list is empty, which no mechanical fixer can fill in for the author.\ndomains: []\nruntime_requirements:\n  policy: active\n',
+    });
+    const out = runCli(r, ["business", "still-broken", "--no-retrieval", "--fix", "--json"]);
+    expect(manifestOf(dir).protocol).toBe("1.0");
+    const bump = out.json.fixes.find((f: any) => f.fixer === "protocol_bump_2");
+    expect(bump.applied).toBe(false);
+    expect(bump.note).toMatch(/error\(s\) still open/);
+
+    const clean = root();
+    businessFixture(clean, "clean-v1", { protocol: "1.0" });
+    runCli(clean, ["business", "clean-v1", "--no-retrieval", "--fix"]);
+    expect(manifestOf(path.join(clean, "businesses", "clean-v1")).protocol).toBe("2.0");
+  });
+
+  test("--fix never deletes an authored file and never drops a route", () => {
+    const r = root();
+    const dir = businessFixture(r, "authored-biz", {
+      protocol: "1.0",
+      routing: 'brief_intake:\n  default_employee: ceo\nauto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n',
+    });
+    fs.writeFileSync(path.join(dir, "culture.md"), "# Culture\n\nWritten by a human.\n", "utf8");
+    fs.writeFileSync(path.join(dir, "escalation-triggers.yaml"), "triggers: []\n", "utf8");
+    writeSurfaceFor(dir, "business");
+    runCli(r, ["business", "authored-biz", "--no-retrieval", "--fix"]);
+    expect(fs.readFileSync(path.join(dir, "culture.md"), "utf8")).toContain("Written by a human.");
+    expect(fs.existsSync(path.join(dir, "escalation-triggers.yaml"))).toBe(true);
+    expect(routingOf(dir).auto_routes).toHaveLength(1);
+  });
+
+  test("a seat's body survives the whole loop byte for byte", () => {
+    const r = root();
+    const dir = brokenBusiness(r, "body-biz");
+    const before = bodyOf(seatFile(dir));
+    runCli(r, ["business", "body-biz", "--no-retrieval", "--fix"]);
+    expect(bodyOf(seatFile(dir))).toBe(before);
+  });
+
+  test("a fixer that breaks the manifest rolls the whole business back", async () => {
+    const r = root();
+    const dir = brokenBusiness(r, "sabotaged-biz");
+    const before = treeDigest(dir);
+    // The saboteur stands in for `heartbeat_strip` and writes YAML that does
+    // not parse. Every other handler still runs; the loop must undo all of it.
+    const sabotaged: KindModule = {
+      ...businessModule,
+      fixers: {
+        ...businessModule.fixers,
+        heartbeat_strip: ({ finding }) => {
+          fs.writeFileSync(path.join(dir, "business.yaml"), "name: [unclosed\n", "utf8");
+          return { fixer: "heartbeat_strip", finding: finding.id, applied: true, changed_files: ["business.yaml"] };
+        },
+      },
+    };
+    const report = await verifyEntity("business", dir, {
+      fix: "mechanical", retrieval: false, baselinePath: null, stateDir: null, emit: null,
+      backupRoot: path.join(r, "backups"), module: sabotaged,
+    });
+    expect(report.fix_outcome?.rolled_back).toBe(true);
+    expect(report.fix_outcome?.rollback_reason).toContain("manifest");
+    expect(treeDigest(dir)).toEqual(before);
+  });
+
+  test("--all --fix walks the library the CLI was pointed at", () => {
+    const r = root();
+    brokenBusiness(r, "one-biz");
+    brokenBusiness(r, "two-biz");
+    const out = runCli(r, ["business", "--all", "--no-retrieval", "--fix", "--json"]);
+    expect(out.json.entities).toBe(2);
+    expect(out.json.summary.errors).toBe(0);
+    expect(out.code).toBe(0);
+  });
+});
+
+// ── the environment contract ────────────────────────────────────────────────
+
+describe("the fixers stay inside the directory they were given", () => {
+  test("nothing under ~/businesses is opened while a fixture is repaired", () => {
+    const r = root();
+    const dir = businessFixture(r, "scoped-biz", { protocol: "1.0", readme: null });
+    const env = cliEnv(r);
+    expect(env.BUSINESSES_DIR).toBe(path.join(r, "businesses"));
+    runCli(r, ["business", "scoped-biz", "--no-retrieval", "--fix"]);
+    expect(fs.existsSync(path.join(dir, "README.md"))).toBe(true);
+    expect(path.resolve(dir).startsWith(path.resolve(r))).toBe(true);
+  });
+});

--- a/skills/businesses/tests/protocol-v2-spec-parity.test.ts
+++ b/skills/businesses/tests/protocol-v2-spec-parity.test.ts
@@ -6,13 +6,11 @@
 // files that never existed. So the table is parsed here and compared, id by id,
 // against the module the gate executes.
 //
-// The business kind module (`_shared/lib/verify/kinds/business.ts`) lands in a
-// later cut. Until it exists, the comparison has nothing to run against — and a
-// silent `skip` would let the spec rot unnoticed for as long as that takes. So
-// the tests below always run: they assert the table is well-formed on its own,
-// and the parity test states out loud that the module is absent and flips to a
-// real comparison the moment the file appears. Nothing has to be re-enabled by
-// hand.
+// The comparison used to run in one direction only (module ⊆ spec), because the
+// module carried three structural criteria and the catalog had not landed yet.
+// It is an equality now: same ids, same severity, same autofix class, same
+// baselineable flag. Adding a criterion to one side without the other is a red
+// test, which is the point.
 //
 // Runs with: bun test skills/businesses/tests
 import { describe, expect, test } from "bun:test";
@@ -93,20 +91,45 @@ describe("Business Protocol 2.0 §16.2 — the table is a catalog", () => {
 });
 
 describe("Business Protocol 2.0 §16.2 — parity with the gate module", () => {
-  test("every criterion the module carries is declared by the spec", async () => {
-    // The gate module grows one cut at a time: PR2 landed the three structural
-    // criteria, the full catalog arrives with the business cut. The direction
-    // asserted here is the one that must hold at every point in between — the
-    // module never checks something §16 does not declare. The other direction
-    // (spec ⊆ module) becomes true when the catalog lands, and the count below
-    // is what tells us how far the module still is.
+  /** The spec writes the autofix class in Portuguese; the module in English. */
+  const AUTOFIX: Record<string, string> = { "mecânico": "mechanical", "agêntico": "agentic", "nenhum": "none" };
+
+  test("the module exists and exports a catalog", () => {
     expect(existsSync(KIND_MODULE)).toBe(true);
+  });
+
+  test("the two id sets are equal, in both directions", async () => {
     const mod = await import(KIND_MODULE);
-    const moduleIds = new Set<string>(
-      (mod.criteria ?? mod.default?.criteria ?? []).map((c: { id: string }) => c.id.split(":")[0]),
-    );
-    const specIds = new Set(spec.map((c) => c.id));
-    expect([...moduleIds].filter((id) => !specIds.has(id))).toEqual([]);
-    expect(moduleIds.size).toBeGreaterThan(0);
+    const moduleIds = (mod.criteria as Array<{ id: string }>).map((c) => c.id);
+    expect(new Set(moduleIds).size).toBe(moduleIds.length);
+    const specIds = spec.map((c) => c.id);
+    expect(moduleIds.filter((id) => !specIds.includes(id))).toEqual([]);   // module ⊆ spec
+    expect(specIds.filter((id) => !moduleIds.includes(id))).toEqual([]);   // spec ⊆ module
+    expect(moduleIds.length).toBe(specIds.length);
+  });
+
+  test("severity, autofix class and baselineable agree row by row", async () => {
+    const mod = await import(KIND_MODULE);
+    const byId = new Map((mod.criteria as Array<Record<string, unknown>>).map((c) => [c.id as string, c]));
+    const drift: string[] = [];
+    for (const row of spec) {
+      const c = byId.get(row.id);
+      if (!c) continue;                                    // the id test above owns this
+      if (c.severity !== row.severity) drift.push(`${row.id}: severity ${String(c.severity)} vs ${row.severity}`);
+      if (c.autofix !== AUTOFIX[row.autofix]) drift.push(`${row.id}: autofix ${String(c.autofix)} vs ${AUTOFIX[row.autofix]}`);
+      if (c.baselineable !== row.baselineable) drift.push(`${row.id}: baselineable ${String(c.baselineable)} vs ${row.baselineable}`);
+    }
+    expect(drift).toEqual([]);
+  });
+
+  test("every mechanical row names a fixer the module can actually run", async () => {
+    const mod = await import(KIND_MODULE);
+    const fixers = new Set(Object.keys(mod.businessModule.fixers));
+    const missing: string[] = [];
+    for (const c of mod.criteria as Array<{ id: string; autofix: string; fixer?: string }>) {
+      if (c.autofix !== "mechanical") continue;
+      if (!c.fixer || !fixers.has(c.fixer)) missing.push(c.id);
+    }
+    expect(missing).toEqual([]);
   });
 });

--- a/skills/businesses/tests/smoke.test.ts
+++ b/skills/businesses/tests/smoke.test.ts
@@ -58,10 +58,32 @@ describe("business lifecycle — init → validate → index → list", () => {
     expect(existsSync(join(home, "businesses", "smoke-solo", "business.yaml"))).toBe(true);
   });
 
-  test("validate exits 0 on the freshly created business", () => {
-    const r = nrv("validate-business.ts", "smoke-solo");
-    expect(`${r.stdout}${r.stderr}`).not.toContain("[FAIL]");
+  // The wizard writes no `.nirvana-surface.json` (§5.3 puts it in the layout and
+  // gives it to the engine), so the gate rejects a scaffold on exactly that one
+  // error and `--fix` clears it. The wizard hook that closes the gap is PR11 of
+  // the program plan; until then this test states the gap instead of hiding it.
+  test("validate names the one error a scaffold carries, and --fix clears it", () => {
+    const first = nrv("validate-business.ts", "smoke-solo", "--json", "--no-retrieval");
+    const report = JSON.parse(first.stdout);
+    expect(report.findings.filter((f: any) => f.severity === "error").map((f: any) => f.id)).toEqual(["surface_missing"]);
+    expect(first.status).toBe(1);
+
+    const fixed = nrv("validate-business.ts", "smoke-solo", "--fix", "--no-retrieval");
+    expect(`${fixed.stdout}${fixed.stderr}`).not.toContain("ROLLED BACK");
+    expect(fixed.status).toBe(0);
+    expect(existsSync(join(home, "businesses", "smoke-solo", ".nirvana-surface.json"))).toBe(true);
+  });
+
+  test("--report writes the JSON under the project's own .audit-state", () => {
+    // Pinned project root: a report belongs to the project that asked for it,
+    // never to the global skills tree (the split audit-businesses-score made).
+    const r = spawnSync(process.execPath, [join(SCRIPTS, "validate-business.ts"), "smoke-solo", "--report", "--no-retrieval"], {
+      cwd: home, env: { ...env, NIRVANA_PROJECT_ROOT: home, NIRVANA_SCOPE: "project" }, encoding: "utf8",
+    });
     expect(r.status).toBe(0);
+    const file = join(home, ".nirvana", ".audit-state", "smoke-solo", "verify.json");
+    expect(r.stdout).toContain(file);
+    expect(JSON.parse(readFileSync(file, "utf8")).schema).toBe("nirvana.verify-report/v1");
   });
 
   test("index writes the registry with the new business", () => {


### PR DESCRIPTION
PR8 of the program plan: `nrv validate business` gets the catalog §16.2 of `BUSINESS_PROTOCOL_V2.md` already declared, and the mechanical fixers that repair what it finds.

Until this cut the business module of the admission gate carried three structural criteria against a spec table of thirty-nine, and the thirteen `fixable_diff` kinds the audit scorer emitted named repairs no code performed — "fixable" meant nothing.

## What lands

- **`skills/_shared/lib/verify/kinds/business.ts`** — the whole §16.2 catalog: 16 errors, 23 warnings, with the severity, autofix class and baselineable flag the spec table declares. No `info` criterion: §16.2 has two severities, so the self-retrieval axis is skipped in silence when the business is not indexed, rather than emitting `registry_absent` as the mind-clone module does.
- **`skills/businesses/lib/business-fixers.js`** — 21 idempotent handlers behind one dispatch table (CJS, mirroring `mechanical-fixers.js`), no LLM. The gate's `--fix` loop and the audit scorer's `fixable_diff` now name the same code.
- **`skills/_shared/lib/frontmatter-edit.ts`** — rewrites only the `---` block, through the `yaml` Document API, and reassembles the file around the original body slice. Comments, key order, line endings and every byte below the header survive a header edit.
- **`skills/businesses/lib/business-audit-criteria.js`** — c2, c3 and c5 realigned to §6.12, §11 and §13.2. The rubric sums to exactly 100 again (it had summed 104 since `seat_sufficiency` was bolted on while the header still said 100), and every `fixable_diff` names a handler that exists plus the class that can apply it (`mechanical` / `agentic` / `none`).
- **`skills/businesses/scripts/validate-business.ts`** — delegates to the runner: `<slug|path>|--all [--fix] [--strict] [--json] [--report] [--no-retrieval]`, report under `.audit-state/<slug>/verify.json`. The script and `nrv validate business` are one code path with the same exit codes.
- **`protocol-v2-spec-parity.test.ts`** — was "module ⊆ spec"; it is equality now, in both directions, over ids, severity, autofix class and baselineable, row by row.

## Measured, against a copy (`~/businesses` was never written)

61 businesses, 581 seats. `nrv validate business --all`: **53 admitted, 8 rejected, 31 errors, 1,262 warnings**, 0.8 s without the retrieval axis and 4.3 s with it. Every error is semantic, none is shape — all 61 manifests and all 581 seats already pass Zod:

| Finding | Businesses |
|---|---|
| `auto_route_in_manifest` (error) | 7 |
| `auto_route_unknown_employee` (error, 24 routes) | 5 |
| `protocol_v1`, `employee_count_authored`, `acceptance_missing` | 61 each |
| `deprecated_field` (302 fields) | 61 |
| `routing_metadata_incomplete` | 56 |
| `auto_route_never_fires` (562 patterns) | 47 |
| `readme_missing` | 38 |
| `squads_authorized_empty` | 33 |
| `self_retrieval_miss` (baselineable debt) | 15 |

`--fix` over the same copy: **578 repairs in 3.2 s, zero rollbacks**, 537 warnings and the 7 misplaced route blocks cleared, all 61 still loading through `loader.ts`, `protocol: "2.0"` raised on the 56 with no error left (the five with an open error keep 1.0, which is what §18.4 asks for). A second `--fix` over the same 61 businesses changed **zero bytes**.

## The three rules the fixers hold

**The seat's body is never touched** — every test that edits a seat compares the body byte for byte afterwards. **Nothing authored is deleted** — a retired *file* is reported and left where it is (`culture.md`, `escalation-triggers.yaml`, `budgets.yaml`), and a route is converted into the field that implements it rather than dropped. **Nothing is invented** — no fixer writes a `not_for`, an `example_brief`, a description or an acceptance criterion, and a `draws_from` source that resolves to no installed clone keeps its field instead of becoming a broken binding.

## Verification

- `bun test skills` — **1,912 pass, 1 fail** across 174 files: `buyer-path.test.ts` (`Cannot find package 'yaml'` from the temp home the test builds), the known worktree-environmental failure from the symlinked `node_modules`. Run against this branch rebased on `main` (PR #125 and #126 included).
- 12 of the 14 `check:all` gates green. `check-not-for-fires --strict` fails in a worktree only — the per-entity ceiling lives in `<repo>/.nirvana/`, which a fresh worktree does not have; the same gate passes in the main checkout on this machine.
- New tests: `skills/_shared/tests/verify-business.test.ts` (42 tests, one fixture per criterion), `skills/businesses/tests/business-fixers.test.ts` (36, including idempotence, body bytes, backup contents and a forced rollback), `skills/businesses/tests/business-audit-criteria.test.ts` (7, the rubric's 100 and every suggestion naming a real handler).

## One judgment call worth a second opinion

`catch_all_to_default_employee` converts a `.*` route into `brief_intake.default_employee` and drops the now-redundant pattern — and only when nothing is lost (the key is absent, or already names the same seat; otherwise the fixer declines and the finding stands). §16.2 marks `auto_route_catch_all` as mechanical, and the destination is preserved in the field §13.2 says implements it, but the plan's wording is "routes are not removed". Say the word and it becomes a demotion to last position instead.

Two gaps reported rather than fixed, both belonging to later cuts: `init-business.ts` writes no `.nirvana-surface.json`, so a fresh scaffold is rejected on exactly that one error until the PR11 wizard hook lands (`smoke.test.ts` now states the gap and proves `--fix` clears it); and `--fix=agentic` is still refused by the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
