### PR TITLE
perf(dev-loop): tests by area, a content-keyed routing eval, and check:quick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,11 @@ skills/harness/tests/reports/
 # golden-negatives.json is committed.
 skills/harness/baselines/golden-routing.json
 
+# Routing eval memo — the eval's own verdict, keyed on a content hash of the
+# registries, the cases and the engine sources. Local dev-loop state: CI starts
+# from a clean checkout, finds no file, and always measures for real.
+skills/harness/baselines/.routing-eval-cache.json
+
 # The project-skeleton TEMPLATES are product files, not local state. The plain
 # `.env` / `.nirvana/` patterns above swallowed them silently: they existed on
 # the author's machine, never reached the repo, and every install shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ would have thrown them out.
 
 `test-script-coverage.test.ts` keeps the split from rotting: the four area scripts have to cover
 every file on disk exactly once, `test:fast` and the slow manifest have to partition the same set,
-and the three measured heavyweights may not drift back into the fast half.
+and the three measured heavyweights may not drift back into the fast half. Every path is walked,
+stored and compared in POSIX form on all three platforms, because `path.relative` returns
+`skills\harness\tests\x.test.ts` on Windows while package.json and `slow-tests.json` hold `/`, and
+an unnormalized comparison reads the entire suite as uncovered.
 
 ### The routing eval remembers a verdict it already reached
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,76 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The dev loop stops paying for the whole repository on every check
+
+`bun test skills` was the only thing anyone could type, and it runs 176 files in 135-180 s. A
+two-line change bought the whole engine. Per-file measurement on 27/08/2026, one Bun process each,
+put the total at 138.3 s: 34 files account for 114.6 s of it, and one file, `routing-eval.test.ts`,
+accounts for 27.4 s on its own.
+
+`scripts/test-timings.ts` is where those numbers come from. It times one `bun test <file>` per file
+instead of reading Bun's reporter, because the reporter times test CASES while the expensive files
+spend their seconds at module scope, where no case is running. `routing-eval.test.ts` is the
+extreme: near zero case time, 27 s of wall clock. `--write` records every file at or over a second
+in `scripts/slow-tests.json`, and the split below is the output of that measurement rather than
+anyone's intuition.
+
+| Script | Runs | Measured |
+|---|---|---|
+| `test:fast` | the 144 files that measured under 1 s | 19 s |
+| `test:squads` | 8 files | 4 s |
+| `test:businesses` | 6 files | 3 s |
+| `test:shared` | 37 files | 20 s |
+| `test:harness` | 127 files | 81 s |
+| `test:gate` | the admission and quality suites | 18 s |
+| `test:full`, and `test` | everything, unchanged | 135-180 s |
+| `check:quick` | the nine gates that finish in milliseconds | 0.6 s |
+| `check:all` | all fourteen, unchanged | CI |
+
+Measurement beat the guess in one place worth naming. Four of the eight `*.e2e.test.ts` files
+finish under a second, so they stay in `test:fast`, where an exclusion written by filename pattern
+would have thrown them out.
+
+`test-script-coverage.test.ts` keeps the split from rotting: the four area scripts have to cover
+every file on disk exactly once, `test:fast` and the slow manifest have to partition the same set,
+and the three measured heavyweights may not drift back into the fast half.
+
+### The routing eval remembers a verdict it already reached
+
+`routing-eval.test.ts` rebuilt the golden set whenever the registry files' mtime moved, and
+`nrv index` rewrites those files on every run. Measured on 27/08/2026: mtime 1787814306 became
+1787814328, same 5,028,411 bytes, same SHA-256 once the `generated_at` stamp is dropped. A re-index
+that changed nothing bought a golden-set rebuild and the 27 s eval behind it.
+
+Staleness is decided by content now. `registryFingerprint()` hashes the registry loader's
+projection, which is exactly what `build-golden-set.ts` reads and what `router.js` indexes, and
+that projection carries no timestamp. The golden set stores the two hashes next to the paths it was
+built from; one built before the field existed carries no hash and is rebuilt once.
+
+The eval itself is memoized on the same principle. `runEvalCached()` keys on the registries, the
+golden cases, the negatives, every top-level source under `harness/lib` and `_shared/lib`, and the
+three router env flags. Back to back, same inputs: 29.7 s cold, 0.15 s warm, and all nine
+assertions read the same numbers (top1 98.5%, MRR 0.989, NO_MATCH 73.3% on 3,449 cases). The key
+errs wide deliberately, since over-invalidating costs one 27 s re-run while under-invalidating
+reports a green routing gate for an engine nobody measured. `NIRVANA_EVAL_NO_CACHE=1` turns it off,
+and `scripts/test-timings.ts` sets it so a warm cache can never make the heaviest file in the suite
+look cheap. CI starts from a clean checkout, finds no cache file and always measures.
+
+### Verification by area becomes the contract, and a failure knows whose it is
+
+The gate was being paid per slice. Four agents cutting four pieces of one change each ran the full
+suite and all fourteen checks over code nobody had integrated yet, and when the merged tree failed,
+no one could say which cut produced it, so the fix went to a fresh agent that had to rediscover the
+context first.
+
+Rule 11 of `skills/harness/SKILL.md` and a matching passage in all seven `agent-x.*.md` personas
+now say it plainly. A dispatched cut verifies its own area and stops there. The whole is verified
+once, after integration, by CI on the three systems and by the orchestrator that merges. A failure
+of the whole is attributed to the cut that produced it, by trace id, commit and diff, and the fix
+goes back to that cut's own session rather than to a new agent. Two things became required in a
+cut's final report, because they are what turns attribution into a lookup: the list of files it
+touched, as paths, and what it did not verify and why.
+
 ### The registry stops dropping what a capability declares
 
 A capability has been allowed to declare `estimated_cost_usd` for two protocol

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -41,7 +41,9 @@ padrão de nome os teria tirado.
 O `test-script-coverage.test.ts` impede que a divisão apodreça: os quatro scripts de área precisam
 cobrir todo arquivo em disco exatamente uma vez, o `test:fast` e o manifesto dos lentos precisam
 particionar o mesmo conjunto, e os três pesos-pesados medidos não podem voltar para a metade
