### PR TITLE
feat(gauntlet): acceptance per capability becomes the judge's contract, produces reaches the rubric, and the evaluator is ranked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,85 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The Gauntlet judges the contract the target declared, not one hard-coded line
+
+`compiler.ts` has always been able to compile N requirements into N gauntlets. It never received
+more than one: no caller passed `requirements`, so every Gauntlet in the system judged the same
+`brief-conformance` question with a threshold read off the intensity profile, while the manifests
+carried `capabilities[].acceptance[]` and `fidelity.threshold` that nothing read.
+
+`skills/harness/lib/gauntlet/success-requirements.ts` builds the contract. `brief-conformance`
+first, always, and then the first rung of this ladder that answers:
+
+| Rung | Source | Blocks |
+|---|---|---|
+| `acceptance` | `capabilities[].acceptance[]` | yes, unless `blocking: false` |
+| `success_indicators` | the invoked workflow's `success_indicators[]`, through the v6 reader | no |
+| `task_acceptance_criteria` | the invoked task's `## Acceptance Criteria` | no |
+| `brief-conformance` | nothing declared | yes |
+
+The derived rungs do not block. An indicator someone wrote as prose was never promised as a gate,
+and turning it into one withholds deliveries nobody agreed to withhold. Ids are namespaced
+(`acceptance.<id>`, `indicator.<n>`, `criterion.<n>`), so a capability that literally declares
+`brief-conformance` cannot shadow the brief, and a scorecard dimension says which rung it came
+from. `minimumScore` falls back to `fidelity.threshold`, then to the profile score. The ceiling is
+twelve requirements, `brief-conformance` included, and what the ceiling drops is counted.
+
+The array reaches BOTH compile sites. `compileGauntletPlan` runs twice per Gauntlet — once in
+`dispatch.ts` to size the evaluator's budget, once inside `runAgentXGauntlet` — and the scorecard is
+validated against the plan the second one built, so a contract only the first site saw would make
+`validateScorecardFile` reject every dimension as "not in the success contract". The three canaries
+compute the array once and hand it to both; the tests pin the two on one `planId`.
+
+A business declares its contract per role instead of per capability. `skills/businesses/lib/acceptance.ts`
+reads the intake employee's `acceptance[]` (Business Protocol 2.0 §11) into the same
+`SuccessRequirement[]`, deduped by id, so two roles copying one house rule contribute one dimension.
+
+`gauntlet.requirements_source` (`brief` | `capability`, default `brief`) gates all of it. At the
+default the contract is the single `brief-conformance` of before and the compiled plan is bit for
+bit today's — the same `planId`, which a test asserts on both compile sites.
+
+### An acceptance entry that names a path is a completeness proof
+
+The gate judges QUALITY, never completeness: it reads the files that exist and says whether they
+are good, never whether they are all of them. The one completeness proof the system had was a
+`deliverables.json` written per run, and a business that never wrote one fell back to the output
+scan, which only knows that SOMETHING was written.
+
+An `acceptance[]` entry with a `path` is the same promise, declared by the role instead of written
+per run. `verify-deliverable.ts` reads those entries when there is no manifest (`manifest_source:
+"acceptance"`, `min_bytes` per entry when declared), and the delivery pipeline runs verification for
+them the way it does for a manifest.
+
+### The Gauntlet's evaluator is ranked, not alphabetical
+
+Declaring the id `quality.specification_conformance` was the whole evaluator contract, and among the
+squads that declared it the first slug in alphabetical order won. Squad Protocol v6 §30 gave the
+capability an `evaluator` block; nothing read it.
+
+Selection ranks now: `fidelity.status` (`validated` > `experimental` > `drifted`, with `retired` not
+a candidate at all), then `evaluator.max_cost_usd` ascending — a capability with no `evaluator` block
+declares no cost, so it sorts behind every one that does — then the slug. A library that declares no
+v6 metadata has only the third key, so today's alphabetical answer is what it still gets. The winning
+row travels on the selection and is what `nrv doctor` prints as the reason, instead of "the first
+one". `max_cost_usd` also caps the spend: the evaluation subprocess runs under
+`min(plan slice, max_cost_usd)` — a declared ceiling limits the budget, never raises it.
+
+### `produces` reaches the judge's rubric selector
+
+`deliveryArgs()` never passed `produces`, so `selectRubricsForProduces` was always called with `[]`
+and every deliverable — a landing page, a dataset, a video script — was judged by `prose_shortform`.
+Both sides of the declaration existed: a squad capability's `produces` and a business manifest's.
+
+The dispatch now forwards it, from the resolved capability for a squad and from the manifest for a
+business. The rubrics gained `aliases:` in their frontmatter for the PT/EN synonyms of the slugs
+they cover, so `pagina-de-vendas` selects the same rubric `landing-page` does instead of falling
+through to the generic one; an alias may not be a slug another rubric already declares, and a test
+holds that. `delivery.produces_to_rubric` (default `false`) gates the forwarding, because the
+rubrics cover roughly 45 of the 3.024 slugs the library declares and a slug with no rubric has to
+degrade to the fallback, never to a refusal. Off, the judge receives `[]` — bit for bit what it
+received before.
+
 ### The dev loop stops paying for the whole repository on every check
 
 `bun test skills` was the only thing anyone could type, and it runs 176 files in 135-180 s. A

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,87 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O Gauntlet julga o contrato que o alvo declarou, não uma linha fixa
+
+`compiler.ts` sempre soube compilar N requisitos em N gauntlets. Nunca recebeu mais de um: nenhum
+chamador passava `requirements`, então todo Gauntlet do sistema julgava a mesma pergunta
+`brief-conformance` com um limiar lido do perfil de intensidade, enquanto os manifestos carregavam
+`capabilities[].acceptance[]` e `fidelity.threshold` que ninguém lia.
+
+`skills/harness/lib/gauntlet/success-requirements.ts` monta o contrato. `brief-conformance` primeiro,
+sempre, e depois o primeiro degrau desta escada que responder:
+
+| Degrau | Origem | Bloqueia |
+|---|---|---|
+| `acceptance` | `capabilities[].acceptance[]` | sim, salvo `blocking: false` |
+| `success_indicators` | `success_indicators[]` do workflow invocado, pelo leitor v6 | não |
+| `task_acceptance_criteria` | `## Acceptance Criteria` da task invocada | não |
+| `brief-conformance` | nada declarado | sim |
+
+Os degraus derivados não bloqueiam. Um indicador que alguém escreveu em prosa nunca foi prometido
+como portão, e transformá-lo em um retém entregas que ninguém combinou reter. Os ids são namespaced
+(`acceptance.<id>`, `indicator.<n>`, `criterion.<n>`), então uma capability que declare literalmente
+`brief-conformance` não consegue sombrear o brief, e uma dimensão do scorecard diz de qual degrau
+veio. `minimumScore` sem valor cai no `fidelity.threshold` e, na falta dele, no score do perfil. O
+teto é de doze requisitos, `brief-conformance` incluído, e o que o teto corta é contado.
+
+O array chega aos DOIS sítios de compilação. `compileGauntletPlan` roda duas vezes por Gauntlet —
+uma em `dispatch.ts`, para dimensionar o orçamento do avaliador, e outra dentro de
+`runAgentXGauntlet` — e o scorecard é validado contra o plano que o segundo montou, então um
+contrato que só o primeiro viu faria o `validateScorecardFile` rejeitar toda dimensão como "fora do
+contrato de sucesso". Os três canários calculam o array uma vez e o entregam aos dois; os testes
+fixam os dois num mesmo `planId`.
+
+Uma empresa declara o contrato por cargo, não por capability. `skills/businesses/lib/acceptance.ts`
+lê o `acceptance[]` do cargo de intake (Business Protocol 2.0 §11) para o mesmo
+`SuccessRequirement[]`, deduplicado por id, então dois cargos que copiam a mesma regra da casa
+contribuem com uma dimensão só.
+
+`gauntlet.requirements_source` (`brief` | `capability`, padrão `brief`) governa tudo isso. No padrão,
+o contrato é o único `brief-conformance` de antes e o plano compilado é bit a bit o de hoje — o mesmo
+`planId`, que um teste afirma nos dois sítios de compilação.
+
+### Uma entrada de aceitação que nomeia um caminho é prova de completude
+
+O portão julga QUALIDADE, nunca completude: ele lê os arquivos que existem e diz se são bons, nunca
+se são todos. A única prova de completude que o sistema tinha era um `deliverables.json` escrito por
+run, e uma empresa que nunca escreveu um caía na varredura de saída, que só sabe que ALGO foi
+escrito.
+
+Uma entrada de `acceptance[]` com `path` é a mesma promessa, declarada pelo cargo em vez de escrita
+por run. O `verify-deliverable.ts` lê essas entradas quando não há manifesto (`manifest_source:
+"acceptance"`, com `min_bytes` por entrada quando declarado), e o pipeline de entrega roda a
+verificação para elas como roda para um manifesto.
+
+### O avaliador do Gauntlet é ranqueado, não alfabético
+
+Declarar o id `quality.specification_conformance` era o contrato inteiro do avaliador, e entre os
+squads que o declaravam vencia o primeiro slug em ordem alfabética. O Squad Protocol v6 §30 deu à
+capability um bloco `evaluator`; ninguém o lia.
+
+Agora a seleção ranqueia: `fidelity.status` (`validated` > `experimental` > `drifted`, com `retired`
+fora da disputa), depois `evaluator.max_cost_usd` crescente — uma capability sem bloco `evaluator`
+declara custo nenhum, então fica atrás de qualquer uma que declare — e o slug por último. Uma
+biblioteca que não declara metadado de v6 tem só a terceira chave, então continua recebendo a
+resposta alfabética de hoje. A linha vencedora viaja na seleção e é o que o `nrv doctor` imprime como
+razão, em vez de "o primeiro". O `max_cost_usd` também limita o gasto: o subprocesso da avaliação
+roda com `min(fatia do plano, max_cost_usd)` — um teto declarado limita o orçamento, nunca o aumenta.
+
+### O `produces` chega ao seletor de rubricas do juiz
+
+O `deliveryArgs()` nunca passava `produces`, então o `selectRubricsForProduces` era sempre chamado
+com `[]` e todo entregável — uma landing page, um dataset, um roteiro de vídeo — era julgado pelo
+`prose_shortform`. Os dois lados da declaração existiam: o `produces` de uma capability de squad e o
+do manifesto de uma empresa.
+
+O dispatch passa a encaminhá-lo, da capability resolvida no caso do squad e do manifesto no caso da
+empresa. As rubricas ganharam `aliases:` no frontmatter para os sinônimos PT/EN dos slugs que
+cobrem, então `pagina-de-vendas` seleciona a mesma rubrica que `landing-page` em vez de cair na
+genérica; um alias não pode ser um slug que outra rubrica já declara, e um teste segura isso.
+`delivery.produces_to_rubric` (padrão `false`) governa o encaminhamento, porque as rubricas cobrem
+cerca de 45 dos 3.024 slugs que a biblioteca declara e um slug sem rubrica tem que degradar para o
+fallback, nunca para uma recusa. Desligado, o juiz recebe `[]` — bit a bit o que ele recebia antes.
+
 ### O laço de desenvolvimento para de pagar o repositório inteiro a cada verificação
 
 `bun test skills` era a única coisa que alguém podia digitar, e ele roda 176 arquivos em 135-180 s.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -51,6 +51,8 @@ Gerada a partir do schema. `nrv config explain <chave>` mostra a descrição de 
 | `gauntlet.business_allowlist` | `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST` | `""` | global, projeto | slugs separados por vírgula (ou vazio) |
 | `gauntlet.business_kill_switch` | `NIRVANA_BUSINESS_GAUNTLET_KILL_SWITCH` | `false` | global, projeto | true / false |
 | `gauntlet.auto_allowed` | `NIRVANA_ALLOW_AUTO_GAUNTLET` | `false` | global, projeto | true / false |
+| `gauntlet.requirements_source` | `NIRVANA_GAUNTLET_REQUIREMENTS_SOURCE` | `brief` | global, projeto | brief / capability |
+| `delivery.produces_to_rubric` | `NIRVANA_PRODUCES_TO_RUBRIC` | `false` | global, projeto | true / false |
 | `execution.default_runtime` | `NIRVANA_DEFAULT_RUNTIME` | `""` | global, projeto | nome de runtime (claude-code, codex, gemini-cli, ...) ou vazio |
 | `execution.model` | `NIRVANA_MODEL` | `""` | global, projeto | id ou alias de modelo (opus, sonnet, haiku, fable, ...) ou vazio |
 | `execution.dna_injection` | `NIRVANA_DNA_INJECTION` | `full` | global, projeto | full / fragments |
@@ -94,6 +96,8 @@ Cada interruptor do schema tem exatamente um caminho de leitura, `resolveSetting
 | `gauntlet.default_mode`, `default_intensity`, `auto_allowed` | `harness/lib/gauntlet/execution-options.ts` |
 | `gauntlet.evaluator` | `harness/scripts/dispatch.ts`, `harness/scripts/doctor-system.ts` |
 | `gauntlet.business_allowlist`, `business_kill_switch` | `harness/scripts/dispatch.ts` (canário de business), `multi-target-dispatch-adapters.ts` (merge da allowlist) |
+| `gauntlet.requirements_source` | `harness/scripts/dispatch.ts` (os três canários, via `lib/gauntlet/success-requirements.ts`) |
+| `delivery.produces_to_rubric` | `harness/scripts/dispatch.ts` (`deliveryArgs`) |
 | `execution.default_runtime` | `harness/scripts/dispatch.ts`, `control-plane/execution-runner.ts` |
 | `execution.model` | `_shared/lib/system-model.ts` |
 | `execution.dna_injection` | `harness/lib/dispatch.ts`, `harness/lib/squad-exec.ts`, `businesses/lib/employee-prompt.ts` |

--- a/docs/architecture/gauntlet-evaluator-contract.md
+++ b/docs/architecture/gauntlet-evaluator-contract.md
@@ -96,7 +96,15 @@ O que envolve o brief cai de ~12.500 para ~4.000 caracteres (um terço); o turno
 A função compartilhada pelos três canários (`gauntletEvaluatorFor` em `dispatch.ts`, sobre `evaluator-selection.ts`) decide o avaliador antes de qualquer produtor, nesta ordem:
 
 1. `NIRVANA_GAUNTLET_EVALUATOR`, quando definida, é honrada ou recusada, nunca reinterpretada. Formas aceitas: `squad:<slug>[:<capabilityId>]`, `judge-x`, `agent-x` e `heuristic`. Um squad tem que estar no registro instalado (`.squads-registry.json`, mantido por `nrv index`); sem capability explícita, usa `quality.specification_conformance` quando o squad a declara, senão a primeira capability declarada. `agent-x` só é aceito quando o produtor não é agent-x. Valor ilegível, squad não instalado, capability não declarada, alvo não independente do produtor ou `judge-x` sem persona para o runtime encerram o dispatch com exit 4 e a explicação, antes do produtor.
-2. Sem a variável, o registro instalado é percorrido em ordem alfabética de slug em busca de um squad que declare exatamente a capability `quality.specification_conformance` e seja independente do produtor. A regra é o id exato, não um domínio: os squads de domínio `qa` da biblioteca (`data-quality-guardian`, `code-review`, `automated-code-review-squad`) julgam datasets, código TypeScript ou PRs, não um entregável qualquer contra o seu brief. Quem quiser um juiz próprio cria um squad com essa capability na própria biblioteca e a seleção o prefere ao judge-x.
+2. Sem a variável, o registro instalado é percorrido em busca dos squads que declaram exatamente a capability `quality.specification_conformance` e são independentes do produtor. A regra é o id exato, não um domínio: os squads de domínio `qa` da biblioteca (`data-quality-guardian`, `code-review`, `automated-code-review-squad`) julgam datasets, código TypeScript ou PRs, não um entregável qualquer contra o seu brief. Quem quiser um juiz próprio cria um squad com essa capability na própria biblioteca e a seleção o prefere ao judge-x. Entre os que se qualificam, o vencedor é **ranqueado** (Squad Protocol v6 §30), não o primeiro do alfabeto:
+
+   | Chave | Ordem | Origem |
+   |---|---|---|
+   | `fidelity.status` | `validated` > `experimental` > `drifted`; `retired` não concorre | `capabilities[].fidelity.status`, `experimental` quando ausente |
+   | `evaluator.max_cost_usd` | crescente; sem bloco `evaluator` fica atrás de quem declara | `capabilities[].evaluator.max_cost_usd` |
+   | slug | alfabética | nome do squad |
+
+   Uma biblioteca que não declara nada de v6 tem só a terceira chave, então a resposta continua sendo a alfabética de antes. A linha escolhida viaja na seleção (`ranking`) e é o que `nrv doctor` imprime como razão. O `max_cost_usd` do vencedor também limita o gasto da avaliação: o `--max-budget` do subprocesso é o **menor** entre a parcela do plano e o teto declarado.
 3. Senão, `judge-x`, para qualquer produtor: agent-x, squad ou business.
 4. Senão, nada. Sem persona do judge para o runtime, ou com o CLI fora do PATH, a seleção é `unavailable`: o dispatch grava `x_gauntlet_evaluator_unavailable`, explica, encerra com exit 4 antes de qualquer produtor e transiciona o Run (criado ali, ou adotado por `--run-id`) para `rolled_back` com `reason: evaluator_unavailable`, o mesmo desenho de `runtime_incompatible`.
 
@@ -158,6 +166,6 @@ Para um Business, some `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST=<slug>` e use `nrv d
 - Um scorecard por avaliação cobre todos os requisitos do contrato; não há um scorecard por gauntlet nem arbitragem entre vários avaliadores.
 - O custo observado depende do `agent_executed` que cada caminho do dispatch grava; um avaliador cujo caminho não grava o evento aparece com custo zero.
 - O isolamento do candidate é por instrução e por diretório separado, não por sistema de arquivos somente leitura.