-rápida.
+rápida. Todo caminho é percorrido, gravado e comparado em forma POSIX nos três sistemas, porque o
+`path.relative` devolve `skills\harness\tests\x.test.ts` no Windows enquanto o package.json e o
+`slow-tests.json` guardam `/`, e uma comparação sem normalizar lê a suíte inteira como descoberta.
 
 ### A avaliação de roteamento lembra do veredito a que já chegou
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,80 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O laço de desenvolvimento para de pagar o repositório inteiro a cada verificação
+
+`bun test skills` era a única coisa que alguém podia digitar, e ele roda 176 arquivos em 135-180 s.
+Uma mudança de duas linhas comprava o engine inteiro. A medição por arquivo em 27/08/2026, um
+processo do Bun para cada um, deu 138,3 s no total: 34 arquivos respondem por 114,6 s disso, e um
+único arquivo, o `routing-eval.test.ts`, responde por 27,4 s sozinho.
+
+O `scripts/test-timings.ts` é de onde esses números vêm. Ele cronometra um `bun test <arquivo>` por
+arquivo em vez de ler o repórter do Bun, porque o repórter cronometra CASOS de teste enquanto os
+arquivos caros gastam seus segundos no escopo do módulo, onde nenhum caso está rodando. O
+`routing-eval.test.ts` é o extremo: tempo de caso perto de zero, 27 s de relógio. O `--write`
+registra todo arquivo com um segundo ou mais em `scripts/slow-tests.json`, e a divisão abaixo é a
+saída dessa medição, não a intuição de ninguém.
+
+| Script | Roda | Medido |
+|---|---|---|
+| `test:fast` | os 144 arquivos que mediram menos de 1 s | 19 s |
+| `test:squads` | 8 arquivos | 4 s |
+| `test:businesses` | 6 arquivos | 3 s |
+| `test:shared` | 37 arquivos | 20 s |
+| `test:harness` | 127 arquivos | 81 s |
+| `test:gate` | as suítes de admissão e de qualidade | 18 s |
+| `test:full`, e o `test` | tudo, sem mudança | 135-180 s |
+| `check:quick` | os nove gates que terminam em milissegundos | 0,6 s |
+| `check:all` | os catorze, sem mudança | CI |
+
+A medição venceu o chute em um ponto que vale nomear. Quatro dos oito arquivos `*.e2e.test.ts`
+terminam em menos de um segundo, então ficam no `test:fast`, de onde uma exclusão escrita por
+padrão de nome os teria tirado.
+
+O `test-script-coverage.test.ts` impede que a divisão apodreça: os quatro scripts de área precisam
+cobrir todo arquivo em disco exatamente uma vez, o `test:fast` e o manifesto dos lentos precisam
+particionar o mesmo conjunto, e os três pesos-pesados medidos não podem voltar para a metade
+rápida.
+
+### A avaliação de roteamento lembra do veredito a que já chegou
+
+O `routing-eval.test.ts` reconstruía o conjunto dourado sempre que o mtime dos arquivos de registro
+mudava, e o `nrv index` reescreve esses arquivos a cada execução. Medido em 27/08/2026: o mtime
+1787814306 virou 1787814328, os mesmos 5.028.411 bytes, o mesmo SHA-256 depois de tirar o carimbo
+`generated_at`. Uma reindexação que não mudou nada comprava uma reconstrução do conjunto dourado e
+os 27 s de avaliação atrás dela.
+
+A obsolescência passa a ser decidida por conteúdo. O `registryFingerprint()` faz o hash da projeção
+do carregador de registros, que é exatamente o que o `build-golden-set.ts` lê e o que o `router.js`
+indexa, e essa projeção não carrega carimbo de tempo. O conjunto dourado guarda os dois hashes ao
+lado dos caminhos de onde foi construído; um conjunto construído antes do campo existir não tem
+hash e é reconstruído uma vez.
+
+A avaliação em si é memorizada pelo mesmo princípio. O `runEvalCached()` chaveia nos registros, nos
+casos dourados, nos negativos, em todo fonte de primeiro nível sob `harness/lib` e `_shared/lib`, e
+nas três variáveis de ambiente do roteador. Uma execução atrás da outra, com as mesmas entradas:
+29,7 s a frio, 0,15 s a quente, e as nove asserções leem os mesmos números (top1 98,5%, MRR 0,989,
+NO_MATCH 73,3% em 3.449 casos). A chave erra para o lado largo de propósito, já que invalidar
+demais custa uma reexecução de 27 s enquanto invalidar de menos entrega um gate de roteamento verde
+para um engine que ninguém mediu. O `NIRVANA_EVAL_NO_CACHE=1` desliga tudo, e o
+`scripts/test-timings.ts` o define para que um cache quente nunca faça o arquivo mais pesado da
+suíte parecer barato. O CI parte de um checkout limpo, não acha arquivo de cache e sempre mede.
+
+### A verificação por área vira contrato, e uma falha sabe de quem é
+
+O gate estava sendo pago por pedaço. Quatro agentes cortando quatro pedaços de uma mesma mudança
+rodavam cada um a suíte inteira e os catorze checks sobre código que ninguém tinha integrado, e
+quando a árvore mesclada reprovava, ninguém sabia dizer qual corte produziu aquilo, então a
+correção ia para um agente novo que precisava redescobrir o contexto antes.
+
+A Regra 11 do `skills/harness/SKILL.md` e um trecho equivalente nas sete personas `agent-x.*.md`
+passam a dizer isso com todas as letras. Um corte despachado verifica a própria área e para por aí.
+O todo é verificado uma vez, depois da integração, pelo CI nos três sistemas e pelo orquestrador
+que mescla. Uma falha do todo é atribuída ao corte que a produziu, pelo trace id, pelo commit e
+pelo diff, e a correção volta para a sessão daquele corte em vez de ir para um agente novo. Duas
+coisas viraram obrigatórias no relatório final de um corte, porque são o que transforma atribuição
+em consulta: a lista de arquivos que ele tocou, em caminhos, e o que ele não verificou e por quê.
+
 ### O registro para de descartar o que a capability declara
 
 Uma capability pode declarar `estimated_cost_usd` há duas versões do protocolo,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
   "scripts": {
     "install:system": "bun scripts/install.ts",
     "test": "bun test skills",
+    "test:full": "bun test skills",
+    "test:fast": "bun scripts/test-timings.ts --run-fast",
+    "test:squads": "bun test skills/squads/tests",
+    "test:businesses": "bun test skills/businesses/tests",
+    "test:shared": "bun test skills/_shared/tests",
+    "test:harness": "bun test skills/harness/tests",
+    "test:gate": "bun test skills/_shared/tests/verify- skills/_shared/tests/validators- skills/_shared/tests/validate-cli-alias skills/harness/tests/entity-admission skills/harness/tests/quality-gate skills/harness/tests/gate-timing skills/harness/tests/gate-zero-files",
+    "test:timings": "bun scripts/test-timings.ts",
     "validate": "bun skills/_shared/scripts/validate-mind-clones.ts && bun skills/harness/scripts/validate.ts",
     "glance": "bun skills/harness/scripts/glance.ts",
     "check:dispatch": "bun scripts/check-dispatch-contract.ts",
@@ -60,6 +68,7 @@
     "check:schemas": "bun scripts/gen-json-schemas.ts --check",
     "check:organizational": "bun scripts/check-organizational-non-regression.ts --strict",
     "check:scope-guard": "bun scripts/check-scope-guard.ts --strict",
+    "check:quick": "bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun scripts/check-dispatch-contract.ts && bun scripts/check-scope-guard.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/check-audit-parity.ts --strict && bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/sync-agent-docs.ts --check",
     "check:all": "bun scripts/check-skillmd-command-parity.ts --strict && bun scripts/check-audit-parity.ts --strict && bun scripts/check-english-source.ts --strict && bun scripts/check-changelog-parity.ts --strict && bun scripts/check-version-parity.ts --strict && bun scripts/gen-json-schemas.ts --check && bun skills/_shared/scripts/coverage-ratchet.ts --check --strict && bun scripts/check-not-for-fires.ts --strict && bun scripts/check-capability-clones.ts --strict && bun scripts/check-clone-bindings.ts --strict && bun scripts/check-engine-purity.ts && bun scripts/sync-agent-docs.ts --check && bun scripts/check-dispatch-contract.ts && bun scripts/check-organizational-non-regression.ts --strict && bun scripts/check-scope-guard.ts --strict"
   }
 }

--- a/scripts/slow-tests.json
+++ b/scripts/slow-tests.json
@@ -1,0 +1,143 @@
+{
+  "threshold_seconds": 1,
+  "measured_at": "2026-08-27",
+  "note": "Files at or over threshold_seconds, measured one Bun process each by scripts/test-timings.ts. `bun run test:fast` runs the complement; `bun run test:full` runs everything.",
+  "files": [
+    {
+      "path": "skills/harness/tests/routing-eval.test.ts",
+      "seconds": 27.38
+    },
+    {
+      "path": "skills/_shared/tests/verify-squad.test.ts",
+      "seconds": 7.54
+    },
+    {
+      "path": "skills/harness/tests/driver-ledger-heartbeat.test.ts",
+      "seconds": 6.75
+    },
+    {
+      "path": "skills/harness/tests/routing-multilingual-probes.test.ts",
+      "seconds": 5.29
+    },
+    {
+      "path": "skills/_shared/tests/verify-business.test.ts",
+      "seconds": 4.75
+    },
+    {
+      "path": "skills/harness/tests/multi-target-cli.test.ts",
+      "seconds": 4.58
+    },
+    {
+      "path": "skills/harness/tests/project-contract-check.test.ts",
+      "seconds": 4.57
+    },
+    {
+      "path": "skills/squads/tests/migrate-squad.test.ts",
+      "seconds": 3.95
+    },
+    {
+      "path": "skills/harness/tests/driver-watchdog.test.ts",
+      "seconds": 3.29
+    },
+    {
+      "path": "skills/harness/tests/gauntlet-evaluator-dispatch.e2e.test.ts",
+      "seconds": 3.14
+    },
+    {
+      "path": "skills/harness/tests/activate-batch.test.ts",
+      "seconds": 2.88
+    },
+    {
+      "path": "skills/harness/tests/revise-delivery.test.ts",
+      "seconds": 2.8
+    },
+    {
+      "path": "skills/_shared/tests/verify-runner.test.ts",
+      "seconds": 2.56
+    },
+    {
+      "path": "skills/harness/tests/glance-agent-x-canary-e2e.test.ts",
+      "seconds": 2.55
+    },
+    {
+      "path": "skills/harness/tests/dispatch-gauntlet-ledger.e2e.test.ts",
+      "seconds": 2.53
+    },
+    {
+      "path": "skills/harness/tests/glance-message-route.test.ts",
+      "seconds": 2.38
+    },
+    {
+      "path": "skills/harness/tests/dispatch-standard-kernel.e2e.test.ts",
+      "seconds": 2.33
+    },
+    {
+      "path": "skills/harness/tests/serve-queue-sse.test.ts",
+      "seconds": 2.23
+    },
+    {
+      "path": "skills/harness/tests/bridge-cases.test.ts",
+      "seconds": 1.9
+    },
+    {
+      "path": "skills/harness/tests/driver-adapters.test.ts",
+      "seconds": 1.9
+    },
+    {
+      "path": "skills/harness/tests/gauntlet-evaluator-adapter.test.ts",
+      "seconds": 1.85
+    },
+    {
+      "path": "skills/harness/tests/run-kernel.test.ts",
+      "seconds": 1.73
+    },
+    {
+      "path": "skills/harness/tests/not-for-fires.test.ts",
+      "seconds": 1.67
+    },
+    {
+      "path": "skills/harness/tests/driver-autonomy-flags.test.ts",
+      "seconds": 1.55
+    },
+    {
+      "path": "skills/harness/tests/serve-api.test.ts",
+      "seconds": 1.52
+    },
+    {
+      "path": "skills/harness/tests/init-existing-project.test.ts",
+      "seconds": 1.35
+    },
+    {
+      "path": "skills/harness/tests/config-command.test.ts",
+      "seconds": 1.34
+    },
+    {
+      "path": "skills/harness/tests/judge-x-dispatch.e2e.test.ts",
+      "seconds": 1.32
+    },
+    {
+      "path": "skills/harness/tests/buyer-path.test.ts",
+      "seconds": 1.3
+    },
+    {
+      "path": "skills/_shared/tests/runtime-links.test.ts",
+      "seconds": 1.25
+    },
+    {
+      "path": "skills/businesses/tests/business-audit-criteria.test.ts",
+      "seconds": 1.17
+    },
+    {
+      "path": "skills/businesses/tests/business-fixers.test.ts",
+      "seconds": 1.16
+    },
+    {
+      "path": "skills/harness/tests/doctor-evaluator.test.ts",
+      "seconds": 1.04
+    },
+    {
+      "path": "skills/harness/tests/watermark-gate.test.ts",
+      "seconds": 1
+    }
+  ]
+}

--- a/scripts/test-timings.ts
+++ b/scripts/test-timings.ts
@@ -29,7 +29,7 @@
 //   bun scripts/test-timings.ts --list-fast         # print that file list, one per line
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -42,12 +42,29 @@ const threshold = thresholdIdx === -1 ? 1 : Number(argv[thresholdIdx + 1]);
 const roots = argv.filter((a, i) => !a.startsWith("--") && i !== thresholdIdx + 1);
 const scope = roots.length ? roots : ["skills"];
 
+/**
+ * A repo-relative path the way package.json and the manifest spell it: POSIX
+ * separators on every platform.
+ *
+ * `path.relative` hands back `skills\harness\tests\x.test.ts` on Windows while
+ * the `bun test <dir>` arguments in package.json and every entry in
+ * scripts/slow-tests.json hold `/`. Unnormalized, no path ever matches a root
+ * and the whole suite reads as uncovered: the Windows runner of PR #131
+ * reported every file on disk as orphaned, and the fast and slow halves as
+ * two sets with nothing in common. Same idiom as
+ * `squad-exec.ts`'s `promptPath`, literal backslash included, which is what
+ * makes the normalization provable off Windows instead of only on it.
+ */
+export function posixPath(p: string): string {
+  return p.split(sep).join("/").replace(/\\/g, "/");
+}
+
 /** Every `*.test.ts` under the given repo-relative roots, repo-relative, sorted. */
 export function testFiles(dirs: string[] = ["skills"]): string[] {
   const out: string[] = [];
   for (const dir of dirs) {
     const glob = new Bun.Glob("**/*.test.ts");
-    for (const hit of glob.scanSync({ cwd: resolve(ROOT, dir), absolute: true })) out.push(relative(ROOT, hit));
+    for (const hit of glob.scanSync({ cwd: resolve(ROOT, dir), absolute: true })) out.push(posixPath(relative(ROOT, hit)));
   }
   return out.sort();
 }