-- `GAUNTLET_EVALUATION_SHARE` e `GAUNTLET_EVALUATION_FLOOR_USD` são constantes; o `estimated_cost_usd` declarado por um squad ainda não entra na estimativa.
+- `GAUNTLET_EVALUATION_SHARE` e `GAUNTLET_EVALUATION_FLOOR_USD` são constantes; o `estimated_cost_usd` declarado por um squad ainda não entra na estimativa. O `evaluator.max_cost_usd`, sim: ele limita o `--max-budget` da avaliação, nunca o aumenta.
 - O subtipo `error_max_budget_usd` é do `claude`; nos outros runtimes não há teto de gasto no CLI (`runHeadless` avisa), então um estouro do juiz aparece como scorecard ausente, sem o nome `budget_exhausted`.
 - O engine não materializa um squad avaliador em `~/squads`: os registros começam vazios por desenho e `~/squads` é camada do usuário. O judge-x cobre toda máquina; um juiz próprio é um squad da biblioteca do usuário com `quality.specification_conformance`.

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -189,6 +189,13 @@ export const SETTINGS = {
   "gauntlet.auto_allowed": booleanSetting("gauntlet.auto_allowed",
     "Permite que o modo auto escolha gauntlet (senão auto resolve para standard).",
     { default: false, env: "NIRVANA_ALLOW_AUTO_GAUNTLET" }),
+  "gauntlet.requirements_source": enumSetting("gauntlet.requirements_source",
+    "De onde vem o contrato do juiz: brief = só brief-conformance (padrão de hoje); capability = brief-conformance + acceptance[] declarada.",
+    ["brief", "capability"], { default: "brief", env: "NIRVANA_GAUNTLET_REQUIREMENTS_SOURCE" }),
+
+  "delivery.produces_to_rubric": booleanSetting("delivery.produces_to_rubric",
+    "Passa o produces[] do alvo ao seletor de rubricas do quality gate; false = o juiz continua caindo na rubrica genérica.",
+    { default: false, env: "NIRVANA_PRODUCES_TO_RUBRIC" }),
 
   "execution.default_runtime": stringSetting("execution.default_runtime",
     "Runtime usado quando a sessão não é identificada; vazio = primeiro disponível no PATH.",

--- a/skills/businesses/lib/acceptance.ts
+++ b/skills/businesses/lib/acceptance.ts
@@ -1,0 +1,134 @@
+// acceptance.ts — the acceptance contract a business declares, per role.
+//
+// Business Protocol 2.0 §11 lets an employee declare `acceptance[]`: the criteria
+// its output has to meet, each one blocking unless the author says otherwise, and
+// each one optionally naming the `path` it promises on disk. The validator has
+// accepted the block since the v2 cut; nothing read it. Two readers do now:
+//
+//   the Gauntlet   `readAcceptance(bizDir, employees)` becomes `SuccessRequirement[]`,
+//                  so a business Gauntlet judges the role's own criteria instead of
+//                  the single `brief-conformance` line every Gauntlet shared.
+//   completeness   an entry with `path` is a promise the disk can be checked against
+//                  (`verify-deliverable.ts`, `manifest_source: "acceptance"`) — the
+//                  one completeness proof the system has, for a business that never
+//                  wrote a `deliverables.json`.
+//
+// Ids are deduped: two roles that declare the same criterion (a shared house rule
+// copied across employees) contribute one requirement, the first one read, so the
+// judge is never asked to score the same dimension twice.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as YAML from "yaml";
+import { paths } from "../../_shared/lib/bun-helpers.ts";
+import type { SuccessRequirement } from "../../harness/lib/gauntlet/types.ts";
+
+/** The capability that judges an acceptance criterion when the author names none. */
+export const CONFORMANCE_CAPABILITY = "quality.specification_conformance";
+
+/** Ceiling of the judge's contract (Squad Protocol v6 §29), `brief-conformance` included. */
+export const ACCEPTANCE_MAX = 11;
+
+export interface AcceptanceEntry {
+  id: string;
+  description: string;
+  blocking: boolean;
+  minimum_score?: number;
+  capability?: string;
+  /** A file the role promises; relative paths resolve against the outputs root. */
+  path?: string;
+  min_bytes?: number;
+  /** The employee that declared it. */
+  employee: string;
+}
+
+export interface BusinessAcceptance {
+  requirements: SuccessRequirement[];
+  entries: AcceptanceEntry[];
+  /** The subset that promises a file — what a completeness check can verify. */
+  paths: Array<{ path: string; minBytes: number | null }>;
+}
+
+const FRONTMATTER = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+function frontmatterOf(file: string): Record<string, unknown> | null {
+  try {
+    const match = FRONTMATTER.exec(fs.readFileSync(file, "utf8"));
+    if (!match) return null;
+    const doc = YAML.parse(match[1], { uniqueKeys: false });
+    return doc && typeof doc === "object" && !Array.isArray(doc) ? doc as Record<string, unknown> : null;
+  } catch { return null; }
+}
+
+function employeeFiles(bizDir: string, employees?: string[] | null): string[] {
+  const dir = path.join(bizDir, "employees");
+  let names: string[];
+  try { names = fs.readdirSync(dir).filter(name => name.endsWith(".md")).sort(); }
+  catch { return []; }
+  if (!employees?.length) return names.map(name => path.join(dir, name));
+  const wanted = new Set(employees.map(name => name.replace(/\.md$/i, "").toLowerCase()));
+  return names.filter(name => wanted.has(name.slice(0, -3).toLowerCase())).map(name => path.join(dir, name));
+}
+
+/**
+ * The acceptance contract of a business, read from the roles named in `employees`
+ * (every role when the list is empty). `minimumScore` falls back to `opts.minimumScore`,
+ * which the caller takes from the Gauntlet's intensity profile.
+ */
+export function readAcceptance(bizDir: string, employees?: string[] | null,
+  opts: { minimumScore?: number } = {}): BusinessAcceptance {
+  const floor = opts.minimumScore ?? 0.92;
+  const entries: AcceptanceEntry[] = [];
+  const seen = new Set<string>();
+  for (const file of employeeFiles(bizDir, employees)) {
+    const front = frontmatterOf(file);
+    const declared = Array.isArray(front?.acceptance) ? front!.acceptance as Array<Record<string, unknown>> : [];
+    const employee = typeof front?.name === "string" ? front.name : path.basename(file, ".md");
+    for (const raw of declared) {
+      if (!raw || typeof raw !== "object") continue;
+      const id = typeof raw.id === "string" ? raw.id.trim() : "";
+      const description = typeof raw.description === "string" ? raw.description.trim() : "";
+      if (!id || !description || seen.has(id)) continue;
+      seen.add(id);
+      entries.push({
+        id, description, employee,
+        blocking: typeof raw.blocking === "boolean" ? raw.blocking : true,
+        ...(typeof raw.minimum_score === "number" ? { minimum_score: raw.minimum_score } : {}),
+        ...(typeof raw.capability === "string" ? { capability: raw.capability } : {}),
+        ...(typeof raw.path === "string" && raw.path.trim() ? { path: raw.path.trim() } : {}),
+        ...(typeof raw.min_bytes === "number" ? { min_bytes: raw.min_bytes } : {}),
+      });
+    }
+  }
+  const kept = entries.slice(0, ACCEPTANCE_MAX);
+  return {
+    entries,
+    requirements: kept.map(entry => ({
+      id: `acceptance.${entry.id}`,
+      description: entry.description,
+      capability: entry.capability ?? CONFORMANCE_CAPABILITY,
+      blocking: entry.blocking,
+      minimumScore: entry.minimum_score ?? floor,
+    })),
+    paths: entries.filter(entry => entry.path)
+      .map(entry => ({ path: entry.path as string, minBytes: entry.min_bytes ?? null })),
+  };
+}
+
+/**
+ * The directory of an installed business: the registry `nrv index` writes (which
+ * knows the extra roots), else `<BUSINESSES_DIR>/<slug>`. Null when neither holds it.
+ */
+export function businessDirFor(slug: string, opts: { registryPath?: string; businessesDir?: string } = {}): string | null {
+  const registryPath = opts.registryPath ?? (paths.BUSINESSES_REGISTRY_PATH as string);
+  try {
+    const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as { businesses?: Record<string, { manifest_path?: unknown }> };
+    const manifestPath = registry?.businesses?.[slug]?.manifest_path;
+    if (typeof manifestPath === "string" && manifestPath) {
+      const dir = path.dirname(manifestPath);
+      if (fs.existsSync(path.join(dir, "business.yaml"))) return dir;
+    }
+  } catch { /* no registry, or an unreadable one */ }
+  const fallback = path.join(opts.businessesDir ?? (paths.BUSINESSES_DIR as string), slug);
+  return fs.existsSync(path.join(fallback, "business.yaml")) ? fallback : null;
+}

--- a/skills/businesses/scripts/verify-deliverable.ts
+++ b/skills/businesses/scripts/verify-deliverable.ts
@@ -25,6 +25,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { businessDirFor, readAcceptance } from "../lib/acceptance.ts";
 
 const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
@@ -49,7 +50,7 @@ export type DeliverableReport = {
 export function verifyDeliverableOnDisk(
   projectId: string,
   businessSlug: string,
-  opts: { outputsRoot?: string; minBytes?: number } = {}
+  opts: { outputsRoot?: string; minBytes?: number; businessDir?: string | null } = {}
 ): DeliverableReport {
   const minBytes = opts.minBytes ?? 200;
   const outputsRoot = opts.outputsRoot;
@@ -111,6 +112,22 @@ export function verifyDeliverableOnDisk(
     }
   }
 
+  // Business Protocol 2.0 §11: an `acceptance[]` entry that names a `path` is a
+  // promise the disk can be checked against — the same completeness proof a
+  // deliverables.json gives, declared by the role instead of written per run. Read
+  // only when there is no manifest: a manifest is the run's own list and wins.
+  let acceptanceMinBytes: Map<string, number> = new Map();
+  if (expectedPathsRaw.length === 0) {
+    const bizDir = opts.businessDir ?? businessDirFor(businessSlug);
+    const promised = bizDir ? readAcceptance(bizDir).paths : [];
+    if (promised.length > 0) {
+      const base = outputsRoot ?? path.join(projectsRoot, projectId);
+      expectedPathsRaw = promised.map(entry => path.isAbsolute(entry.path) ? entry.path : path.resolve(base, entry.path));
+      acceptanceMinBytes = new Map(promised.map((entry, index) => [expectedPathsRaw[index], entry.minBytes ?? minBytes]));
+      manifestSource = "acceptance";
+    }
+  }
+
   // Fallback: scan brief.md for explicit absolute paths
   if (expectedPathsRaw.length === 0) {
     const pathRegex = /\/(?:Users|home|tmp|opt)\/[^\s`'"\)\]]+\.(md|json|ya?ml|png|jpg|jpeg|html|txt|pdf|csv|tsv|svg|webp)/g;
@@ -129,14 +146,16 @@ export function verifyDeliverableOnDisk(
   if (expectedPathsRaw.length === 0) {
     return base("FAIL_INDETERMINATE", {
       manifest_source: manifestSource,
-      reason: "no deliverables.json and brief.md has no /path markers",
+      reason: "no deliverables.json, no acceptance[] entry with a path, and brief.md has no /path markers",
     });
   }
 
   const results = expectedPathsRaw.map(p => {
     const exists = fs.existsSync(p);
     const bytes = exists ? fs.statSync(p).size : 0;
-    return { path: p, exists, bytes, isStub: exists && bytes < minBytes };
+    // An acceptance entry may declare its own `min_bytes`; otherwise the run's threshold.
+    const threshold = acceptanceMinBytes.get(p) ?? minBytes;
+    return { path: p, exists, bytes, isStub: exists && bytes < threshold };
   });
 
   const found = results.filter(r => r.exists).length;

--- a/skills/businesses/tests/acceptance.test.ts
+++ b/skills/businesses/tests/acceptance.test.ts
@@ -1,0 +1,131 @@
+// acceptance.test.ts — the acceptance contract a business declares per role
+// (Business Protocol 2.0 §11), read into the Gauntlet's requirements and into the
+// completeness check. Pure: fixtures on disk, no process, no registry outside them.
+// Runs with: bun test skills/businesses/tests
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ACCEPTANCE_MAX, businessDirFor, readAcceptance } from "../lib/acceptance.ts";
+import { verifyDeliverableOnDisk } from "../scripts/verify-deliverable.ts";
+
+const roots: string[] = [];
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+function business(employees: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-acceptance-")); roots.push(root);
+  fs.writeFileSync(path.join(root, "business.yaml"), "name: fixture\n", "utf8");
+  fs.mkdirSync(path.join(root, "employees"), { recursive: true });
+  for (const [name, front] of Object.entries(employees)) {
+    fs.writeFileSync(path.join(root, "employees", `${name}.md`), `---\nname: ${name}\n${front}---\n\n# ${name}\n`, "utf8");
+  }
+  return root;
+}
+
+describe("readAcceptance", () => {
+  test("a role's criteria become requirements, blocking by default and namespaced", () => {
+    const dir = business({ "brief-intake": "acceptance:\n  - id: sources_cited\n    description: Cada afirmação cita a fonte\n  - id: one_page\n    description: Cabe em uma página\n    blocking: false\n    minimum_score: 0.6\n" });
+    const read = readAcceptance(dir, ["brief-intake"], { minimumScore: 0.85 });
+    expect(read.requirements).toEqual([
+      { id: "acceptance.sources_cited", description: "Cada afirmação cita a fonte", capability: "quality.specification_conformance", blocking: true, minimumScore: 0.85 },
+      { id: "acceptance.one_page", description: "Cabe em uma página", capability: "quality.specification_conformance", blocking: false, minimumScore: 0.6 },
+    ]);
+  });
+
+  test("reads only the roles asked for, and every role when none is named", () => {
+    const dir = business({
+      "brief-intake": "acceptance:\n  - id: intake_rule\n    description: A do intake\n",
+      "editor": "acceptance:\n  - id: editor_rule\n    description: A do editor\n",
+    });
+    expect(readAcceptance(dir, ["brief-intake"]).entries.map(entry => entry.id)).toEqual(["intake_rule"]);
+    expect(readAcceptance(dir).entries.map(entry => entry.id)).toEqual(["intake_rule", "editor_rule"]);
+    expect(readAcceptance(dir).entries.map(entry => entry.employee)).toEqual(["brief-intake", "editor"]);
+  });
+
+  test("the same id declared by two roles contributes one requirement", () => {
+    const dir = business({
+      "a-role": "acceptance:\n  - id: house_rule\n    description: A regra da casa\n",
+      "b-role": "acceptance:\n  - id: house_rule\n    description: A mesma regra, copiada\n",
+    });
+    expect(readAcceptance(dir).requirements.map(item => item.id)).toEqual(["acceptance.house_rule"]);
+  });
+
+  test("entries with a path are the completeness promise; the rest is ignored there", () => {
+    const dir = business({ "brief-intake": "acceptance:\n  - id: has_report\n    description: Entrega o relatório\n    path: report.md\n    min_bytes: 10\n  - id: no_path\n    description: Sem arquivo\n" });
+    expect(readAcceptance(dir).paths).toEqual([{ path: "report.md", minBytes: 10 }]);
+  });
+
+  test("a malformed or absent business is an empty contract, never a throw", () => {
+    expect(readAcceptance("/definitely/not/here")).toEqual({ entries: [], requirements: [], paths: [] });
+    const dir = business({ "broken": "acceptance: not-a-list\n" });
+    fs.writeFileSync(path.join(dir, "employees", "no-frontmatter.md"), "# nada\n", "utf8");
+    expect(readAcceptance(dir).entries).toEqual([]);
+  });
+
+  test("the ceiling keeps the contract inside the judge's twelve requirements", () => {
+    const many = Array.from({ length: 20 }, (_, index) => `  - id: c_${index}\n    description: criterion ${index}\n`).join("");
+    const dir = business({ "brief-intake": `acceptance:\n${many}` });
+    const read = readAcceptance(dir);
+    expect(read.entries).toHaveLength(20);
+    expect(read.requirements).toHaveLength(ACCEPTANCE_MAX);
+  });
+
+  test("businessDirFor prefers the registry, falls back to the businesses dir, and admits when it has neither", () => {
+    const dir = business({ "brief-intake": "acceptance: []\n" });
+    const registry = path.join(dir, "registry.json");
+    fs.writeFileSync(registry, JSON.stringify({ businesses: { fixture: { manifest_path: path.join(dir, "business.yaml") } } }), "utf8");
+    expect(businessDirFor("fixture", { registryPath: registry })).toBe(dir);
+    // No registry: <businessesDir>/<slug>, and only when it really holds a business.yaml.
+    const businessesDir = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-businesses-")); roots.push(businessesDir);
+    fs.mkdirSync(path.join(businessesDir, "fixture"), { recursive: true });
+    fs.writeFileSync(path.join(businessesDir, "fixture", "business.yaml"), "name: fixture\n", "utf8");
+    expect(businessDirFor("fixture", { registryPath: path.join(dir, "missing.json"), businessesDir }))
+      .toBe(path.join(businessesDir, "fixture"));
+    expect(businessDirFor("ghost", { registryPath: registry, businessesDir })).toBeNull();
+  });
+});
+
+describe("verify-deliverable reads the acceptance promise", () => {
+  function project(files: Record<string, string>): { cwd: string; outputsRoot: string } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-acceptance-project-")); roots.push(root);
+    const projectDir = path.join(root, "outputs", "prj_1");
+    const outputsRoot = path.join(projectDir, "deliverables");
+    fs.mkdirSync(outputsRoot, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "brief.md"), "Produza o relatório.\n", "utf8");
+    for (const [name, body] of Object.entries(files)) fs.writeFileSync(path.join(outputsRoot, name), body, "utf8");
+    return { cwd: root, outputsRoot };
+  }
+
+  test("a promised path that exists passes, and manifest_source names the acceptance", () => {
+    const bizDir = business({ "brief-intake": "acceptance:\n  - id: has_report\n    description: Entrega o relatório\n    path: report.md\n    min_bytes: 10\n" });
+    const { cwd, outputsRoot } = project({ "report.md": "Um relatório com corpo suficiente para não ser stub.\n" });
+    const saved = process.cwd();
+    try {
+      process.chdir(cwd);
+      const report = verifyDeliverableOnDisk("prj_1", "fixture", { outputsRoot, businessDir: bizDir });
+      expect(report).toMatchObject({ status: "PASS", manifest_source: "acceptance", expected: 1, found: 1 });
+    } finally { process.chdir(saved); }
+  });
+
+  test("a promised path that is missing fails, naming the file", () => {
+    const bizDir = business({ "brief-intake": "acceptance:\n  - id: has_report\n    description: Entrega o relatório\n    path: report.md\n" });
+    const { cwd, outputsRoot } = project({});
+    const saved = process.cwd();
+    try {
+      process.chdir(cwd);
+      const report = verifyDeliverableOnDisk("prj_1", "fixture", { outputsRoot, businessDir: bizDir });
+      expect(report.status).toBe("FAIL");
+      expect(report.missing[0]).toBe(path.join(outputsRoot, "report.md"));
+    } finally { process.chdir(saved); }
+  });
+
+  test("a business that promises nothing keeps the brief-regex behavior", () => {
+    const bizDir = business({ "brief-intake": "acceptance:\n  - id: quality\n    description: Sem path\n" });
+    const { cwd, outputsRoot } = project({ "report.md": "conteúdo" });
+    const saved = process.cwd();
+    try {
+      process.chdir(cwd);
+      expect(verifyDeliverableOnDisk("prj_1", "fixture", { outputsRoot, businessDir: bizDir }).manifest_source).toBe("brief-regex");
+    } finally { process.chdir(saved); }
+  });
+});

--- a/skills/harness/lib/delivery-pipeline.ts
+++ b/skills/harness/lib/delivery-pipeline.ts
@@ -114,6 +114,25 @@ export interface GateRunOpts {
   env?: Record<string, string | undefined>;
 }
 
+/**
+ * The `produces[]` slugs the judge's rubric selector receives.
+ *
+ * `deliveryArgs()` never passed `produces`, so `selectRubricsForProduces` was
+ * always called with `[]` and every deliverable — a landing page, a dataset, a
+ * video script — was judged by `prose_shortform`. The declaration exists on both
+ * sides (a squad capability's `produces`, a business manifest's), so the fix is
+ * to forward it; `delivery.produces_to_rubric` gates the forwarding because the
+ * rubrics cover roughly 45 of the 3.024 slugs the library declares, and a slug
+ * with no rubric must degrade to the fallback, never to a refusal.
+ *
+ * Off (the default) returns `[]` — bit for bit what the judge received before.
+ */
+export function producesForRubric(produces: readonly string[] | null | undefined, enabled: boolean): string[] {
+  if (!enabled) return [];
+  const slugs = (produces ?? []).map(slug => String(slug ?? "").trim()).filter(Boolean);
+  return [...new Set(slugs)];
+}
+
 /** Run the quality gate over each artifact; collect fix lists for failures.
  * Accepts a bare script path (legacy signature, offline heuristics) or full
  * GateRunOpts. Parses the normalized verdict {status, mode, results[]}. */
@@ -172,6 +191,14 @@ export interface DeliveryArgs {
    * business slug exists), verification runs through verify-deliverable.ts
    * and its exit code is honored; otherwise the homegrown scan applies. */
   manifest?: string | null;
+  /**
+   * The business promised files through its roles' `acceptance[]` (Business Protocol
+   * 2.0 §11, businesses/lib/acceptance.ts). Those entries are a completeness proof the
+   * same way a manifest is, so verification runs through verify-deliverable.ts for them
+   * too — a business that never wrote a `deliverables.json` stops falling back to the
+   * output scan, which only knows whether SOMETHING was written.
+   */
+  acceptancePromisesPaths?: boolean;
   pid: string;
   /** Business slug; null for squad-only / agent-x paths. */
   slug: string | null;
@@ -239,7 +266,7 @@ export interface DeliveryResult {
   revisionsUsed: number;
   sessionId: string | null;
   zipPath: string | null;
-  verifySource: "manifest" | "scan";
+  verifySource: "manifest" | "acceptance" | "scan";
   /** Reason string when the completeness ceiling downgraded an otherwise
    * deliverable outcome to `withheld`; null when no cap bound the result. */
   ceilingApplied: string | null;
@@ -292,27 +319,29 @@ export function runDelivery(args: DeliveryArgs): DeliveryResult {
   let verifySource: DeliveryResult["verifySource"] = "scan";
   let manifestVerified = false;
 
-  if (args.manifest && args.slug) {
-    // Manifest path: verify-deliverable.ts owns the disk-truth check and its
+  const promisedSource: "manifest" | "acceptance" | null = args.slug ? (args.manifest ? "manifest" : args.acceptancePromisesPaths ? "acceptance" : null) : null;
+  if (promisedSource) {
+    // Promised-paths path: verify-deliverable.ts owns the disk-truth check and its
     // exit code is honored (0 pass · 1 fail · 2 indeterminate → fall back to
-    // the scan below). It emits verify_passed/verify_failed itself.
+    // the scan below). It emits verify_passed/verify_failed itself. The promise comes
+    // from the run's manifest, or — with no manifest — from the roles' acceptance[].
     const v = spawnSync("bun", [verifyScript, args.pid, args.slug, "--outputs-root", args.outputsRoot], {
       encoding: "utf8",
       cwd: args.workingDir ?? process.cwd(),
       env: { ...process.env, ...gateEnv },
     });
     if (v.status === 0) {
-      verifySource = "manifest";
+      verifySource = promisedSource;
       manifestVerified = true;
-      log(`  verify (manifest): PASS`);
+      log(`  verify (${promisedSource}): PASS`);
     } else if (v.status === 1) {
-      warn(`  verify (manifest): FAIL — deliverables missing or stubbed`);
+      warn(`  verify (${promisedSource}): FAIL — deliverables missing or stubbed`);
       warn((v.stdout || v.stderr || "").trim().slice(0, 800));
       mark("failed", { error: "verify-deliverable: FAIL" });
-      return fail(1, "indeterminate", { verifySource: "manifest" });
+      return fail(1, "indeterminate", { verifySource: promisedSource });
     } else {
-      // exit 2 (indeterminate: no manifest markers) or spawn error → scan.
-      warn(`  verify (manifest): indeterminate (rc=${v.status}) — falling back to output scan`);
+      // exit 2 (indeterminate: no promised paths on either side) or spawn error → scan.
+      warn(`  verify (${promisedSource}): indeterminate (rc=${v.status}) — falling back to output scan`);
     }
   }
 

--- a/skills/harness/lib/gauntlet/agent-x-cutover.ts
+++ b/skills/harness/lib/gauntlet/agent-x-cutover.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import { GauntletController } from "./controller.ts";
 import { compileGauntletPlan } from "./compiler.ts";
 import { listCandidateRevisions, listScorecards } from "./store.ts";
-import type { CandidateRevision, EvaluationScorecard, GauntletIntensity, GauntletPlan, GauntletProjection } from "./types.ts";
+import type { CandidateRevision, EvaluationScorecard, GauntletIntensity, GauntletPlan, GauntletProjection, SuccessRequirement } from "./types.ts";
 import {
   RunAlreadyTerminalError, RunKernelCompatibilityFacade, TERMINAL_RUN_STATES, appendEvent, getRun, saveArtifactRef, verifyArtifactRef,
   type ArtifactRef, type CanonicalRunState, type KernelHandle, type LegacyCompatibilityAdapter, type RunProjection, type TargetRef,
@@ -67,6 +67,13 @@ export interface AgentXGauntletInput {
   /** Cost reserved per round: the per-candidate estimate times `candidateStrategy.count`. */
   expectedCostUsd: number;
   intensity?: GauntletIntensity;
+  /** The judge's contract (lib/gauntlet/success-requirements.ts). `compileGauntletPlan`
+   *  runs twice per Gauntlet — once in scripts/dispatch.ts to size the evaluator's budget
+   *  and once here — so the two must receive the SAME array: the scorecard is validated
+   *  against this plan's requirements, and a contract the evaluator never saw would make
+   *  `validateScorecardFile` reject every dimension. Absent = the compiler's own
+   *  `brief-conformance`, which is what every caller passed before v6. */
+  requirements?: SuccessRequirement[];
   producerTarget?: TargetRef;
   executionSnapshot?: Record<string, unknown>;
   /** Legacy audit emitter: `x_run_id_collision` when the Run under `runId` already ended. */
@@ -312,7 +319,7 @@ export function runAgentXGauntlet(input: AgentXGauntletInput): AgentXGauntletRes
   let sessionId: string | null = null;
   try {
     const controller = new GauntletController(input.kernel, { projectId: input.projectId, runId: input.runId, traceId, actor, correlationId });
-    const plan = compileGauntletPlan({ brief: input.brief, intensity: input.intensity ?? "light" });
+    const plan = compileGauntletPlan({ brief: input.brief, intensity: input.intensity ?? "light", requirements: input.requirements });
     const candidateIds = Array.from({ length: plan.candidateStrategy.count }, (_, index) => `can_${index + 1}`);
     const holdout = plan.gauntlets.some(gauntlet => gauntlet.holdout.enabled);
     let gauntlet = controller.begin(plan);

--- a/skills/harness/lib/gauntlet/compiler.ts
+++ b/skills/harness/lib/gauntlet/compiler.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { canonicalJson } from "../run-kernel/canonical-json.ts";
 import type { ExecutionConfig, GauntletIntensity, GauntletPlan, SuccessRequirement } from "./types.ts";
 
-const PROFILES = {
+// Exported for lib/gauntlet/success-requirements.ts: a requirement that declares
+// no `minimumScore` and whose capability declares no `fidelity.threshold` falls
+// back to the intensity profile's score — the same number this compiler puts on
+// its own `brief-conformance` line.
+export const PROFILES = {
   // `light` was USD 5: one candidate, two rounds, a USD 2.50 slice per candidate that the
   // evaluation floor (GAUNTLET_EVALUATION_FLOOR_USD, USD 1.50) would leave the producer USD 1.00
   // of, below what one real candidate costs (USD 1.65 in the first smoke). USD 8 gives each

--- a/skills/harness/lib/gauntlet/evaluator-adapter.ts
+++ b/skills/harness/lib/gauntlet/evaluator-adapter.ts
@@ -81,12 +81,25 @@ export interface DispatchEvaluatorInput {
   spawn?: EvaluatorSpawn;
   /** `--max-budget` of the evaluator subprocess; omitted when absent or zero. */
   budgetUsd?: number;
+  /** `evaluator.max_cost_usd` the chosen capability declares (Squad Protocol v6 §30).
+   *  The spend cap is the LOWER of the two: the plan's slice never buys more than the
+   *  evaluator says one judgement costs, and a declared ceiling never raises the slice. */
+  maxCostUsd?: number | null;
   /** Wall-clock cap of one evaluation; defaults to the plan's `maxDurationSeconds`. */
   timeoutMs?: number;
   signal?: AbortSignal;
   env?: Record<string, string>;
   audit?: (event: string, payload: Record<string, unknown>) => void;
   now?: () => string;
+}
+
+/** The `--max-budget` an evaluation runs under: the plan's slice capped by the
+ *  capability's declared `max_cost_usd`. Null when neither is a positive number. */
+export function evaluatorSpendCapUsd(budgetUsd?: number, maxCostUsd?: number | null): number | null {
+  const slice = Number.isFinite(budgetUsd) && (budgetUsd as number) > 0 ? budgetUsd as number : null;
+  const declared = typeof maxCostUsd === "number" && Number.isFinite(maxCostUsd) && maxCostUsd > 0 ? maxCostUsd : null;
+  if (slice === null) return declared;
+  return declared === null ? slice : Math.min(slice, declared);
 }
 
 const DEFAULT_DISPATCH_SCRIPT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "scripts", "dispatch.ts");
@@ -186,7 +199,8 @@ export function createDispatchEvaluator(input: DispatchEvaluatorInput): AgentXGa
     command.push("--brief-file", briefFile, "--exec", "--project", projectId, "--outputs-root", outputsRoot,
       "--execution-mode=standard", "--max-revisions", "0");
     if (input.runtime) command.push("--runtime", input.runtime);
-    if (Number.isFinite(input.budgetUsd) && (input.budgetUsd as number) > 0) command.push("--max-budget", String(input.budgetUsd));
+    const spendCap = evaluatorSpendCapUsd(input.budgetUsd, input.maxCostUsd);
+    if (spendCap !== null) command.push("--max-budget", String(spendCap));
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries({ ...process.env, ...input.env })) if (value !== undefined) env[key] = value;
     // The effective settings, as the variables the child reads (settings.ts settingsEnvForChild).
@@ -202,8 +216,9 @@ export function createDispatchEvaluator(input: DispatchEvaluatorInput): AgentXGa
     if (input.signal?.aborted) return indeterminate(`aborted while the evaluator ran: ${String(input.signal.reason)}`, detail);
     if (!fs.existsSync(scorecardPath)) {
       if (budgetExhausted(spawned)) {
-        return indeterminate(`budget_exhausted: the evaluator's spend cap of USD ${input.budgetUsd} ended the run before ${SCORECARD_FILE} was written `
-          + `(dispatch exit ${spawned.exitCode ?? "signal"}: ${summarizeStderr(spawned.stderr)})`, { ...detail, reason_code: "budget_exhausted", budget_usd: input.budgetUsd ?? null });
+        return indeterminate(`budget_exhausted: the evaluator's spend cap of USD ${spendCap} ended the run before ${SCORECARD_FILE} was written `
+          + `(dispatch exit ${spawned.exitCode ?? "signal"}: ${summarizeStderr(spawned.stderr)})`,
+          { ...detail, reason_code: "budget_exhausted", budget_usd: spendCap, plan_slice_usd: input.budgetUsd ?? null, max_cost_usd: input.maxCostUsd ?? null });
       }
       return indeterminate(`${SCORECARD_FILE} not found at ${scorecardPath} (dispatch exit ${spawned.exitCode ?? "signal"}: ${summarizeStderr(spawned.stderr)})`, detail);
     }

--- a/skills/harness/lib/gauntlet/evaluator-selection.ts
+++ b/skills/harness/lib/gauntlet/evaluator-selection.ts
@@ -13,10 +13,18 @@
 //      an error the caller reports before any producer runs.
 //   2. Without the variable, the installed registry is searched for a squad that
 //      declares the capability `quality.specification_conformance` and is
-//      independent of the producer; the first slug in alphabetical order wins.
-//      The rule is the exact capability id, not a domain: the `qa` domain squads
-//      of the library judge datasets, code or landing pages, not an arbitrary
-//      deliverable against its brief.
+//      independent of the producer. The rule is the exact capability id, not a
+//      domain: the `qa` domain squads of the library judge datasets, code or
+//      landing pages, not an arbitrary deliverable against its brief. Among the
+//      squads that qualify the winner is RANKED, not alphabetical (Squad
+//      Protocol v6 §30): fidelity first (`validated` > `experimental` >
+//      `drifted`, and `retired` is not a candidate at all), then
+//      `evaluator.max_cost_usd` ascending — a capability with no `evaluator`
+//      block declares no cost, so it sorts behind every one that does — and the
+//      slug last, which is the only key a library that declares neither has, so
+//      today's alphabetical answer is what a library with no v6 metadata still
+//      gets. The chosen row's keys travel on the selection so the caller and
+//      `nrv doctor` can say WHY, instead of "the first one".
 //   3. Otherwise judge-x (lib/gauntlet/judge-x.ts), for any producer: its
 //      identity `{ kind: "agent-x", slug: "judge-x" }` is independent of the
 //      agent-x producer, of every squad and of every business.
@@ -38,9 +46,42 @@ import { JUDGE_X_TARGET } from "./judge-x.ts";
 export const GAUNTLET_EVALUATOR_ENV = "NIRVANA_GAUNTLET_EVALUATOR";
 export const CONFORMANCE_CAPABILITY = "quality.specification_conformance";
 
+/** `fidelity.status` of a capability; the registry defaults an absent block to `experimental`. */
+export type EvaluatorFidelity = "validated" | "experimental" | "drifted" | "retired";
+
+/** The v6 evaluator contract of one conformance capability (Squad Protocol v6 §30). */
+export interface InstalledEvaluator {
+  capabilityId: string;
+  fidelity: EvaluatorFidelity;
+  /** `evaluator.max_cost_usd`; null when the capability declares no `evaluator` block. */
+  maxCostUsd: number | null;
+}
+
 export interface InstalledSquad {
   slug: string;
   capabilities: string[];
+  /** Evaluator contracts this squad declares, by capability. Absent = nothing declared. */
+  evaluators?: InstalledEvaluator[];
+}
+
+/** Why one squad won the registry rung. */
+export interface EvaluatorRanking {
+  slug: string;
+  capabilityId: string;
+  fidelity: EvaluatorFidelity;
+  maxCostUsd: number | null;
+  /** Independent candidates that declared the capability, `retired` excluded. */
+  considered: number;
+  /** Candidates dropped because their contract is `retired`. */
+  retired: number;
+}
+
+const FIDELITY_ORDER: Record<EvaluatorFidelity, number> = { validated: 0, experimental: 1, drifted: 2, retired: 3 };
+
+/** The evaluator contract a squad declares for a capability; nothing declared is `experimental` with no cost ceiling. */
+export function evaluatorContractOf(squad: InstalledSquad, capabilityId: string): InstalledEvaluator {
+  const found = squad.evaluators?.find(entry => entry.capabilityId === capabilityId);
+  return found ?? { capabilityId, fidelity: "experimental", maxCostUsd: null };
 }
 
 export type EvaluatorSpec =
@@ -64,7 +105,7 @@ export interface EvaluatorFallback {
 
 export type EvaluatorSelection =
   | { kind: "heuristic"; source: "env"; fallbacks: EvaluatorFallback[] }
-  | { kind: "dispatch"; target: DispatchEvaluatorTarget; source: EvaluatorSelectionSource; fallbacks: EvaluatorFallback[] }
+  | { kind: "dispatch"; target: DispatchEvaluatorTarget; source: EvaluatorSelectionSource; fallbacks: EvaluatorFallback[]; ranking?: EvaluatorRanking }
   | { kind: "unavailable"; reason: string; fallbacks: EvaluatorFallback[] };
 
 /** Parses NIRVANA_GAUNTLET_EVALUATOR; throws on a value it cannot read. */
@@ -82,13 +123,74 @@ export function defaultSquadsRegistryPath(): string {
   return paths.SQUADS_REGISTRY_PATH as string;
 }
 
-/** Installed squads and their capability ids from the registry `nrv index` maintains; a missing or unreadable registry is an empty library. */
+type RegistryCapability = { squad?: unknown; fidelity?: { status?: unknown }; fidelity_status?: unknown; evaluator?: { max_cost_usd?: unknown } };
+
+function fidelityOf(entry: RegistryCapability): EvaluatorFidelity {
+  const raw = entry?.fidelity?.status ?? entry?.fidelity_status;
+  return typeof raw === "string" && raw in FIDELITY_ORDER ? raw as EvaluatorFidelity : "experimental";
+}
+
+/** Installed squads, their capability ids and the evaluator contract each conformance
+ *  capability declares, from the registry `nrv index` maintains. A missing or unreadable
+ *  registry is an empty library; a registry from before the v6 passthrough simply carries
+ *  no `evaluator`/`fidelity`, which reads as `experimental` with no declared ceiling. */
 export function loadInstalledSquads(registryPath = defaultSquadsRegistryPath()): InstalledSquad[] {
-  let registry: { squads?: Record<string, { capabilities?: unknown }> };
+  let registry: { squads?: Record<string, { capabilities?: unknown }>; capabilities?: Record<string, RegistryCapability[]> };
   try { registry = JSON.parse(fs.readFileSync(registryPath, "utf8")); } catch { return []; }
+  const contracts = new Map<string, InstalledEvaluator[]>();
+  for (const [capabilityId, providers] of Object.entries(registry.capabilities ?? {})) {
+    for (const provider of Array.isArray(providers) ? providers : []) {
+      if (typeof provider?.squad !== "string") continue;
+      const maxCost = provider?.evaluator?.max_cost_usd;
+      contracts.set(provider.squad, [...(contracts.get(provider.squad) ?? []), {
+        capabilityId, fidelity: fidelityOf(provider),
+        maxCostUsd: typeof maxCost === "number" && Number.isFinite(maxCost) ? maxCost : null,
+      }]);
+    }
+  }
   return Object.entries(registry.squads ?? {})
-    .map(([slug, entry]) => ({ slug, capabilities: Array.isArray(entry?.capabilities) ? entry.capabilities.filter((id): id is string => typeof id === "string") : [] }))
+    .map(([slug, entry]) => {
+      const evaluators = contracts.get(slug);
+      return {
+        slug,
+        capabilities: Array.isArray(entry?.capabilities) ? entry.capabilities.filter((id): id is string => typeof id === "string") : [],
+        ...(evaluators?.length ? { evaluators } : {}),
+      };
+    })
     .sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
+ * The independent squads that can judge, best first: fidelity, then declared cost
+ * ceiling ascending (undeclared last), then slug. `retired` is not a candidate.
+ */
+export function rankConformanceEvaluators(installed: InstalledSquad[], producer: TargetRef): { ranked: EvaluatorRanking[]; retired: number } {
+  let retired = 0;
+  const candidates: Array<{ squad: InstalledSquad; contract: InstalledEvaluator }> = [];
+  for (const squad of installed) {
+    if (!squad.capabilities.includes(CONFORMANCE_CAPABILITY)) continue;
+    if (!targetsAreIndependent(producer, squadTarget(squad.slug, CONFORMANCE_CAPABILITY))) continue;
+    const contract = evaluatorContractOf(squad, CONFORMANCE_CAPABILITY);
+    if (contract.fidelity === "retired") { retired += 1; continue; }
+    candidates.push({ squad, contract });
+  }
+  candidates.sort((left, right) =>
+    FIDELITY_ORDER[left.contract.fidelity] - FIDELITY_ORDER[right.contract.fidelity]
+    || (left.contract.maxCostUsd ?? Infinity) - (right.contract.maxCostUsd ?? Infinity)
+    || left.squad.slug.localeCompare(right.squad.slug));
+  const ranked = candidates.map(({ squad, contract }) => ({
+    slug: squad.slug, capabilityId: CONFORMANCE_CAPABILITY, fidelity: contract.fidelity,
+    maxCostUsd: contract.maxCostUsd, considered: candidates.length, retired,
+  }));
+  return { ranked, retired };
+}
+
+/** One line saying why the ranking chose this squad — what `nrv doctor` prints. */
+export function describeRanking(ranking: EvaluatorRanking): string {
+  const cost = ranking.maxCostUsd === null ? "no declared max_cost_usd" : `max_cost_usd USD ${ranking.maxCostUsd}`;
+  const others = ranking.considered - 1;
+  return `fidelity ${ranking.fidelity}, ${cost}${others > 0 ? `, ahead of ${others} other candidate(s)` : ""}`
+    + `${ranking.retired > 0 ? `; ${ranking.retired} retired excluded` : ""}`;
 }
 
 const AGENT_X: DispatchEvaluatorTarget = { kind: "agent-x", slug: "agent-x" };
@@ -128,9 +230,9 @@ export function selectGauntletEvaluator(input: { envValue?: string; producer: Ta
     return { kind: "dispatch", target: requireIndependent(squadTarget(spec.slug, capabilityId), producer), source: "env", fallbacks: [] };
   }
   const fallbacks: EvaluatorFallback[] = [{ from: "env", reason: "unset" }];
-  const conformant = installed.find(entry => entry.capabilities.includes(CONFORMANCE_CAPABILITY)
-    && targetsAreIndependent(producer, squadTarget(entry.slug, CONFORMANCE_CAPABILITY)));
-  if (conformant) return { kind: "dispatch", target: squadTarget(conformant.slug, CONFORMANCE_CAPABILITY), source: "registry", fallbacks };
+  const { ranked } = rankConformanceEvaluators(installed, producer);
+  const winner = ranked[0];
+  if (winner) return { kind: "dispatch", target: squadTarget(winner.slug, winner.capabilityId), source: "registry", fallbacks, ranking: winner };
   fallbacks.push({ from: "registry", reason: "registry_no_match" });
   if (judge.available) return { kind: "dispatch", target: JUDGE_X, source: "default", fallbacks };
   fallbacks.push({ from: "judge-x", reason: "judge_unavailable", detail: judge.reason });

--- a/skills/harness/lib/gauntlet/success-requirements.ts
+++ b/skills/harness/lib/gauntlet/success-requirements.ts
@@ -1,0 +1,198 @@
+// success-requirements.ts — the judge's contract, built from what the target declared.
+//
+// `compiler.ts` has always been able to compile N requirements into N gauntlets;
+// it never received more than one, because no caller passed `requirements` and
+// the compiler's own fallback is the single `brief-conformance` line. Every
+// Gauntlet in the system therefore judged the same one question ("does this
+// satisfy the brief?") with a threshold taken from the intensity profile, while
+// the manifests carried `capabilities[].acceptance[]` and
+// `capabilities[].fidelity.threshold` that nothing read.
+//
+// This module turns a declared acceptance contract into `SuccessRequirement[]`.
+// `brief-conformance` always comes first — the brief is the contract even when a
+// capability adds its own — and the rest is the first rung of this ladder that
+// answers (Squad Protocol v6 §29):
+//
+//   acceptance                 `capabilities[].acceptance[]`, the declared contract.
+//   success_indicators         the invoked workflow's `success_indicators[]`, read
+//                              through the v6 reader so every legacy dialect
+//                              normalizes to the same list.
+//   task_acceptance_criteria   the `## Acceptance Criteria` section of the invoked
+//                              task, the scaffold `task.md.tmpl` has always written.
+//   brief-conformance          nothing declared: exactly today's single requirement.
+//
+// A derived rung (the last two) is non-blocking: an indicator a human wrote as
+// prose was never promised as a gate, and turning it into one would withhold
+// deliveries nobody agreed to withhold. Only `acceptance[]` blocks by default,
+// and only because §29 says a declared criterion blocks unless the author says
+// otherwise.
+//
+// Ids are namespaced (`acceptance.<id>`, `indicator.<n>`, `criterion.<n>`) so a
+// capability that literally declares `brief-conformance` cannot shadow the brief,
+// and so a scorecard dimension names which rung it came from.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { normalizeWorkflow, readWorkflow, resolveWorkflowRef } from "../../../squads/lib/workflow-reader.ts";
+import { PROFILES } from "./compiler.ts";
+import type { GauntletIntensity, SuccessRequirement } from "./types.ts";
+
+/** The requirement every Gauntlet carries, whatever else the target declared. */
+export const BRIEF_CONFORMANCE_ID = "brief-conformance";
+
+/** The capability that judges a requirement — the evaluator's contract id. */
+export const CONFORMANCE_CAPABILITY = "quality.specification_conformance";
+
+/** Squad Protocol v6 §29: at most twelve requirements reach the judge, `brief-conformance` included. */
+export const REQUIREMENTS_MAX = 12;
+
+/** Which rung of the ladder answered. */
+export type RequirementsOrigin = "brief-conformance" | "acceptance" | "success_indicators" | "task_acceptance_criteria";
+
+/** `gauntlet.requirements_source`: `brief` keeps the compiler's own single requirement. */
+export type RequirementsSource = "brief" | "capability";
+
+export interface AcceptanceEntry {
+  id: string;
+  description: string;
+  blocking?: boolean;
+  minimumScore?: number;
+}
+
+/** The slice of a capability record (manifest or registry) this module reads. */
+export interface CapabilityContract {
+  id?: string;
+  acceptance?: AcceptanceEntry[];
+  fidelity?: { threshold?: number };
+  invoke?: { type?: string; ref?: string };
+}
+
+export interface RequirementsForInput {
+  /** Root of the squad, for the workflow and task rungs; absent skips both. */
+  squadDir?: string | null;
+  capability?: CapabilityContract | null;
+  intensity?: GauntletIntensity;
+}
+
+export interface RequirementsResult {
+  requirements: SuccessRequirement[];
+  origin: RequirementsOrigin;
+  /** Entries the ceiling of `REQUIREMENTS_MAX` dropped. */
+  truncated: number;
+}
+
+/** The intensity profile's passing score — the floor a requirement inherits when nothing declares one. */
+export function profileScore(intensity: GauntletIntensity = "balanced"): number {
+  return PROFILES[intensity].score;
+}
+
+/** The single requirement today's compiler builds on its own. */
+export function briefConformance(intensity: GauntletIntensity = "balanced"): SuccessRequirement {
+  return {
+    id: BRIEF_CONFORMANCE_ID,
+    description: "The candidate satisfies the explicit brief",
+    capability: CONFORMANCE_CAPABILITY,
+    blocking: true,
+    minimumScore: profileScore(intensity),
+  };
+}
+
+/** A declared acceptance entry blocks unless the author said otherwise (§29); a derived one never does. */
+function requirement(id: string, description: string, blocking: boolean, minimumScore: number): SuccessRequirement {
+  return { id, description, capability: CONFORMANCE_CAPABILITY, blocking, minimumScore };
+}
+
+function trimmedLines(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values.map(value => String(value ?? "").trim()).filter(Boolean);
+}
+
+/** `## Acceptance Criteria` of a task file: its `-`/`*` bullets, up to the next heading. */
+export function acceptanceCriteriaOf(markdown: string): string[] {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const heading = lines.findIndex(line => /^#{1,6}\s+acceptance\s+criteria\s*$/i.test(line.trim()));
+  if (heading === -1) return [];
+  const out: string[] = [];
+  for (let index = heading + 1; index < lines.length; index++) {
+    const line = lines[index];
+    if (/^#{1,6}\s/.test(line)) break;
+    const bullet = /^\s*[-*]\s+(.*\S)\s*$/.exec(line);
+    if (bullet) out.push(bullet[1].trim());
+  }
+  return out;
+}
+
+/** The invoked workflow's `success_indicators[]`, through the v6 reader so every dialect yields one list. */
+function workflowIndicators(squadDir: string, ref: string): string[] {
+  try {
+    const file = resolveWorkflowRef(squadDir, ref);
+    if (!file) return [];
+    const raw = readWorkflow(file);
+    if (!raw.doc) return [];
+    return trimmedLines(normalizeWorkflow(raw.doc, { stem: raw.stem }).canonical.success_indicators);
+  } catch { return []; }
+}
+
+/** The invoked task's `## Acceptance Criteria`. */
+function taskCriteria(squadDir: string, ref: string): string[] {
+  for (const base of [ref, path.join("tasks", ref)]) {
+    for (const ext of ["", ".md"]) {
+      const file = path.join(squadDir, base + ext);
+      try {
+        if (!fs.statSync(file).isFile()) continue;
+        const found = acceptanceCriteriaOf(fs.readFileSync(file, "utf8"));
+        if (found.length) return found;
+      } catch { /* next candidate */ }
+    }
+  }
+  return [];
+}
+
+/**
+ * The judge's contract for one capability: `brief-conformance` plus whatever the
+ * capability declared, capped at `REQUIREMENTS_MAX` and scored against
+ * `acceptance[].minimumScore`, then `fidelity.threshold`, then the profile.
+ */
+export function requirementsFor(input: RequirementsForInput): RequirementsResult {
+  const intensity = input.intensity ?? "balanced";
+  const capability = input.capability ?? null;
+  const floor = capability?.fidelity?.threshold ?? profileScore(intensity);
+  const head = briefConformance(intensity);
+  const room = REQUIREMENTS_MAX - 1;
+
+  const declared = Array.isArray(capability?.acceptance) ? capability!.acceptance!.filter(entry => entry?.id && entry?.description) : [];
+  if (declared.length) {
+    const kept = declared.slice(0, room);
+    return {
+      requirements: [head, ...kept.map(entry => requirement(`acceptance.${entry.id}`, entry.description,
+        entry.blocking ?? true, entry.minimumScore ?? floor))],
+      origin: "acceptance",
+      truncated: declared.length - kept.length,
+    };
+  }
+
+  const squadDir = input.squadDir ?? null;
+  const ref = capability?.invoke?.ref ?? "";
+  const kind = capability?.invoke?.type ?? "";
+  if (squadDir && ref) {
+    const indicators = kind === "task" ? [] : workflowIndicators(squadDir, ref);
+    if (indicators.length) {
+      const kept = indicators.slice(0, room);
+      return {
+        requirements: [head, ...kept.map((text, index) => requirement(`indicator.${index + 1}`, text, false, floor))],
+        origin: "success_indicators",
+        truncated: indicators.length - kept.length,
+      };
+    }
+    const criteria = kind === "workflow" ? [] : taskCriteria(squadDir, ref);
+    if (criteria.length) {
+      const kept = criteria.slice(0, room);
+      return {
+        requirements: [head, ...kept.map((text, index) => requirement(`criterion.${index + 1}`, text, false, floor))],
+        origin: "task_acceptance_criteria",
+        truncated: criteria.length - kept.length,
+      };
+    }
+  }
+  return { requirements: [head], origin: "brief-conformance", truncated: 0 };
+}

--- a/skills/harness/lib/glance/views/settings-panel.js
+++ b/skills/harness/lib/glance/views/settings-panel.js
@@ -18,7 +18,7 @@
 export const GROUP_LABELS = Object.freeze({
   multi_target: 'Multi-target', gauntlet: 'Gauntlet', execution: 'Execução', glance: 'Glance', runtime: 'Runtime',
   routing: 'Roteamento', supervisor: 'Supervisor', updates: 'Atualizações', budget: 'Orçamento',
-  baselines: 'Baselines de custo', quality_gate: 'Quality gate',
+  baselines: 'Baselines de custo', quality_gate: 'Quality gate', delivery: 'Entrega',
 });
 
 export const SOURCE_LABELS = Object.freeze({

--- a/skills/harness/lib/rubric-selector.ts
+++ b/skills/harness/lib/rubric-selector.ts
@@ -25,6 +25,16 @@ export interface RubricMeta {
   target_model: "haiku" | "sonnet" | "opus" | "inherit";
   pass_threshold: number;
   applies_to_produces: string[];
+  /**
+   * PT/EN synonyms of the slugs above. The library declares ~3.024 distinct
+   * `produces` slugs and the rubrics name ~45 of them, half in English and half
+   * in Portuguese: `landing-page` and `pagina-de-vendas` are the same artifact
+   * and used to select different rubrics (in practice, none — the fallback).
+   * An alias matches exactly like an entry of `applies_to_produces`; it exists
+   * so a rubric can accept both spellings without pretending the second one is
+   * a different deliverable.
+   */
+  aliases: string[];
   description: string;
   body: string;
   version: string;
@@ -105,6 +115,7 @@ function loadAll(): RubricMeta[] {
     const applies = Array.isArray(meta.applies_to_produces)
       ? (meta.applies_to_produces as string[])
       : [];
+    const aliases = Array.isArray(meta.aliases) ? (meta.aliases as string[]) : [];
     out.push({
       name: String(meta.name ?? basename(f, ".md")),
       display_name: String(meta.display_name ?? meta.name ?? f),
@@ -112,6 +123,7 @@ function loadAll(): RubricMeta[] {
       target_model: ((meta.target_model as string) ?? "inherit") as RubricMeta["target_model"],
       pass_threshold: Number(meta.pass_threshold ?? 70),
       applies_to_produces: applies,
+      aliases,
       description: String(meta.description ?? ""),
       body,
       version: String(meta.version ?? "1.0.0"),
@@ -152,12 +164,11 @@ export function selectRubricsForProduces(
     };
   }
   const matched = new Map<string, RubricMeta>();
+  const matchedAlias: string[] = [];
   for (const r of all) {
     for (const slug of produces) {
-      if (r.applies_to_produces.includes(slug)) {
-        matched.set(r.name, r);
-        break;
-      }
+      if (r.applies_to_produces.includes(slug)) { matched.set(r.name, r); break; }
+      if (r.aliases.includes(slug)) { matched.set(r.name, r); matchedAlias.push(`${slug}→${r.name}`); break; }
     }
   }
   if (matched.size > 0) {
@@ -169,7 +180,8 @@ export function selectRubricsForProduces(
     return {
       rubrics: [...matched.values()],
       fallback_used: false,
-      reason: `matched ${matched.size} rubric(s) on produces: ${[...matched.keys()].join(", ")}`,
+      reason: `matched ${matched.size} rubric(s) on produces: ${[...matched.keys()].join(", ")}`
+        + (matchedAlias.length ? ` (by alias: ${matchedAlias.join(", ")})` : ""),
     };
   }
   // No match — best-effort fallback.

--- a/skills/harness/rubrics/code.md
+++ b/skills/harness/rubrics/code.md
@@ -12,6 +12,18 @@ applies_to_produces:
   - api-endpoint
   - migration
   - refactor
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - codigo
+  - código
+  - script-python
+  - biblioteca
+  - componente
+  - patch
+  - cli
+  - test-suite
+  - sdk
 description: |
   Aplica-se a artefatos de código. Falhas pegáveis sem rodar: typos,
   imports faltando, security smells, padrões anti-canônicos.

--- a/skills/harness/rubrics/data-research.md
+++ b/skills/harness/rubrics/data-research.md
@@ -12,6 +12,19 @@ applies_to_produces:
   - data-analysis
   - benchmark
   - audit-report
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - pesquisa
+  - pesquisa-de-mercado
+  - analise-de-dados
+  - análise-de-dados
+  - analise-competitiva
+  - análise-competitiva
+  - relatorio-de-pesquisa
+  - auditoria
+  - research
+  - planilha
 description: |
   Pesquisa rigorosa: fontes verificáveis, sem fabricação. Opus por padrão
   porque hallucinations são catastróficas aqui.

--- a/skills/harness/rubrics/design.md
+++ b/skills/harness/rubrics/design.md
@@ -11,6 +11,19 @@ applies_to_produces:
   - design-system
   - ui-component
   - figma-frame
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - design
+  - pagina-de-vendas
+  - página-de-vendas
+  - landing
+  - wireframe
+  - prototipo
+  - protótipo
+  - identidade-visual
+  - brand-kit
+  - site
 description: |
   Avalia design (assumindo HTML/CSS gerado ou descrição estruturada do
   Figma). WCAG 2.2 AA é hard gate de acessibilidade.

--- a/skills/harness/rubrics/image.md
+++ b/skills/harness/rubrics/image.md
@@ -11,6 +11,18 @@ applies_to_produces:
   - banner
   - logo
   - infographic
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - imagem
+  - ilustracao
+  - ilustração
+  - logotipo
+  - capa
+  - thumbnail
+  - poster
+  - infografico
+  - infográfico
 description: |
   Avalia imagens descritivamente (assumindo que o judge pode ver a imagem
   via base64 ou recebe descrição estruturada do gerador). Foca em

--- a/skills/harness/rubrics/juridical.md
+++ b/skills/harness/rubrics/juridical.md
@@ -12,6 +12,16 @@ applies_to_produces:
   - jurisprudencia
   - juridical-research
   - analise-contratual
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - parecer-juridico
+  - parecer-jurídico
+  - petição
+  - peça-processual
+  - contract
+  - legal-opinion
+  - legal-research
 description: |
   Threshold alto (80) porque erros jurídicos têm custo alto. Opus por padrão.
   Cita legislação e jurisprudência só quando verificável; sem alucinar

--- a/skills/harness/rubrics/prose-longform.md
+++ b/skills/harness/rubrics/prose-longform.md
@@ -12,6 +12,18 @@ applies_to_produces:
   - dossie
   - market-research-report
   - board-memo
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - livro
+  - relatorio
+  - relatório
+  - ebook
+  - dossier
+  - whitepaper
+  - long-form-report
+  - memorando
+  - report
 description: |
   Critérios de qualidade para deliverables de prosa longa (≥ 1500 palavras).
   Foco em estrutura, coerência argumentativa, precisão factual e ausência

--- a/skills/harness/rubrics/prose-shortform.md
+++ b/skills/harness/rubrics/prose-shortform.md
@@ -13,6 +13,20 @@ applies_to_produces:
   - newsletter
   - copy
   - caption
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - post
+  - post-instagram
+  - post-blog
+  - artigo
+  - legenda
+  - copy-de-anuncio
+  - social-post
+  - ad-copy
+  - email
+  - email-marketing
+  - roteiro-de-post
 description: |
   Curto, denso, sem gordura. Critérios refletem que o falhas mais comuns
   em prose curta são genericidade, hook fraco e CTA ausente/genérico.

--- a/skills/harness/rubrics/video.md
+++ b/skills/harness/rubrics/video.md
@@ -10,6 +10,15 @@ applies_to_produces:
   - reel
   - explainer
   - ad-video
+# PT/EN synonyms of the slugs above (rubric-selector.ts): the same artifact
+# spelled the other way selects this rubric instead of the generic fallback.
+aliases:
+  - vídeo
+  - reels
+  - anuncio-em-video
+  - roteiro-de-video
+  - motion-graphic
+  - shorts
 description: |
   Avalia vídeo (assumindo que o judge recebe descrição estruturada ou
   storyboard + frames-chave). Hook nos primeiros 3s é decisivo.

--- a/skills/harness/scripts/dispatch.ts
+++ b/skills/harness/scripts/dispatch.ts
@@ -54,7 +54,7 @@ import { describeSettingSource, resolveSetting, settingsEnvForChild } from "../.
 import { planRouteWithFallback, resolveDispatchPlan, runAgentX, type DispatchPlan } from "../lib/dispatch-cascade.ts";
 import { runSquadHeadless } from "../lib/squad-exec.ts";
 import { parseSquadTarget, resolveSquadCapability } from "../lib/capability-resolver.ts";
-import { runDelivery, deliverAfterRuntimeError, gateableFiles, runGateOnce, type DeliveryArgs, type DeliveryResult, type RuntimeErrorOutcome } from "../lib/delivery-pipeline.ts";
+import { runDelivery, deliverAfterRuntimeError, gateableFiles, producesForRubric, runGateOnce, type DeliveryArgs, type DeliveryResult, type RuntimeErrorOutcome } from "../lib/delivery-pipeline.ts";
 import { runBusinessPostGate } from "../lib/business-post-gate.ts";
 import { parseExecutionOptions } from "../lib/gauntlet/execution-options.ts";
 import { decideBusinessCanary, runBusinessCanaryWithRollback } from "../lib/gauntlet/business-canary.ts";
@@ -66,8 +66,10 @@ import {
 import { EVALUATION_REQUEST_FILE, SCORECARD_FILE, type EvaluationRequest } from "../lib/gauntlet/evaluation-contract.ts";
 import { createDispatchEvaluator, describeTarget } from "../lib/gauntlet/evaluator-adapter.ts";
 import { CONFORMANCE_CAPABILITY, GAUNTLET_EVALUATOR_ENV, loadInstalledSquads, selectGauntletEvaluator } from "../lib/gauntlet/evaluator-selection.ts";
+import { REQUIREMENTS_MAX, briefConformance, profileScore, requirementsFor, type CapabilityContract } from "../lib/gauntlet/success-requirements.ts";
+import { readAcceptance } from "../../businesses/lib/acceptance.ts";
 import { JUDGE_X_TARGET, judgeXAvailability, judgeXOutcome, runJudgeX } from "../lib/gauntlet/judge-x.ts";
-import type { GauntletPlan } from "../lib/gauntlet/types.ts";
+import type { GauntletPlan, SuccessRequirement } from "../lib/gauntlet/types.ts";
 import { RunAlreadyTerminalError, createHarnessLegacyAdapter, openKernel, type TargetRef } from "../lib/run-kernel/index.ts";
 import { inertStandardPublication, openStandardPublication } from "../lib/run-kernel/standard-publication.ts";
 import { freezeExecutionSnapshot } from "../lib/runtime-snapshot.ts";
@@ -798,6 +800,76 @@ function heuristicGauntletEvaluator(env: Record<string, string>): AgentXGauntlet
   };
 }
 
+// ── The judge's contract ────────────────────────────────────────────────────
+//
+// `compileGauntletPlan` runs TWICE per Gauntlet — here, to size the evaluator's
+// budget, and inside `runAgentXGauntlet` — and the scorecard is validated against
+// the plan the second one built. The two must therefore receive the SAME array,
+// or `validateScorecardFile` rejects every dimension as "not in the success
+// contract". `gauntletRequirements()` is computed once per canary and handed to
+// both; the tests pin the resulting `planId` on both sides.
+//
+// `gauntlet.requirements_source` gates where the array comes from:
+//   brief       (default) exactly the single `brief-conformance` the compiler
+//               builds on its own — the same array, so the same plan id.
+//   capability  `brief-conformance` + the target's declared acceptance contract
+//               (lib/gauntlet/success-requirements.ts), with the workflow's
+//               `success_indicators` and the invoked task's `## Acceptance
+//               Criteria` as the fallbacks below it.
+const requirementsSourceSetting = resolveSetting("gauntlet.requirements_source");
+
+/** The capability record the registry kept for `<slug>:<capabilityId>`, and the squad's directory. */
+function squadCapabilityRecord(slug: string, capabilityId: string): { squadDir: string | null; capability: (CapabilityContract & { produces?: string[] }) | null } {
+  try {
+    const registry = require("../lib/registry-loader.js").loadSquads().registry;
+    const manifestPath = registry?.squads?.[slug]?.manifest_path;
+    const squadDir = typeof manifestPath === "string" && manifestPath ? path.dirname(manifestPath) : null;
+    const providers = registry?.capabilities?.[capabilityId];
+    const capability = (Array.isArray(providers) ? providers : []).find((entry: any) => entry?.squad === slug) ?? null;
+    return { squadDir, capability: capability ? { id: capabilityId, ...capability } : null };
+  } catch { return { squadDir: null, capability: null }; }
+}
+
+/** The judge's contract for one dispatch, audited so the scorecard's dimensions can be traced to what declared them. */
+function gauntletRequirements(projectId: string, producer: TargetRef,
+  contract: { squadDir?: string | null; capability?: CapabilityContract | null; requirements?: SuccessRequirement[] } = {}): SuccessRequirement[] {
+  const intensity = executionOptions.intensity;
+  if (requirementsSourceSetting.value !== "capability") return [briefConformance(intensity)];
+  // A business declares its contract per role (businesses/lib/acceptance.ts), so its
+  // requirements arrive already built; a squad's come from the resolved capability.
+  const resolved = contract.requirements?.length
+    ? { requirements: [briefConformance(intensity), ...contract.requirements].slice(0, REQUIREMENTS_MAX), origin: "acceptance" as const,
+        truncated: Math.max(0, contract.requirements.length + 1 - REQUIREMENTS_MAX) }
+    : requirementsFor({ squadDir: contract.squadDir, capability: contract.capability, intensity });
+  emit("x_gauntlet_requirements_resolved", { trace_id: projectId, project_id: projectId, producer: describeTarget(producer),
+    origin: resolved.origin, requirements: resolved.requirements.map(item => item.id), truncated: resolved.truncated,
+    source: describeSettingSource(requirementsSourceSetting) });
+  return resolved.requirements;
+}
+
+/** The business's directory and `produces[]`, from the registry `nrv index` maintains. */
+function businessRecord(slug: string): { bizDir: string | null; produces: string[] } {
+  try {
+    const registry = require("../lib/registry-loader.js").loadBusinesses().registry;
+    const entry = registry?.businesses?.[slug];
+    const manifestPath = entry?.manifest_path;
+    return {
+      bizDir: typeof manifestPath === "string" && manifestPath ? path.dirname(manifestPath) : null,
+      produces: Array.isArray(entry?.produces) ? entry.produces : [],
+    };
+  } catch { return { bizDir: null, produces: [] }; }
+}
+
+/** `produces[]` the judge's rubric selector receives, behind `delivery.produces_to_rubric`
+ *  (lib/delivery-pipeline.ts owns the rule; here we only read the target's declaration). */
+function producesForDelivery(read: () => string[]): string[] | undefined {
+  const enabled = resolveSetting("delivery.produces_to_rubric").value === true;
+  let declared: string[] = [];
+  try { declared = read(); } catch { declared = []; }
+  const slugs = producesForRubric(declared, enabled);
+  return slugs.length ? slugs : undefined;
+}
+
 // Gauntlet evaluator and round budget shared by the three canaries. The target comes from
 // lib/gauntlet/evaluator-selection.ts (NIRVANA_GAUNTLET_EVALUATOR, else an installed squad
 // declaring quality.specification_conformance, else judge-x for any producer); every fallback
@@ -888,6 +960,10 @@ interface DeliverOpts {
   pid: string; slugOrNull: string | null; targetKind: "business" | "squad" | "agent-x";
   rt: Runtime; oroot: string; projDir: string; projectRoot: string;
   sessionId: string | null; withManifest: boolean;
+  /** `produces[]` of the dispatched target, for the judge's rubric selector; see producesForRubric. */
+  produces?: string[];
+  /** The business's roles promise files through `acceptance[]` — a completeness proof like a manifest. */
+  acceptancePromisesPaths?: boolean;
   afterGate?: Parameters<typeof runDelivery>[0]["afterGate"];
   onSession?: (sid: string) => void;
 }
@@ -900,6 +976,8 @@ function deliveryArgs(opts: DeliverOpts): DeliveryArgs {
     pid: opts.pid,
     slug: opts.slugOrNull,
     targetKind: opts.targetKind,
+    produces: opts.produces,
+    acceptancePromisesPaths: opts.acceptancePromisesPaths,
     runtime: opts.rt,
     projectDir: opts.projDir,
     projectRoot: opts.projectRoot,
@@ -1026,11 +1104,17 @@ if (pendingCascade?.kind === "squad-only") {
   }).capabilityId;
   const capabilityById = new Map(squads.map(sq => [sq, capabilityFor(sq)]));
   const capabilityId = capabilityById.get(squads[0])!;
+  // The capability the resolver chose is what declares the acceptance contract the judge
+  // reads and the `produces` slugs its rubric selector matches on.
+  const squadContract = squadCapabilityRecord(squads[0], capabilityId);
+  const squadProduces = producesForDelivery(() => squadContract.capability?.produces ?? []);
   if (shouldRunSquadGauntlet({ squadCount: squads.length, wantExec, resolvedMode: executionOptions.resolvedMode })) {
     const squad = squads[0];
     const producerTarget = { kind: "squad" as const, slug: squad, capabilityId };
     const canonicalRunId = canonicalRunIdFor(pid, runIdFlag);
-    const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: producerTarget, plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity }),
+    const requirements = gauntletRequirements(pid, producerTarget, squadContract);
+    const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: producerTarget,
+      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }),
       projectRoot, rt, kernelPath: canaryKernelPath(projectRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
     const kernel = openKernel(canaryKernelPath(projectRoot));
     const legacy = runLedger.openLedger();
@@ -1050,14 +1134,14 @@ if (pendingCascade?.kind === "squad-only") {
       const result = runAgentXGauntlet({
         kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: projDir }), producerTarget,
         projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot, outputsRoot: oroot,
-        intensity: executionOptions.intensity, executionSnapshot, audit: emit,
+        intensity: executionOptions.intensity, requirements, executionSnapshot, audit: emit,
         expectedCostUsd: budget.roundBudgetUsd,
         executeCandidate: candidateRoot => produce(candidateRoot, brief),
         reviseCandidate: request => produce(request.candidateRoot, writeRevisionBrief(brief, request).text),
         evaluator,
         finalGate({ sessionId }) {
           finalDelivery = runDelivery({ ...deliveryArgs({ pid, slugOrNull: null, targetKind: "squad", rt, oroot,
-            projDir, projectRoot, sessionId, withManifest: false }), ledger: null, maxRevisions: 0 });
+            projDir, projectRoot, sessionId, withManifest: false, produces: squadProduces }), ledger: null, maxRevisions: 0 });
           return { exitCode: finalDelivery.exitCode, gateOutcome: finalDelivery.gateOutcome };
         },
       });
@@ -1120,7 +1204,7 @@ if (pendingCascade?.kind === "squad-only") {
 
   const squadDeliverOpts = {
     pid, slugOrNull: null, targetKind: "squad" as const, rt, oroot,
-    projDir, projectRoot, sessionId: lastSession, withManifest: false,
+    projDir, projectRoot, sessionId: lastSession, withManifest: false, produces: squadProduces,
   };
   publication.verify();
   if (squadError) {
@@ -1243,8 +1327,11 @@ if (pendingCascade?.kind === "agent-x") {
   fs.mkdirSync(oroot, { recursive: true });
   if (shouldRunAgentXGauntlet({ targetKind: "agent-x", wantExec, resolvedMode: executionOptions.resolvedMode })) {
     const canonicalRunId = canonicalRunIdFor(pid, runIdFlag);
+    // agent-x declares no capability, so its contract is `brief-conformance` under either
+    // setting — the array still travels to both compile sites, which is what keeps them equal.
+    const requirements = gauntletRequirements(pid, { kind: "agent-x", slug: "agent-x" });
     const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: { kind: "agent-x", slug: "agent-x" },
-      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity }), projectRoot: base, rt,
+      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }), projectRoot: base, rt,
       kernelPath: canaryKernelPath(base), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
     const kernel = openKernel(canaryKernelPath(base));
     const legacy = runLedger.openLedger();
@@ -1266,7 +1353,7 @@ if (pendingCascade?.kind === "agent-x") {
       const result = runAgentXGauntlet({
         kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: projDir }),
         projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot: base, outputsRoot: oroot,
-        intensity: executionOptions.intensity, executionSnapshot, audit: emit,
+        intensity: executionOptions.intensity, requirements, executionSnapshot, audit: emit,
         expectedCostUsd: budget.roundBudgetUsd,
         executeCandidate: candidateRoot => produce(candidateRoot, brief, briefPath),
         reviseCandidate(request) {
@@ -1376,6 +1463,15 @@ if (!pid || !intake || !projDir) {
   process.exit(1);
 }
 
+// The business's own contract: the intake role's `acceptance[]` (Business Protocol 2.0 §11)
+// becomes the judge's requirements, and the manifest's `produces[]` the rubric selector's
+// input. Both are gated — `gauntlet.requirements_source` and `delivery.produces_to_rubric`.
+const businessEntry = businessRecord(slug);
+const businessAcceptance = businessEntry.bizDir
+  ? readAcceptance(businessEntry.bizDir, [intake], { minimumScore: profileScore(executionOptions.intensity) })
+  : { requirements: [], entries: [], paths: [] };
+const businessProduces = producesForDelivery(() => businessEntry.produces);
+
 // Step 2 — build employee prompt
 console.log(c("lime", "▶") + c("bold", ` Step 2/4 — buildEmployeePrompt (${intake}@${slug})`));
 // brief-business writes brief.md at the project root (parent of businesses/<slug>/), not inside the business subdir
@@ -1480,8 +1576,9 @@ if (wantExec) {
   }
   if (businessCanaryDecision.enabled) {
     const canonicalRunId = canonicalRunIdFor(pid, runIdFlag);
+      const requirements = gauntletRequirements(pid, { kind: "business", slug }, { requirements: businessAcceptance.requirements });
     const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: { kind: "business", slug },
-      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity }), projectRoot, rt,
+      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }), projectRoot, rt,
       kernelPath: canaryKernelPath(projectRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid, NIRVANA_BUSINESS_SLUG: slug } });
     const kernel = openKernel(canaryKernelPath(projectRoot));
     const canaryLedger = runLedger.openLedger();
@@ -1516,7 +1613,7 @@ if (wantExec) {
           kernel, legacy: createHarnessLegacyAdapter({ ledger: canaryLedger, auditCwd: projDir }),
           producerTarget: { kind: "business", slug }, projectId: pid, runId: canonicalRunId, traceId: pid,
           brief, projectRoot, outputsRoot: oroot, expectedCostUsd: budget.roundBudgetUsd, intensity: executionOptions.intensity,
-          executionSnapshot, audit: emit,
+          requirements, executionSnapshot, audit: emit,
           executeCandidate: candidateRoot => produce(candidateRoot, tmpBriefFile, brief),
           reviseCandidate(request) {
             const revision = writeRevisionBrief(brief, request);
@@ -1536,7 +1633,8 @@ if (wantExec) {
               offlineSnapshot: process.argv.includes("--offline-snapshot"), routingMode, wantZip, emit,
               log: message => console.log(c("lime", message)), warn: message => console.error(c("yellow", message)) });
             finalDelivery = runDelivery({ ...deliveryArgs({ pid, slugOrNull: slug, targetKind: "business", rt, oroot,
-              projDir, projectRoot, sessionId, withManifest: true, afterGate }), ledger: null, maxRevisions: 0 });
+              projDir, projectRoot, sessionId, withManifest: true, afterGate, produces: businessProduces,
+              acceptancePromisesPaths: businessAcceptance.paths.length > 0 }), ledger: null, maxRevisions: 0 });
             return { exitCode: finalDelivery.exitCode, gateOutcome: finalDelivery.gateOutcome };
           },
         });
@@ -1703,7 +1801,7 @@ if (wantExec) {
   const bizDeliverOpts = {
     pid, slugOrNull: slug, targetKind: "business" as const, rt, oroot,
     projDir, projectRoot, sessionId: res.sessionId, withManifest: true,
-    afterGate,
+    afterGate, produces: businessProduces, acceptancePromisesPaths: businessAcceptance.paths.length > 0,
     onSession: (sid: string) => {
       res.sessionId = sid;
       sessionData.session_id = sid;

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -134,7 +134,7 @@ add(
 // that has a persona and is on PATH. The offline heuristic only by explicit
 // opt-in, and no agentic evaluator at all means the Gauntlet will not start.
 try {
-  const { CONFORMANCE_CAPABILITY, loadInstalledSquads, selectGauntletEvaluator } = await import("../lib/gauntlet/evaluator-selection.ts");
+  const { CONFORMANCE_CAPABILITY, describeRanking, loadInstalledSquads, selectGauntletEvaluator } = await import("../lib/gauntlet/evaluator-selection.ts");
   const { resolveJudgeXPromptPath } = await import("../lib/gauntlet/judge-x.ts");
   const agentsDir = path.join(SKILLS, "_shared", "agents");
   const judgeRuntimes = listRuntimes().filter((rt) => which(rt.cli) && resolveJudgeXPromptPath(rt.name, agentsDir)).map((rt) => rt.name);
@@ -156,7 +156,11 @@ try {
     add("gauntlet: evaluator", "WARN",
       `none — a Gauntlet will not start (${selection.reason}); install a squad declaring ${CONFORMANCE_CAPABILITY} and run nrv index, or a runtime with a judge-x persona (nrv update refreshes the engine's personas)`);
   } else if (selection.target.kind === "squad") {
-    add("gauntlet: evaluator", "PASS", `squad:${selection.target.slug}:${selection.target.capabilityId} (${selection.source === "env" ? chosenBy : `registry, declares ${CONFORMANCE_CAPABILITY}`})`);
+    // The registry rung ranks (Squad Protocol v6 §30) — print WHY this squad won, not just that it did.
+    const why = selection.source === "env" ? chosenBy
+      : selection.ranking ? `registry, declares ${CONFORMANCE_CAPABILITY}; ${describeRanking(selection.ranking)}`
+      : `registry, declares ${CONFORMANCE_CAPABILITY}`;
+    add("gauntlet: evaluator", "PASS", `squad:${selection.target.slug}:${selection.target.capabilityId} (${why})`);
   } else {
     add("gauntlet: evaluator", "PASS", `${selection.target.slug} (${selection.source === "env" ? chosenBy : "engine default: no installed squad declares " + CONFORMANCE_CAPABILITY}; runtimes with a persona on PATH: ${judgeRuntimes.join(", ")})`);
   }

--- a/skills/harness/tests/agent-x-gauntlet-cutover.test.ts
+++ b/skills/harness/tests/agent-x-gauntlet-cutover.test.ts
@@ -7,6 +7,7 @@ import {
   shouldRunAgentXGauntlet, shouldRunSquadGauntlet, type AgentXGauntletEvaluator,
 } from "../lib/gauntlet/agent-x-cutover.ts";
 import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
+import { briefConformance, requirementsFor } from "../lib/gauntlet/success-requirements.ts";
 import {
   RunAlreadyTerminalError, TERMINAL_RUN_STATES, createHarnessLegacyAdapter, createRun, getRun, listEvents, openKernel, transitionRun, type KernelHandle,
 } from "../lib/run-kernel/index.ts";
@@ -69,6 +70,47 @@ function run(overrides: Partial<Parameters<typeof runAgentXGauntlet>[0]> = {}) {
   });
   return { ...fixture, result, executions, finalGates };
 }
+
+// The judge's contract reaches BOTH compile sites. `compileGauntletPlan` runs once in
+// scripts/dispatch.ts (to size the evaluator's budget) and once here; the scorecard is
+// validated against the plan compiled HERE, so a contract only the first site saw would
+// make every dimension "not in the success contract". These pin the two on one plan id.
+describe("the judge's contract reaches the second compile site", () => {
+  const BRIEF = "Create report.md";
+  const contract = requirementsFor({ intensity: "light", capability: { acceptance: [
+    { id: "sources_cited", description: "Cada afirmação cita a fonte" },
+    { id: "one_page", description: "O resumo cabe em uma página", blocking: false },
+  ] } }).requirements;
+
+  function contractEvaluator(requirements: typeof contract): AgentXGauntletEvaluator {
+    const target = { kind: "squad" as const, slug: "quality-gate", capabilityId: "quality.specification_conformance" };
+    return {
+      target,
+      evaluate({ candidateId, revisionId, artifactRefs }) {
+        return [{ evaluationId: `evl_${revisionId}`, candidateId, revisionId, gauntletId: requirements[0].id,
+          rubricVersion: "test/v1", verdict: "pass",
+          dimensions: requirements.map(requirement => ({ id: requirement.id, score: 1, confidence: 1,
+            blocking: requirement.blocking, passed: true, evidenceRefs: artifactRefs.map(ref => ref.revisionId) })),
+          regressions: [], revisionRequests: [], evaluator: target, costUsd: 0, createdAt: "2026-08-25T12:00:02.000Z" }];
+      },
+    };
+  }
+
+  test("the plan the cutover compiles is the plan dispatch.ts compiled to size the budget", () => {
+    const { result } = run({ brief: BRIEF, intensity: "light", requirements: contract, evaluator: contractEvaluator(contract) });
+    // The literal expression scripts/dispatch.ts evaluates before calling runAgentXGauntlet.
+    expect(result.gauntlet.plan).toEqual(compileGauntletPlan({ brief: BRIEF, intensity: "light", requirements: contract }));
+    expect(result.gauntlet.plan.gauntlets.map(item => item.id)).toEqual(["brief-conformance", "acceptance.sources_cited", "acceptance.one_page"]);
+    expect(result.run.state).toBe("completed");
+  }, KERNEL_BUDGET_MS);
+
+  test("gauntlet.requirements_source at its default compiles the plan id it compiles today, bit for bit", () => {
+    const today = run({ brief: BRIEF, intensity: "light" }).result.gauntlet.plan;
+    const gated = run({ brief: BRIEF, intensity: "light", requirements: [briefConformance("light")] }).result.gauntlet.plan;
+    expect(gated).toEqual(today);
+    expect(gated.planId).toBe(compileGauntletPlan({ brief: BRIEF, intensity: "light" }).planId);
+  }, KERNEL_BUDGET_MS);
+});
 
 describe("agent-x Gauntlet cutover", () => {
   test("keeps standard, scaffold-only, business and squad execution outside the agent-x canary at every intensity", () => {

--- a/skills/harness/tests/delivery-pipeline.test.ts
+++ b/skills/harness/tests/delivery-pipeline.test.ts
@@ -21,6 +21,7 @@ import {
   gateableFiles,
   nonStubText,
   decideGateOutcome,
+  producesForRubric,
   type DeliveryArgs,
   type RuntimeErrorOutcome,
 } from "../lib/delivery-pipeline.ts";
@@ -629,5 +630,17 @@ describe("runDelivery — gate exhausted: accepted with reservations", () => {
     expect(res.exitCode).toBe(2);
     expect(res.delivered).toBe(false);
     expect(calls.map(x => x.event)).toContain("x_delivery_withheld");
+  });
+});
+
+describe("producesForRubric — delivery.produces_to_rubric", () => {
+  test("off (the default) hands the judge [], which is what it received before v6", () => {
+    expect(producesForRubric(["landing-page", "copy"], false)).toEqual([]);
+    expect(producesForRubric(undefined, false)).toEqual([]);
+  });
+
+  test("on, the target's declaration reaches the rubric selector, trimmed and deduped", () => {
+    expect(producesForRubric([" landing-page ", "copy", "landing-page", "", "  "], true)).toEqual(["landing-page", "copy"]);
+    expect(producesForRubric(null, true)).toEqual([]);
   });
 });

--- a/skills/harness/tests/gauntlet-evaluator-adapter.test.ts
+++ b/skills/harness/tests/gauntlet-evaluator-adapter.test.ts
@@ -10,12 +10,13 @@ import * as path from "node:path";
 import { SCOPE_GUARD_SENTINEL_PT_BR } from "../../_shared/lib/scope-guard.ts";
 import { GAUNTLET_EVALUATION_SHARE, gauntletRoundBudget, runAgentXGauntlet, type AgentXGauntletEvaluationInput } from "../lib/gauntlet/agent-x-cutover.ts";
 import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
+import { requirementsFor } from "../lib/gauntlet/success-requirements.ts";
 import {
   EVALUATION_BRIEF_FILE, EVALUATION_OUTPUTS_DIR, EVALUATION_REQUEST_FILE, EVALUATION_RUBRIC_VERSION, SCORECARD_FILE, SCORECARD_SCHEMA_VERSION,
   renderEvaluationBrief, validateScorecardFile, type EvaluationRequest,
 } from "../lib/gauntlet/evaluation-contract.ts";
 import {
-  createDispatchEvaluator, evaluationDirFor, evaluationProjectId, type DispatchEvaluatorTarget, type EvaluatorSpawnRequest,
+  createDispatchEvaluator, evaluationDirFor, evaluationProjectId, evaluatorSpendCapUsd, type DispatchEvaluatorTarget, type EvaluatorSpawnRequest,
 } from "../lib/gauntlet/evaluator-adapter.ts";
 import { JUDGE_X_BUDGET_EXHAUSTED_MARK, JUDGE_X_TARGET } from "../lib/gauntlet/judge-x.ts";
 import { listScorecards } from "../lib/gauntlet/store.ts";
@@ -83,6 +84,58 @@ const validFile = () => ({
   schemaVersion: SCORECARD_SCHEMA_VERSION, verdict: "pass",
   dimensions: [{ id: "brief-conformance", score: 0.95, confidence: 0.9, blocking: true, passed: true, evidenceRefs: ["report.md#L1"] }],
   revisionRequests: [], regressions: [],
+});
+
+// A real acceptance contract: three requirements, so the judge is scored on the
+// contract it was given instead of the single line every Gauntlet used to share.
+describe("a three-requirement contract", () => {
+  const threeRequirements = requirementsFor({ intensity: "light", capability: { acceptance: [
+    { id: "sources_cited", description: "Cada afirmação cita a fonte" },
+    { id: "one_page", description: "O resumo cabe em uma página", blocking: false },
+  ] } }).requirements;
+  const threePlan = compileGauntletPlan({ brief: BRIEF, intensity: "light", requirements: threeRequirements });
+  const dimension = (requirement: { id: string; blocking: boolean }) =>
+    ({ id: requirement.id, score: 0.97, confidence: 0.9, blocking: requirement.blocking, passed: true, evidenceRefs: ["report.md#L1"] });
+  const scorecardWith = (count: number) => ({
+    schemaVersion: SCORECARD_SCHEMA_VERSION, verdict: "pass",
+    dimensions: threeRequirements.slice(0, count).map(dimension), revisionRequests: [], regressions: [],
+  });
+
+  test("three requirements compile three gauntlets and the contract the judge is validated against", () => {
+    expect(threePlan.gauntlets.map(item => item.id)).toEqual(["brief-conformance", "acceptance.sources_cited", "acceptance.one_page"]);
+    expect(threePlan.successContract.requirements).toEqual(threeRequirements);
+  });
+
+  test("a scorecard with three dimensions is accepted; two or four are refused by name", () => {
+    expect(validateScorecardFile(scorecardWith(3), threeRequirements).ok).toBeTrue();
+    const short = validateScorecardFile(scorecardWith(2), threeRequirements);
+    expect(short.ok).toBeFalse();
+    expect((short as { reason: string }).reason).toContain("requirement 'acceptance.one_page' was not scored");
+    const four = scorecardWith(3);
+    four.dimensions.push({ id: "acceptance.invented", score: 1, confidence: 1, blocking: true, passed: true, evidenceRefs: [] });
+    const extra = validateScorecardFile(four, threeRequirements);
+    expect(extra.ok).toBeFalse();
+    expect((extra as { reason: string }).reason).toContain("dimension 'acceptance.invented' is not in the success contract");
+  });
+
+  test("an evaluator writing N dimensions passes and one writing N−1 comes back indeterminate, every requirement failed", () => {
+    const setup = fixture();
+    let count = 3;
+    const spawned = fakeSpawn((request) =>
+      fs.writeFileSync(path.join(flag(request.command, "--outputs-root")!, SCORECARD_FILE), JSON.stringify(scorecardWith(count))));
+    const judge = evaluator(setup, { plan: threePlan, spawn: spawned.spawn });
+
+    const [good] = judge.evaluate(setup.evaluation(1));
+    expect(good.verdict).toBe("pass");
+    expect(good.dimensions.map(item => item.id)).toEqual(threeRequirements.map(item => item.id));
+
+    count = 2;
+    const [short] = judge.evaluate(setup.evaluation(2));
+    expect(short.verdict).toBe("indeterminate");
+    expect(short.dimensions.map(item => item.id)).toEqual(threeRequirements.map(item => item.id));
+    expect(short.dimensions.every(item => !item.passed)).toBeTrue();
+    expect(short.dimensions[0].evidenceRefs[0]).toContain("acceptance.one_page' was not scored");
+  });
 });
 
 describe("scorecard contract", () => {
@@ -264,6 +317,19 @@ describe("dispatch evaluator adapter", () => {
     const [scorecard] = evaluator(setup, { signal: during.signal, spawn: late.spawn }).evaluate(setup.evaluation(2));
     expect(scorecard.verdict).toBe("indeterminate");
     expect(scorecard.dimensions[0].evidenceRefs[0]).toBe("indeterminate: aborted while the evaluator ran: stop");
+  });
+
+  test("the spend cap is the lower of the plan's slice and the capability's declared max_cost_usd", () => {
+    expect(evaluatorSpendCapUsd(1.5, 0.4)).toBe(0.4);
+    expect(evaluatorSpendCapUsd(0.4, 1.5)).toBe(0.4);
+    expect(evaluatorSpendCapUsd(1.5, null)).toBe(1.5);
+    expect(evaluatorSpendCapUsd(0, 0.9)).toBe(0.9);
+    expect(evaluatorSpendCapUsd(0, null)).toBeNull();
+    expect(evaluatorSpendCapUsd(undefined, 0)).toBeNull();
+    const setup = fixture();
+    const spawned = fakeSpawn((request) => fs.writeFileSync(path.join(flag(request.command, "--outputs-root")!, SCORECARD_FILE), JSON.stringify(validFile())));
+    evaluator(setup, { spawn: spawned.spawn, budgetUsd: 1.5, maxCostUsd: 0.4 }).evaluate(setup.evaluation());
+    expect(flag(spawned.calls[0].command, "--max-budget")).toBe("0.4");
   });
 
   test("the plan's duration is the default timeout and the budget flag is omitted when absent", () => {

--- a/skills/harness/tests/gauntlet-evaluator-selection.test.ts
+++ b/skills/harness/tests/gauntlet-evaluator-selection.test.ts
@@ -8,7 +8,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-  CONFORMANCE_CAPABILITY, loadInstalledSquads, parseEvaluatorSpec, selectGauntletEvaluator, type InstalledSquad, type JudgeAvailability,
+  CONFORMANCE_CAPABILITY, describeRanking, loadInstalledSquads, parseEvaluatorSpec, rankConformanceEvaluators, selectGauntletEvaluator,
+  type InstalledSquad, type JudgeAvailability,
 } from "../lib/gauntlet/evaluator-selection.ts";
 import { JUDGE_X_TARGET } from "../lib/gauntlet/judge-x.ts";
 import type { TargetRef } from "../lib/run-kernel/types.ts";
@@ -68,14 +69,17 @@ describe("NIRVANA_GAUNTLET_EVALUATOR", () => {
 });
 
 describe("selection without the variable", () => {
-  test("picks the first installed squad declaring quality.specification_conformance, skipping the producer", () => {
+  test("ranks the installed squads declaring quality.specification_conformance, skipping the producer", () => {
+    // A library that declares no v6 evaluator metadata ranks on the slug alone — the
+    // alphabetical answer of before, now as the LAST key instead of the only one.
     expect(selectGauntletEvaluator({ producer: AGENT_X, installed, judge: judgeReady })).toEqual({
-      kind: "dispatch", target: { kind: "squad", slug: "spec-judge", capabilityId: CONFORMANCE_CAPABILITY }, source: "registry",
-      fallbacks: [{ from: "env", reason: "unset" }] });
-    const alphabetical = [...installed].sort((a, b) => a.slug.localeCompare(b.slug));
-    expect(selectGauntletEvaluator({ producer: AGENT_X, installed: alphabetical, judge: judgeReady })).toMatchObject({ target: { slug: "document-factory" } });
+      kind: "dispatch", target: { kind: "squad", slug: "document-factory", capabilityId: CONFORMANCE_CAPABILITY }, source: "registry",
+      fallbacks: [{ from: "env", reason: "unset" }],
+      ranking: { slug: "document-factory", capabilityId: CONFORMANCE_CAPABILITY, fidelity: "experimental", maxCostUsd: null, considered: 2, retired: 0 } });
+    const shuffled = [...installed].reverse();
+    expect(selectGauntletEvaluator({ producer: AGENT_X, installed: shuffled, judge: judgeReady })).toMatchObject({ target: { slug: "document-factory" } });
     const documentFactoryProducer: TargetRef = { kind: "squad", slug: "document-factory", capabilityId: CONFORMANCE_CAPABILITY };
-    expect(selectGauntletEvaluator({ producer: documentFactoryProducer, installed: alphabetical, judge: judgeReady })).toMatchObject({ target: { slug: "spec-judge" }, source: "registry" });
+    expect(selectGauntletEvaluator({ producer: documentFactoryProducer, installed: shuffled, judge: judgeReady })).toMatchObject({ target: { slug: "spec-judge" }, source: "registry" });
     expect(selectGauntletEvaluator({ producer: AGENT_X, installed, envValue: "   ", judge: judgeReady })).toMatchObject({ source: "registry" });
     // The registry squad wins over judge-x even when the judge is available: a user's own judge is preferred.
     expect(selectGauntletEvaluator({ producer: BUSINESS, installed: [JUDGE], judge: judgeReady })).toMatchObject({ target: { slug: "spec-judge" }, source: "registry" });
@@ -95,6 +99,67 @@ describe("selection without the variable", () => {
         kind: "unavailable", reason: judgeMissing.reason,
         fallbacks: [{ from: "env", reason: "unset" }, { from: "registry", reason: "registry_no_match" }, { from: "judge-x", reason: "judge_unavailable", detail: judgeMissing.reason }] });
     }
+  });
+});
+
+describe("evaluator ranking (Squad Protocol v6 §30)", () => {
+  const contract = (slug: string, fidelity: string, maxCostUsd: number | null): InstalledSquad => ({
+    slug, capabilities: [CONFORMANCE_CAPABILITY],
+    evaluators: [{ capabilityId: CONFORMANCE_CAPABILITY, fidelity: fidelity as never, maxCostUsd }],
+  });
+
+  test("fidelity first, then the declared cost ceiling, then the slug", () => {
+    const installed = [
+      contract("z-cheap-drifted", "drifted", 0.5),
+      contract("a-expensive-validated", "validated", 9),
+      contract("b-cheap-validated", "validated", 1),
+      contract("m-experimental", "experimental", 0.1),
+    ];
+    expect(rankConformanceEvaluators(installed, AGENT_X).ranked.map(entry => entry.slug))
+      .toEqual(["b-cheap-validated", "a-expensive-validated", "m-experimental", "z-cheap-drifted"]);
+  });
+
+  test("a capability without an evaluator block sorts behind every one that declares a ceiling, inside its fidelity tier", () => {
+    const installed = [
+      { slug: "a-no-contract", capabilities: [CONFORMANCE_CAPABILITY] },
+      contract("z-declares-cost", "experimental", 3),
+      contract("y-validated-no-cost", "validated", null),
+    ];
+    expect(rankConformanceEvaluators(installed, AGENT_X).ranked.map(entry => entry.slug))
+      .toEqual(["y-validated-no-cost", "z-declares-cost", "a-no-contract"]);
+  });
+
+  test("a retired contract is not a candidate, and its exclusion is counted", () => {
+    const installed = [contract("retired-judge", "retired", 0.1), contract("live-judge", "drifted", 8)];
+    const ranked = rankConformanceEvaluators(installed, AGENT_X);
+    expect(ranked.ranked.map(entry => entry.slug)).toEqual(["live-judge"]);
+    expect(ranked.retired).toBe(1);
+    expect(selectGauntletEvaluator({ producer: AGENT_X, installed: [contract("retired-judge", "retired", 0.1)], judge: judgeReady }))
+      .toMatchObject({ target: JUDGE_X_TARGET, source: "default" });
+  });
+
+  test("the selection carries the reason, which is what nrv doctor prints", () => {
+    const selection = selectGauntletEvaluator({ producer: AGENT_X, judge: judgeReady,
+      installed: [contract("chosen", "validated", 2), contract("other", "experimental", 1), contract("gone", "retired", 0)] });
+    expect(selection).toMatchObject({ target: { slug: "chosen" }, ranking: { fidelity: "validated", maxCostUsd: 2, considered: 2, retired: 1 } });
+    expect(describeRanking((selection as { ranking: NonNullable<ReturnType<typeof rankConformanceEvaluators>["ranked"][number]> }).ranking))
+      .toBe("fidelity validated, max_cost_usd USD 2, ahead of 1 other candidate(s); 1 retired excluded");
+  });
+
+  test("reads the evaluator contract out of the registry's capability records", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-evaluator-contract-")); roots.push(root);
+    const file = path.join(root, ".squads-registry.json");
+    fs.writeFileSync(file, JSON.stringify({
+      squads: { "judge-a": { capabilities: [CONFORMANCE_CAPABILITY] }, "judge-b": { capabilities: [CONFORMANCE_CAPABILITY] } },
+      capabilities: { [CONFORMANCE_CAPABILITY]: [
+        { squad: "judge-a", fidelity: { status: "drifted" }, evaluator: { scorecard: "s", rubric: "r", max_cost_usd: 0.2 } },
+        { squad: "judge-b", fidelity_status: "validated" },
+      ] },
+    }), "utf8");
+    const installed = loadInstalledSquads(file);
+    expect(installed.find(entry => entry.slug === "judge-a")?.evaluators)
+      .toEqual([{ capabilityId: CONFORMANCE_CAPABILITY, fidelity: "drifted", maxCostUsd: 0.2 }]);
+    expect(rankConformanceEvaluators(installed, AGENT_X).ranked.map(entry => entry.slug)).toEqual(["judge-b", "judge-a"]);
   });
 });
 

--- a/skills/harness/tests/gauntlet-success-requirements.test.ts
+++ b/skills/harness/tests/gauntlet-success-requirements.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
+import {
+  BRIEF_CONFORMANCE_ID, REQUIREMENTS_MAX, acceptanceCriteriaOf, briefConformance, profileScore, requirementsFor,
+} from "../lib/gauntlet/success-requirements.ts";
+
+const roots: string[] = [];
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+function squad(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-success-req-")); roots.push(root);
+  for (const [rel, body] of Object.entries(files)) {
+    const file = path.join(root, rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, body, "utf8");
+  }
+  return root;
+}
+
+describe("requirementsFor — the judge's contract", () => {
+  test("without a capability it is exactly today's single requirement", () => {
+    const result = requirementsFor({ intensity: "light" });
+    expect(result).toEqual({ requirements: [briefConformance("light")], origin: "brief-conformance", truncated: 0 });
+    // The same object the compiler builds on its own: same id, same threshold, same capability.
+    expect(compileGauntletPlan({ brief: "Build", intensity: "light" }).successContract.requirements).toEqual(result.requirements);
+  });
+
+  test("a squad without acceptance, workflow or task receives exactly brief-conformance", () => {
+    const dir = squad({ "squad.yaml": "name: empty\n" });
+    expect(requirementsFor({ squadDir: dir, capability: { id: "x.y", invoke: { type: "workflow", ref: "workflows/ghost" } } }))
+      .toMatchObject({ origin: "brief-conformance", requirements: [{ id: BRIEF_CONFORMANCE_ID }] });
+  });
+
+  test("declared acceptance blocks by default, is namespaced and inherits the fidelity threshold", () => {
+    const result = requirementsFor({
+      intensity: "balanced",
+      capability: {
+        fidelity: { threshold: 0.7 },
+        acceptance: [
+          { id: "offer_stated", description: "The offer is stated in the first screen" },
+          { id: "brief-conformance", description: "A criterion that would shadow the brief", blocking: false, minimumScore: 0.99 },
+        ],
+      },
+    });
+    expect(result.origin).toBe("acceptance");
+    expect(result.requirements.map(item => item.id)).toEqual([BRIEF_CONFORMANCE_ID, "acceptance.offer_stated", "acceptance.brief-conformance"]);
+    expect(result.requirements[0].minimumScore).toBe(profileScore("balanced"));
+    expect(result.requirements[1]).toMatchObject({ blocking: true, minimumScore: 0.7 });
+    expect(result.requirements[2]).toMatchObject({ blocking: false, minimumScore: 0.99 });
+  });
+
+  test("the ceiling keeps twelve requirements and reports what it dropped", () => {
+    const acceptance = Array.from({ length: 12 }, (_, index) => ({ id: `c_${index}`, description: `criterion ${index}` }));
+    const result = requirementsFor({ capability: { acceptance } });
+    expect(result.requirements).toHaveLength(REQUIREMENTS_MAX);
+    expect(result.truncated).toBe(1);
+  });
+
+  test("falls back to the invoked workflow's success_indicators, non-blocking", () => {
+    const dir = squad({
+      "workflows/build.md": "---\nname: build\nsteps:\n  - id: write\n    agent: writer\nsuccess_indicators:\n  - O relatório cita as fontes\n  - Cada seção tem um número\n---\n\n## write\nEscreva.\n",
+    });
+    const result = requirementsFor({ squadDir: dir, intensity: "light", capability: { invoke: { type: "workflow", ref: "build" } } });
+    expect(result.origin).toBe("success_indicators");
+    expect(result.requirements.map(item => item.id)).toEqual([BRIEF_CONFORMANCE_ID, "indicator.1", "indicator.2"]);
+    expect(result.requirements[1]).toMatchObject({ blocking: false, description: "O relatório cita as fontes", minimumScore: profileScore("light") });
+  });
+
+  test("reads the legacy dialect through the v6 reader (success_criteria in a .yaml workflow)", () => {
+    const dir = squad({ "workflows/build.yaml": "name: build\nsteps:\n  - id: write\n    agent: writer\nsuccess_criteria:\n  - Um indicador legado\n" });
+    const result = requirementsFor({ squadDir: dir, capability: { invoke: { type: "workflow", ref: "workflows/build" } } });
+    expect(result.origin).toBe("success_indicators");
+    expect(result.requirements[1].description).toBe("Um indicador legado");
+  });
+
+  test("falls back to the invoked task's ## Acceptance Criteria", () => {
+    const dir = squad({ "tasks/render.md": "# Render\n\n## Steps\n1. Do it\n\n## Acceptance Criteria\n- O PDF abre sem erro\n- A capa tem o logo\n\n## Output Schema\nnone\n" });
+    const result = requirementsFor({ squadDir: dir, capability: { invoke: { type: "task", ref: "render" } } });
+    expect(result.origin).toBe("task_acceptance_criteria");
+    expect(result.requirements.map(item => item.description).slice(1)).toEqual(["O PDF abre sem erro", "A capa tem o logo"]);
+    expect(result.requirements.slice(1).every(item => item.blocking === false)).toBeTrue();
+  });
+
+  test("acceptance wins over the workflow's indicators", () => {
+    const dir = squad({ "workflows/build.md": "---\nname: build\nsteps: []\nsuccess_indicators:\n  - ignorado\n---\n" });
+    expect(requirementsFor({ squadDir: dir, capability: { acceptance: [{ id: "declared", description: "vence" }], invoke: { type: "workflow", ref: "build" } } }).origin)
+      .toBe("acceptance");
+  });
+
+  test("acceptanceCriteriaOf reads only the section's bullets", () => {
+    expect(acceptanceCriteriaOf("## Acceptance Criteria\n- um\n* dois\n\n## Output\n- não\n")).toEqual(["um", "dois"]);
+    expect(acceptanceCriteriaOf("# Task\nsem seção\n")).toEqual([]);
+  });
+});
+
+describe("compileGauntletPlan with a real contract", () => {
+  test("three requirements compile three gauntlets, chained and holdout-aware", () => {
+    const requirements = requirementsFor({ intensity: "balanced", capability: { acceptance: [
+      { id: "a", description: "primeiro" }, { id: "b", description: "segundo", blocking: false },
+    ] } }).requirements;
+    const plan = compileGauntletPlan({ brief: "Produza o relatório", intensity: "balanced", requirements });
+    expect(plan.gauntlets).toHaveLength(3);
+    expect(plan.gauntlets.map(item => item.id)).toEqual(["brief-conformance", "acceptance.a", "acceptance.b"]);
+    expect(plan.gauntlets.map(item => item.dependsOn)).toEqual([[], ["brief-conformance"], ["acceptance.a"]]);
+    expect(plan.gauntlets.map(item => item.holdout.enabled)).toEqual([true, true, false]);
+    expect(plan.successContract.requirements).toEqual(requirements);
+  });
+
+  test("the brief-only contract compiles the plan id it compiles today, bit for bit", () => {
+    const today = compileGauntletPlan({ brief: "Produza o relatório", intensity: "balanced" });
+    // What `gauntlet.requirements_source=brief` (the default) hands the compiler.
+    const passed = compileGauntletPlan({ brief: "Produza o relatório", intensity: "balanced", requirements: [briefConformance("balanced")] });
+    expect(passed).toEqual(today);
+    expect(compileGauntletPlan({ brief: "Produza o relatório", intensity: "balanced", requirements: undefined }).planId).toBe(today.planId);
+    // And a real contract is a different plan — the id is not insensitive to the requirements.
+    expect(compileGauntletPlan({ brief: "Produza o relatório", intensity: "balanced",
+      requirements: requirementsFor({ capability: { acceptance: [{ id: "a", description: "primeiro" }] } }).requirements }).planId)
+      .not.toBe(today.planId);
+  });
+});

--- a/skills/harness/tests/quality-gate.test.ts
+++ b/skills/harness/tests/quality-gate.test.ts
@@ -30,6 +30,29 @@ describe("selectRubricsForProduces", () => {
     expect(r.rubrics[0]?.name).toBe("code");
   });
 
+  test("a PT/EN alias selects the same rubric the English slug does, and says so", () => {
+    const alias = selectRubricsForProduces(["pagina-de-vendas"]);
+    expect(alias.fallback_used).toBe(false);
+    expect(alias.rubrics.map((r) => r.name)).toEqual(["design"]);
+    expect(alias.reason).toContain("by alias: pagina-de-vendas→design");
+    expect(selectRubricsForProduces(["landing-page"]).rubrics.map((r) => r.name)).toEqual(["design"]);
+    // A declared slug still wins on `applies_to_produces`, with no alias note.
+    expect(selectRubricsForProduces(["landing-page"]).reason).not.toContain("by alias");
+  });
+
+  test("every alias is a slug no rubric already declares, so a rubric never claims another's slug", () => {
+    const declared = new Set(listRubrics().flatMap((r) => r.applies_to_produces));
+    const seen = new Map<string, string>();
+    for (const rubric of listRubrics()) {
+      for (const alias of rubric.aliases) {
+        expect(declared.has(alias)).toBe(false);
+        expect(seen.has(alias)).toBe(false);
+        seen.set(alias, rubric.name);
+      }
+    }
+    expect(seen.size).toBeGreaterThan(0);
+  });
+
   test("a mind-clone hint adds the voice-fidelity rubric to a real match", () => {
     // Find a produces slug that some rubric actually declares, so this stays
     // valid as the rubric set evolves.

--- a/skills/squads/SQUAD_PROTOCOL_V6.md
+++ b/skills/squads/SQUAD_PROTOCOL_V6.md
@@ -36,7 +36,7 @@ Squads v4 e v5 continuam carregando sem alteração. O leitor aceita as duas cod
 
 ### Limites desta versão
 
-Três contratos desta spec são **declarativos hoje**: o schema os aceita, o portão os valida, e nenhum leitor de execução ainda os consome. Cada um está marcado no texto como **limite**, com o que falta. Documentá-los agora é o que permite que o conteúdo seja escrito antes do encanamento, em vez de depois. São eles: a ordem de fallback da aceitação (§29.3), a ordem de seleção do avaliador (§30.3) e as arestas de composição no grafo de entidades (§31.4).
+Um contrato desta spec continua **declarativo hoje**: o schema o aceita, o portão o valida, e nenhum leitor de execução ainda o consome. Está marcado no texto como **limite**, com o que falta: as arestas de composição no grafo de entidades (§31.4). A ordem de fallback da aceitação (§29.3) e a ordem de seleção do avaliador (§30.3) eram limites e passaram a ser encanamento — as duas atrás de interruptor, com o comportamento de hoje como padrão.
 
 ---
 
@@ -212,11 +212,20 @@ Schema (`CapabilitySchema.acceptance`, `.strict()`, **máximo 12 entradas**):
 
 Cada requisito de aceitação vira um gauntlet sequencial, uma linha no brief do juiz e uma dimensão exigida no scorecard. `validateScorecardFile` exige **exatamente N** dimensões: com N requisitos e N−1 dimensões o scorecard vira `indeterminate` e o entregável fica retido. Doze é o teto em que o custo do julgamento ainda cabe no orçamento de um run.
 
-### 29.3 Ordem de fallback — **limite**
+### 29.3 Ordem de fallback
 
-A ordem projetada, quando o encanamento existir, é: `acceptance[]` → `success_indicators` do workflow invocado → `## Acceptance Criteria` da task invocada → `brief-conformance`. `brief-conformance` sempre vem antes de tudo, e `minimumScore` sem valor cai no `fidelity.threshold` da capability e, na falta dele, no score do perfil de intensidade.
+`skills/harness/lib/gauntlet/success-requirements.ts` (`requirementsFor`) resolve o contrato do juiz nesta ordem, e o primeiro degrau que responde vence:
 
-**Hoje nada disso é lido.** `acceptance[]` é aceito pelo schema, derivado por `nrv migrate --to 6` (§35) e reportado pelo portão; nenhum caminho de execução o consome. O que falta é `skills/harness/lib/gauntlet/success-requirements.ts` e a passagem de `requirements` nos dois sítios que compilam o plano do gauntlet. Até lá, toda execução de squad é julgada por `brief-conformance` sozinho, exatamente como antes da v6.
+| Degrau | Origem | Bloqueia |
+|---|---|---|
+| `acceptance` | `capabilities[].acceptance[]` | sim, salvo `blocking: false` |
+| `success_indicators` | `success_indicators[]` do workflow invocado, pelo leitor v6 (§28) | não |
+| `task_acceptance_criteria` | `## Acceptance Criteria` da task invocada | não |
+| `brief-conformance` | nada declarado | sim |
+
+`brief-conformance` sempre vem antes de tudo, os ids derivados são namespaced (`acceptance.<id>`, `indicator.<n>`, `criterion.<n>`) para que nenhuma capability consiga sombrear o brief, e `minimumScore` sem valor cai no `fidelity.threshold` da capability e, na falta dele, no score do perfil de intensidade. Os dois últimos degraus não bloqueiam: um indicador que alguém escreveu em prosa nunca foi prometido como portão, e transformá-lo em um retém entregas que ninguém combinou reter.
+
+**Interruptor.** `gauntlet.requirements_source` (`brief` | `capability`, padrão `brief`). No padrão, o contrato é o único `brief-conformance` de sempre e o plano compilado é bit a bit o de antes — o mesmo `planId`. Em `capability`, o contrato é o desta seção, e o `x_gauntlet_requirements_resolved` do audit diz de qual degrau ele veio.
 
 ---
 
@@ -241,11 +250,11 @@ Schema (`CapabilitySchema.evaluator`, `.strict()`): `scorecard` (string, obrigat
 
 O critério `evaluator_missing` dispara para a capability de id `quality.specification_conformance` que não declara o bloco. É **erro sob 6.0** e aviso sob 5.0, e o reparo é agêntico: só quem escreveu a squad sabe qual é o scorecard dela.
 
-### 30.3 Ordem de seleção — **limite**
+### 30.3 Ordem de seleção
 
-A ordem projetada, entre vários avaliadores instalados: `fidelity.status` `validated` antes de `experimental` antes de `drifted`, com `retired` fora; empate resolvido por `max_cost_usd` crescente; empate restante resolvido por slug. `max_cost_usd` também vira o teto do orçamento passado ao avaliador (`min(fatia do run, max_cost_usd)`).
+Entre vários avaliadores instalados e independentes do produtor (`evaluator-selection.ts`, `rankConformanceEvaluators`): `fidelity.status` `validated` antes de `experimental` antes de `drifted`, com `retired` fora da disputa; empate resolvido por `max_cost_usd` crescente, e uma capability sem bloco `evaluator` declara custo nenhum, então fica atrás de qualquer uma que declare; empate restante resolvido por slug. Uma biblioteca sem metadado de v6 tem só a terceira chave, então continua recebendo a resposta alfabética da v5.
 
-**Hoje a seleção ainda é a da v5** (`evaluator-selection.ts`, ordem alfabética com override por variável de ambiente). O bloco `evaluator` é validado e reportado, e não é lido por quem escolhe.
+`max_cost_usd` também vira o teto do orçamento passado ao avaliador: o `--max-budget` do subprocesso é `min(fatia do run, max_cost_usd)` — o teto declarado limita o gasto, nunca o aumenta. A linha vencedora viaja na seleção e é a razão que `nrv doctor` imprime. O override por `NIRVANA_GAUNTLET_EVALUATOR` continua acima de tudo isso, honrado ou recusado, nunca reinterpretado.
 
 ---
 


### PR DESCRIPTION
## What this cut fixes

`compileGauntletPlan` has always been able to compile N requirements into N gauntlets. It never received more than one: no caller passed `requirements` (`dispatch.ts` × 3, `agent-x-cutover.ts:315`), so every Gauntlet in the system judged the same `brief-conformance` question with a threshold read off the intensity profile — while the registry carried `acceptance`, `evaluator`, `fidelity` and `estimated_cost_usd` (PR4) and `capabilityId` already reached dispatch (PR5), and nothing read any of it.

Everything below ships behind a flag whose default is today's behavior.

## 1. The judge's contract

New `skills/harness/lib/gauntlet/success-requirements.ts`. `brief-conformance` first, always, then the first rung that answers:

| Rung | Source | Blocks |
|---|---|---|
| `acceptance` | `capabilities[].acceptance[]` | yes, unless `blocking: false` |
| `success_indicators` | the invoked workflow's `success_indicators[]`, through the v6 reader | no |
| `task_acceptance_criteria` | the invoked task's `## Acceptance Criteria` | no |
| `brief-conformance` | nothing declared | yes |

The derived rungs do not block: an indicator someone wrote as prose was never promised as a gate. Ids are namespaced (`acceptance.<id>`, `indicator.<n>`, `criterion.<n>`) so a capability declaring `brief-conformance` cannot shadow the brief. `minimumScore` = `acceptance.minimumScore` ?? `fidelity.threshold` ?? `PROFILES[intensity].score` (now exported from `compiler.ts`). Ceiling of twelve, `brief-conformance` included, and what it drops is counted.

A business declares the same contract per role: `skills/businesses/lib/acceptance.ts` reads the intake employee's `acceptance[]` (Business Protocol 2.0 §11), deduped by id.

## 2. Both compile sites get the same array

`compileGauntletPlan` runs twice per Gauntlet — once in `dispatch.ts` to size the evaluator's budget, once inside `runAgentXGauntlet` — and the scorecard is validated against the plan the **second** one built. A contract only the first site saw would make `validateScorecardFile` reject every dimension as "not in the success contract". `AgentXGauntletInput.requirements` closes it; the three canaries compute the array once and hand it to both.

Proved in `agent-x-gauntlet-cutover.test.ts`: `result.gauntlet.plan` equals the literal expression `dispatch.ts` evaluates (`compileGauntletPlan({ brief, intensity, requirements })`), and the default flag compiles the exact plan of today.

## 3. Flags

| Key | Values | Default | Gates |
|---|---|---|---|
| `gauntlet.requirements_source` | `brief` \| `capability` | `brief` | where the requirements come from |
| `delivery.produces_to_rubric` | boolean | `false` | whether `produces` reaches the rubric selector |

At the defaults the compiled plan is bit for bit today's — same `planId` — and the judge still receives `[]`.

## 4. `produces` → rubric

`deliveryArgs()` now carries `produces` (squad: the resolved capability's; business: the manifest's). Rubrics gained `aliases:` for PT/EN synonyms, so `pagina-de-vendas` selects the same rubric `landing-page` does instead of falling to `prose_shortform`. An alias may not be a slug another rubric already declares — a test holds it. `producesForRubric` lives in `delivery-pipeline.ts` so one rule serves every caller.

## 5. Evaluator contract

`evaluator-selection.ts` ranks instead of taking the first slug alphabetically: fidelity (`validated` > `experimental` > `drifted`, `retired` excluded) → `evaluator.max_cost_usd` ascending (no `evaluator` block = no declared cost = behind everyone who declares one) → slug. A library with no v6 metadata has only the third key, so its answer is unchanged. The winning row travels on the selection; `doctor-system.ts` prints it as the reason. `evaluator-adapter.ts` runs the evaluation under `min(plan slice, max_cost_usd)`.

## 6. Acceptance as a completeness proof

An `acceptance[]` entry with a `path` is the same promise a `deliverables.json` is, declared by the role instead of written per run. `verify-deliverable.ts` reads it when there is no manifest (`manifest_source: "acceptance"`, per-entry `min_bytes`), and `delivery-pipeline.ts` verifies through it — "manifest **or** acceptance with path".

## Tests

New: `gauntlet-success-requirements.test.ts` (11), `businesses/tests/acceptance.test.ts` (10). Extended: `gauntlet-evaluator-selection.test.ts` (+5 ranking), `gauntlet-evaluator-adapter.test.ts` (+4: three-requirement contract, 3 dimensions accepted / 2 and 4 refused, an evaluator writing N then N−1 → `indeterminate`), `agent-x-gauntlet-cutover.test.ts` (+2 compile-site parity), `quality-gate.test.ts` (+2 aliases), `delivery-pipeline.test.ts` (+2 flag), `glance-settings-panel.test.ts` (label).

Area verification: `test:harness` 1313 pass / 1 fail (`buyer-path.test.ts`, `Cannot find package 'yaml'` — the worktree symlink failure the verification contract §3 names), `test:shared` 534, `test:businesses` 98, `test:squads` 75, `test:gate` 180, `test:fast` 1575, `check:quick` green, `git diff --check` clean. The full suite and `check:all` run once over the whole, after integration.

## Docs

`SQUAD_PROTOCOL_V6.md` §29.3 and §30.3 stop being **limite** sections; `docs/architecture/gauntlet-evaluator-contract.md` gets the ranking table and the budget cap; `docs/architecture/configuration.md` gets both keys and their readers. Changelogs EN + PT in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)