@@ -56,7 +73,9 @@ export function testFiles(dirs: string[] = ["skills"]): string[] {
 export function slowTests(): string[] {
   if (!existsSync(SLOW_MANIFEST)) return [];
   const m = JSON.parse(readFileSync(SLOW_MANIFEST, "utf8"));
-  return (m.files ?? []).map((f: any) => f.path).sort();
+  // Normalized on read as well as on write: a manifest regenerated on Windows
+  // before this fix landed would otherwise stay unmatchable for everyone else.
+  return (m.files ?? []).map((f: any) => posixPath(String(f.path))).sort();
 }
 
 /** The fast half: every test file minus the measured-slow set. A test file added
@@ -96,7 +115,7 @@ if (import.meta.main) {
   const startedAll = Date.now();
 
   for (const [i, file] of files.entries()) {
-    const rel = relative(ROOT, file);
+    const rel = posixPath(relative(ROOT, file));
     if (!asJson) process.stderr.write(`[${i + 1}/${files.length}] ${rel}\r`);
     const t0 = Date.now();
     // Cold cache on purpose. `routing-eval.test.ts` memoizes its verdict on a

--- a/scripts/test-timings.ts
+++ b/scripts/test-timings.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env bun
+// test-timings.ts — per-file wall time for the test suite, slowest first.
+//
+// Why a separate script instead of reading Bun's own reporter: the JUnit
+// reporter times TEST CASES, and the files that actually dominate the suite
+// spend their seconds at module scope (top-level await building a corpus,
+// spawning a child process, warming a registry) where no test case is running.
+// `routing-eval.test.ts` is the extreme case — it costs ~30s and reports ~0s
+// of test-case time. Only wall clock per `bun test <file>` tells the truth, so
+// that is what this measures: one Bun process per file, exactly the cost a
+// developer pays when running that file alone.
+//
+// The output is the input for the `test:fast` split in package.json: exclude
+// what measurement says is heavy, never what intuition says.
+//
+// The slow half it finds is recorded in scripts/slow-tests.json, and
+// `--run-fast` (what `bun run test:fast` calls) runs the complement. Keeping
+// the two together is deliberate: the list of slow files is the OUTPUT of the
+// measurement, and a hand-maintained list would rot the moment a test grows a
+// subprocess.
+//
+// Usage:
+//   bun scripts/test-timings.ts                     # every test file under skills/
+//   bun scripts/test-timings.ts skills/harness      # one subtree
+//   bun scripts/test-timings.ts --threshold 2       # flag files at or over 2s
+//   bun scripts/test-timings.ts --json              # machine-readable
+//   bun scripts/test-timings.ts --write             # re-measure, rewrite slow-tests.json
+//   bun scripts/test-timings.ts --run-fast          # run everything NOT in slow-tests.json
+//   bun scripts/test-timings.ts --list-fast         # print that file list, one per line
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+export const SLOW_MANIFEST = join(ROOT, "scripts", "slow-tests.json");
+const argv = process.argv.slice(2);
+const asJson = argv.includes("--json");
+const write = argv.includes("--write");
+const thresholdIdx = argv.indexOf("--threshold");
+const threshold = thresholdIdx === -1 ? 1 : Number(argv[thresholdIdx + 1]);
+const roots = argv.filter((a, i) => !a.startsWith("--") && i !== thresholdIdx + 1);
+const scope = roots.length ? roots : ["skills"];
+
+/** Every `*.test.ts` under the given repo-relative roots, repo-relative, sorted. */
+export function testFiles(dirs: string[] = ["skills"]): string[] {
+  const out: string[] = [];
+  for (const dir of dirs) {
+    const glob = new Bun.Glob("**/*.test.ts");
+    for (const hit of glob.scanSync({ cwd: resolve(ROOT, dir), absolute: true })) out.push(relative(ROOT, hit));
+  }
+  return out.sort();
+}
+
+/** The measured-slow set. Missing manifest = nothing is slow yet. */
+export function slowTests(): string[] {
+  if (!existsSync(SLOW_MANIFEST)) return [];
+  const m = JSON.parse(readFileSync(SLOW_MANIFEST, "utf8"));
+  return (m.files ?? []).map((f: any) => f.path).sort();
+}
+
+/** The fast half: every test file minus the measured-slow set. A test file added
+ *  since the last measurement is fast until measured otherwise. */
+export function fastTests(): string[] {
+  const slow = new Set(slowTests());
+  return testFiles().filter((f) => !slow.has(f));
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+//
+// Guarded: the functions above are imported by
+// skills/harness/tests/test-script-coverage.test.ts to check that the area
+// scripts and the fast/slow split still cover every file on disk. Without the
+// guard that import would run a 140s measurement of the whole suite.
+if (import.meta.main) {
+  if (argv.includes("--list-fast")) {
+    console.log(fastTests().join("\n"));
+    process.exit(0);
+  }
+
+  if (argv.includes("--run-fast")) {
+    const fast = fastTests();
+    const r = spawnSync(process.execPath, ["test", ...fast], { cwd: ROOT, stdio: "inherit" });
+    process.exit(r.status ?? 1);
+  }
+
+  const files = testFiles(scope).map((f) => resolve(ROOT, f));
+
+  if (!files.length) {
+    console.error(`test-timings: no *.test.ts under ${scope.join(", ")}`);
+    process.exit(1);
+  }
+
+  interface Row { file: string; seconds: number; ok: boolean }
+  const rows: Row[] = [];
+  const startedAll = Date.now();
+
+  for (const [i, file] of files.entries()) {
+    const rel = relative(ROOT, file);
+    if (!asJson) process.stderr.write(`[${i + 1}/${files.length}] ${rel}\r`);
+    const t0 = Date.now();
+    // Cold cache on purpose. `routing-eval.test.ts` memoizes its verdict on a
+    // content key, so a warm run reports ~1s and would drop out of the slow
+    // manifest — putting a 27s worst case inside `test:fast` the next time a
+    // registry moves. The manifest must record what a developer pays when the
+    // key misses, which is the number that decides the split.
+    const r = spawnSync(process.execPath, ["test", file], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, NIRVANA_EVAL_NO_CACHE: "1" },
+    });
+    rows.push({ file: rel, seconds: (Date.now() - t0) / 1000, ok: r.status === 0 });
+  }
+
+  const wallAll = (Date.now() - startedAll) / 1000;
+  rows.sort((a, b) => b.seconds - a.seconds);
+  const total = rows.reduce((n, r) => n + r.seconds, 0);
+  const heavy = rows.filter((r) => r.seconds >= threshold);
+
+  if (asJson) {
+    console.log(JSON.stringify({ threshold, wall_seconds: wallAll, sum_seconds: total, files: rows }, null, 2));
+    process.exit(0);
+  }
+
+  process.stderr.write("\n");
+  console.log(`${"seconds".padStart(8)}  ${"cum%".padStart(6)}  file`);
+  let cum = 0;
+  for (const r of rows) {
+    cum += r.seconds;
+    const flag = r.ok ? " " : "!";
+    console.log(`${r.seconds.toFixed(2).padStart(8)}  ${((cum / total) * 100).toFixed(1).padStart(6)}  ${flag}${r.file}`);
+  }
+  console.log("");
+  console.log(`files ................ ${rows.length}`);
+  console.log(`sum of per-file runs . ${total.toFixed(1)}s (one Bun process each)`);
+  console.log(`wall clock ........... ${wallAll.toFixed(1)}s`);
+  console.log(`at or over ${threshold}s ........ ${heavy.length} file(s), ${heavy.reduce((n, r) => n + r.seconds, 0).toFixed(1)}s`);
+  for (const r of heavy) console.log(`  ${r.seconds.toFixed(2).padStart(7)}s  ${r.file}`);
+  const failed = rows.filter((r) => !r.ok);
+  if (failed.length) console.log(`\nnon-zero exit (marked !): ${failed.map((r) => r.file).join(", ")}`);
+
+  if (write) {
+    if (scope.length !== 1 || scope[0] !== "skills") {
+      console.error("\n--write needs a full run (no subtree argument): the manifest covers the whole suite.");
+      process.exit(1);
+    }
+    const manifest = {
+      threshold_seconds: threshold,
+      measured_at: new Date().toISOString().slice(0, 10),
+      note: "Files at or over threshold_seconds, measured one Bun process each by scripts/test-timings.ts. `bun run test:fast` runs the complement; `bun run test:full` runs everything.",
+      files: heavy.map((r) => ({ path: r.file, seconds: Number(r.seconds.toFixed(2)) })),
+    };
+    writeFileSync(SLOW_MANIFEST, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+    console.log(`\nslow manifest written: ${relative(ROOT, SLOW_MANIFEST)} (${heavy.length} files)`);
+  }
+}

--- a/skills/_shared/agents/agent-x.antigravity.md
+++ b/skills/_shared/agents/agent-x.antigravity.md
@@ -80,6 +80,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.claude-code.md
+++ b/skills/_shared/agents/agent-x.claude-code.md
@@ -80,6 +80,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.codex.md
+++ b/skills/_shared/agents/agent-x.codex.md
@@ -80,6 +80,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout, last line): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.gemini.md
+++ b/skills/_shared/agents/agent-x.gemini.md
@@ -82,6 +82,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.grok.md
+++ b/skills/_shared/agents/agent-x.grok.md
@@ -82,6 +82,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout, last line): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.kimi.md
+++ b/skills/_shared/agents/agent-x.kimi.md
@@ -82,6 +82,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout, last line): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/_shared/agents/agent-x.pi.md
+++ b/skills/_shared/agents/agent-x.pi.md
@@ -83,6 +83,10 @@ Before declaring done:
 - Emit `verify_passed` audit event.
 - Final report (stdout, last line): `{ files_created, criteria_met, criteria_skipped, warnings, assumptions_logged, rollovers_used }`.
 
+**Verify your area, not the repository.** While you work, run only the tests of what you are touching. Before handing back, run that area's tests once plus the gates your own diff can break by itself, and stop there. The whole is verified once, after integration, by CI and by the orchestrator that merges. Four cuts in parallel each running the full suite pay the same 135-180 s four times, over pieces nobody has integrated yet.
+
+**A failure of the whole comes back to you.** Your cut carries a `trace_id` and a `run_id`, and your session stays alive after the turn ends. When the integrated verification fails on something your diff produced, the orchestrator attributes it by that contract and sends the fix back to this session with the failure log, instead of opening a fresh agent that would have to rediscover your context. Two things make that attribution mechanical, so both are required in your final report: the list of files you touched (paths, not descriptions), and what you did not verify and why.
+
 ## Forbidden
 
 - ❌ Recursing into the `harness` skill for the same brief (anti-loop).

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -142,6 +142,21 @@ Never switch the runtime into its own plan mode (Claude Code plan mode, Codex pl
 
 ---
 
+### Rule 11 — A cut verifies its area; the whole is verified once, after integration
+
+A dispatched cut verifies **its own area**. While it works it runs only the tests of what it is touching. Before it hands back it runs that area's tests once, plus the gates its own diff can break by itself, and it stops there. It does not run the full suite and it does not run `check:all`.
+
+The whole is verified **once, after integration**: by CI on the three systems, and by you when you merge. That is not a weaker gate, it is the same gate charged once instead of once per slice. Measured on this engine on 27/08/2026, the full suite costs 135-180 s and `check:all` adds fourteen more checks, so four parallel cuts each running both spend twenty minutes proving things about code nobody has integrated yet. The same twenty minutes buy one honest verdict when they run on the merged tree.
+
+Two obligations make the arrangement safe, and both belong in the dispatch instruction you write:
+
+- **Every cut names what it touched and what it did not verify.** File paths, not descriptions, plus the areas outside its own that it suspects it may have broken, and why. That is what turns attribution into a lookup instead of a hunt.
+- **A failure of the whole is attributed to the cut that produced it, and the fix goes back to that cut's session.** Not to a fresh agent: the session that wrote the code still holds the context, and re-deriving it is the expensive part. Match the failing files against each cut's `trace_id`, commit and diff, then send the failure log back to that session.
+
+The loop the engine gives a cut: `bun test <dir>` while working, `bun run test:fast` for a whole-repo smell check (144 files, 19 s, everything the timing script measured under 1 s), `bun run test:<area>` once before handing back, `bun run check:quick` during (nine gates, 0.6 s), and `bun run test:full` plus `bun run check:all` once on the integrated tree. Write a large new file in blocks with the area's tests running between them: a single 700-line write measured 173 s, and three of them stalled one cut for eight minutes.
+
+---
+
 ---
 
 ## Pipeline — Agentic Mode

--- a/skills/harness/scripts/build-golden-set.ts
+++ b/skills/harness/scripts/build-golden-set.ts
@@ -20,10 +20,29 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 
 const registryLoader = require(path.join(import.meta.dir, "..", "lib", "registry-loader.js"));
 
 const OUTPUT_PATH = path.join(import.meta.dir, "..", "baselines", "golden-routing.json");
+
+/**
+ * Fingerprint of the two registries AS THEIR READERS SEE THEM.
+ *
+ * registry-loader projects each file onto the fields this script and router.js
+ * read, and the projection leaves `generated_at` behind — so re-indexing an
+ * unchanged library yields the same fingerprint. mtime does not have that
+ * property, and the staleness check used to key on mtime: every `nrv index`
+ * declared the golden set stale and forced a rebuild of a file whose content
+ * was identical, followed by a ~30s eval.
+ *
+ * Lives here, not in eval-routing.ts, so the staleness check can be made
+ * without loading the router.
+ */
+export function registryFingerprint(registries: any): { squads: string; businesses: string } {
+  const sha = (v: any) => createHash("sha256").update(JSON.stringify(v ?? null)).digest("hex");
+  return { squads: sha(registries?.squads), businesses: sha(registries?.businesses) };
+}
 
 // ── language guess ──────────────────────────────────────────────────────────
 
@@ -168,11 +187,20 @@ if (import.meta.main) {
     byKind[c.kind] = (byKind[c.kind] || 0) + 1;
   }
 
+  const fingerprint = registryFingerprint({ squads, businesses });
+
   const golden = {
     generated_at: new Date().toISOString(),
     source_registries: {
       squads_path: squads.source_path,
       businesses_path: businesses.source_path,
+      // Content, not mtime: `nrv index` rewrites both files on every run and
+      // stamps a fresh `generated_at`, so an mtime key called the golden set
+      // stale after a re-index that changed nothing. The fingerprint covers
+      // the loader's projection — exactly what this script reads and what
+      // router.js indexes — and that projection carries no timestamp.
+      squads_sha256: fingerprint.squads,
+      businesses_sha256: fingerprint.businesses,
       squads_mtime: fs.statSync(squads.source_path).mtime.toISOString(),
       businesses_mtime: fs.statSync(businesses.source_path).mtime.toISOString(),
     },

--- a/skills/harness/scripts/eval-routing.ts
+++ b/skills/harness/scripts/eval-routing.ts
@@ -29,15 +29,68 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { registryFingerprint } from "./build-golden-set.ts";
 
 const router = require(path.join(import.meta.dir, "..", "lib", "router.js"));
 const registryLoader = require(path.join(import.meta.dir, "..", "lib", "registry-loader.js"));
 
 export const GOLDEN_PATH = path.join(import.meta.dir, "..", "baselines", "golden-routing.json");
 export const NEGATIVES_PATH = path.join(import.meta.dir, "..", "baselines", "golden-negatives.json");
+export const EVAL_CACHE_PATH = path.join(import.meta.dir, "..", "baselines", ".routing-eval-cache.json");
 
 // Env flags that change router behavior — flagged as warnings, never mutated.
 const ROUTER_ENV_FLAGS = ["NIRVANA_ROUTER_DENSE", "NIRVANA_ROUTER_FUSION", "NIRVANA_ROUTER_INTENT_FILTER"];
+
+// ── content fingerprints ────────────────────────────────────────────────────
+
+const sha = (s: string): string => createHash("sha256").update(s).digest("hex");
+
+/**
+ * Fingerprint of the routing engine — every top-level `.js`/`.ts` under
+ * skills/harness/lib and skills/_shared/lib, not just router.js + bm25.js.
+ * The require graph moves (router.js already reaches into `_shared/lib` for
+ * paths, the host driver and the dense index), and an under-broad key would
+ * hand back a cached gate verdict for an engine that changed. Over-invalidating
+ * costs one 30s re-run; under-invalidating costs a green gate on a broken
+ * router, so the key errs wide on purpose.
+ */
+export function engineFingerprint(): string {
+  const dirs = [
+    path.join(import.meta.dir, "..", "lib"),
+    path.join(import.meta.dir, "..", "..", "_shared", "lib"),
+  ];
+  const parts: string[] = [];
+  for (const dir of dirs) {
+    if (!fs.existsSync(dir)) continue;
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (!/\.(js|ts)$/.test(name)) continue;
+      const full = path.join(dir, name);
+      if (!fs.statSync(full).isFile()) continue;
+      parts.push(`${path.basename(dir)}/${name}:${sha(fs.readFileSync(full, "utf8"))}`);
+    }
+  }
+  parts.push(`eval-routing.ts:${sha(fs.readFileSync(path.join(import.meta.dir, "eval-routing.ts"), "utf8"))}`);
+  return sha(parts.join("\n"));
+}
+
+/**
+ * The cache key: everything that can change the numbers. Registries (what the
+ * router indexes), golden cases (what is asked), negatives (the safety axis),
+ * engine sources, and the env flags that switch router arms on.
+ */
+export function evalCacheKey(registries: any, goldenCases: any, negatives: any): string {
+  const reg = registryFingerprint(registries);
+  const env = ROUTER_ENV_FLAGS.map((f) => `${f}=${process.env[f] ?? ""}`).join(";");
+  return sha([
+    `squads:${reg.squads}`,
+    `businesses:${reg.businesses}`,
+    `golden:${sha(JSON.stringify(goldenCases ?? null))}`,
+    `negatives:${sha(JSON.stringify(negatives ?? null))}`,
+    `engine:${engineFingerprint()}`,
+    `env:${env}`,
+  ].join("\n"));
+}
 
 // ── candidate resolution ────────────────────────────────────────────────────
 
@@ -262,6 +315,57 @@ export async function runEval(opts: RunEvalOptions = {}) {
       },
     },
   };
+}
+
+/**
+ * runEval, memoized on content. The eval is a pure function of the registries,
+ * the golden cases, the negatives and the engine sources — none of which the
+ * act of running it changes — so a second run over the same inputs can read
+ * its verdict back instead of routing ~3.4k briefs again.
+ *
+ * This is a dev-loop cache, not a weaker gate: any edit to a registry, a case
+ * file or an engine source changes the key and the eval runs for real. CI
+ * starts from a clean checkout with no cache file, so it always measures.
+ */
+export async function runEvalCached(opts: RunEvalOptions & { cachePath?: string } = {}) {
+  const cachePath = opts.cachePath || EVAL_CACHE_PATH;
+  const goldenPath = opts.goldenPath || GOLDEN_PATH;
+  const negativesPath = opts.negativesPath || NEGATIVES_PATH;
+  const registries = opts.registries || registryLoader.loadAll();
+
+  // One escape hatch, for measurement and for a run that must not trust disk
+  // state: `NIRVANA_EVAL_NO_CACHE=1` skips both the read and the write.
+  // scripts/test-timings.ts sets it so the recorded per-file cost is the cold
+  // one, which is the cost the fast/slow split has to be decided on.
+  const bypass = process.env.NIRVANA_EVAL_NO_CACHE === "1";
+  if (bypass) return { ...(await runEval({ ...opts, registries })), from_cache: false };
+
+  let key: string | null = null;
+  try {
+    const golden = JSON.parse(fs.readFileSync(goldenPath, "utf8"));
+    const negatives = fs.existsSync(negativesPath)
+      ? JSON.parse(fs.readFileSync(negativesPath, "utf8"))
+      : { cases: [] };
+    key = evalCacheKey(registries, golden.cases, negatives.cases);
+  } catch {
+    key = null; // unreadable inputs: let runEval raise the real error
+  }
+
+  if (key && fs.existsSync(cachePath)) {
+    try {
+      const hit = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+      if (hit.key === key && hit.result) return { ...hit.result, from_cache: true };
+    } catch { /* corrupt cache: measure again and overwrite */ }
+  }
+
+  const result = await runEval({ ...opts, registries });
+  if (key) {
+    try {
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+      fs.writeFileSync(cachePath, JSON.stringify({ key, cached_at: new Date().toISOString(), result }) + "\n", "utf8");
+    } catch { /* a read-only checkout still gets a correct (uncached) result */ }
+  }
+  return { ...result, from_cache: false };
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────────────

--- a/skills/harness/tests/routing-eval-cache.test.ts
+++ b/skills/harness/tests/routing-eval-cache.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The routing eval costs ~27s because it routes ~3,400 briefs. It is also a
+ * pure function of four things — the registries, the golden cases, the
+ * negatives, and the engine sources — none of which running it changes. So the
+ * verdict is memoized on a content key.
+ *
+ * The staleness check it replaced keyed on the registry file's mtime, and
+ * `nrv index` rewrites that file on every run with a fresh `generated_at` and
+ * byte-identical content. Measured on 27/08/2026: mtime 1787814306 → 1787814328,
+ * same 5,028,411 bytes, same SHA once `generated_at` is dropped. Every
+ * re-index therefore declared the golden set stale and bought a full rebuild
+ * plus a full eval for a library that had not moved.
+ *
+ * What must stay true is the other direction: the key has to notice everything
+ * that CAN change the numbers. A cache that misses too often wastes 27s; a
+ * cache that hits when it should not reports a green routing gate for an
+ * engine nobody measured. These checks pin the second failure, which is the
+ * one that is silent.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evalCacheKey, engineFingerprint, runEvalCached } from "../scripts/eval-routing.ts";
+import { registryFingerprint } from "../scripts/build-golden-set.ts";
+
+/** A registry shaped like the loader's projection, small enough to mutate by hand. */
+const registries = () => ({
+  squads: {
+    schema_version: 5,
+    squads: [{ slug: "brandcraft", capabilities: ["branding.identity.create"] }],
+    capabilities: { "branding.identity.create": { squad: "brandcraft" } },
+    source_path: "/tmp/.squads-registry.json",
+  },
+  businesses: {
+    schema_version: 2,
+    businesses: [{ slug: "editora", domains: ["publishing"] }],
+    source_path: "/tmp/.businesses-registry.json",
+  },
+});
+
+const cases = [{ brief: "crie a identidade visual da marca", expected: "brandcraft" }];
+const negatives = [{ brief: "que horas são", expected: "NO_MATCH" }];
+
+describe("the eval cache key notices everything that moves the numbers", () => {
+  test("same inputs, same key", () => {
+    expect(evalCacheKey(registries(), cases, negatives))
+      .toBe(evalCacheKey(registries(), cases, negatives));
+  });
+
+  test("a changed squad registry changes the key", () => {
+    const moved = registries();
+    moved.squads.squads[0].capabilities = ["branding.identity.refresh"];
+    expect(evalCacheKey(moved, cases, negatives))
+      .not.toBe(evalCacheKey(registries(), cases, negatives));
+  });
+
+  test("a changed business registry changes the key", () => {
+    const moved = registries();
+    moved.businesses.businesses[0].domains = ["publishing", "education"];
+    expect(evalCacheKey(moved, cases, negatives))
+      .not.toBe(evalCacheKey(registries(), cases, negatives));
+  });
+
+  test("a changed golden case changes the key", () => {
+    expect(evalCacheKey(registries(), [{ ...cases[0], expected: "la-bottega" }], negatives))
+      .not.toBe(evalCacheKey(registries(), cases, negatives));
+  });
+
+  test("a changed negative changes the key", () => {
+    // The negatives carry the safety axis (false dispatch), so they belong in
+    // the key even though they never touch the golden numbers.
+    expect(evalCacheKey(registries(), cases, [{ brief: "oi", expected: "NO_MATCH" }]))
+      .not.toBe(evalCacheKey(registries(), cases, negatives));
+  });
+
+  test("a router env flag changes the key", () => {
+    const before = evalCacheKey(registries(), cases, negatives);
+    process.env.NIRVANA_ROUTER_DENSE = "1";
+    try {
+      expect(evalCacheKey(registries(), cases, negatives)).not.toBe(before);
+    } finally {
+      delete process.env.NIRVANA_ROUTER_DENSE;
+    }
+  });
+
+  test("the engine fingerprint covers the whole require graph, not just router.js", () => {
+    // router.js reaches into _shared/lib for paths, the host driver and the
+    // dense index. Keying on router.js + bm25.js alone would hand back a
+    // cached verdict for an engine that changed underneath it.
+    expect(engineFingerprint()).toMatch(/^[0-9a-f]{64}$/);
+    expect(engineFingerprint()).toBe(engineFingerprint());
+  });
+
+  test("the registry fingerprint reads the projection, which carries no timestamp", () => {
+    const a = registryFingerprint(registries());
+    const b = registryFingerprint(registries());
+    expect(a).toEqual(b);
+    expect(a.squads).not.toBe(a.businesses);
+  });
+});
+
+describe("a hit returns the stored verdict without routing anything", () => {
+  test("matching key short-circuits runEval", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "eval-cache-"));
+    const goldenPath = join(dir, "golden.json");
+    const negativesPath = join(dir, "negatives.json");
+    const cachePath = join(dir, "cache.json");
+    writeFileSync(goldenPath, JSON.stringify({ cases }), "utf8");
+    writeFileSync(negativesPath, JSON.stringify({ cases: negatives }), "utf8");
+
+    const regs = registries();
+    const key = evalCacheKey(regs, cases, negatives);
+    // A sentinel no real eval could produce: if runEval ran, this fails.
+    writeFileSync(cachePath, JSON.stringify({ key, result: { sentinel: "stored" } }), "utf8");
+
+    const r: any = await runEvalCached({ registries: regs, goldenPath, negativesPath, cachePath, quiet: true });
+    expect(r.sentinel).toBe("stored");
+    expect(r.from_cache).toBe(true);
+  });
+});

--- a/skills/harness/tests/routing-eval.test.ts
+++ b/skills/harness/tests/routing-eval.test.ts
@@ -114,7 +114,8 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
-import { runEval, GOLDEN_PATH } from "../scripts/eval-routing.ts";
+import { runEvalCached, GOLDEN_PATH } from "../scripts/eval-routing.ts";
+import { registryFingerprint } from "../scripts/build-golden-set.ts";
 import { corpusGate } from "../../_shared/lib/corpus-gate.ts";
 
 const registryLoader = require("../lib/registry-loader.js");
@@ -129,22 +130,33 @@ const HAVE_REGISTRIES = !!(all.squads.source_path && all.businesses.source_path)
 // library. A clean install / partial pack has fewer entries — skip.
 const FULL_LIBRARY = HAVE_REGISTRIES && providerCount >= 500 && businessCount >= 40;
 
+/**
+ * Staleness by CONTENT, not mtime. `nrv index` rewrites both registry files on
+ * every run — same library, new mtime, new `generated_at` — and the old check
+ * read mtime, so a re-index that changed nothing forced a golden set rebuild
+ * and the ~30s eval behind it. The fingerprint is taken over the loader's
+ * projection (what build-golden-set.ts reads and router.js indexes), which
+ * carries no timestamp: same library, same hash, no rebuild.
+ *
+ * A golden set built before the fingerprint existed has no `*_sha256` field
+ * and is treated as stale — one rebuild, then the content key holds.
+ */
 function goldenIsStale(): boolean {
   if (!fs.existsSync(GOLDEN_PATH)) return true;
   try {
     const g = JSON.parse(fs.readFileSync(GOLDEN_PATH, "utf8"));
-    const sm = fs.statSync(all.squads.source_path).mtime.toISOString();
-    const bm = fs.statSync(all.businesses.source_path).mtime.toISOString();
-    return g.source_registries?.squads_mtime !== sm
-      || g.source_registries?.businesses_mtime !== bm
-      || g.source_registries?.squads_path !== all.squads.source_path
-      || g.source_registries?.businesses_path !== all.businesses.source_path;
+    const fp = registryFingerprint(all);
+    const src = g.source_registries || {};
+    return src.squads_sha256 !== fp.squads
+      || src.businesses_sha256 !== fp.businesses
+      || src.squads_path !== all.squads.source_path
+      || src.businesses_path !== all.businesses.source_path;
   } catch {
     return true;
   }
 }
 
-let r: Awaited<ReturnType<typeof runEval>> | null = null;
+let r: Awaited<ReturnType<typeof runEvalCached>> | null = null;
 if (FULL_LIBRARY) {
   if (goldenIsStale()) {
     const build = spawnSync(
@@ -156,11 +168,11 @@ if (FULL_LIBRARY) {
       throw new Error(`build-golden-set.ts failed (exit ${build.status}): ${build.stderr}`);
     }
   }
-  r = await runEval({ quiet: true });
+  r = await runEvalCached({ quiet: true, registries: all });
   const o = r.golden.overall;
   const pctf = (f: number) => (f * 100).toFixed(1) + "%";
   console.log(
-    `[routing-eval] measured: n=${r.golden.total} · top1=${pctf(o.top1)} · top3=${pctf(o.top3)} · MRR=${o.mrr.toFixed(3)}` +
+    `[routing-eval] ${r.from_cache ? "cached (content key hit)" : "measured"}: n=${r.golden.total} · top1=${pctf(o.top1)} · top3=${pctf(o.top3)} · MRR=${o.mrr.toFixed(3)}` +
     ` · squad_capability top1=${pctf(r.golden.by_kind.squad_capability?.top1 ?? 0)}` +
     ` · business top1=${pctf(r.golden.by_kind.business?.top1 ?? 0)} fabric@1=${pctf(r.golden.by_kind.business?.fabric_top1 ?? 0)}` +
     ` · negatives NO_MATCH=${pctf(r.negatives.no_match.no_match_rate)} (n=${r.negatives.no_match.n})` +

--- a/skills/harness/tests/test-script-coverage.test.ts
+++ b/skills/harness/tests/test-script-coverage.test.ts
@@ -10,7 +10,13 @@
  *     nothing but `test:full` ever runs it. Nobody notices, because every
  *     command anyone types still exits 0;
  *   - a file named in the slow manifest is renamed, so `test:fast` starts
- *     paying for a heavy file while excluding one that no longer exists.
+ *     paying for a heavy file while excluding one that no longer exists;
+ *   - the walk returns native separators. On Windows `path.relative` hands back
+ *     `skills\harness\tests\x.test.ts` while package.json and the manifest
+ *     hold `/`, nothing matches anything, and the split reads as total. That is
+ *     what the Windows runner of PR #131 reported, and the reason the cases
+ *     below feed a literal backslash: the normalization has to be provable on
+ *     macOS and Linux, where `path.sep` alone would hide it.
  *
  * These checks read package.json and the disk. They never keep a second copy
  * of either list, so they fail on the drift itself and not on a stale mirror.
@@ -18,7 +24,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { fastTests, slowTests, testFiles } from "../../../scripts/test-timings.ts";
+import { fastTests, posixPath, slowTests, testFiles } from "../../../scripts/test-timings.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8"));
@@ -40,6 +46,16 @@ describe("the area scripts still add up to the whole suite", () => {
     const doubled = onDisk.filter((f) => roots.filter((r) => f.startsWith(r + "/")).length > 1);
     // Reported together so a failure names the file, not just a count.
     expect({ orphans, doubled }).toEqual({ orphans: [], doubled: [] });
+  });
+
+  test("a native-separator path lands on the same entry as the walk", () => {
+    const sample = onDisk[0];
+    expect(posixPath("skills\\harness\\tests\\x.test.ts")).toBe("skills/harness/tests/x.test.ts");
+    expect(posixPath(sample)).toBe(sample);
+    // The predicate the coverage check runs, fed the Windows spelling of a real file.
+    const roots = AREA_SCRIPTS.flatMap(pathsOf);
+    const windowsSpelling = sample.split("/").join("\\");
+    expect(roots.some((r) => posixPath(windowsSpelling).startsWith(r + "/"))).toBe(true);
   });
 
   test("test:full is the whole tree, and `bun test` still means the same thing", () => {
@@ -68,6 +84,15 @@ describe("the fast/slow split is a partition of the same set", () => {
   test("every file the manifest calls slow still exists", () => {
     const disk = new Set(onDisk);
     expect(slowTests().filter((f) => !disk.has(f))).toEqual([]);
+  });
+
+  test("both halves, and the manifest on disk, are spelled in POSIX separators", () => {
+    // Normalizing on read would still leave a Windows regeneration of
+    // slow-tests.json checked in with backslashes, unreadable to a human diff
+    // and to any reader that does not normalize. The file itself must be POSIX.
+    expect([...fastTests(), ...slowTests()].filter((f) => f.includes("\\"))).toEqual([]);
+    const manifest = JSON.parse(readFileSync(join(REPO, "scripts", "slow-tests.json"), "utf8"));
+    expect(manifest.files.map((f: any) => f.path).filter((p: string) => p.includes("\\"))).toEqual([]);
   });
 
   test("the measured heavyweights stay out of test:fast", () => {

--- a/skills/harness/tests/test-script-coverage.test.ts
+++ b/skills/harness/tests/test-script-coverage.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The suite is split two ways for the dev loop: by AREA (`test:squads`,
+ * `test:businesses`, `test:shared`, `test:harness`) so a cut runs only what it
+ * touches, and by measured COST (`test:fast` = everything not in
+ * scripts/slow-tests.json) so a whole-repo smell check stays under half a
+ * minute. A split is only safe while it still adds up to the whole, and both
+ * halves rot silently:
+ *
+ *   - a test lands under a directory no area script names, and from then on
+ *     nothing but `test:full` ever runs it. Nobody notices, because every
+ *     command anyone types still exits 0;
+ *   - a file named in the slow manifest is renamed, so `test:fast` starts
+ *     paying for a heavy file while excluding one that no longer exists.
+ *
+ * These checks read package.json and the disk. They never keep a second copy
+ * of either list, so they fail on the drift itself and not on a stale mirror.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fastTests, slowTests, testFiles } from "../../../scripts/test-timings.ts";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8"));
+const AREA_SCRIPTS = ["test:squads", "test:businesses", "test:shared", "test:harness"];
+
+/** The path arguments a `bun test …` script hands to Bun. */
+function pathsOf(script: string): string[] {
+  const cmd: string | undefined = pkg.scripts?.[script];
+  if (!cmd) throw new Error(`package.json declares no "${script}"`);
+  return cmd.replace(/^bun test\s+/, "").trim().split(/\s+/).filter(Boolean);
+}
+
+const onDisk = testFiles();
+
+describe("the area scripts still add up to the whole suite", () => {
+  test("every test file on disk belongs to exactly one area script", () => {
+    const roots = AREA_SCRIPTS.flatMap(pathsOf);
+    const orphans = onDisk.filter((f) => !roots.some((r) => f.startsWith(r + "/")));
+    const doubled = onDisk.filter((f) => roots.filter((r) => f.startsWith(r + "/")).length > 1);
+    // Reported together so a failure names the file, not just a count.
+    expect({ orphans, doubled }).toEqual({ orphans: [], doubled: [] });
+  });
+
+  test("test:full is the whole tree, and `bun test` still means the same thing", () => {
+    expect(pkg.scripts["test:full"]).toBe("bun test skills");
+    expect(pkg.scripts["test"]).toBe(pkg.scripts["test:full"]);
+  });
+
+  test("every filter in test:gate still selects a file", () => {
+    // test:gate is a deliberate SUBSET (the admission and quality gates), named
+    // by path prefix. A renamed gate test would empty its filter in silence.
+    const dead = pathsOf("test:gate").filter((p) => !onDisk.some((f) => f.startsWith(p)));
+    expect(dead).toEqual([]);
+  });
+});
+
+describe("the fast/slow split is a partition of the same set", () => {
+  test("fast plus measured-slow is exactly what is on disk", () => {
+    expect([...fastTests(), ...slowTests()].sort()).toEqual(onDisk);
+  });
+
+  test("no file is in both halves", () => {
+    const slow = new Set(slowTests());
+    expect(fastTests().filter((f) => slow.has(f))).toEqual([]);
+  });
+
+  test("every file the manifest calls slow still exists", () => {
+    const disk = new Set(onDisk);
+    expect(slowTests().filter((f) => !disk.has(f))).toEqual([]);
+  });
+
+  test("the measured heavyweights stay out of test:fast", () => {
+    // These three dominate the suite (27.4s, 5.3s, 4.6s measured on 27/08/2026)
+    // and routing-eval is the one that can lie: it memoizes its verdict, so a
+    // warm run reports ~0.1s and would drop out of a naive re-measurement,
+    // putting a 27s worst case back inside the fast loop the next time a
+    // registry moves. scripts/test-timings.ts measures with the cache off for
+    // exactly this reason; this check is the second lock.
+    const named = [
+      "skills/harness/tests/routing-eval.test.ts",
+      "skills/harness/tests/routing-multilingual-probes.test.ts",
+      "skills/harness/tests/multi-target-cli.test.ts",
+    ];
+    const slow = new Set(slowTests());
+    expect(named.filter((f) => !slow.has(f))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

`bun test skills` was the only test command that existed: 176 files, 135-180 s, paid in full to check a two-line change. The measured cost of that habit is in the agent logs: one cut ran the suite 38 times.

## What changed

**Measurement first.** `scripts/test-timings.ts` times one `bun test <file>` per file rather than reading Bun's reporter, because the reporter times test CASES while the expensive files spend their seconds at module scope, where no case is running (`routing-eval.test.ts` reports near-zero case time and costs 27 s of wall clock). `--write` records every file at or over a second in `scripts/slow-tests.json`. Measured 27/08/2026: 138.3 s total, 34 files holding 114.6 s of it, `routing-eval.test.ts` holding 27.4 s alone.

| Script | Runs | Measured |
|---|---|---|
| `test:fast` | the 144 files that measured under 1 s | 19 s |
| `test:squads` | 8 files | 4 s |
| `test:businesses` | 6 files | 3 s |
| `test:shared` | 37 files | 20 s |
| `test:harness` | 127 files | 81 s |
| `test:gate` | the admission and quality suites | 18 s |
| `test:full`, and `test` | everything, unchanged | 135-180 s |
| `check:quick` | the nine gates that finish in milliseconds | 0.6 s |
| `check:all` | all fourteen, unchanged | CI |

Measurement beat the guess once: four of the eight `*.e2e.test.ts` files finish under a second and stay in `test:fast`, where a filename-pattern exclusion would have dropped them.

**The routing eval stops rebuilding for nothing.** Staleness keyed on the registry files' mtime, and `nrv index` rewrites them every run. Measured: mtime `1787814306` → `1787814328`, same 5,028,411 bytes, same SHA-256 once `generated_at` is dropped. `registryFingerprint()` now hashes the loader's projection, which carries no timestamp, and `runEvalCached()` memoizes the verdict on registries + golden cases + negatives + every top-level source under `harness/lib` and `_shared/lib` + the three router env flags. Back to back: **29.7 s cold, 0.15 s warm**, all nine assertions reading the same numbers (top1 98.5%, MRR 0.989, NO_MATCH 73.3% on 3,449 cases). `NIRVANA_EVAL_NO_CACHE=1` turns it off; `test-timings.ts` sets it so a warm cache can never make the heaviest file in the suite look cheap. CI starts clean, finds no cache and always measures.

**The verification discipline became a contract.** Rule 11 in `skills/harness/SKILL.md` and a matching passage in all seven `agent-x.*.md` personas: a dispatched cut verifies its own area and stops there; the whole is verified once, after integration, by CI and by the orchestrator that merges; a failure of the whole is attributed to the cut that produced it (trace id, commit, diff) and the fix goes back to that cut's own session. A cut's final report must list the files it touched and declare what it did not verify.

**Nothing was weakened.** `test:full` is still `bun test skills`, `check:all` still runs all fourteen gates, and CI still runs everything on the three systems.

## New tests

- `skills/harness/tests/test-script-coverage.test.ts` — the four area scripts cover every file on disk exactly once, `test:fast` and the slow manifest partition the same set, every `test:gate` filter still selects a file, and the three measured heavyweights may not drift back into the fast half.
- `skills/harness/tests/routing-eval-cache.test.ts` — the cache key moves when the squads registry, the businesses registry, a golden case, a negative, an env flag or the engine sources move, and a matching key short-circuits `runEval` without routing anything.

## Verification

Area verification only, per the dispatch contract; the whole tree is CI's job.

- `bun run test:shared` — 534 pass, 0 fail (37 files, 20.7 s)
- `bun run test:harness` — 1260 pass, **1 fail**, 4 skip (127 files, 80.2 s). The failure is `buyer-path.test.ts`, the documented worktree-environment failure: `error: Cannot find package 'yaml' from '…/.nirvana/skills/_shared/lib/entity-graph.ts'` → `setup.ts failed (1)`, caused by `node_modules` being a symlink in a git worktree. Not touched by this diff.
- `bun run test:fast` — 1519 pass, 0 fail (144 files, 18.9 s)
- `bun run check:quick` — 9/9 green, 0.45 s (includes `check-english-source --strict`, `check-changelog-parity --strict`, `check-skillmd-command-parity --strict`, `sync-agent-docs --check`)
- `git diff --check` clean

Not verified here, deliberately: `bun test skills` in one process, `check:all`, and the two remaining area suites (`test:squads`, `test:businesses` passed earlier at 4.2 s / 3.2 s but before the doc edits, which cannot reach them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
