### PR TITLE
feat(validate): the gate runs at creation, activation, install and pack build, with a Glance button and an agentic --fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,56 @@ holds that. `delivery.produces_to_rubric` (default `false`) gates the forwarding
 rubrics cover roughly 45 of the 3.024 slugs the library declares and a slug with no rubric has to
 degrade to the fallback, never to a refusal. Off, the judge receives `[]` — bit for bit what it
 received before.
+### The gate runs at creation, install, activation and pack build
+
+`nrv validate` shipped as a verb nobody called. The criteria catalogs, the debt baseline, the
+`--fix` loop with backup and rollback — all of it existed, and an entity could still enter the
+system through four other doors without any of it being asked. This wires the four doors to one
+module, `skills/_shared/lib/verify/hooks.ts`, and the whole design answers to a single constraint:
+turning a gate on must not be the reason a paid pack stops installing on the day it ships.
+
+| Moment | Flag off (shipped default) | Flag on |
+|---|---|---|
+| Creation (`init-squad`, `init-business`) | mechanical repair, then the verdict is printed | a remaining error deletes the scaffold |
+| Install (`installer.ts`, `install-content.ts`) | warns per entity and installs | refuses; nothing is written |
+| Activation (`nrv activate`) | warns and activates | refuses before touching a dependency |
+| Pack build (`check-entity-admission`, `check-seat-sufficiency`) | wrappers over `verifyPack` / `verifyAll`, flags and exit codes frozen | — |
+
+Three rules keep a buyer's machine safe. `verify.mode` ships `report` and
+`verify.enforce_on_install` / `verify.enforce_on_activate` ship `false`, so with the shipped
+defaults every hook prints and proceeds. A machine with no debt baseline gets one RECORDED
+(`x_verify_baseline_recorded`, `reason: hook_grandfathering`) instead of a refusal of the library it
+already had — only `baselineable` criteria become debt, never a HARD error. And `--skip-validate` /
+`--skip-verify` always walk past.
+
+Creation is the one hook that refuses by default, for two reasons: `init-business.ts` already
+deleted the scaffold when the loader failed, and the hook repairs before it judges. A scaffold is
+authored content minus what the ENGINE owns — the component files the manifest declares and
+`.nirvana-surface.json`, a hash of files that do not exist until the wizard has written them. A
+fresh business was REJECTED on that single error; now the surface is generated in the scaffold and
+a brand-new squad and business are both born ADMITTED.
+
+The two pack gates became wrappers with their flags, output and exit codes untouched, and their
+tests were not edited. Proof beyond the tests: run against all 17 pack content dirs (231 entities in
+genesis alone), the old implementation and the wrapper produce the same violations, the same debt
+map and the same counts — after two real gaps in the clone catalog were closed, a numbered legacy
+`category` written at the top level instead of under `manifest:`, and `source_material.primary_works`,
+the older spelling three of 527 live clones use.
+
+`--fix=agentic` is real now (`skills/_shared/lib/verify/agentic.ts`): mechanical pass first, then a
+staging copy, `runHeadless` with the scope guard, and a result accepted only when errors did not
+grow AND a targeted finding is gone. Routing metadata additionally has to survive the self-retrieval
+gate or the backup is restored. Nothing runs without `--yes` — exit 2 quotes the ceiling
+(`--budget-usd`, default 3) — and the spend leaves a ledger row plus
+`x_verify_fix_started` / `x_verify_fix_finished`.
+
+In the cockpit, `GET /api/v1/verify/<kind>/<slug>` answers a full report from a CHILD process with a
+wall clock (504 on overrun), because the server is single-threaded and one slow entity would freeze
+every other panel. Repair is a separate mutating action, `POST /api/actions/verify-fix`, confirmed
+before it leaves the browser; squad, business and mind-clone panels gained a "Verificar" button.
+`nrv doctor` gained a Protocol section counting squads by protocol and businesses still on 1.0 or
+carrying retired fields — WARN, never FAIL, because CI reads `doctor >= 2` as a broken machine and a
+library mid-migration is everyone's normal state.
 
 ### The dev loop stops paying for the whole repository on every check
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -143,6 +143,56 @@ genérica; um alias não pode ser um slug que outra rubrica já declara, e um te
 `delivery.produces_to_rubric` (padrão `false`) governa o encaminhamento, porque as rubricas cobrem
 cerca de 45 dos 3.024 slugs que a biblioteca declara e um slug sem rubrica tem que degradar para o
 fallback, nunca para uma recusa. Desligado, o juiz recebe `[]` — bit a bit o que ele recebia antes.
+### O portão roda na criação, na instalação, na ativação e no build de packs
+
+O `nrv validate` nasceu como um verbo que ninguém chamava. Os catálogos de critérios, a baseline de
+dívida, o laço `--fix` com backup e rollback — tudo já existia, e uma entidade ainda entrava no
+sistema por outras quatro portas sem que nada disso fosse perguntado. Este corte liga as quatro
+portas a um módulo só, `skills/_shared/lib/verify/hooks.ts`, e o desenho inteiro responde a uma
+restrição: ligar um portão não pode ser o motivo de um pack pago parar de instalar no dia em que sai.
+
+| Momento | Flag desligada (padrão de fábrica) | Flag ligada |
+|---|---|---|
+| Criação (`init-squad`, `init-business`) | reparo mecânico e o veredito impresso | erro que sobra apaga o scaffold |
+| Instalação (`installer.ts`, `install-content.ts`) | avisa por entidade e instala | recusa; nada é escrito |
+| Ativação (`nrv activate`) | avisa e ativa | recusa antes de tocar em qualquer dependência |
+| Build de packs (`check-entity-admission`, `check-seat-sufficiency`) | invólucros de `verifyPack` / `verifyAll`, flags e exit codes congelados | — |
+
+Três regras protegem a máquina do comprador. O `verify.mode` sai em `report` e o
+`verify.enforce_on_install` / `verify.enforce_on_activate` saem em `false`, então com os padrões de
+fábrica todo gancho imprime e segue. Uma máquina sem baseline de dívida GRAVA uma
+(`x_verify_baseline_recorded`, `reason: hook_grandfathering`) em vez de recusar a biblioteca que já
+estava lá — só critérios `baselineable` viram dívida, um erro HARD nunca. E o `--skip-validate` /
+`--skip-verify` sempre passa por cima.
+
+A criação é o único gancho que recusa por padrão, por dois motivos: o `init-business.ts` já apagava
+o scaffold quando o loader falhava, e o gancho repara antes de julgar. Um scaffold é conteúdo
+autoral menos o que o ENGINE possui — os arquivos de componente que o manifesto declara e o
+`.nirvana-surface.json`, que é um hash de arquivos que só existem depois que o wizard os escreve.
+Uma empresa nova era REPROVADA nesse único erro; agora a superfície é gerada no scaffold e tanto um
+squad quanto uma empresa recém-criados nascem ADMITIDOS.
+
+Os dois gates do build de packs viraram invólucros com flags, saída e exit codes intactos, e os
+testes deles não foram editados. Prova além dos testes: rodando contra os 17 diretórios de conteúdo
+de pack (231 entidades só no genesis), a implementação antiga e o invólucro produzem as mesmas
+violações, o mesmo mapa de dívida e as mesmas contagens — depois de fechar duas lacunas reais no
+catálogo de clone, uma `category` numerada legada escrita no topo em vez de sob `manifest:`, e
+`source_material.primary_works`, a grafia antiga que três de 527 clones vivos usam.
+
+O `--fix=agentic` existe de verdade (`skills/_shared/lib/verify/agentic.ts`): passe mecânica
+primeiro, depois cópia de staging, `runHeadless` com o scope-guard, e um resultado aceito só quando
+os erros não cresceram E um achado alvo sumiu. Metadado de roteamento ainda precisa sobreviver ao
+self-retrieval-gate, senão o backup é restaurado. Nada roda sem `--yes` — o exit 2 cita o teto
+(`--budget-usd`, padrão 3) — e o gasto deixa uma linha no ledger mais
+`x_verify_fix_started` / `x_verify_fix_finished`.
+
+No cockpit, `GET /api/v1/verify/<kind>/<slug>` responde o relatório inteiro de um processo FILHO com
+relógio (504 no estouro), porque o servidor é de uma thread só e uma entidade lenta congelaria todos
+os outros painéis. O reparo é uma ação mutante à parte, `POST /api/actions/verify-fix`, confirmada
+antes de sair do navegador; os painéis de squad, empresa e mind-clone ganharam um botão "Verificar".
+O `nrv doctor` ganhou uma seção Protocol contando squads por protocolo e empresas ainda em 1.0 ou
+carregando campos aposentados — WARN, nunca FAIL, porque o CI lê `doctor >= 2` como máquina quebrada
+e uma biblioteca em migração é o estado normal de todo mundo.
 
 ### O laço de desenvolvimento para de pagar o repositório inteiro a cada verificação
 

--- a/docs/architecture/control-plane-api.md
+++ b/docs/architecture/control-plane-api.md
@@ -63,6 +63,7 @@ interface RuntimeProvider {
 | `GET /settings?project_id={id}` | Schema das configurações do engine com valor efetivo, origem e `locked` por chave |
 | `PUT /settings/{key}` | Grava `{ value, scope }` no arquivo do escopo (projeto ou global) |
 | `DELETE /settings/{key}?scope=` | Remove a chave do arquivo do escopo; a camada seguinte passa a valer |
+| `GET /verify/{kind}/{slug}` | Relatório de admissão da entidade (`nirvana.verify-report/v1`); leitura, em processo filho com teto de relógio |
 
 ## 4. Stream
 
@@ -90,6 +91,22 @@ As três rotas de `settings` são adapters do núcleo de configuração (`skills
 | mesma `Idempotency-Key` com outro corpo | `409` |
 
 Uma escrita bem-sucedida responde `{ key, scope, path, from, to, changed, effective }`, onde `effective` é a resolução da chave depois da gravação (o valor em vigor pode continuar vindo de uma camada acima). Cada gravação que muda um arquivo grava `x_settings_changed { key, scope, path, from, to, actor: "glance" }` no audit do projeto. O painel que consome estas rotas está em [Configuração pelo Glance](glance-settings.md).
+
+## 4.3. Portão de admissão
+
+`GET /api/v1/verify/{kind}/{slug}` responde o relatório de `nrv validate` para um squad, uma empresa ou um mind-clone. `kind` é `squad`, `business` ou `mind-clone`; qualquer outro valor não casa a rota e é `404`.
+
+A rota **não roda no laço de eventos**. Ela inicia um processo filho (`nrv validate <kind> <slug> --json --no-retrieval`) com teto de relógio (`NIRVANA_GLANCE_VERIFY_TIMEOUT_MS`, padrão 20 s). O cockpit responde todo painel de uma thread só, e um verify é dezenas de milissegundos de I/O síncrono por entidade: sem o filho, uma entidade lenta congelaria todos os outros painéis enquanto rodasse.
+
+| Situação | Código |
+|---|---|
+| relatório pronto | `200` com `nirvana.verify-report/v1` |
+| entidade que o portão não encontra (exit 64) | `404` |
+| método diferente de `GET` | `405` |
+| o filho não terminou dentro do teto | `504`, nomeando o teto; o servidor continua respondendo |
+| o portão morreu sem relatório | `502`, com a saída de erro no `detail` |
+
+É **leitura**: sem `--fix`, sem `--record`, e com o eixo de auto-recuperação desligado (é o único que precisa do índice BM25). O reparo é uma ação à parte, `POST /api/actions/verify-fix` com `{ kind, slug }`, declarada `mutating: true` e confirmada no painel antes de sair do navegador; ela roda `nrv validate <kind> <slug> --fix`, que tem backup e rollback automático. Um `kind` ou `slug` que a ação não reconhece é `400`, antes de qualquer spawn.
 
 ## 5. Segurança
 

--- a/docs/architecture/validate-gate.md
+++ b/docs/architecture/validate-gate.md
@@ -210,9 +210,41 @@ Medição de `nrv validate business --all` sobre uma cópia da biblioteca instal
 
 O Glance chama o mesmo módulo: `GET /api/mind-clones/validate?slug=…` responde um clone e `GET /api/mind-clones/validate-all` a biblioteca, mantendo `ok`, `errors` e `warnings` e ganhando `findings`. As duas rotas rodam sem auto-recuperação e sem gravar estado.
 
+## Os quatro ganchos
+
+Uma entidade entra no sistema em quatro momentos, e agora os quatro passam pela mesma porta: `verifyHook` (`skills/_shared/lib/verify/hooks.ts`).
+
+| Momento | Onde | Com a flag desligada | Com a flag ligada |
+|---|---|---|---|
+| Criação | `init-squad.ts`, `init-business.ts` | reparo mecânico e o veredito impresso | erro que sobra apaga o scaffold |
+| Instalação | `installer.ts` (na cópia de staging), `install-content.ts` (por entidade, antes do primeiro espelhamento) | avisa e instala | recusa; nada é escrito |
+| Ativação | `nrv activate` (antes de instalar dependências) | avisa e ativa | recusa antes de tocar em qualquer dependência |
+| Build de packs | `check-entity-admission.ts`, `check-seat-sufficiency.ts` | invólucros de `verifyPack`/`verifyAll` com flags, saída e exit codes congelados | — |
+
+Três regras impedem que um gancho quebre a máquina de um comprador:
+
+1. **Desligado por padrão.** `verify.mode` sai em `report` e `verify.enforce_on_install` / `verify.enforce_on_activate` saem em `false`. Com os padrões, todo gancho imprime e segue. `verify.mode: block` liga os três de uma vez.
+2. **Grandfathering.** Em `mode: "hook"`, uma máquina sem baseline **grava** a dívida que encontra (`x_verify_baseline_recorded`, `reason: hook_grandfathering`) em vez de reprovar o que já estava instalado. Só critérios `baselineable` viram dívida; um erro HARD nunca.
+3. **Escape documentado.** `--skip-validate` na instalação, `--skip-verify` na ativação e na criação. Um gancho também nunca lança: falha interna vira `ran: false` com o motivo, e o chamador segue.
+
+A criação é o único gancho que reprova por padrão, e por dois motivos: `init-business.ts` já apagava o scaffold quando o loader falhava, e o gancho roda `fix: "mechanical"` **antes** de julgar. Um scaffold é conteúdo autoral menos o que o **engine** possui — os componentes que o manifesto declara e o `.nirvana-surface.json`, que é um hash de arquivos que só existem depois que o wizard escreve. Reparar isso é o que transforma um squad recém-criado de REPROVADO em ADMITIDO; o que os fixers não consertam é um scaffold quebrado, e um scaffold quebrado é apagado.
+
+## `--fix=agentic`
+
+`skills/_shared/lib/verify/agentic.ts`. Os fixers mecânicos consertam **forma**; o que eles não sabem escrever é **sentido** — uma descrição que carrega sinal de roteamento, `example_briefs` que alguém digitaria, o bloco `routing:` de um clone. Esses achados são `autofix: "agentic"`.
+
+O laço: passe mecânica primeiro (nunca peça ao modelo o que um fixer escreve de graça) → cópia de staging da entidade → `runHeadless` do `host-agent-driver` com o `scope-guard` no prompt → re-check **na cópia** → aceita só se os erros não cresceram **e** ao menos um achado alvo sumiu → backup da entidade real e cópia por cima. Quando o alvo era metadado de roteamento (`one_liner`, `domains`, `serves`, `description`), o `self-retrieval-gate` roda depois da cópia e uma reprovação restaura o backup.
+
+Teto de gasto em `--budget-usd` (padrão 3) e relógio em `--timeout-min` (padrão 15). **Nada roda sem `--yes`**: sem ele o comando sai com **exit 2** citando o teto — a confirmação é propriedade do pedido, não da máquina, então a resposta é a mesma em todo lugar. Uma linha no ledger (`openAgenticRun({ targetKind: "verify-fix" })`) e o par `x_verify_fix_started` / `x_verify_fix_finished` tornam o gasto visível. Desligado em `--pack` e sem runtime no PATH.
+
+## No Glance
+
+`GET /api/v1/verify/<kind>/<slug>` responde um `nirvana.verify-report/v1`. Roda em **processo filho** com teto de relógio (`NIRVANA_GLANCE_VERIFY_TIMEOUT_MS`, padrão 20 s), nunca no laço de eventos: o cockpit é uma thread só, e uma entidade lenta congelaria todos os outros painéis. Estouro do teto = `504`; entidade desconhecida = `404`; método diferente de GET = `405`. Sem `--fix`, sem `--record`, sem auto-recuperação.
+
+O reparo é uma ação à parte: `POST /api/actions/verify-fix` (`mutating: true`), com confirmação no painel antes de sair do navegador. Os painéis de squad, empresa e mind-clone ganharam um botão **Verificar** e, quando há achado com fixer mecânico, **Corrigir (--fix)**.
+
+`nrv doctor` ganhou uma seção **Protocol** com as contagens da biblioteca (squads por protocolo, empresas em 1.0 e com campos aposentados). É **WARN, nunca FAIL** — o CI lê `doctor >= 2` como máquina quebrada, e uma biblioteca em migração é o estado normal de todo mundo durante o rollout. Bloquear é papel do `nrv validate`.
+
 ## O que ainda não existe
 
-- **`--fix=agentic`**: recusado com uma mensagem clara. O laço agêntico (cópia de staging, `runHeadless`, orçamento, linha no ledger) é um corte próprio.
-- **Ganchos**: os wizards, `nrv activate`, a instalação e o build de packs ainda não chamam o módulo. `check-entity-admission.ts` e `check-seat-sufficiency.ts` continuam como estão.
-- **Rota versionada do Glance** (`GET /api/v1/verify/<kind>/<slug>`) e a ação `verify-fix`.
-- **Flags de rollout** (`verify.mode`, `verify.enforce_on_install`, `verify.enforce_on_activate`).
+- **Ledger de reparo agêntico por lote**: `--fix=agentic` roda uma entidade por vez; `--all --fix=agentic` pede confirmação na primeira e pára.

--- a/scripts/check-entity-admission.ts
+++ b/scripts/check-entity-admission.ts
@@ -11,19 +11,24 @@
  * green. MRR for an unrouted clone is 0.05 against 1.00 routed — the clone
  * shipped, and was invisible.
  *
- * This is the entity-metadata slice of the admission bar. The full bar is the
- * ensemble the build already runs — validate-squad, check-not-for-fires --pack,
- * check-clone-bindings --pack, check-copy-drift — plus this file:
+ * SINCE THE ADMISSION GATE (`nrv validate`), THIS FILE IS A WRAPPER. The
+ * questions below are asked by `verifyPack` (skills/_shared/lib/verify/), one
+ * criterion each, and translated back into this gate's own vocabulary. Its
+ * flags, its output and its exit codes are FROZEN: `build-all-packs.sh:318`
+ * calls it unchanged and its tests are untouched. What changed is that there
+ * is now one implementation of "is this entity admissible" instead of two that
+ * could drift.
  *
  *   HARD (always fails — cheap to fix, zero debt in the source today):
- *     clone MANIFEST parses
- *     clone has routing.one_liner        (the definition of "enriched")
- *     clone category is bare             (not the numbered legacy `09-…` form)
- *     every entity has .nirvana-surface.json
+ *     clone MANIFEST parses                     manifest_parse
+ *     clone has routing.one_liner               routing_block_missing / one_liner_missing
+ *     clone category is bare                    category_numbered
+ *     every entity has .nirvana-surface.json    surface_missing
  *
  *   BASELINED (absolute for NEW entities; recorded debt for existing ones):
- *     clone has validation_verdict       (68 gaps in today's source)
- *     clone has source_material          (23 gaps in today's source)
+ *     clone has validation_verdict              validation_verdict_missing
+ *     clone has source_material                 source_material_missing
+ *     every seat stands without a clone         seat_thin
  *
  * The split follows the fence gate's lesson: verdict and source_material are
  * produced by the validation pipeline, not by a text edit — a bar that fails
@@ -34,7 +39,10 @@
  *
  * The baseline lives beside the machine's global state (like the fence
  * ceiling): it names library entities, which never belong in the engine repo,
- * and it must not move with the working directory.
+ * and it must not move with the working directory. It stays in ITS OWN legacy
+ * shape (`.admission-baseline.json`, `{entities: {slug: Gap[]}}`) — the gate's
+ * own `.verify-baseline.json` imports it once, and until every pack build has
+ * moved over, the two must both be readable.
  *
  * Usage:
  *   bun scripts/check-entity-admission.ts --pack <content-dir>     # the bar (exit 1 on any violation)
@@ -42,12 +50,10 @@
  *   bun scripts/check-entity-admission.ts --pack <dir> --json
  */
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { parseArgs, paths as nrvPaths } from "../skills/_shared/lib/bun-helpers.ts";
-
-const require_ = createRequire(import.meta.url);
-const YAML = require_("yaml");
+import { verifyPack } from "../skills/_shared/lib/verify/index.ts";
+import type { Finding, VerifyReport } from "../skills/_shared/lib/verify/index.ts";
 
 const { flags } = parseArgs(process.argv.slice(2));
 const packDir = typeof flags.pack === "string" ? flags.pack : null;
@@ -73,70 +79,77 @@ const violations: Violation[] = [];
 const debtNow: Record<string, Gap[]> = {};
 const scanned = new Set<string>();
 
-// ── clones ─────────────────────────────────────────────────────────────────
-const clonesRoot = join(packDir, "mind-clones");
+/**
+ * The HARD half, by criterion id. `routing_block_missing` and
+ * `one_liner_missing` are one bar with two causes (no block at all, or a block
+ * without the line), so both carry the sentence this gate has always printed.
+ */
+const HARD_CLONE: Record<string, string | ((f: Finding) => string)> = {
+  manifest_parse: "MANIFEST.yaml does not parse",
+  routing_block_missing: "no routing.one_liner — invisible to semantic dispatch (MRR 0.05 vs 1.00)",
+  one_liner_missing: "no routing.one_liner — invisible to semantic dispatch (MRR 0.05 vs 1.00)",
+  category_numbered: (f) => f.message,
+};
+
+/** The BASELINED half: which criterion becomes which recorded gap. */
+const DEBT_CLONE: Record<string, Gap> = {
+  validation_verdict_missing: "no_verdict",
+  source_material_missing: "no_source",
+};
+
+const PLURAL = { squad: "squads", business: "businesses", "mind-clone": "mind-clones" } as const;
+
+const batch = await verifyPack(packDir, { baselinePath: null, retrieval: false, stateDir: null, emit: null });
+
 let clones = 0;
-if (existsSync(clonesRoot)) {
-  for (const slug of readdirSync(clonesRoot)) {
-    const mf = join(clonesRoot, slug, "MANIFEST.yaml");
-    if (!existsSync(mf)) continue;
-    clones++;
-    scanned.add(slug);
-    let doc: Record<string, unknown> = {};
-    try { doc = YAML.parse(readFileSync(mf, "utf8")) ?? {}; }
-    catch { violations.push({ entity: slug, kind: "hard", problem: "MANIFEST.yaml does not parse" }); continue; }
-    const man = (doc.manifest ?? doc) as Record<string, unknown>;
-    const routing = (doc.routing ?? {}) as Record<string, unknown>;
-
-    if (!routing.one_liner) {
-      violations.push({ entity: slug, kind: "hard", problem: "no routing.one_liner — invisible to semantic dispatch (MRR 0.05 vs 1.00)" });
-    }
-    const cat = String(doc.category ?? man.category ?? "");
-    if (/^\d\d-/.test(cat)) {
-      violations.push({ entity: slug, kind: "hard", problem: `numbered legacy category "${cat}" — the library is bare-form` });
-    }
-    const gaps: Gap[] = [];
-    if (!(doc.validation_verdict ?? man.validation_verdict)) gaps.push("no_verdict");
-    if (!(doc.source_material ?? man.source_material)) gaps.push("no_source");
-    if (gaps.length) debtNow[slug] = gaps;
-  }
-}
-
-// ── seats: every employee body must stand without a clone ──────────────────
-// Baselined, not hard: alientech-360 ships 9 thin seats in the flagship today,
-// and a hard bar with no immediate path out is the bar everyone learns to
-// skip. When enrichment zeroes the debt, the bar is absolute in practice.
-// Keyed by "business/employee.md" so two packs shipping the same business
-// share the debt entry (same rule as clone slugs).
-const { sufficiencyOfFile } = require_("../skills/_shared/lib/seat-sufficiency.js");
-const bizRoot = join(packDir, "businesses");
-if (existsSync(bizRoot)) {
-  for (const biz of readdirSync(bizRoot)) {
-    const empDir = join(bizRoot, biz, "employees");
-    if (!existsSync(empDir)) continue;
-    for (const f of readdirSync(empDir)) {
-      if (!f.endsWith(".md")) continue;
-      const key = `${biz}/${f}`;
-      scanned.add(key);
-      const r = sufficiencyOfFile(readFileSync(join(empDir, f), "utf8"));
-      if (r.verdict === "thin") (debtNow[key] ??= []).push("thin_seat");
-    }
-  }
-}
-
-// ── surface files, every kind ──────────────────────────────────────────────
 let entities = 0;
-for (const kind of ["squads", "businesses", "mind-clones"]) {
-  const root = join(packDir, kind);
-  if (!existsSync(root)) continue;
-  for (const slug of readdirSync(root)) {
-    const dir = join(root, slug);
-    const manifest = kind === "squads" ? "squad.yaml" : kind === "businesses" ? "business.yaml" : "MANIFEST.yaml";
-    if (!existsSync(join(dir, manifest))) continue;
-    entities++;
-    if (!existsSync(join(dir, ".nirvana-surface.json"))) {
-      violations.push({ entity: `${kind}/${slug}`, kind: "hard", problem: "no .nirvana-surface.json — outside the changes/drift mechanism" });
+for (const report of batch.reports as VerifyReport[]) {
+  entities++;
+  const byId = new Map<string, Finding>();
+  for (const f of report.findings) if (!byId.has(f.id)) byId.set(f.id, f);
+  const seen = new Set<string>();
+  const hard = (problem: string) => {
+    if (seen.has(problem)) return;
+    seen.add(problem);
+    violations.push({ entity: report.slug, kind: "hard", problem });
+  };
+
+  if (report.kind === "mind-clone") {
+    clones++;
+    scanned.add(report.slug);
+    for (const [id, problem] of Object.entries(HARD_CLONE)) {
+      const f = byId.get(id);
+      if (f) hard(typeof problem === "string" ? problem : problem(f));
     }
+    // A manifest that does not parse says nothing about the rest of itself.
+    if (!byId.has("manifest_parse")) {
+      const gaps: Gap[] = [];
+      for (const [id, gap] of Object.entries(DEBT_CLONE)) if (byId.has(id)) gaps.push(gap);
+      if (gaps.length) debtNow[report.slug] = gaps;
+    }
+  }
+
+  if (report.kind === "business") {
+    // Keyed by "business/employee.md" so two packs shipping the same business
+    // share the debt entry (same rule as clone slugs). Every seat is scanned,
+    // not only the thin ones: a seat that was enriched must be able to LEAVE
+    // the baseline when `--record` merges.
+    const empDir = join(report.dir, "employees");
+    if (existsSync(empDir)) {
+      for (const f of readdirSync(empDir)) if (f.endsWith(".md")) scanned.add(`${report.slug}/${f}`);
+    }
+    for (const f of report.findings) {
+      if (f.id !== "seat_thin") continue;
+      const key = `${report.slug}/${(f.where ?? "").replace(/^employees\//, "")}`;
+      (debtNow[key] ??= []).push("thin_seat");
+    }
+  }
+
+  if (byId.has("surface_missing")) {
+    violations.push({
+      entity: `${PLURAL[report.kind]}/${report.slug}`, kind: "hard",
+      problem: "no .nirvana-surface.json — outside the changes/drift mechanism",
+    });
   }
 }
 

--- a/skills/_shared/lib/installer.ts
+++ b/skills/_shared/lib/installer.ts
@@ -28,6 +28,7 @@ import { createHash, randomBytes } from "node:crypto";
 
 import { InstallManifest, type AssetKind, type InstallEvent, type InstalledItem } from "./install-manifest.ts";
 import { resolveScope } from "./scope.ts";
+import { verifyHook } from "./verify/index.ts";
 
 // Lazy path resolution — picks up env changes (useful for tests + project scope).
 function nirvanaHome(): string { return process.env.NIRVANA_HOME ?? homedir(); }
@@ -485,6 +486,22 @@ export async function install(opts: InstallOptions): Promise<InstallResult> {
         return failed();
       }
       warnings.push(...v.warnings);
+    }
+
+    // The admission gate, on the STAGED copy — before anything is written to
+    // the library, so a refusal leaves the machine exactly as it was. It is
+    // report-only until the buyer turns `verify.enforce_on_install` on: the
+    // whole point of a gate at install time is that it cannot be the reason a
+    // paid pack stops installing on the day it ships.
+    {
+      const gate = await verifyHook({ kind, target: resolved.workdir, gate: "install", skip: opts.skipValidate, stateDir: null });
+      if (!opts.quiet) for (const line of gate.lines) console.error(line);
+      if (gate.blocked) {
+        errors.push(...gate.errors.map((f) => `verify: ${f.id}${f.where ? `:${f.where}` : ""} — ${f.message}`));
+        errors.push(`verify: ${kind} ${meta.name} was refused by the admission gate (verify.enforce_on_install); re-run with --skip-validate to install it anyway`);
+        return failed();
+      }
+      warnings.push(...gate.warnings.map((f) => `verify: ${f.id}${f.where ? `:${f.where}` : ""} — ${f.message}`));
     }
 
     const checksum = checksumDir(resolved.workdir);

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -288,6 +288,21 @@ export const SETTINGS = {
     "Rubrica usada quando produces[] não casa com nenhuma.", { default: "prose_shortform", type: z.string().min(1), expects: "nome de rubrica" }),
   "quality_gate.default_judge_model": stringSetting("quality_gate.default_judge_model",
     "Modelo do juiz; inherit = o modelo configurado no runtime do usuário.", { default: "inherit", type: z.string().min(1), expects: "id de modelo ou inherit" }),
+
+  // The admission gate's rollout switches. `verify.mode` is what the HOOKS
+  // read (creation, install, activation, pack build); the explicit CLI
+  // (`nrv validate`) is never governed by it — a user who asks for a verdict
+  // gets the honest one. Defaults ship the gate in report-only so an existing
+  // machine keeps installing what it already has.
+  "verify.mode": enumSetting("verify.mode",
+    "Como os ganchos do portão de admissão tratam um achado: report = só relata; warn = avisa em destaque; block = recusa erro não baselinado.",
+    ["report", "warn", "block"], { default: "report", env: "NIRVANA_VERIFY_MODE" }),
+  "verify.enforce_on_install": booleanSetting("verify.enforce_on_install",
+    "Instalação recusa uma entidade com erro não baselinado (escape: --skip-validate).",
+    { default: false, env: "NIRVANA_VERIFY_ENFORCE_ON_INSTALL" }),
+  "verify.enforce_on_activate": booleanSetting("verify.enforce_on_activate",
+    "`nrv activate` recusa um squad com erro não baselinado antes de instalar dependências (escape: --skip-verify).",
+    { default: false, env: "NIRVANA_VERIFY_ENFORCE_ON_ACTIVATE" }),
 } as const;
 
 export type SettingKey = keyof typeof SETTINGS;

--- a/skills/_shared/lib/verify/agentic.ts
+++ b/skills/_shared/lib/verify/agentic.ts
@@ -1,0 +1,268 @@
+// agentic.ts — `nrv validate <kind> <slug> --fix=agentic`.
+//
+// The mechanical fixers repair SHAPE: a missing surface, a stub component, a
+// field in the wrong place. What they cannot write is MEANING — a description
+// that carries routing signal, `example_briefs` a real user would type, the
+// `routing:` block of a clone. Those findings are declared `autofix:
+// "agentic"` and, until this file, had nowhere to go.
+//
+// The pattern is enrich-routing-metadata.ts's, not `nrv dispatch --agent-x`
+// (which aims at an outputs root and runs the whole delivery pipeline). What
+// makes it safe to point a model at an author's own squad:
+//
+//   STAGING       the model edits a COPY. The library is untouched until the
+//                 result is judged better, so a bad run costs a temp dir.
+//   BUDGET        a hard `--max-budget-usd` (default 3) and a wall clock, and
+//                 nothing runs at all until the spend is confirmed (exit 2).
+//   ACCEPTANCE    errors may not GROW and at least one targeted finding must
+//                 be GONE. "The model wrote something" is not a result.
+//   RETRIEVAL     when routing metadata was the target, the entity has to be
+//                 findable afterwards — the self-retrieval gate says so, and a
+//                 failure rolls the whole thing back.
+//   LEDGER        one row (`targetKind: "verify-fix"`) and a start/finish pair
+//                 of audit events, so a spend is never invisible.
+//
+// Off in `--pack` (a pack source is not an installed entity and has no
+// registry to retrieve from) and off when no runtime is on PATH.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { paths } from "../bun-helpers.ts";
+import { scopeGuard } from "../scope-guard.ts";
+import { runHeadless, runtimeAvailable, type RunHeadlessOpts, type RunHeadlessResult, type Runtime } from "../host-agent-driver.ts";
+import { createBackup, restoreBackup } from "./backup.ts";
+import { countFindings } from "./report.ts";
+import { findingKey, type CheckContext, type Finding, type FixOutcome, type FixResult, type KindModule } from "./types.ts";
+
+export const DEFAULT_BUDGET_USD = 3;
+export const DEFAULT_TIMEOUT_MS = 15 * 60_000;
+
+/** Every runtime the driver knows, in the order a default pick prefers them. */
+export const RUNTIME_PREFERENCE: Runtime[] = [
+  "claude-code", "codex", "gemini-cli", "antigravity-cli", "kimi-cli", "grok-cli", "pi", "qwen-code", "opencode",
+];
+
+/** The gate needs a spend confirmed before it runs. Exit 2, never a silent bill. */
+export class AgenticConfirmationRequired extends Error {
+  exit = 2;
+}
+
+export interface AgenticOptions {
+  runtime?: Runtime;
+  budgetUsd?: number;
+  timeoutMs?: number;
+  /** `--yes`: the spend is authorized. Without it the run refuses with exit 2. */
+  confirmed?: boolean;
+  /** Pack sources are never agentically fixed. */
+  pack?: boolean;
+  emit?: ((event: string, payload: Record<string, unknown>) => void) | null;
+  backupRoot?: string;
+  stagingRoot?: string;
+  traceId?: string;
+  // ── test seams ──
+  runHeadlessImpl?: (opts: RunHeadlessOpts) => RunHeadlessResult;
+  runtimeAvailableImpl?: (runtime: Runtime) => boolean;
+  /** Self-retrieval check; returns false to roll the run back. */
+  retrievalCheck?: (slug: string, kind: string) => boolean | Promise<boolean>;
+  openRunImpl?: (opts: Record<string, unknown>) => { runId: string } | null;
+}
+
+export interface AgenticResult {
+  findings: Finding[];
+  fixes: FixResult[];
+  outcome: FixOutcome;
+}
+
+/**
+ * Criteria whose repair is only real if the entity can still be retrieved.
+ * These are the fields the router READS — a rewritten one-liner that stops
+ * returning its own clone is a regression dressed as a fix. `not_for` is
+ * deliberately absent: it is a fence, judged by check-not-for-fires, and it
+ * never makes an entity more findable.
+ */
+const RETRIEVAL_SENSITIVE = new Set([
+  "routing_metadata_incomplete", "routing_block_missing", "one_liner_missing",
+  "description_short", "domains_count", "serves_missing", "self_retrieval_miss",
+]);
+
+function noop(module: KindModule, findings: Finding[], note: string): AgenticResult {
+  const c = countFindings(findings);
+  const before = { errors: c.errors, warnings: c.warnings };
+  return {
+    findings, fixes: [{ fixer: "agentic", finding: "-", applied: false, changed_files: [], note }],
+    outcome: { mode: "agentic", backup: null, rolled_back: false, rollback_reason: note, before, after: before },
+  };
+}
+
+function pickRuntime(opts: AgenticOptions): Runtime | null {
+  const available = opts.runtimeAvailableImpl ?? runtimeAvailable;
+  if (opts.runtime) return available(opts.runtime) ? opts.runtime : null;
+  for (const rt of RUNTIME_PREFERENCE) if (available(rt)) return rt;
+  return null;
+}
+
+/**
+ * The real self-retrieval gate: does the entity come back first for its own
+ * example briefs? `reindex: false` — the caller decides when to reindex, and a
+ * repair that only works after a reindex is not a repair the user can trust.
+ * An unavailable gate never blocks an otherwise accepted run.
+ */
+async function defaultRetrievalCheck(slug: string, kind: string): Promise<boolean> {
+  try {
+    const { runGate } = await import("../../scripts/self-retrieval-gate.ts");
+    const r = await runGate(slug, { kind: kind as never, reindex: false });
+    return r.passed;
+  } catch {
+    return true;
+  }
+}
+
+function stagingRoot(opts: AgenticOptions): string {
+  return opts.stagingRoot ?? path.join((paths as Record<string, string>).NIRVANA_HOME ?? os.tmpdir(), ".nirvana", "verify-staging");
+}
+
+/**
+ * The brief the model receives. It names the findings by id with their own
+ * evidence, states the contract of the kind, and carries the scope guard — a
+ * `--fix` that "improves" three things nobody asked about is the failure mode
+ * this whole cut exists to avoid.
+ */
+export function buildBrief(module: KindModule, slug: string, targets: Finding[]): string {
+  const titles = new Map(module.criteria.map((c) => [c.id, c.title]));
+  const lines: string[] = [];
+  lines.push(`You are repairing ONE ${module.kind} — \`${slug}\` — inside a staging copy of it.`);
+  lines.push("");
+  lines.push(`The admission gate (\`nrv validate ${module.kind} ${slug}\`) reported the findings below.`);
+  lines.push("Each one names a criterion, what the criterion requires, and the evidence that made it fire.");
+  lines.push("");
+  for (const f of targets) {
+    lines.push(`- **${findingKey(f)}** — ${titles.get(f.id) ?? f.id}`);
+    lines.push(`  - reported: ${f.message}`);
+    if (f.evidence) lines.push(`  - evidence: ${f.evidence}`);
+  }
+  lines.push("");
+  lines.push("Rules:");
+  lines.push(`1. Edit only files inside this directory. The manifest is \`${module.manifestFile}\`.`);
+  lines.push("2. Fix EXACTLY the findings listed above. Nothing else in this entity is yours to change.");
+  lines.push("3. Never delete authored content. Never invent a source, a citation or a validation verdict.");
+  lines.push("4. Keep the file's own language and comments; the engine re-reads them.");
+  lines.push("5. Write real content, never a placeholder or a TODO — the gate will re-check and reject a stub.");
+  lines.push("");
+  lines.push(scopeGuard("en"));
+  return lines.join("\n");
+}
+
+/**
+ * Runs the agentic repair. The caller has already run `check`; `findings0` is
+ * that result, and the returned findings are the post-run re-check.
+ */
+export async function agenticFix(
+  module: KindModule, ctx: CheckContext, findings0: Finding[], opts: AgenticOptions = {},
+): Promise<AgenticResult> {
+  const emit = opts.emit === null ? () => {} : (opts.emit ?? (() => {}));
+  const targets = findings0.filter((f) => f.autofix === "agentic" && !f.baselined);
+  if (opts.pack) return noop(module, findings0, "--fix=agentic is off for --pack: a pack source is not an installed entity");
+  if (targets.length === 0) return noop(module, findings0, "nothing to repair agentically");
+
+  // Confirmation BEFORE the runtime probe, deliberately: whether this command
+  // may spend money is a property of the request, not of the machine, so the
+  // answer is the same on every machine and a `which` is never run for a
+  // command the user has not authorized yet.
+  const budgetUsd = opts.budgetUsd ?? DEFAULT_BUDGET_USD;
+  if (!opts.confirmed) {
+    throw new AgenticConfirmationRequired(
+      `--fix=agentic spends up to $${budgetUsd.toFixed(2)} on ${targets.length} finding(s) of ${module.kind} ${ctx.slug}. ` +
+      "Re-run with --yes to authorize (change the ceiling with --budget-usd).");
+  }
+
+  const runtime = pickRuntime(opts);
+  if (!runtime) return noop(module, findings0, "no agent runtime on PATH — install one, or use --fix (mechanical)");
+
+  const before = (() => { const c = countFindings(findings0); return { errors: c.errors, warnings: c.warnings }; })();
+  const staging = path.join(stagingRoot(opts), module.kind, `${ctx.slug}.${new Date().toISOString().replace(/[:.]/g, "-")}`);
+  fs.mkdirSync(path.dirname(staging), { recursive: true });
+  fs.cpSync(ctx.dir, staging, { recursive: true, verbatimSymlinks: true });
+
+  const traceId = opts.traceId ?? `verify-fix-${ctx.slug}-${Date.now().toString(36)}`;
+  let runId: string | null = null;
+  try {
+    const open = opts.openRunImpl ?? (await import("../../harness/lib/run-ledger.ts")).openAgenticRun as (o: Record<string, unknown>) => { runId: string } | null;
+    runId = open({ projectId: traceId, traceId, targetSlug: ctx.slug, targetKind: "verify-fix", outputsRoot: staging, runtime })?.runId ?? null;
+  } catch { /* a run that is not ledgered still runs; it is just not watched */ }
+
+  const brief = buildBrief(module, ctx.slug, targets);
+  emit("x_verify_fix_started", {
+    kind: module.kind, slug: ctx.slug, runtime, run_id: runId, trace_id: traceId,
+    findings: targets.map(findingKey), budget_usd: budgetUsd, staging,
+  });
+
+  const run = (opts.runHeadlessImpl ?? runHeadless)({
+    runtime, prompt: brief, cwd: staging, addDirs: [staging],
+    maxBudgetUsd: budgetUsd, timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+
+  const finish = (accepted: boolean, reason: string | undefined, after: { errors: number; warnings: number }) => {
+    emit("x_verify_fix_finished", {
+      kind: module.kind, slug: ctx.slug, runtime, run_id: runId, trace_id: traceId,
+      accepted, reason: reason ?? null, cost_usd: run.costUsd, duration_ms: run.durationMs,
+      errors_before: before.errors, errors_after: after.errors,
+    });
+  };
+
+  const discard = (reason: string): AgenticResult => {
+    fs.rmSync(staging, { recursive: true, force: true });
+    finish(false, reason, before);
+    return {
+      findings: findings0,
+      fixes: [{ fixer: "agentic", finding: targets.map(findingKey).join(", "), applied: false, changed_files: [], note: reason }],
+      outcome: { mode: "agentic", backup: null, rolled_back: true, rollback_reason: reason, before, after: before },
+    };
+  };
+
+  if (!run.ok) return discard(`the ${runtime} run failed: ${run.error ?? `exit ${run.exitCode}`}`);
+
+  const staged = await module.check({ ...ctx, dir: staging });
+  const stagedCounts = (() => { const c = countFindings(staged); return { errors: c.errors, warnings: c.warnings }; })();
+  if (stagedCounts.errors > before.errors) return discard(`errors grew ${before.errors} → ${stagedCounts.errors}`);
+  const gone = targets.filter((t) => !staged.some((f) => findingKey(f) === findingKey(t)));
+  if (gone.length === 0) return discard("no targeted finding was repaired");
+
+  // Accepted on the staging copy: back the real entity up, then overwrite it.
+  const backup = createBackup(ctx.dir, module.kind, ctx.slug, opts.backupRoot);
+  fs.rmSync(ctx.dir, { recursive: true, force: true });
+  fs.cpSync(staging, ctx.dir, { recursive: true, verbatimSymlinks: true });
+  fs.rmSync(staging, { recursive: true, force: true });
+
+  // Routing metadata is only repaired if the entity can be FOUND with it.
+  // The gate has to read the entity from disk, which is why it runs here and
+  // not on the staging copy: the registry knows the installed path, not a
+  // temp dir. A miss restores the backup, so the cost of asking late is one
+  // more copy, never a corrupted entity.
+  if (targets.some((t) => RETRIEVAL_SENSITIVE.has(t.id))) {
+    const check = opts.retrievalCheck ?? defaultRetrievalCheck;
+    if (!(await check(ctx.slug, module.kind))) {
+      restoreBackup(backup, ctx.dir);
+      const reverted = await module.check(ctx);
+      const reason = "the self-retrieval gate still does not return the entity for its own briefs";
+      finish(false, reason, before);
+      return {
+        findings: reverted,
+        fixes: [{ fixer: "agentic", finding: gone.map(findingKey).join(", "), applied: false, changed_files: [], note: reason }],
+        outcome: { mode: "agentic", backup, rolled_back: true, rollback_reason: reason, before, after: before },
+      };
+    }
+  }
+
+  const after = await module.check(ctx);
+  const afterCounts = (() => { const c = countFindings(after); return { errors: c.errors, warnings: c.warnings }; })();
+  finish(true, undefined, afterCounts);
+  return {
+    findings: after,
+    fixes: [{
+      fixer: "agentic", finding: gone.map(findingKey).join(", "), applied: true,
+      changed_files: [], note: `${gone.length} of ${targets.length} finding(s) repaired by ${runtime}${run.costUsd === null ? "" : ` ($${run.costUsd.toFixed(2)})`}`,
+    }],
+    outcome: { mode: "agentic", backup, rolled_back: false, before, after: afterCounts },
+  };
+}

--- a/skills/_shared/lib/verify/hooks.ts
+++ b/skills/_shared/lib/verify/hooks.ts
@@ -1,0 +1,162 @@
+// hooks.ts — the four moments an entity enters the system.
+//
+// Creation (init-squad / init-business), installation (installer.ts and
+// install-content.ts), activation (`nrv activate`) and the pack build all ask
+// the same question — is this entity admissible — and all four used to answer
+// it with something else: a spawned loader, a light manifest read, or nothing
+// at all. This module is the single door, and the reason it is a module and
+// not four call sites is the buyer: a gate wired straight into an install path
+// turns "my pack no longer installs" into the first thing a new customer sees.
+//
+// Three rules keep that from happening:
+//
+//   1. **Flagged off by default.** `verify.mode` ships `report`, and
+//      `verify.enforce_on_install` / `verify.enforce_on_activate` ship false.
+//      With the defaults, a hook prints its verdict and returns `blocked:
+//      false` no matter what it found.
+//   2. **Grandfathering.** `mode: "hook"` in the runner records a debt
+//      baseline the first time it meets an entity on a machine that has none,
+//      instead of rejecting a library that was installed before the gate
+//      existed. Only `baselineable` criteria — facts the pipeline produces —
+//      ever become debt; a HARD error never does.
+//   3. **A documented escape.** `--skip-validate` (install) and
+//      `--skip-verify` (activate, creation) return `ran: false` without
+//      touching disk, so a buyer is never stuck behind a gate.
+//
+// A hook NEVER throws: an internal failure is reported as `ran: false` with a
+// reason, and the caller proceeds. Losing the check is bad; losing the install
+// because the check broke is worse.
+
+import { resolveSetting } from "../settings.ts";
+import { verifyEntity, type Emitter, type VerifyOptions } from "./runner.ts";
+import type { Finding, Kind, VerifyReport } from "./types.ts";
+
+export type HookGate = "create" | "install" | "activate" | "pack";
+
+export interface HookOptions {
+  kind: Kind;
+  /** Slug or directory; the kind module resolves it. */
+  target: string;
+  gate: HookGate;
+  /** The caller's documented escape (`--skip-validate` / `--skip-verify`). */
+  skip?: boolean;
+  /** Creation repairs its own scaffold before judging it. */
+  fix?: false | "mechanical";
+  emit?: Emitter | null;
+  baselinePath?: string | null;
+  stateDir?: string | null;
+  retrieval?: boolean;
+  /** Injected resolution (tests); default reads the settings table. */
+  settings?: Partial<HookSettings>;
+}
+
+export interface HookSettings {
+  mode: "report" | "warn" | "block";
+  enforceOnInstall: boolean;
+  enforceOnActivate: boolean;
+}
+
+export interface HookOutcome {
+  ran: boolean;
+  /** The caller must refuse. Only ever true when the gate enforces. */
+  blocked: boolean;
+  /** Whether this gate was enforcing at all (the flag's answer). */
+  enforcing: boolean;
+  report: VerifyReport | null;
+  errors: Finding[];
+  warnings: Finding[];
+  /** Ready-to-print lines, in the caller's own voice-neutral form. */
+  lines: string[];
+  reason?: string;
+}
+
+const DEFAULTS: HookSettings = { mode: "report", enforceOnInstall: false, enforceOnActivate: false };
+
+/** Reads the three rollout flags; an unreadable config never blocks a hook. */
+export function hookSettings(injected?: Partial<HookSettings>): HookSettings {
+  if (injected && injected.mode && injected.enforceOnInstall !== undefined && injected.enforceOnActivate !== undefined) {
+    return injected as HookSettings;
+  }
+  let resolved = { ...DEFAULTS };
+  try {
+    resolved = {
+      mode: resolveSetting("verify.mode").value as HookSettings["mode"],
+      enforceOnInstall: resolveSetting("verify.enforce_on_install").value as boolean,
+      enforceOnActivate: resolveSetting("verify.enforce_on_activate").value as boolean,
+    };
+  } catch { /* a broken config file is `nrv config`'s problem, never the gate's */ }
+  return { ...resolved, ...(injected ?? {}) };
+}
+
+/**
+ * Does this gate refuse an entity that carries an error the baseline does not
+ * cover? Creation always does — it judges a scaffold the engine itself just
+ * wrote, and deleting it is what `init-business` already did with the loader.
+ * The other three answer to their flag, or to `verify.mode: block`.
+ */
+export function enforcesAt(gate: HookGate, s: HookSettings): boolean {
+  if (gate === "create") return true;
+  if (s.mode === "block") return true;
+  if (gate === "install" || gate === "pack") return s.enforceOnInstall;
+  return s.enforceOnActivate;
+}
+
+const ESCAPE: Record<HookGate, string> = {
+  create: "--skip-verify",
+  install: "--skip-validate",
+  activate: "--skip-verify",
+  pack: "--skip-validate",
+};
+
+/** Runs the gate for one entity and says what the caller should do about it. */
+export async function verifyHook(opts: HookOptions): Promise<HookOutcome> {
+  const settings = hookSettings(opts.settings);
+  const enforcing = enforcesAt(opts.gate, settings);
+  const base: HookOutcome = { ran: false, blocked: false, enforcing, report: null, errors: [], warnings: [], lines: [] };
+
+  if (opts.skip) {
+    return { ...base, reason: "skipped", lines: [`verify: skipped by ${ESCAPE[opts.gate]} — ${opts.kind} ${opts.target} was not checked`] };
+  }
+
+  let report: VerifyReport;
+  try {
+    const runOpts: VerifyOptions = {
+      mode: "hook",
+      fix: opts.fix ?? false,
+      retrieval: opts.retrieval ?? false,
+      emit: opts.emit,
+      ...(opts.baselinePath !== undefined ? { baselinePath: opts.baselinePath } : {}),
+      ...(opts.stateDir !== undefined ? { stateDir: opts.stateDir } : {}),
+    };
+    report = await verifyEntity(opts.kind, opts.target, runOpts);
+  } catch (e: unknown) {
+    const reason = (e as Error)?.message ?? String(e);
+    return { ...base, reason, lines: [`verify: could not check ${opts.kind} ${opts.target} (${reason}) — proceeding`] };
+  }
+
+  const errors = report.findings.filter((f) => f.severity === "error" && !f.baselined);
+  const warnings = report.findings.filter((f) => f.severity === "warning" && !f.baselined);
+  const blocked = enforcing && errors.length > 0;
+  const lines = renderHookLines(opts, settings, report, errors, warnings, blocked);
+  return { ran: true, blocked, enforcing, report, errors, warnings, lines };
+}
+
+function renderHookLines(
+  opts: HookOptions, settings: HookSettings, report: VerifyReport,
+  errors: Finding[], warnings: Finding[], blocked: boolean,
+): string[] {
+  const label = `${opts.kind} ${report.slug}`;
+  if (errors.length === 0 && warnings.length === 0) {
+    return settings.mode === "report" ? [] : [`verify: ${label} ADMITTED`];
+  }
+  const head = `verify: ${label} — ${errors.length} error(s), ${warnings.length} warning(s)${report.summary.debt ? `, ${report.summary.debt} baselined` : ""}`;
+  const lines = [head];
+  const shown = [...errors, ...warnings].slice(0, settings.mode === "report" ? 3 : 8);
+  for (const f of shown) lines.push(`  ${f.severity === "error" ? "✗" : "⚠"} ${f.id}${f.where ? `:${f.where}` : ""} — ${f.message}`);
+  if (blocked) {
+    lines.push(`  refused: run \`nrv validate ${opts.kind} ${report.slug} --fix\`, or repeat with ${ESCAPE[opts.gate]}`);
+  } else if (errors.length) {
+    lines.push(`  proceeding anyway (verify.mode=${settings.mode}${opts.gate === "install" || opts.gate === "pack" ? ", verify.enforce_on_install=false" : opts.gate === "activate" ? ", verify.enforce_on_activate=false" : ""}) — \`nrv validate ${opts.kind} ${report.slug}\` for the detail`);
+  }
+  return lines;
+}

--- a/skills/_shared/lib/verify/index.ts
+++ b/skills/_shared/lib/verify/index.ts
@@ -1,8 +1,10 @@
 // index.ts — public surface of the admission gate module.
 export * from "./types.ts";
 export { verifyEntity, verifyAll, verifyPack, VerifyUsageError, MODULES, kindFromAlias, type VerifyOptions, type BatchOptions, type Emitter } from "./runner.ts";
+export { verifyHook, hookSettings, enforcesAt, type HookGate, type HookOptions, type HookOutcome, type HookSettings } from "./hooks.ts";
 export { renderReport, renderBatch, countFindings, exitCodeFor, type BatchReport } from "./report.ts";
 export { loadBaseline, recordBaseline, applyBaseline, debtOf, importLegacy, defaultBaselinePath, writeBaseline, type Baseline, type RecordResult } from "./baseline.ts";
+export { agenticFix, buildBrief, AgenticConfirmationRequired, DEFAULT_BUDGET_USD, DEFAULT_TIMEOUT_MS, RUNTIME_PREFERENCE, type AgenticOptions, type AgenticResult } from "./agentic.ts";
 export { createBackup, restoreBackup, listBackups, prune, withBackup, defaultBackupRoot, BACKUP_KEEP } from "./backup.ts";
 export { mindCloneModule, criteria as mindCloneCriteria, measureDnaSchema, countLayerItems, CANONICAL_ARTIFACTS } from "./kinds/mind-clone.ts";
 export { squadModule } from "./kinds/squad.ts";

--- a/skills/_shared/lib/verify/kinds/mind-clone.ts
+++ b/skills/_shared/lib/verify/kinds/mind-clone.ts
@@ -197,6 +197,15 @@ export async function check(ctx: CheckContext): Promise<Finding[]> {
       }
       if (generic.length) out.push(mk("manifest_schema", `MANIFEST.yaml violates the schema (${generic.length} issue${generic.length === 1 ? "" : "s"})`, generic.slice(0, 6).join(" · ")));
     }
+    // `category` is authored in two places across the live library: under
+    // `manifest:` (canonical, and the only one the schema sees) and at the top
+    // level (older compilations). The numbered legacy form has to be caught in
+    // both — `category_bare` has always repaired both — otherwise a clone that
+    // writes it at the top level walks past a bar the fixer would have fixed.
+    const topCategory = String((doc as Record<string, unknown>).category ?? "");
+    if (/^\d\d-/.test(topCategory) && !out.some((f) => f.id === "category_numbered")) {
+      out.push(mk("category_numbered", `numbered legacy category "${topCategory}" — the library is bare-form`, "category"));
+    }
     if (typeof man.name === "string" && man.name !== slug) {
       out.push(mk("manifest_name_mismatch", `manifest.name "${man.name}" differs from the directory slug "${slug}"`, "manifest.name"));
     }
@@ -244,7 +253,11 @@ export async function check(ctx: CheckContext): Promise<Finding[]> {
     const verdict = doc.validation_verdict ?? man.validation_verdict;
     if (!verdict) out.push(mk("validation_verdict_missing", "no validation_verdict — produced by the validation pipeline, never by a text edit", "validation_verdict"));
     const src = doc.source_material ?? man.source_material;
-    const primary = src && typeof src === "object" ? (src as any).primary : undefined;
+    // `primary_works` is the same list under an older name (3 of 527 live
+    // clones write it). The bar is that the sources are DECLARED; refusing a
+    // clone that declares them under the older key would invent a failure the
+    // pack build has never had, and no source is fabricated either way.
+    const primary = src && typeof src === "object" ? ((src as any).primary ?? (src as any).primary_works) : undefined;
     if (!src || !Array.isArray(primary) || primary.length === 0) out.push(mk("source_material_missing", "no source_material.primary — the gate never fabricates a source", "source_material.primary"));
 
     // dna_layers vs the schema file

--- a/skills/_shared/lib/verify/runner.ts
+++ b/skills/_shared/lib/verify/runner.ts
@@ -15,6 +15,7 @@ import { createRequire } from "node:module";
 import { paths } from "../bun-helpers.ts";
 import { detectKind } from "../surface.ts";
 import { applyBaseline, debtOf, defaultBaselinePath, loadBaseline, recordBaseline, type Baseline } from "./baseline.ts";
+import { agenticFix, type AgenticOptions } from "./agentic.ts";
 import { createBackup, restoreBackup } from "./backup.ts";
 import { businessModule } from "./kinds/business.ts";
 import { mindCloneModule } from "./kinds/mind-clone.ts";
@@ -58,6 +59,8 @@ export interface VerifyOptions {
   cloneRegistry?: Record<string, unknown>;
   /** test seam: a module standing in for the kind's */
   module?: KindModule;
+  /** `--fix=agentic`: runtime, budget, confirmation and the test seams. */
+  agentic?: AgenticOptions;
 }
 
 let _audit: Emitter | null = null;
@@ -142,7 +145,6 @@ async function runOne(
   baseline: Baseline | null, baselineFile: string | null, persist: boolean,
 ): Promise<VerifyReport> {
   const kind = module.kind;
-  if (opts.fix === "agentic") throw new VerifyUsageError("--fix=agentic is not available yet; use --fix (mechanical fixers)");
   const ctx: CheckContext = { kind, slug, dir, retrieval: opts.retrieval !== false, registries: opts.registries, cloneRegistry: opts.cloneRegistry };
   const emit: Emitter = opts.emit === null ? () => {} : (opts.emit ?? auditEmit());
 
@@ -152,6 +154,16 @@ async function runOne(
   if (opts.fix === "mechanical") {
     const r = await fixLoop(module, ctx, findings, opts.backupRoot);
     findings = r.findings; fixes = r.fixes; fix_outcome = r.outcome;
+  } else if (opts.fix === "agentic") {
+    // The mechanical pass runs first on purpose: shape before meaning, so the
+    // model is never asked to hand-write what a fixer writes for free — and
+    // never spends the budget on an entity a fixer would have admitted.
+    const mech = await fixLoop(module, ctx, findings, opts.backupRoot);
+    findings = mech.findings; fixes = mech.fixes;
+    const r = await agenticFix(module, ctx, findings, { emit, backupRoot: opts.backupRoot, ...(opts.agentic ?? {}) });
+    findings = r.findings;
+    fixes = [...fixes, ...r.fixes];
+    fix_outcome = { ...r.outcome, before: mech.outcome.before };
   }
 
   const baselineable = new Set(module.criteria.filter((c) => c.baselineable).map((c) => c.id));

--- a/skills/_shared/scripts/check-seat-sufficiency.ts
+++ b/skills/_shared/scripts/check-seat-sufficiency.ts
@@ -11,6 +11,12 @@
  * content, calibrated against the whole library (488 rich → 0 thin, 28 real
  * thin seats found, every verdict on the short side verified by reading).
  *
+ * SINCE THE ADMISSION GATE, THIS FILE IS A WRAPPER over `verifyAll("business")`
+ * and its `seat_thin` criterion — the same measure, asked once, in the place
+ * every other admission question is asked. Flags, output and exit codes are
+ * FROZEN: this gate's tests are untouched and its callers (`SKILL.md` Round 5,
+ * the pack build) need no edit.
+ *
  * Same debt pattern as the admission gate and the fence ceiling:
  *
  *   a seat the baseline has never seen  →  enters SUFFICIENT or not at all
@@ -34,7 +40,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { parseArgs, paths as nrvPaths } from "../lib/bun-helpers.ts";
-import { resolveScope, enumerate } from "../lib/scope.ts";
+import { verifyAll } from "../lib/verify/index.ts";
 
 const require_ = createRequire(import.meta.url);
 const { sufficiencyOfFile } = require_("../lib/seat-sufficiency.js");
@@ -50,33 +56,27 @@ const BASELINE = typeof flags.baseline === "string"
 /** Businesses root override for tests; default is the resolved scope. */
 const rootsFlag = typeof flags.businesses === "string" ? flags.businesses : null;
 
-function businessDirs(): Array<{ slug: string; dir: string }> {
-  if (rootsFlag) {
-    return readdirSync(rootsFlag)
-      .filter((s) => !s.startsWith(".") && s !== "_library")
-      .map((slug) => ({ slug, dir: join(rootsFlag, slug) }))
-      .filter((e) => existsSync(join(e.dir, "business.yaml")));
-  }
-  try {
-    return enumerate(resolveScope(), "businesses").filter((e: { overridden?: boolean }) => !e.overridden);
-  } catch { return []; }
-}
-
 interface Seat { key: string; business: string; employee: string; signals: Record<string, number>; }
 const thin: Seat[] = [];
 let seats = 0;
 
-for (const { slug, dir } of businessDirs()) {
-  if (only && slug !== only) continue;
-  const empDir = join(dir, "employees");
-  if (!existsSync(empDir)) continue;
-  for (const f of readdirSync(empDir)) {
-    if (!f.endsWith(".md")) continue;
-    seats++;
-    const r = sufficiencyOfFile(readFileSync(join(empDir, f), "utf8"));
-    if (r.verdict === "thin") {
-      thin.push({ key: `${slug}/${f}`, business: slug, employee: f, signals: r.signals });
-    }
+// The gate answers "is this seat thin"; the signals below are read straight
+// from the file only to PRINT them (`h=… decisions=… chars=…`), which is what
+// the single-business listing has always shown.
+const batch = await verifyAll("business", {
+  roots: rootsFlag ? [rootsFlag] : undefined,
+  baselinePath: null, retrieval: false, stateDir: null, emit: null,
+});
+for (const report of batch.reports) {
+  if (only && report.slug !== only) continue;
+  const empDir = join(report.dir, "employees");
+  if (existsSync(empDir)) seats += readdirSync(empDir).filter((f) => f.endsWith(".md")).length;
+  for (const f of report.findings) {
+    if (f.id !== "seat_thin") continue;
+    const employee = (f.where ?? "").replace(/^employees\//, "");
+    let signals: Record<string, number> = {};
+    try { signals = sufficiencyOfFile(readFileSync(join(empDir, employee), "utf8")).signals; } catch { /* printed only */ }
+    thin.push({ key: `${report.slug}/${employee}`, business: report.slug, employee, signals });
   }
 }
 

--- a/skills/_shared/scripts/install-asset.ts
+++ b/skills/_shared/scripts/install-asset.ts
@@ -63,7 +63,7 @@ OPTIONS
   --force                         replace existing install (auto-backs up to <path>.<version>.bak.<ts>/)
   --dry-run                       show what would happen, do not write
   --skip-reindex                  skip nrv index call (faster batch installs)
-  --skip-validate                 skip light validation (NOT recommended)
+  --skip-validate                 skip light validation AND the admission gate (NOT recommended)
   --quiet                         suppress stderr progress
   --json                          emit JSON result on stdout
 

--- a/skills/_shared/scripts/install-content.ts
+++ b/skills/_shared/scripts/install-content.ts
@@ -11,7 +11,7 @@
  * squads/businesses/clones or another pack's components.
  *
  * Usage:
- *   bun install-content.ts <contentDir> --slug <slug> [--dry]
+ *   bun install-content.ts <contentDir> --slug <slug> [--dry] [--skip-validate]
  *
  * <contentDir> = the pack's `starter-pack` dir (squads/ businesses/ mind-clones/).
  */
@@ -39,6 +39,7 @@ const PACKS_DIR = join(HOME, ".nirvana", "packs");
 
 const argv = process.argv.slice(2);
 const DRY = argv.includes("--dry");
+const SKIP_VALIDATE = argv.includes("--skip-validate");
 const slugIdx = argv.indexOf("--slug");
 const SLUG = slugIdx >= 0 ? (argv[slugIdx + 1] ?? "") : "";
 const verIdx = argv.indexOf("--version");
@@ -186,13 +187,13 @@ const availableIn = (dir: string, marker: string): string[] =>
   existsSync(dir) ? readdirSync(dir).filter((e) => !e.startsWith(".") && e !== "README.md" && existsSync(join(dir, e, marker))) : [];
 
 interface SyncRes { added: string[]; updated: string[]; unchanged: string[]; removed: string[]; overwritten: string[]; hashes: Record<string, string>; breaking: BreakingChange[]; }
-function syncKind(kind: string, srcRoot: string, dstRoot: string, available: string[], old: Record<string, string>): SyncRes {
+function syncKind(kind: string, srcRoot: string, dstRoot: string, available: string[], old: Record<string, string>, precomputed?: Record<string, string>): SyncRes {
   const ex = RUNSTATE_EXCLUDES[kind] ?? [];
   const res: SyncRes = { added: [], updated: [], unchanged: [], removed: [], overwritten: [], hashes: {}, breaking: [] };
   if (available.length) mkdirSync(dstRoot, { recursive: true });
   for (const slug of available) {
     const src = join(srcRoot, slug), dst = join(dstRoot, slug);
-    const h = hashDir(src, ex); res.hashes[slug] = h;
+    const h = precomputed?.[slug] ?? hashDir(src, ex); res.hashes[slug] = h;
     if (!existsSync(dst)) { res.added.push(slug); if (!DRY) mirror(src, dst, ex); }
     // Collision: it exists on disk but the pack never owned it (outside the
     // manifest) — a user creation with the same slug. The pack wins (it is the
@@ -235,10 +236,61 @@ auditEmit("x_install_order_resolved", {
   edges: packGraph.edges.length,
 });
 
+const KIND_SOURCES: Record<string, { src: string; dst: string; marker: string; entity: "squad" | "business" | "mind-clone"; recorded: Record<string, string> }> = {
+  "squads": { src: squadsSrc, dst: SQUADS_DIR, marker: "squad.yaml", entity: "squad", recorded: man.squads ?? {} },
+  "businesses": { src: bizSrc, dst: BUSINESSES_DIR, marker: "business.yaml", entity: "business", recorded: man.businesses ?? {} },
+  "mind-clones": { src: cloneSrc, dst: DNA_DIR, marker: "MANIFEST.yaml", entity: "mind-clone", recorded: man["mind-clones"] ?? {} },
+};
+
+// ── The admission gate, per entity, BEFORE anything is mirrored ─────────────
+//
+// Only what is actually ENTERING is checked: a slug whose source hash equals
+// the one this pack recorded last time is already installed and unchanged, and
+// re-judging it every update would make an install pay for the whole library.
+// The hashes computed here are handed to syncKind so nothing is hashed twice.
+//
+// A refusal aborts the WHOLE overlay before the first file moves — a pack that
+// half-installs is worse than one that does not install. And it only ever
+// refuses when the buyer turned `verify.enforce_on_install` on: with the
+// shipped defaults this block prints and proceeds.
+const srcHashes: Record<string, Record<string, string>> = {};
+const entering: Array<{ kind: string; entity: "squad" | "business" | "mind-clone"; slug: string; dir: string }> = [];
+for (const [kind, k] of Object.entries(KIND_SOURCES)) {
+  const ex = RUNSTATE_EXCLUDES[kind] ?? [];
+  srcHashes[kind] = {};
+  for (const slug of availableIn(k.src, k.marker)) {
+    const dir = join(k.src, slug);
+    const h = hashDir(dir, ex);
+    srcHashes[kind][slug] = h;
+    if (!existsSync(join(k.dst, slug)) || k.recorded[slug] !== h) entering.push({ kind, entity: k.entity, slug, dir });
+  }
+}
+if (entering.length) {
+  // Loaded lazily and defensively: a gate that cannot even be imported (a
+  // partially updated engine, a skills tree mid-copy) must not be the reason
+  // a paid pack fails to install.
+  const verifyHook = await import("../lib/verify/index.ts")
+    .then((m) => m.verifyHook)
+    .catch((e) => { console.warn(`  verify: the admission gate is unavailable (${(e as Error).message}) — installing without it`); return null; });
+  const refused: string[] = [];
+  for (const e of verifyHook ? entering : []) {
+    const gate = await verifyHook!({ kind: e.entity, target: e.dir, gate: "install", skip: SKIP_VALIDATE, stateDir: null });
+    for (const line of gate.lines) console.warn(`  ${line}`);
+    if (gate.blocked) refused.push(`${e.kind}/${e.slug}`);
+  }
+  if (refused.length) {
+    console.error(`\ninstall-content: ${refused.length} component(s) were refused by the admission gate (verify.enforce_on_install):`);
+    for (const r of refused) console.error(`    ✗ ${r}`);
+    console.error("  Nothing was installed. Fix them with `nrv validate <kind> <slug> --fix`, or re-run with --skip-validate.\n");
+    auditEmit("x_verify_install_refused", { pack: SLUG, refused });
+    process.exit(1);
+  }
+}
+
 const kindRuns: Record<string, () => SyncRes> = {
-  "squads": () => syncKind("squads", squadsSrc, SQUADS_DIR, availableIn(squadsSrc, "squad.yaml"), man.squads ?? {}),
-  "businesses": () => syncKind("businesses", bizSrc, BUSINESSES_DIR, availableIn(bizSrc, "business.yaml"), man.businesses ?? {}),
-  "mind-clones": () => syncKind("mind-clones", cloneSrc, DNA_DIR, availableIn(cloneSrc, "MANIFEST.yaml"), man["mind-clones"] ?? {}),
+  "squads": () => syncKind("squads", squadsSrc, SQUADS_DIR, availableIn(squadsSrc, "squad.yaml"), man.squads ?? {}, srcHashes["squads"]),
+  "businesses": () => syncKind("businesses", bizSrc, BUSINESSES_DIR, availableIn(bizSrc, "business.yaml"), man.businesses ?? {}, srcHashes["businesses"]),
+  "mind-clones": () => syncKind("mind-clones", cloneSrc, DNA_DIR, availableIn(cloneSrc, "MANIFEST.yaml"), man["mind-clones"] ?? {}, srcHashes["mind-clones"]),
 };
 const runs: Record<string, SyncRes> = {};
 for (const kind of kindOrder.order) runs[kind] = kindRuns[kind]();

--- a/skills/_shared/scripts/verify.ts
+++ b/skills/_shared/scripts/verify.ts
@@ -3,7 +3,7 @@
  * verify.ts — `nrv validate`, the admission gate for squads, businesses and
  * mind-clones (`nrv verify` is an alias).
  *
- *   nrv validate <squad|business|mind-clone> <slug|path> [--fix] [--strict] [--json] [--no-retrieval] [--baseline <file>]
+ *   nrv validate <squad|business|mind-clone> <slug|path> [--fix[=agentic]] [--strict] [--json] [--no-retrieval] [--baseline <file>]
  *   nrv validate <path>                               kind detected from the manifest on disk
  *   nrv validate <kind> --all [--fix] [--strict] [--json] [--record [--allow-regression]] [--root <dir>]
  *   nrv validate --pack <content-dir> [<kind>|--all-kinds] [--json] [--record]
@@ -20,12 +20,13 @@
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import {
-  KINDS, VERIFY_EXIT, VerifyUsageError, kindFromAlias, renderBatch, renderReport, verifyAll, verifyEntity, verifyPack,
-  type Kind,
+  AgenticConfirmationRequired, DEFAULT_BUDGET_USD, KINDS, VERIFY_EXIT, VerifyUsageError,
+  kindFromAlias, renderBatch, renderReport, verifyAll, verifyEntity, verifyPack,
+  type AgenticOptions, type Kind,
 } from "../lib/verify/index.ts";
 
-const BOOL_FLAGS = new Set(["fix", "strict", "json", "all", "record", "allow-regression", "no-retrieval", "all-kinds", "quiet", "q", "help", "h"]);
-const VALUE_FLAGS = new Set(["baseline", "pack", "root"]);
+const BOOL_FLAGS = new Set(["fix", "strict", "json", "all", "record", "allow-regression", "no-retrieval", "all-kinds", "quiet", "q", "yes", "y", "help", "h"]);
+const VALUE_FLAGS = new Set(["baseline", "pack", "root", "runtime", "budget-usd", "timeout-min"]);
 
 interface Args { positional: string[]; flags: Record<string, string | boolean>; roots: string[]; }
 
@@ -64,7 +65,12 @@ USAGE
 
 OPTIONS
   --fix              apply the mechanical fixers (backup, re-check, rollback on a new error)
-  --fix=agentic      not available yet
+  --fix=agentic      mechanical first, then an agent repairs what only meaning can fix,
+                     in a staging copy; needs --yes (exit 2 without it)
+  --yes              authorize the spend of --fix=agentic
+  --budget-usd <n>   ceiling of an agentic run (default ${DEFAULT_BUDGET_USD})
+  --timeout-min <n>  wall clock of an agentic run (default 15)
+  --runtime <name>   runtime for --fix=agentic (default: the first one on PATH)
   --strict           warnings also reject (exit 2)
   --json             nirvana.verify-report/v1 (one entity) or nirvana.verify-batch/v1
   --record           --all/--pack: record the current debt as the baseline (merge; refuses growth)
@@ -106,8 +112,20 @@ async function main(): Promise<number> {
   const json = !!flags.json;
   const strict = !!flags.strict;
   const fix: false | "mechanical" | "agentic" = flags.fix === true ? "mechanical" : flags.fix === "mechanical" ? "mechanical" : flags.fix === "agentic" ? "agentic" : flags.fix ? (() => { throw new VerifyUsageError(`--fix accepts mechanical or agentic, not ${flags.fix}`); })() : false;
+  const num = (name: string, fallback: number): number => {
+    if (flags[name] === undefined) return fallback;
+    const n = Number(flags[name]);
+    if (!Number.isFinite(n) || n < 0) throw new VerifyUsageError(`--${name} needs a number >= 0, not ${flags[name]}`);
+    return n;
+  };
+  const agentic: AgenticOptions = {
+    confirmed: !!(flags.yes || flags.y),
+    budgetUsd: num("budget-usd", DEFAULT_BUDGET_USD),
+    ...(flags["timeout-min"] !== undefined ? { timeoutMs: num("timeout-min", 15) * 60_000 } : {}),
+    ...(typeof flags.runtime === "string" ? { runtime: flags.runtime as AgenticOptions["runtime"] } : {}),
+  };
   const common = {
-    fix, strict,
+    fix, strict, agentic,
     retrieval: !flags["no-retrieval"],
     baselinePath: typeof flags.baseline === "string" ? flags.baseline : undefined,
   };
@@ -116,7 +134,7 @@ async function main(): Promise<number> {
     const packDir = String(flags.pack);
     const kindArg = positional[0] ? kindFromAlias(positional[0]) : null;
     if (positional[0] && !kindArg) throw new VerifyUsageError(`unknown kind: ${positional[0]} (squad|business|mind-clone)`);
-    const b = await verifyPack(packDir, { ...common, kinds: kindArg ? [kindArg] : [...KINDS], record: !!flags.record, allowRegression: !!flags["allow-regression"] });
+    const b = await verifyPack(packDir, { ...common, agentic: { ...agentic, pack: true }, kinds: kindArg ? [kindArg] : [...KINDS], record: !!flags.record, allowRegression: !!flags["allow-regression"] });
     console.log(json ? JSON.stringify(b, null, 2) : renderBatch(b, { quiet: !!(flags.quiet || flags.q) }));
     return b.exit_code;
   }
@@ -138,6 +156,7 @@ async function main(): Promise<number> {
 }
 
 main().then((code) => process.exit(code)).catch((e) => {
+  if (e instanceof AgenticConfirmationRequired) { console.error(`nrv validate: ${e.message}`); process.exit(e.exit); }
   if (e instanceof VerifyUsageError) { console.error(`nrv validate: ${e.message}`); process.exit(e.exit); }
   console.error(`nrv validate: ${e?.stack ?? e}`);
   process.exit(1);

--- a/skills/_shared/tests/settings-schema.test.ts
+++ b/skills/_shared/tests/settings-schema.test.ts
@@ -69,6 +69,9 @@ describe("the table", () => {
       "budget.default_max_cost_usd": null,
       "quality_gate.judge_enabled": null,
       "quality_gate.max_revisions": null,
+      "verify.mode": "NIRVANA_VERIFY_MODE",
+      "verify.enforce_on_install": "NIRVANA_VERIFY_ENFORCE_ON_INSTALL",
+      "verify.enforce_on_activate": "NIRVANA_VERIFY_ENFORCE_ON_ACTIVATE",
     };
     for (const [key, variable] of Object.entries(expected)) expect(getSettingSpec(key)?.env).toBe(variable);
   });

--- a/skills/_shared/tests/verify-agentic.test.ts
+++ b/skills/_shared/tests/verify-agentic.test.ts
@@ -1,0 +1,232 @@
+// verify-agentic.test.ts — `--fix=agentic`, with a fake runtime.
+//
+// Zero tokens: `runHeadless` is an injected seam that edits the staging copy
+// the way a model would (or fails, or makes things worse), so every branch of
+// the acceptance rule is exercised without a CLI, a network or a bill.
+//
+// The rule under test, in one line: the library is only overwritten when the
+// errors did not grow AND a targeted finding is actually gone — and when the
+// target was routing metadata, when the entity can still be found.
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parse as parseYaml, parseDocument } from "yaml";
+import { cloneFixture, rmrf, tempRoot } from "./helpers/verify-fixture.ts";
+import { AgenticConfirmationRequired, agenticFix, buildBrief, type AgenticOptions } from "../lib/verify/agentic.ts";
+import { mindCloneModule } from "../lib/verify/kinds/mind-clone.ts";
+import type { CheckContext, Finding } from "../lib/verify/types.ts";
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) rmrf(r); });
+function root(): string { const r = tempRoot(); ROOTS.push(r); return r; }
+
+/** A clone missing `routing.not_for` — one agentic finding, nothing else. */
+function subject(r: string): { dir: string; ctx: CheckContext } {
+  const dir = cloneFixture(r, "jane-doe", { routing: { not_for: undefined } });
+  return { dir, ctx: { kind: "mind-clone", slug: "jane-doe", dir, retrieval: false } };
+}
+
+/** Writes `routing.not_for` into the staging copy, as a good run would. */
+function goodRun(seen: { cwd?: string; prompt?: string }) {
+  return (opts: any) => {
+    seen.cwd = opts.cwd; seen.prompt = opts.prompt;
+    const mf = path.join(opts.cwd, "MANIFEST.yaml");
+    const doc = parseDocument(fs.readFileSync(mf, "utf8"));
+    doc.setIn(["routing", "not_for"], "Visual identity and logo design (see a design clone).");
+    fs.writeFileSync(mf, String(doc), "utf8");
+    return { ok: true, runtime: "claude-code", sessionId: null, result: "done", costUsd: 0.42, exitCode: 0, stderr: "", durationMs: 1200 };
+  };
+}
+
+function base(extra: Partial<AgenticOptions> = {}): AgenticOptions {
+  return {
+    confirmed: true,
+    runtimeAvailableImpl: (rt) => rt === "claude-code",
+    openRunImpl: () => ({ runId: "run-fake" }),
+    emit: null,
+    ...extra,
+  };
+}
+
+async function findings(ctx: CheckContext): Promise<Finding[]> {
+  return mindCloneModule.check(ctx);
+}
+
+describe("acceptance: better, or nothing", () => {
+  test("a run that repairs the finding is copied back, backed up and audited", async () => {
+    const r = root();
+    const { dir, ctx } = subject(r);
+    const seen: { cwd?: string; prompt?: string } = {};
+    const events: Array<[string, Record<string, unknown>]> = [];
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: goodRun(seen),
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+      emit: (e, p) => { events.push([e, p]); },
+    }));
+
+    expect(out.outcome.rolled_back).toBe(false);
+    expect(out.fixes[0].applied).toBe(true);
+    expect(out.findings.map((f) => f.id)).not.toContain("not_for_missing");
+    expect(parseYaml(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).routing.not_for).toContain("Visual identity");
+
+    // The model never saw the library: it edited a staging copy.
+    expect(seen.cwd).toStartWith(path.join(r, "staging"));
+    expect(seen.cwd).not.toBe(dir);
+    expect(fs.existsSync(seen.cwd!)).toBe(false);           // cleaned up
+    expect(out.outcome.backup).toBeTruthy();
+    expect(fs.existsSync(out.outcome.backup!)).toBe(true);  // the way back
+
+    expect(events.map(([e]) => e)).toEqual(["x_verify_fix_started", "x_verify_fix_finished"]);
+    expect(events[0][1].findings).toContain("not_for_missing");
+    expect(events[0][1].run_id).toBe("run-fake");
+    expect(events[1][1].accepted).toBe(true);
+    expect(events[1][1].cost_usd).toBe(0.42);
+  });
+
+  test("the brief names the findings, the manifest and the scope guard", async () => {
+    const r = root();
+    const { ctx } = subject(r);
+    const brief = buildBrief(mindCloneModule, "jane-doe", (await findings(ctx)).filter((f) => f.id === "not_for_missing"));
+    expect(brief).toContain("not_for_missing");
+    expect(brief).toContain("MANIFEST.yaml");
+    expect(brief).toContain("out of scope: do not act on them");
+    expect(brief).toContain("Never invent a source");
+  });
+
+  test("a run that repairs nothing is discarded and the entity is byte-identical", async () => {
+    const r = root();
+    const { dir, ctx } = subject(r);
+    const before = fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8");
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: (o: any) => {
+        fs.writeFileSync(path.join(o.cwd, "NOTES.md"), "I thought about it.\n", "utf8");
+        return { ok: true, runtime: "claude-code", sessionId: null, result: "", costUsd: 0, exitCode: 0, stderr: "", durationMs: 5 };
+      },
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(out.outcome.rolled_back).toBe(true);
+    expect(out.outcome.rollback_reason).toContain("no targeted finding was repaired");
+    expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).toBe(before);
+    expect(fs.existsSync(path.join(dir, "NOTES.md"))).toBe(false);
+  });
+
+  test("a run that grows the errors is discarded even though it repaired the target", async () => {
+    const r = root();
+    const { dir, ctx } = subject(r);
+    const before = fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8");
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: (o: any) => {
+        goodRun({})(o);
+        fs.rmSync(path.join(o.cwd, "agent", "SOUL.md"));   // a new HARD error
+        return { ok: true, runtime: "claude-code", sessionId: null, result: "", costUsd: 0, exitCode: 0, stderr: "", durationMs: 5 };
+      },
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(out.outcome.rolled_back).toBe(true);
+    expect(out.outcome.rollback_reason).toContain("errors grew");
+    expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).toBe(before);
+    expect(fs.existsSync(path.join(dir, "agent", "SOUL.md"))).toBe(true);
+  });
+
+  test("a failed runtime run leaves nothing behind", async () => {
+    const r = root();
+    const { dir, ctx } = subject(r);
+    const before = fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8");
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: () => ({ ok: false, runtime: "claude-code", sessionId: null, result: "", costUsd: null, exitCode: 1, stderr: "boom", durationMs: 3, error: "boom" }),
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(out.outcome.rolled_back).toBe(true);
+    expect(out.outcome.rollback_reason).toContain("boom");
+    expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).toBe(before);
+    expect(fs.readdirSync(path.join(r, "staging", "mind-clone"))).toEqual([]);
+  });
+});
+
+describe("routing metadata has to survive retrieval", () => {
+  /** A clone with no `one_liner` — the field the router actually reads. */
+  function unrouted(r: string): { dir: string; ctx: CheckContext } {
+    const dir = cloneFixture(r, "jane-doe", { routing: { one_liner: undefined } });
+    return { dir, ctx: { kind: "mind-clone", slug: "jane-doe", dir, retrieval: false } };
+  }
+  const writeOneLiner = (opts: any) => {
+    const mf = path.join(opts.cwd, "MANIFEST.yaml");
+    const doc = parseDocument(fs.readFileSync(mf, "utf8"));
+    doc.setIn(["routing", "one_liner"], "Jane Doe — the choice for brand tone of voice and verbal identity");
+    fs.writeFileSync(mf, String(doc), "utf8");
+    return { ok: true, runtime: "claude-code", sessionId: null, result: "done", costUsd: 0.1, exitCode: 0, stderr: "", durationMs: 30 };
+  };
+
+  test("a repaired clone the gate cannot retrieve is rolled back to the backup", async () => {
+    const r = root();
+    const { dir, ctx } = unrouted(r);
+    const before = fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8");
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: writeOneLiner,
+      retrievalCheck: () => false,
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(out.outcome.rolled_back).toBe(true);
+    expect(out.outcome.rollback_reason).toContain("self-retrieval");
+    expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).toBe(before);
+  });
+
+  test("the same run is kept when retrieval passes", async () => {
+    const r = root();
+    const { dir, ctx } = unrouted(r);
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: writeOneLiner,
+      retrievalCheck: () => true,
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(out.outcome.rolled_back).toBe(false);
+    expect(parseYaml(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).routing.one_liner).toContain("Jane Doe");
+  });
+
+  test("a fence (`not_for`) is not a retrieval signal: no gate is consulted", async () => {
+    const r = root();
+    const { dir, ctx } = subject(r);
+    let consulted = false;
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), base({
+      runHeadlessImpl: goodRun({}),
+      retrievalCheck: () => { consulted = true; return false; },
+      stagingRoot: path.join(r, "staging"), backupRoot: path.join(r, "backups"),
+    }));
+    expect(consulted).toBe(false);
+    expect(out.outcome.rolled_back).toBe(false);
+    expect(parseYaml(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).routing.not_for).toBeTruthy();
+  });
+});
+
+describe("the doors that stay shut", () => {
+  test("no confirmation, no run", async () => {
+    const r = root();
+    const { ctx } = subject(r);
+    const boom = () => { throw new Error("the runtime must not be called"); };
+    await expect(agenticFix(mindCloneModule, ctx, await findings(ctx), { ...base(), confirmed: false, runHeadlessImpl: boom as any }))
+      .rejects.toBeInstanceOf(AgenticConfirmationRequired);
+  });
+
+  test("--pack is off, and so is a machine with no runtime", async () => {
+    const r = root();
+    const { ctx } = subject(r);
+    const f = await findings(ctx);
+    const boom = () => { throw new Error("the runtime must not be called"); };
+    const packed = await agenticFix(mindCloneModule, ctx, f, { ...base(), pack: true, runHeadlessImpl: boom as any });
+    expect(packed.fixes[0].applied).toBe(false);
+    expect(packed.fixes[0].note).toContain("--pack");
+
+    const bare = await agenticFix(mindCloneModule, ctx, f, { ...base(), runtimeAvailableImpl: () => false, runHeadlessImpl: boom as any });
+    expect(bare.fixes[0].note).toContain("no agent runtime on PATH");
+  });
+
+  test("an entity with nothing agentic to repair never spends", async () => {
+    const r = root();
+    const dir = cloneFixture(r, "complete-clone");
+    const ctx: CheckContext = { kind: "mind-clone", slug: "complete-clone", dir, retrieval: false };
+    const boom = () => { throw new Error("the runtime must not be called"); };
+    const out = await agenticFix(mindCloneModule, ctx, await findings(ctx), { ...base(), runHeadlessImpl: boom as any });
+    expect(out.fixes[0].note).toContain("nothing to repair");
+    expect(out.outcome.rolled_back).toBe(false);
+  });
+});

--- a/skills/_shared/tests/verify-hooks.test.ts
+++ b/skills/_shared/tests/verify-hooks.test.ts
@@ -1,0 +1,176 @@
+// verify-hooks.test.ts — the four moments an entity enters the system.
+//
+// The gate is only useful if it is wired in; it is only safe if wiring it in
+// cannot break a machine that already has content installed. Both halves are
+// asserted here: with the rollout flags at their defaults every hook reports
+// and proceeds, with the flag on the same finding refuses, the documented
+// escape returns without touching disk, and a machine with no debt baseline
+// gets one recorded (grandfathering) instead of a refusal.
+//
+// Every fixture lives under mkdtemp; the baseline path is a fixture file and
+// the entity is addressed by DIRECTORY, so no installed library is consulted.
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { businessFixture, cloneFixture, rmrf, squadFixture, tempRoot } from "./helpers/verify-fixture.ts";
+import { enforcesAt, verifyHook, type HookSettings } from "../lib/verify/hooks.ts";
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) rmrf(r); });
+function root(): string { const r = tempRoot(); ROOTS.push(r); return r; }
+
+const OFF: HookSettings = { mode: "report", enforceOnInstall: false, enforceOnActivate: false };
+const events: Array<[string, Record<string, unknown>]> = [];
+const collect = (e: string, p: Record<string, unknown>) => { events.push([e, p]); };
+
+function hookOpts(r: string, extra: Record<string, unknown> = {}) {
+  return {
+    baselinePath: path.join(r, "baseline.json"),
+    stateDir: null as null,
+    emit: null,
+    retrieval: false,
+    ...extra,
+  };
+}
+
+/** A squad missing its surface file: one HARD error, nothing baselineable. */
+function brokenSquad(r: string, slug: string): string {
+  return squadFixture(r, slug, { surface: false });
+}
+
+describe("the flag decides, and the default never blocks", () => {
+  test("an entity with an error installs anyway while the flag is off", async () => {
+    const r = root();
+    const dir = brokenSquad(r, "broken-squad");
+    const out = await verifyHook({ kind: "squad", target: dir, gate: "install", settings: OFF, ...hookOpts(r) });
+    expect(out.ran).toBe(true);
+    expect(out.enforcing).toBe(false);
+    expect(out.blocked).toBe(false);
+    expect(out.errors.map((f) => f.id)).toContain("surface_missing");
+    expect(out.lines.join("\n")).toContain("proceeding anyway");
+  });
+
+  test("the same entity is refused with verify.enforce_on_install on", async () => {
+    const r = root();
+    const dir = brokenSquad(r, "broken-squad");
+    const out = await verifyHook({
+      kind: "squad", target: dir, gate: "install",
+      settings: { ...OFF, enforceOnInstall: true }, ...hookOpts(r),
+    });
+    expect(out.enforcing).toBe(true);
+    expect(out.blocked).toBe(true);
+    expect(out.lines.join("\n")).toContain("refused");
+    expect(out.lines.join("\n")).toContain("--skip-validate");
+  });
+
+  test("--skip-validate returns without checking anything", async () => {
+    const r = root();
+    const dir = brokenSquad(r, "broken-squad");
+    const out = await verifyHook({
+      kind: "squad", target: dir, gate: "install", skip: true,
+      settings: { ...OFF, enforceOnInstall: true }, ...hookOpts(r),
+    });
+    expect(out.ran).toBe(false);
+    expect(out.blocked).toBe(false);
+    expect(out.report).toBeNull();
+    expect(out.lines.join("\n")).toContain("skipped by --skip-validate");
+  });
+
+  test("activation answers to its own flag, never to the install one", async () => {
+    const r = root();
+    const dir = brokenSquad(r, "broken-squad");
+    const install = await verifyHook({
+      kind: "squad", target: dir, gate: "activate",
+      settings: { ...OFF, enforceOnInstall: true }, ...hookOpts(r),
+    });
+    expect(install.blocked).toBe(false);
+    const activate = await verifyHook({
+      kind: "squad", target: dir, gate: "activate",
+      settings: { ...OFF, enforceOnActivate: true }, ...hookOpts(r),
+    });
+    expect(activate.blocked).toBe(true);
+    expect(activate.lines.join("\n")).toContain("--skip-verify");
+  });
+
+  test("verify.mode: block enforces every gate at once; report and warn do not", () => {
+    const block: HookSettings = { mode: "block", enforceOnInstall: false, enforceOnActivate: false };
+    for (const gate of ["install", "activate", "pack"] as const) {
+      expect(enforcesAt(gate, block)).toBe(true);
+      expect(enforcesAt(gate, OFF)).toBe(false);
+      expect(enforcesAt(gate, { ...OFF, mode: "warn" })).toBe(false);
+    }
+    // Creation judges a scaffold the engine itself just wrote: always.
+    expect(enforcesAt("create", OFF)).toBe(true);
+  });
+
+  test("a clean entity is silent in report mode and speaks in warn mode", async () => {
+    const r = root();
+    const dir = businessFixture(r, "clean-co");
+    const quiet = await verifyHook({ kind: "business", target: dir, gate: "install", settings: OFF, ...hookOpts(r) });
+    expect(quiet.errors).toEqual([]);
+    expect(quiet.lines).toEqual([]);
+    const loud = await verifyHook({ kind: "business", target: dir, gate: "install", settings: { ...OFF, mode: "warn" }, ...hookOpts(r) });
+    expect(loud.lines.join("\n")).toContain("ADMITTED");
+  });
+});
+
+describe("grandfathering: a machine with no baseline gets one, not a refusal", () => {
+  test("the first hook records the debt once and the second finds it recorded", async () => {
+    const r = root();
+    const dir = cloneFixture(r, "jane-doe", { verdict: null });
+    const baselinePath = path.join(r, "baseline.json");
+    expect(fs.existsSync(baselinePath)).toBe(false);
+
+    events.length = 0;
+    const first = await verifyHook({
+      kind: "mind-clone", target: dir, gate: "install",
+      settings: { ...OFF, enforceOnInstall: true }, baselinePath, stateDir: null, emit: collect, retrieval: false,
+    });
+    expect(first.blocked).toBe(false);
+    expect(fs.existsSync(baselinePath)).toBe(true);
+    const recorded = events.filter(([e]) => e === "x_verify_baseline_recorded");
+    expect(recorded.length).toBe(1);
+    expect(recorded[0][1].reason).toBe("hook_grandfathering");
+    expect(recorded[0][1].debt).toContain("validation_verdict_missing");
+    expect(first.report!.baseline.present).toBe(true);
+    expect(first.warnings.map((f) => f.id)).not.toContain("validation_verdict_missing");
+
+    events.length = 0;
+    const second = await verifyHook({
+      kind: "mind-clone", target: dir, gate: "install",
+      settings: { ...OFF, enforceOnInstall: true }, baselinePath, stateDir: null, emit: collect, retrieval: false,
+    });
+    expect(events.filter(([e]) => e === "x_verify_baseline_recorded").length).toBe(0);
+    expect(second.report!.summary.debt).toBeGreaterThan(0);
+    expect(second.blocked).toBe(false);
+  });
+
+  test("a HARD error is never grandfathered — it is not baselineable", async () => {
+    const r = root();
+    const dir = cloneFixture(r, "jane-doe");
+    fs.rmSync(path.join(dir, "agent", "SOUL.md"));
+    const baselinePath = path.join(r, "baseline.json");
+    const out = await verifyHook({
+      kind: "mind-clone", target: dir, gate: "install",
+      settings: { ...OFF, enforceOnInstall: true }, baselinePath, stateDir: null, emit: null, retrieval: false,
+    });
+    expect(out.blocked).toBe(true);
+    expect(out.errors.map((f) => `${f.id}:${f.where}`)).toContain("artifact_missing:agent/SOUL.md");
+    const recorded = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, "utf8")) : { entities: {} };
+    expect(JSON.stringify(recorded.entities ?? {})).not.toContain("artifact_missing");
+  });
+});
+
+describe("the hook never takes the caller down with it", () => {
+  test("an unknown entity is reported, not thrown", async () => {
+    const r = root();
+    const out = await verifyHook({
+      kind: "squad", target: path.join(r, "squads", "nobody"), gate: "install",
+      settings: { ...OFF, enforceOnInstall: true }, ...hookOpts(r),
+    });
+    expect(out.ran).toBe(false);
+    expect(out.blocked).toBe(false);
+    expect(out.reason).toContain("unknown squad");
+    expect(out.lines.join("\n")).toContain("proceeding");
+  });
+});

--- a/skills/_shared/tests/verify-runner.test.ts
+++ b/skills/_shared/tests/verify-runner.test.ts
@@ -52,10 +52,32 @@ describe("exit codes", () => {
     expect(runCli(r, ["dragon", "jane-doe"]).code).toBe(64);
     expect(runCli(r, ["mind-clone", "jane-doe", "--bogus"]).code).toBe(64);
     expect(runCli(r, ["mind-clone"]).code).toBe(64);
-    const agentic = runCli(r, ["mind-clone", "jane-doe", "--fix=agentic", "--no-retrieval"]);
-    expect(agentic.code).toBe(64);
-    expect(agentic.stderr).toContain("not available yet");
+    expect(runCli(r, ["mind-clone", "jane-doe", "--fix=agentic", "--budget-usd", "nope"]).code).toBe(64);
     expect(runCli(r, ["--help"]).code).toBe(0);
+  }, spawnBudgetMs(2));
+});
+
+describe("--fix=agentic", () => {
+  test("a spend is never silent: no --yes, exit 2, and nothing was touched", () => {
+    const r = root();
+    // `not_for` absent is an `autofix: "agentic"` finding — the mode has
+    // something to do, so the confirmation is the only thing standing in the
+    // way. With the fixture complete there would be nothing to confirm.
+    const dir = cloneFixture(r, "jane-doe", { routing: { not_for: undefined } });
+    const before = fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8");
+    const out = runCli(r, ["mind-clone", "jane-doe", "--fix=agentic", "--no-retrieval"]);
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain("Re-run with --yes");
+    expect(out.stderr).toContain("$3.00");
+    expect(fs.readFileSync(path.join(dir, "MANIFEST.yaml"), "utf8")).toBe(before);
+  }, spawnBudgetMs(2));
+
+  test("--budget-usd names the ceiling the confirmation quotes", () => {
+    const r = root();
+    cloneFixture(r, "jane-doe", { routing: { not_for: undefined } });
+    const out = runCli(r, ["mind-clone", "jane-doe", "--fix=agentic", "--budget-usd", "0.5", "--no-retrieval"]);
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain("$0.50");
   }, spawnBudgetMs(2));
 });
 

--- a/skills/businesses/SKILL.md
+++ b/skills/businesses/SKILL.md
@@ -231,7 +231,7 @@ When intent = CREATE, follow this sequence without skipping steps.
 **Round 5 — Readiness gate (MANDATORY, after the registry update — creation is NOT done until it passes)**
 - **Admission gate (blocking).** Run and require exit 0:
   `nrv validate business <slug> --strict`
-  It is the single verb that carries the criteria catalog of `BUSINESS_PROTOCOL_V2.md` §16 — manifest, employees, org chart, routing metadata, acceptance, surface. `--fix` repairs the mechanical findings; authorship (fences, acceptance, thin seats) stays with you.
+  It is the single verb that carries the criteria catalog of `BUSINESS_PROTOCOL_V2.md` §16 — manifest, employees, org chart, routing metadata, acceptance, surface. `--fix` repairs the mechanical findings; authorship (fences, acceptance, thin seats) stays with you. `init-business.ts` already ran it in `--fix` mode over the scaffold, so the engine-owned `.nirvana-surface.json` is on disk before you start writing.
 - Optimization pass: reread each employee as a hostile reviewer — a generic
   persona, a role without a clear deliverable, or knowledge Round 0 researched
   that the employee does not use are defects; fix them before declaring ready.

--- a/skills/businesses/scripts/init-business.ts
+++ b/skills/businesses/scripts/init-business.ts
@@ -9,8 +9,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as YAML from "yaml";
-import { exec, ensureDir, paths, EXIT, parseArgs, BUN_BIN } from "../../_shared/lib/bun-helpers.ts";
+import { ensureDir, paths, EXIT, parseArgs } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope, writeDir } from "../../_shared/lib/scope.ts";
+import { verifyHook } from "../../_shared/lib/verify/index.ts";
 
 const SKILL_DIR = path.join(paths.CLAUDE_SKILLS_DIR, "businesses");
 const TYPES_DIR = path.join(SKILL_DIR, "templates", "business-types");
@@ -26,6 +27,7 @@ const template = String(flags.template || flags.type || "");
 const fromJson = flags["from-json"] ? String(flags["from-json"]) : "";
 const force = Boolean(flags.force);
 const nonInteractive = Boolean(flags["non-interactive"]);
+const skipVerify = Boolean(flags["skip-verify"]);
 const domains = flags.domains ? String(flags.domains) : "";
 const description = flags.description ? String(flags.description) : "";
 
@@ -37,7 +39,7 @@ function listTypes(): string[] {
 }
 
 function usage(): void {
-  console.error(`usage: init-business <slug> [--template <type>|--type <type>] [--from-json <path>] [--non-interactive] [--domains a,b] [--description <s>] [--force]
+  console.error(`usage: init-business <slug> [--template <type>|--type <type>] [--from-json <path>] [--non-interactive] [--domains a,b] [--description <s>] [--force] [--skip-verify]
 
 Available types: ${listTypes().join(", ") || "(none)"}`);
 }
@@ -112,12 +114,24 @@ try {
   process.exit(EXIT.FAILURES);
 }
 
-const validation = exec(`${JSON.stringify(BUN_BIN)} ${JSON.stringify(path.join(SKILL_DIR, "lib", "loader.ts"))} ${JSON.stringify(target)}`, { silent: true });
-if (!validation.ok) {
+// The admission gate, at the first moment the entity exists (§34). It replaces
+// the spawned loader: the loader answered "does this parse", the gate answers
+// the whole catalog, in-process, and repairs first.
+//
+// `fix: "mechanical"` is what makes the hook safe to run on a scaffold. The
+// template is authored content minus the parts the ENGINE owns —
+// `.nirvana-surface.json` above all, which no template can carry because it is
+// a hash of the files that only exist once the overlay above has run. Without
+// the repair pass a brand-new business is REJECTED on that single error, which
+// is precisely the wizard bug this hook closes. What the fixers cannot repair
+// is a broken scaffold, and a broken scaffold is deleted, exactly as the
+// loader's failure deleted it before.
+const gate = await verifyHook({ kind: "business", target, gate: "create", fix: "mechanical", skip: skipVerify });
+for (const line of gate.lines) console.error(line);
+if (gate.blocked) {
   console.error(`ERROR: validation failed for '${slug}' after scaffold.`);
-  console.error(validation.stdout || validation.stderr);
   fs.rmSync(target, { recursive: true, force: true });
-  process.exit(validation.code ?? EXIT.FAILURES);
+  process.exit(EXIT.FAILURES);
 }
 
 console.log(`OK: business '${slug}' (type=${selectedTemplate}) created at ${target}`);

--- a/skills/businesses/tests/smoke.test.ts
+++ b/skills/businesses/tests/smoke.test.ts
@@ -58,20 +58,23 @@ describe("business lifecycle — init → validate → index → list", () => {
     expect(existsSync(join(home, "businesses", "smoke-solo", "business.yaml"))).toBe(true);
   });
 
-  // The wizard writes no `.nirvana-surface.json` (§5.3 puts it in the layout and
-  // gives it to the engine), so the gate rejects a scaffold on exactly that one
-  // error and `--fix` clears it. The wizard hook that closes the gap is PR11 of
-  // the program plan; until then this test states the gap instead of hiding it.
-  test("validate names the one error a scaffold carries, and --fix clears it", () => {
+  // A template cannot carry `.nirvana-surface.json` — it is a hash of files
+  // that exist only once the wizard has overlaid the manifest — so the
+  // scaffold used to be born REJECTED on exactly that one error. The creation
+  // hook repairs what the engine owns before judging, which is why the
+  // surface is on disk here without anyone running --fix.
+  test("the scaffold is born admitted, surface included", () => {
+    expect(existsSync(join(home, "businesses", "smoke-solo", ".nirvana-surface.json"))).toBe(true);
     const first = nrv("validate-business.ts", "smoke-solo", "--json", "--no-retrieval");
     const report = JSON.parse(first.stdout);
-    expect(report.findings.filter((f: any) => f.severity === "error").map((f: any) => f.id)).toEqual(["surface_missing"]);
-    expect(first.status).toBe(1);
+    expect(report.findings.filter((f: any) => f.severity === "error")).toEqual([]);
+    expect(report.verdict).toBe("ADMITTED");
+    expect(first.status).toBe(0);
 
+    // Idempotent: a --fix over an already-admitted scaffold changes nothing.
     const fixed = nrv("validate-business.ts", "smoke-solo", "--fix", "--no-retrieval");
     expect(`${fixed.stdout}${fixed.stderr}`).not.toContain("ROLLED BACK");
     expect(fixed.status).toBe(0);
-    expect(existsSync(join(home, "businesses", "smoke-solo", ".nirvana-surface.json"))).toBe(true);
   });
 
   test("--report writes the JSON under the project's own .audit-state", () => {

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -307,6 +307,46 @@ export async function startServer(opts: ServerOptions) {
   const problem = (status: number, title: string, detail: string) => new Response(JSON.stringify({
     type: "about:blank", title, status, detail, correlation_id: `cor_${crypto.randomUUID()}`,
   }), { status, headers: { "content-type": "application/problem+json", "cache-control": "no-store" } });
+  /**
+   * `GET /api/v1/verify/<kind>/<slug>` — one entity's admission report.
+   *
+   * Read-only by construction: no `--fix`, no `--record`, and the self-
+   * retrieval axis is off (it needs the BM25 index and is the one axis that
+   * can take a second). Repair is a separate, mutating, confirmed action
+   * (`POST /api/actions/verify-fix`).
+   */
+  const verifyRead = async (kind: string, slug: string): Promise<Response> => {
+    const timeoutMs = Number(process.env.NIRVANA_GLANCE_VERIFY_TIMEOUT_MS || 20_000);
+    const script = path.join(SKILLS_ROOT, "_shared", "scripts", "verify.ts");
+    if (!fs.existsSync(script)) return problem(501, "Gate unavailable", `the admission gate is not installed at ${script}`);
+    let child: ReturnType<typeof Bun.spawn> | null = null;
+    try {
+      child = Bun.spawn([process.env.NIRVANA_BUN || "bun", script, kind, slug, "--json", "--no-retrieval"], {
+        env: { ...process.env, NO_COLOR: "1" }, stdout: "pipe", stderr: "pipe",
+      });
+      const proc = child;
+      const finished = (async () => ({ code: await proc.exited, out: await new Response(proc.stdout).text(), err: await new Response(proc.stderr).text() }))();
+      const timedOut = Symbol("timeout");
+      const timer = new Promise<typeof timedOut>((r) => setTimeout(() => r(timedOut), timeoutMs));
+      const outcome = await Promise.race([finished, timer]);
+      if (outcome === timedOut) {
+        try { proc.kill(); } catch { /* already gone */ }
+        return problem(504, "Verify timed out", `the admission gate did not finish in ${timeoutMs}ms for ${kind} ${slug}`);
+      }
+      const { code, out, err } = outcome as { code: number; out: string; err: string };
+      // 64 is the gate's EX_USAGE: an unknown entity, not a server fault.
+      if (code === 64) return problem(404, "Unknown entity", (err || out).trim().slice(0, 400) || `no ${kind} named ${slug}`);
+      try {
+        return json(JSON.parse(out));
+      } catch {
+        return problem(502, "Verify failed", (err || out).trim().slice(0, 400) || `the admission gate exited ${code} with no report`);
+      }
+    } catch (e) {
+      try { child?.kill(); } catch { /* already gone */ }
+      return problem(502, "Verify failed", (e as Error).message);
+    }
+  };
+
   const validId = (value: string, prefix: string) => new RegExp(`^${prefix}_[A-Za-z0-9-]+$`).test(value);
   const writeAuthorized = (req: Request): Response | null => {
     if (!opts.allowActions) return problem(403, "Forbidden", "Glance actions are disabled");
@@ -578,6 +618,16 @@ export async function startServer(opts: ServerOptions) {
             } catch (error) { return settingsProblem(error); }
           });
         }
+        // The admission gate, read-only. It runs in a CHILD PROCESS with a
+        // wall-clock timeout, never in this event loop: a verify over a squad
+        // with 600 workflow steps is tens of milliseconds of synchronous fs
+        // work, and the cockpit is single-threaded — one slow entity would
+        // freeze every other panel while it ran. The child also means a crash
+        // in a kind module is a 502, not a dead server.
+        const verifyMatch = p.match(/^\/api\/v1\/verify\/(squad|business|mind-clone)\/([A-Za-z0-9][A-Za-z0-9._-]*)$/);
+        if (verifyMatch && req.method === "GET") return await verifyRead(verifyMatch[1], verifyMatch[2]);
+        if (verifyMatch) return methodNotAllowed();
+
         return notFound("control-plane route not found");
       }
 
@@ -1979,6 +2029,20 @@ const ACTIONS: Record<string, ActionDef> = {
       return [`${SKILLS}/squads/scripts/activate-squad.ts`, "activate", slug, "--dry-run", "--verbose"];
     },
     mutating: false,
+  },
+  // The repair half of the gate. Mutating (it writes into the entity, with a
+  // backup and an automatic rollback when a fixer makes things worse), so the
+  // panel asks for confirmation before it is ever sent.
+  "verify-fix": {
+    command: "bun",
+    mutating: true,
+    argsBuilder: (b) => {
+      const kind = (b?.kind || "").toString();
+      const slug = (b?.slug || "").toString();
+      if (!["squad", "business", "mind-clone"].includes(kind)) throw new Error("kind must be squad, business or mind-clone");
+      if (!/^[a-z0-9][a-z0-9._-]*$/i.test(slug)) throw new Error("invalid or missing slug");
+      return [`${SKILLS}/_shared/scripts/verify.ts`, kind, slug, "--fix", "--no-retrieval"];
+    },
   },
   "index-squads": {
     command: "bun",

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -631,6 +631,26 @@ body {
 .action-btn.warning:hover { filter: brightness(0.95); }
 .action-btn.small { font-size: var(--text-xs); padding: var(--space-1) var(--space-2); }
 
+/* ─── Admission gate verdict (nrv validate, read-only) ─── */
+.verify-panel {
+  margin: 0 var(--space-4) var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  background: var(--surface-1);
+  display: flex; flex-direction: column; gap: 6px;
+  max-height: 280px; overflow-y: auto;
+}
+.verify-verdict { font-weight: var(--weight-medium); font-size: var(--text-sm); }
+.verify-verdict.ok { color: var(--status-success-fg); }
+.verify-verdict.bad { color: var(--status-danger-fg); }
+.verify-finding {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  color: var(--text-secondary); line-height: 1.5;
+}
+.verify-finding.error { color: var(--status-danger-fg); }
+.verify-finding.warning { color: var(--status-warn-fg); }
+
 /* ─── Console drawer ─── */
 .console-drawer {
   position: fixed; bottom: 0; left: 0; right: 0;

--- a/skills/harness/lib/glance/views/glance.js
+++ b/skills/harness/lib/glance/views/glance.js
@@ -161,6 +161,11 @@ function glance() {
     jobStreams: {},
     // Per-kind audit scores: { squads: { slug: {tier, score} }, businesses: ..., 'mind-clones': ... }
     auditScores: { squads: {}, businesses: {}, 'mind-clones': {} },
+    // Admission gate (nrv validate) — one report at a time, keyed "<kind>:<slug>"
+    // so a stale verdict never shows under a different entity.
+    verifyKey: null,
+    verifyReport: null,
+    verifyBusy: false,
 
     // ─── Computed ───
     get currentList() {
@@ -2222,6 +2227,30 @@ function glance() {
         this.flash(`✗ ${e.message}`, 4000);
       }
     },
+    // ─── Admission gate ───
+    // Read-only: the server runs `nrv validate --json` in a child with a
+    // timeout, so a slow entity answers 504 instead of freezing the cockpit.
+    async verifyEntity(kind, slug) {
+      if (!slug || this.verifyBusy) return;
+      this.verifyBusy = true;
+      this.verifyKey = `${kind}:${slug}`;
+      this.verifyReport = null;
+      try {
+        const r = await fetch(`/api/v1/verify/${kind}/${encodeURIComponent(slug)}`);
+        const data = await r.json();
+        if (!r.ok) { this.flash(`✗ ${data.title || 'verify'}: ${data.detail || r.status}`, 5000); this.verifyKey = null; return; }
+        this.verifyReport = data;
+        const s = data.summary || {};
+        this.flash(`${data.verdict} · ${s.errors || 0} erro(s), ${s.warnings || 0} aviso(s)`, 3000);
+      } catch (e) {
+        this.flash(`✗ ${e.message}`, 4000);
+        this.verifyKey = null;
+      } finally {
+        this.verifyBusy = false;
+      }
+    },
+    verifyShown(kind, slug) { return !!this.verifyReport && this.verifyKey === `${kind}:${slug}`; },
+    verifyFixable() { return (this.verifyReport?.findings || []).some(f => f.autofix === 'mechanical'); },
     confirmAction(name, body, prompt) {
       if (!window.confirm(prompt)) return;
       this.runAction(name, body);

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -296,12 +296,27 @@
               </div>
             </div>
             <!-- Per-squad actions (only when --allow-actions) -->
+            <div class="detail-actions">
+              <button @click="verifyEntity('squad', detail?.slug || selected.slug)" class="action-btn">Verificar</button>
+            </div>
             <div class="detail-actions" x-cloak x-show="health.allow_actions">
               <button @click="runAction('activate-dry-run', { slug: detail.slug })" class="action-btn">Activate (dry-run)</button>
               <button @click="runAction('audit-improve', { slug: detail.slug, dry_run: true })" class="action-btn">Audit (dry-run)</button>
               <button @click="confirmAction('audit-improve', { slug: detail.slug, dry_run: false }, `Improve ${detail.slug} with backup + auto-rollback?`)" class="action-btn warning">Improve (apply)</button>
             </div>
           </header>
+          <div class="verify-panel" x-cloak x-show="verifyShown('squad', detail?.slug || selected.slug)">
+            <div class="verify-verdict" :class="verifyReport?.verdict === 'ADMITTED' ? 'ok' : 'bad'"
+                 x-text="`${verifyReport?.verdict} · ${verifyReport?.summary?.errors || 0} erro(s) · ${verifyReport?.summary?.warnings || 0} aviso(s) · ${verifyReport?.summary?.debt || 0} baselinado(s)`"></div>
+            <template x-for="f in (verifyReport?.findings || [])" :key="f.id + (f.where || '')">
+              <div class="verify-finding" :class="f.severity"
+                   x-text="`${f.severity === 'error' ? '✗' : f.severity === 'warning' ? '⚠' : 'ℹ'} ${f.id}${f.where ? ':' + f.where : ''} — ${f.message}`"></div>
+            </template>
+            <div class="detail-actions" x-show="health.allow_actions && verifyFixable()">
+              <button @click="confirmAction('verify-fix', { kind: 'squad', slug: detail?.slug || selected.slug }, `Aplicar os reparos mecânicos em ${detail?.slug || selected.slug}? Há backup e rollback automático se algo piorar.`)"
+                      class="action-btn warning">Corrigir (--fix)</button>
+            </div>
+          </div>
           <nav class="tabs">
             <template x-for="t in squadTabs"><button @click="tab = t" :class="tab === t ? 'tab active' : 'tab'" x-text="t"></button></template>
           </nav>
@@ -382,7 +397,22 @@
                 <template x-for="d in detail?.meta?.domains || []"><span class="domain-pill" x-text="d"></span></template>
               </div>
             </div>
+            <div class="detail-actions">
+              <button @click="verifyEntity('business', detail?.slug || selected.slug)" class="action-btn">Verificar</button>
+            </div>
           </header>
+          <div class="verify-panel" x-cloak x-show="verifyShown('business', detail?.slug || selected.slug)">
+            <div class="verify-verdict" :class="verifyReport?.verdict === 'ADMITTED' ? 'ok' : 'bad'"
+                 x-text="`${verifyReport?.verdict} · ${verifyReport?.summary?.errors || 0} erro(s) · ${verifyReport?.summary?.warnings || 0} aviso(s) · ${verifyReport?.summary?.debt || 0} baselinado(s)`"></div>
+            <template x-for="f in (verifyReport?.findings || [])" :key="f.id + (f.where || '')">
+              <div class="verify-finding" :class="f.severity"
+                   x-text="`${f.severity === 'error' ? '✗' : f.severity === 'warning' ? '⚠' : 'ℹ'} ${f.id}${f.where ? ':' + f.where : ''} — ${f.message}`"></div>
+            </template>
+            <div class="detail-actions" x-show="health.allow_actions && verifyFixable()">
+              <button @click="confirmAction('verify-fix', { kind: 'business', slug: detail?.slug || selected.slug }, `Aplicar os reparos mecânicos em ${detail?.slug || selected.slug}? Há backup e rollback automático se algo piorar.`)"
+                      class="action-btn warning">Corrigir (--fix)</button>
+            </div>
+          </div>
           <nav class="tabs">
             <template x-for="t in businessTabs"><button @click="tab = t" :class="tab === t ? 'tab active' : 'tab'" x-text="t"></button></template>
           </nav>
@@ -491,7 +521,22 @@
                 <span class="meta-pill" x-show="mindCloneDetail?.total_bytes" x-text="formatBytes(mindCloneDetail?.total_bytes || 0)"></span>
               </div>
             </div>
+            <div class="detail-actions">
+              <button @click="verifyEntity('mind-clone', selected.slug)" class="action-btn">Verificar</button>
+            </div>
           </header>
+          <div class="verify-panel" x-cloak x-show="verifyShown('mind-clone', selected.slug)">
+            <div class="verify-verdict" :class="verifyReport?.verdict === 'ADMITTED' ? 'ok' : 'bad'"
+                 x-text="`${verifyReport?.verdict} · ${verifyReport?.summary?.errors || 0} erro(s) · ${verifyReport?.summary?.warnings || 0} aviso(s) · ${verifyReport?.summary?.debt || 0} baselinado(s)`"></div>
+            <template x-for="f in (verifyReport?.findings || [])" :key="f.id + (f.where || '')">
+              <div class="verify-finding" :class="f.severity"
+                   x-text="`${f.severity === 'error' ? '✗' : f.severity === 'warning' ? '⚠' : 'ℹ'} ${f.id}${f.where ? ':' + f.where : ''} — ${f.message}`"></div>
+            </template>
+            <div class="detail-actions" x-show="health.allow_actions && verifyFixable()">
+              <button @click="confirmAction('verify-fix', { kind: 'mind-clone', slug: selected.slug }, `Aplicar os reparos mecânicos em ${selected.slug}? Há backup e rollback automático se algo piorar.`)"
+                      class="action-btn warning">Corrigir (--fix)</button>
+            </div>
+          </div>
 
           <div class="mind-clone-body" x-show="mindCloneDetail">
             <!-- Sidebar: file tree grouped by category -->

--- a/skills/harness/lib/glance/views/settings-panel.js
+++ b/skills/harness/lib/glance/views/settings-panel.js
@@ -18,7 +18,7 @@
 export const GROUP_LABELS = Object.freeze({
   multi_target: 'Multi-target', gauntlet: 'Gauntlet', execution: 'Execução', glance: 'Glance', runtime: 'Runtime',
   routing: 'Roteamento', supervisor: 'Supervisor', updates: 'Atualizações', budget: 'Orçamento',
-  baselines: 'Baselines de custo', quality_gate: 'Quality gate', delivery: 'Entrega',
+  baselines: 'Baselines de custo', quality_gate: 'Quality gate', delivery: 'Entrega', verify: 'Portão de admissão',
 });
 
 export const SOURCE_LABELS = Object.freeze({

--- a/skills/harness/scripts/activate.ts
+++ b/skills/harness/scripts/activate.ts
@@ -14,8 +14,8 @@
  * that door, with the batch the library-sized case always needed.
  *
  * Usage:
- *   nrv activate <slug> [--dry-run] [--confirm-heavy] [--verbose]
- *   nrv activate --all [--dry-run] [--confirm-heavy] [--only-declared]
+ *   nrv activate <slug> [--dry-run] [--confirm-heavy] [--verbose] [--skip-verify]
+ *   nrv activate --all [--dry-run] [--confirm-heavy] [--only-declared] [--skip-verify]
  *   nrv activate status <slug>
  *
  * Exit codes mirror the per-squad contract, aggregated over the batch:
@@ -27,6 +27,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { resolveScope, enumerate } from "../../_shared/lib/scope.ts";
+import { verifyHook } from "../../_shared/lib/verify/index.ts";
 
 const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(process.env.HOME || "", ".nirvana", "skills"))
@@ -42,12 +43,13 @@ const flags = argv.filter((a) => a.startsWith("--"));
 const positional = argv.filter((a) => !a.startsWith("--"));
 const all = flags.includes("--all");
 const onlyDeclared = flags.includes("--only-declared");
+const skipVerify = flags.includes("--skip-verify");
 const passthrough = flags.filter((f) => ["--dry-run", "--confirm-heavy", "--verbose", "-v"].includes(f));
 
 if (flags.includes("--help") || flags.includes("-h") || (!all && positional.length === 0)) {
   console.error(`usage:
-  nrv activate <slug> [--dry-run] [--confirm-heavy] [--verbose]
-  nrv activate --all [--dry-run] [--confirm-heavy] [--only-declared]
+  nrv activate <slug> [--dry-run] [--confirm-heavy] [--verbose] [--skip-verify]
+  nrv activate --all [--dry-run] [--confirm-heavy] [--only-declared] [--skip-verify]
   nrv activate status <slug>
 
 Installs what a squad's dependencies.yaml declares: system tools, Python and
@@ -58,7 +60,12 @@ squad is re-verified, not reinstalled.
 --all walks the library ONE SQUAD AT A TIME and never stops on a failure;
 the summary at the end says what is ready, what needs confirmation and what
 broke. --only-declared skips squads with no dependencies.yaml (they need no
-activation at all).`);
+activation at all).
+
+Each squad passes the admission gate before its dependencies are installed.
+The gate reports by default; with verify.enforce_on_activate on, a squad
+carrying an error the debt baseline does not cover is refused instead of
+activated. --skip-verify is the documented escape.`);
   process.exit(flags.includes("--help") || flags.includes("-h") ? 0 : 4);
 }
 
@@ -68,13 +75,27 @@ if (positional[0] === "status" || positional[0] === "deactivate") {
   process.exit(r.status ?? 1);
 }
 
-function runOne(slug: string): number {
+/**
+ * Activation is where a squad stops being prose and starts touching the real
+ * world — it installs tools, downloads models, runs verification commands. So
+ * it is the last honest moment to ask whether the squad is admissible at all,
+ * and it asks BEFORE the first dependency is installed: a refusal leaves the
+ * machine untouched. Report-only until `verify.enforce_on_activate` is on.
+ */
+async function gateOne(slug: string): Promise<boolean> {
+  const gate = await verifyHook({ kind: "squad", target: slug, gate: "activate", skip: skipVerify });
+  for (const line of gate.lines) console.error(`  ${line}`);
+  return !gate.blocked;
+}
+
+async function runOne(slug: string): Promise<number> {
+  if (!(await gateOne(slug))) return 1;
   const r = spawnSync(BUN, [ACTIVATOR, "activate", slug, ...passthrough], { stdio: "inherit" });
   return r.status ?? 1;
 }
 
 if (!all) {
-  process.exit(runOne(positional[0]));
+  process.exit(await runOne(positional[0]));
 }
 
 // ── batch ──────────────────────────────────────────────────────────────────
@@ -108,7 +129,7 @@ for (const s of squads) {
   }
   // A failure never stops the walk: the point of --all is to leave the
   // library as ready as it can be, then report what still needs a human.
-  const code = runOne(s.slug);
+  const code = await runOne(s.slug);
   if (code === 0) ready.push(s.slug);
   else if (code === 2) needsConfirm.push(s.slug);
   else failed.push(s.slug);

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -655,6 +655,64 @@ if (fs.existsSync(dnaLib)) {
   add("library: mind-clones", "WARN", "no mind-clone library — run with --starter");
 }
 
+// SECTION 6.2: PROTOCOL
+//
+// What the library DECLARES, counted, so a rollout is visible before it is
+// enforced: how many squads are still on v5 while the engine reads v6, and how
+// many businesses still carry fields v2 retired. Never a FAIL — this is a
+// migration dashboard, and CI treats a doctor exit >= 2 as a broken machine.
+// Blocking is `nrv validate`'s job, behind its own flags.
+{
+  const RETIRED_SEAT_FIELDS = /^(heartbeat|self_score_contract|draws_from|dna_reference|budget_monthly_usd|mentions|escalation_triggers|disclosure_template|default_tools|project_tool_overrides):/m;
+  const declared = (file: string): string | null => {
+    try { return /^protocol:\s*["']?([\d.]+)/m.exec(fs.readFileSync(file, "utf8").slice(0, 4096))?.[1] ?? null; }
+    catch { return null; }
+  };
+  const dirsOf = (root: string): string[] => {
+    try { return fs.readdirSync(root).filter((d) => !d.startsWith("_") && !d.startsWith(".")); } catch { return []; }
+  };
+
+  if (fs.existsSync(homeSquads)) {
+    const byProtocol = new Map<string, number>();
+    for (const slug of dirsOf(homeSquads)) {
+      const manifest = path.join(homeSquads, slug, "squad.yaml");
+      if (!fs.existsSync(manifest)) continue;
+      const v = declared(manifest) ?? "unset";
+      byProtocol.set(v, (byProtocol.get(v) ?? 0) + 1);
+    }
+    const total = [...byProtocol.values()].reduce((a, b) => a + b, 0);
+    const spread = [...byProtocol.entries()].sort((a, b) => b[1] - a[1]).map(([v, n]) => `${n}×${v}`).join(" · ");
+    const belowSix = total - (byProtocol.get("6.0") ?? 0);
+    add("protocol: squads", belowSix > 0 ? "WARN" : "PASS",
+      belowSix > 0
+        ? `${spread} — ${belowSix} below 6.0; migrate one with \`nrv migrate <slug> --to 6\``
+        : `${total} squads, all on 6.0`);
+  }
+
+  if (fs.existsSync(homeBiz)) {
+    let v1 = 0, withRetired = 0, total = 0;
+    for (const slug of dirsOf(homeBiz)) {
+      const manifest = path.join(homeBiz, slug, "business.yaml");
+      if (!fs.existsSync(manifest)) continue;
+      total++;
+      if ((declared(manifest) ?? "1.0") !== "2.0") v1++;
+      const empDir = path.join(homeBiz, slug, "employees");
+      let hit = false;
+      try {
+        for (const f of fs.readdirSync(empDir)) {
+          if (!f.endsWith(".md")) continue;
+          if (RETIRED_SEAT_FIELDS.test(fs.readFileSync(path.join(empDir, f), "utf8").slice(0, 4096))) { hit = true; break; }
+        }
+      } catch { /* no employees/ is a different check's problem */ }
+      if (hit) withRetired++;
+    }
+    add("protocol: businesses", v1 > 0 || withRetired > 0 ? "WARN" : "PASS",
+      v1 > 0 || withRetired > 0
+        ? `${v1} of ${total} still on protocol 1.0 · ${withRetired} carry fields v2 retired — \`nrv validate business <slug> --fix\``
+        : `${total} businesses on protocol 2.0, no retired fields`);
+  }
+}
+
 // SECTION 6.5: PAID INSTALL
 //
 // The doctor had nothing here. On a machine where a paid pack installed its

--- a/skills/harness/tests/doctor-protocol.test.ts
+++ b/skills/harness/tests/doctor-protocol.test.ts
@@ -1,0 +1,92 @@
+// doctor-protocol.test.ts — the migration dashboard, and the promise it makes.
+//
+// The doctor's exit code is a CI signal: >= 2 means the machine is broken. A
+// library still on Squad Protocol 5 and Business Protocol 1 is the DEFAULT
+// state of every installed machine during a rollout, so counting it must never
+// be able to turn a green CI red. These cases pin that: the Protocol section
+// reports, and its worst status is WARN.
+//
+// Runs with: bun test skills/harness/tests
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const DOCTOR = join(REPO, "skills", "harness", "scripts", "doctor-system.ts");
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function library(opts: { squads: Array<[string, string | null]>; businesses: Array<[string, string, boolean]> }): string {
+  const home = mkdtempSync(join(tmpdir(), "nrv-doctor-protocol-"));
+  ROOTS.push(home);
+  for (const [slug, protocol] of opts.squads) {
+    mkdirSync(join(home, "squads", slug), { recursive: true });
+    writeFileSync(join(home, "squads", slug, "squad.yaml"),
+      `name: ${slug}\nversion: 1.0.0\n${protocol ? `protocol: "${protocol}"\n` : ""}description: fixture\n`, "utf8");
+  }
+  for (const [slug, protocol, retired] of opts.businesses) {
+    mkdirSync(join(home, "businesses", slug, "employees"), { recursive: true });
+    writeFileSync(join(home, "businesses", slug, "business.yaml"),
+      `name: ${slug}\nversion: 1.0.0\nprotocol: "${protocol}"\ndescription: fixture\n`, "utf8");
+    writeFileSync(join(home, "businesses", slug, "employees", "ceo.md"),
+      `---\nname: ceo\nis_brief_intake: true\n${retired ? "heartbeat:\n  enabled: true\n" : ""}---\n\n# CEO\n`, "utf8");
+  }
+  return home;
+}
+
+function doctor(home: string) {
+  const r = spawnSync(process.execPath, [DOCTOR, "--json"], {
+    cwd: home, encoding: "utf8",
+    env: {
+      ...process.env, HOME: home, NIRVANA_HOME: home,
+      NIRVANA_SKILLS_DIR: join(REPO, "skills"), CLAUDE_SKILLS_DIR: join(REPO, "skills"),
+      NIRVANA_SCOPE: "global", NIRVANA_SCOPE_QUIET: "1", NIRVANA_NO_UPDATE_CHECK: "1",
+    } as Record<string, string>,
+  });
+  const report = JSON.parse(r.stdout);
+  const checks: Array<{ name: string; status: string; note: string }> = report.checks;
+  return {
+    code: r.status ?? -1,
+    protocol: Object.fromEntries(checks.filter((c) => c.name.startsWith("protocol:")).map((c) => [c.name, c])),
+  };
+}
+
+describe("the Protocol section counts what the library declares", () => {
+  test("a library mid-migration is WARN, with the spread and the command", () => {
+    const out = doctor(library({
+      squads: [["a", "5.0"], ["b", "5.0"], ["c", "6.0"], ["d", null]],
+      businesses: [["biz-one", "1.0", true], ["biz-two", "2.0", false]],
+    }));
+    expect(out.protocol["protocol: squads"].status).toBe("WARN");
+    expect(out.protocol["protocol: squads"].note).toContain("2×5.0");
+    expect(out.protocol["protocol: squads"].note).toContain("3 below 6.0");
+    expect(out.protocol["protocol: squads"].note).toContain("nrv migrate");
+    expect(out.protocol["protocol: businesses"].status).toBe("WARN");
+    expect(out.protocol["protocol: businesses"].note).toContain("1 of 2 still on protocol 1.0");
+    expect(out.protocol["protocol: businesses"].note).toContain("1 carry fields v2 retired");
+  }, 60_000);
+
+  test("a fully migrated library passes and says so", () => {
+    const out = doctor(library({
+      squads: [["a", "6.0"], ["b", "6.0"]],
+      businesses: [["biz-one", "2.0", false]],
+    }));
+    expect(out.protocol["protocol: squads"].status).toBe("PASS");
+    expect(out.protocol["protocol: squads"].note).toContain("all on 6.0");
+    expect(out.protocol["protocol: businesses"].status).toBe("PASS");
+    expect(out.protocol["protocol: businesses"].note).toContain("no retired fields");
+  }, 60_000);
+
+  test("it is never a FAIL — the whole point, because CI reads exit >= 2", () => {
+    const out = doctor(library({
+      squads: [["a", "4.0"], ["b", null]],
+      businesses: [["biz-one", "1.0", true], ["biz-two", "1.0", true]],
+    }));
+    for (const check of Object.values(out.protocol)) expect(check.status).not.toBe("FAIL");
+    // A library that is entirely un-migrated must not be able to produce the
+    // exit code CI reads as "this machine is broken" through THIS section.
+    expect(Object.values(out.protocol).every((c) => c.status === "WARN")).toBe(true);
+  }, 60_000);
+});

--- a/skills/harness/tests/glance-verify-route.test.ts
+++ b/skills/harness/tests/glance-verify-route.test.ts
@@ -1,0 +1,131 @@
+// glance-verify-route.test.ts — the admission gate in the cockpit.
+//
+// Two properties, and the second is the one that matters: the read must never
+// be able to freeze the server. Glance answers every panel from one event
+// loop, and a verify is tens of milliseconds of synchronous filesystem work
+// per entity — so the route runs a CHILD with a wall-clock cap and answers 504
+// when the cap is hit, instead of holding the loop while a slow entity walks.
+//
+// The repair half is deliberately NOT this route: it is a mutating action,
+// declared as such, so the panel confirms before it is ever sent.
+//
+// Runs with: bun test skills/harness/tests
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeDir } from "./helpers/temp-dirs.ts";
+
+const REPO = path.resolve(import.meta.dir, "..", "..", "..");
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-glance-verify-"));
+let instance: any;
+let base = "";
+
+/** A squad complete except for the one file the engine owns. */
+function squad(slug: string): string {
+  const dir = path.join(root, "squads", slug);
+  fs.mkdirSync(path.join(dir, "agents"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "squad.yaml"), [
+    `name: ${slug}`, "version: 1.0.0", 'protocol: "5.0"',
+    "description: A squad the cockpit can ask the gate about", "",
+  ].join("\n"), "utf8");
+  fs.writeFileSync(path.join(dir, "agents", "solo.md"), "---\nname: solo\nmaxTurns: 8\ntools: [Read]\n---\n\n# solo\n", "utf8");
+  return dir;
+}
+
+// The server reads its roots from the environment, so this file has to set
+// them — and then put every one of them back. `bun test` runs a directory in
+// ONE process: a variable left behind here is a variable every later file
+// inherits, and `NIRVANA_SCOPE=global` in particular changes how the engine
+// resolves a business for the rest of the run. That is exactly how this file
+// broke `check-scope-guard --strict` on Linux (the gate's fixture business
+// resolved to `~/businesses` instead of its own project scope) while macOS hid
+// it, because Bun there hands a spawned child the environment captured at
+// process start rather than the mutated one.
+const ENV_KEYS = [
+  "NIRVANA_PROJECT_ROOT", "NIRVANA_SKILLS_DIR", "SQUADS_DIR",
+  "NIRVANA_STATE_DIR", "HARNESS_LOGS_DIR", "NIRVANA_SCOPE",
+  "NIRVANA_GLANCE_VERIFY_TIMEOUT_MS",
+] as const;
+const SAVED: Record<string, string | undefined> = {};
+
+beforeAll(async () => {
+  fs.mkdirSync(path.join(root, ".nirvana"), { recursive: true });
+  squad("cockpit-squad");
+  for (const k of ENV_KEYS) SAVED[k] = process.env[k];
+  process.env.NIRVANA_PROJECT_ROOT = root;
+  process.env.NIRVANA_SKILLS_DIR = path.join(REPO, "skills");
+  process.env.SQUADS_DIR = path.join(root, "squads");
+  process.env.NIRVANA_STATE_DIR = path.join(root, "state");
+  process.env.HARNESS_LOGS_DIR = path.join(root, "logs");
+  process.env.NIRVANA_SCOPE = "global";
+  const { startServer } = await import("../lib/glance/server.ts");
+  instance = await startServer({ port: 0, open: false, idleMin: 60, allowActions: true, theme: "apple" });
+  base = `http://127.0.0.1:${instance.port}`;
+});
+
+afterAll(() => {
+  try { instance?.close(); } catch { /* already closed */ }
+  for (const k of ENV_KEYS) {
+    if (SAVED[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED[k];
+  }
+  removeDir(root);
+});
+
+describe("GET /api/v1/verify/<kind>/<slug>", () => {
+  test("answers a full verify report and stays a read", async () => {
+    const r = await fetch(`${base}/api/v1/verify/squad/cockpit-squad`);
+    expect(r.status).toBe(200);
+    const report = await r.json() as any;
+    expect(report.schema).toBe("nirvana.verify-report/v1");
+    expect(report.slug).toBe("cockpit-squad");
+    expect(report.verdict).toBe("REJECTED");
+    expect(report.findings.map((f: any) => f.id)).toContain("surface_missing");
+    // A read never repairs: the file the fixer would write is still absent.
+    expect(fs.existsSync(path.join(root, "squads", "cockpit-squad", ".nirvana-surface.json"))).toBe(false);
+  }, 30_000);
+
+  test("an unknown entity is 404 and an unknown kind is not a route at all", async () => {
+    expect((await fetch(`${base}/api/v1/verify/squad/nobody-here`)).status).toBe(404);
+    expect((await fetch(`${base}/api/v1/verify/dragon/cockpit-squad`)).status).toBe(404);
+  }, 30_000);
+
+  test("a write to the read route is refused", async () => {
+    const r = await fetch(`${base}/api/v1/verify/squad/cockpit-squad`, {
+      method: "POST", headers: { "content-type": "application/json", "idempotency-key": crypto.randomUUID(), origin: base }, body: "{}",
+    });
+    expect(r.status).toBe(405);
+  }, 30_000);
+
+  test("the timeout answers 504 and the server keeps serving", async () => {
+    process.env.NIRVANA_GLANCE_VERIFY_TIMEOUT_MS = "1";
+    const r = await fetch(`${base}/api/v1/verify/squad/cockpit-squad`);
+    expect(r.status).toBe(504);
+    const body = await r.json() as any;
+    expect(body.title).toBe("Verify timed out");
+    delete process.env.NIRVANA_GLANCE_VERIFY_TIMEOUT_MS;
+    // The point of the child: the loop that timed out is still answering.
+    expect((await fetch(`${base}/api/v1/capabilities`)).status).toBe(200);
+  }, 30_000);
+});
+
+describe("POST /api/actions/verify-fix", () => {
+  test("it is declared mutating, and the panel confirms before sending it", () => {
+    const server = fs.readFileSync(path.join(REPO, "skills", "harness", "lib", "glance", "server.ts"), "utf8");
+    const block = server.slice(server.indexOf('"verify-fix": {'), server.indexOf('"index-squads": {'));
+    expect(block).toContain("mutating: true");
+    expect(block).toContain("--fix");
+    const html = fs.readFileSync(path.join(REPO, "skills", "harness", "lib", "glance", "views", "index.html"), "utf8");
+    expect(html.match(/confirmAction\('verify-fix'/g)?.length).toBe(3);
+  });
+
+  test("it refuses a kind or slug it does not recognise", async () => {
+    for (const body of [{ kind: "dragon", slug: "x" }, { kind: "squad", slug: "../etc" }, { kind: "squad" }]) {
+      const r = await fetch(`${base}/api/actions/verify-fix`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+      });
+      expect(r.status).toBe(400);
+    }
+  }, 30_000);
+});

--- a/skills/harness/tests/verify-install-hooks.test.ts
+++ b/skills/harness/tests/verify-install-hooks.test.ts
@@ -1,0 +1,226 @@
+// verify-install-hooks.test.ts — the gate wired into the paths a buyer walks.
+//
+// verify-hooks.test.ts proves the decision module; this file proves the
+// WIRING, through the real CLIs, with the flags coming from the environment
+// exactly as a buyer's `nrv config` would set them:
+//
+//   nrv install <dir>               → installer.ts, on the staged copy
+//   install-content.ts <pack>       → per entity, before the first mirror
+//   nrv activate <slug>             → before the first dependency is installed
+//
+// The rule the whole cut answers to: with the shipped defaults every one of
+// them proceeds. Only the flag turns a report into a refusal, and
+// --skip-validate / --skip-verify always walk past it.
+//
+// Runs with: bun test skills/harness/tests
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const INSTALL = join(REPO, "skills", "_shared", "scripts", "install-asset.ts");
+const INSTALL_CONTENT = join(REPO, "skills", "_shared", "scripts", "install-content.ts");
+const ACTIVATE = join(REPO, "skills", "harness", "scripts", "activate.ts");
+
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function home(): string {
+  const root = mkdtempSync(join(tmpdir(), "nrv-install-gate-"));
+  ROOTS.push(root);
+  for (const d of ["squads", "businesses", "source", "state", "logs"]) mkdirSync(join(root, d), { recursive: true });
+  return root;
+}
+
+/**
+ * A home the child actually believes in, on every platform.
+ *
+ * `installer.ts` resolves its roots lazily from `NIRVANA_HOME` / `SQUADS_DIR`,
+ * so redirecting those is enough for it. `install-content.ts` does not: it
+ * reads `os.homedir()` once, at module scope, and joins `squads`,
+ * `businesses` and `.nirvana/packs` onto it. `os.homedir()` follows `$HOME` on
+ * macOS and Linux and `%USERPROFILE%` on Windows — so a test that sets only
+ * `HOME` redirects the overlay on two platforms out of three and silently
+ * writes into the real profile on the third. That is what turned this file red
+ * on the Windows runner and nowhere else.
+ */
+function homeEnv(root: string): Record<string, string> {
+  const drive = /^([A-Za-z]:)(.*)$/.exec(root);
+  return {
+    HOME: root,
+    USERPROFILE: root,
+    // uv_os_homedir falls back to HOMEDRIVE + HOMEPATH when USERPROFILE is
+    // absent; keeping them consistent means no third answer exists.
+    ...(drive ? { HOMEDRIVE: drive[1], HOMEPATH: drive[2] || "\\" } : {}),
+  };
+}
+
+function env(root: string, extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    ...process.env,
+    ...homeEnv(root),
+    NIRVANA_HOME: root,
+    NIRVANA_STATE_DIR: join(root, "state"),
+    HARNESS_LOGS_DIR: join(root, "logs"),
+    SQUADS_DIR: join(root, "squads"),
+    BUSINESSES_DIR: join(root, "businesses"),
+    DNA_LIBRARY: join(root, "businesses", "_library", "dna"),
+    NIRVANA_SKILLS_DIR: join(REPO, "skills"),
+    CLAUDE_SKILLS_DIR: join(REPO, "skills"),
+    NIRVANA_SCOPE: "global",
+    NIRVANA_SCOPE_QUIET: "1",
+    NIRVANA_NO_UPDATE_CHECK: "1",
+    ...extra,
+  } as Record<string, string>;
+}
+
+function run(script: string, args: string[], root: string, extra: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [script, ...args], { cwd: root, env: env(root, extra), encoding: "utf8" });
+  return { code: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+/**
+ * A squad with a real manifest and NO `.nirvana-surface.json` — the HARD error
+ * a buyer's own hand-made squad carries most often, and the one the gate would
+ * have blocked on day one if it blocked by default.
+ */
+function brokenSquad(dir: string, slug: string): string {
+  mkdirSync(join(dir, "agents"), { recursive: true });
+  mkdirSync(join(dir, "workflows"), { recursive: true });
+  writeFileSync(join(dir, "squad.yaml"), [
+    `name: ${slug}`,
+    "version: 1.0.0",
+    'protocol: "5.0"',
+    "description: A squad a buyer wrote by hand, complete except for what the engine owns",
+    "",
+  ].join("\n"), "utf8");
+  writeFileSync(join(dir, "agents", "solo.md"), "---\nname: solo\nmaxTurns: 8\ntools: [Read]\n---\n\n# solo\n", "utf8");
+  return dir;
+}
+
+const ENFORCE = { NIRVANA_VERIFY_ENFORCE_ON_INSTALL: "1" };
+
+describe("nrv install", () => {
+  test("the flag off: the gate reports and the squad installs", () => {
+    const root = home();
+    const src = brokenSquad(join(root, "source", "handmade"), "handmade");
+    const r = run(INSTALL, [src, "--type=squad", "--skip-reindex"], root);
+    expect(r.out).toContain("surface_missing");
+    expect(r.out).toContain("proceeding anyway");
+    expect(r.code).toBe(0);
+    expect(existsSync(join(root, "squads", "handmade", "squad.yaml"))).toBe(true);
+  }, 30_000);
+
+  test("the flag on: the same squad is refused and nothing lands", () => {
+    const root = home();
+    const src = brokenSquad(join(root, "source", "handmade"), "handmade");
+    const r = run(INSTALL, [src, "--type=squad", "--skip-reindex"], root, ENFORCE);
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("refused by the admission gate");
+    expect(existsSync(join(root, "squads", "handmade"))).toBe(false);
+  }, 30_000);
+
+  test("--skip-validate escapes the refusal", () => {
+    const root = home();
+    const src = brokenSquad(join(root, "source", "handmade"), "handmade");
+    const r = run(INSTALL, [src, "--type=squad", "--skip-reindex", "--skip-validate"], root, ENFORCE);
+    expect(r.code).toBe(0);
+    expect(existsSync(join(root, "squads", "handmade", "squad.yaml"))).toBe(true);
+  }, 30_000);
+});
+
+describe("install-content (the paid overlay)", () => {
+  // One pack slug per case. The overlay records what it installed in
+  // `<home>/.nirvana/packs/<slug>.json` and then only checks what is ENTERING
+  // — a slug already installed at the same hash is not re-judged, by design.
+  // Sharing one slug across the three cases means that as soon as the home is
+  // not isolated, case 2 finds case 1's manifest, has nothing entering, and
+  // passes the gate by never reaching it. Distinct slugs make that impossible
+  // to happen quietly.
+  function pack(root: string, slug: string): string {
+    const content = join(root, "source", slug);
+    brokenSquad(join(content, "squads", slug), slug);
+    return content;
+  }
+
+  /** The overlay must have written inside this root, never into a real home. */
+  function landedIn(root: string, slug: string): boolean {
+    return existsSync(join(root, "squads", slug, "squad.yaml"));
+  }
+
+  test("the flag off: it warns per entity and mirrors the pack", () => {
+    const root = home();
+    const r = run(INSTALL_CONTENT, [pack(root, "packed-a"), "--slug", "pack-a"], root);
+    expect(r.out).toContain("surface_missing");
+    expect(r.out).toContain("proceeding anyway");
+    expect(r.code).toBe(0);
+    expect(landedIn(root, "packed-a")).toBe(true);
+    // The overlay resolves its roots from os.homedir(), so this asserts the
+    // redirection itself: without it the mirror lands in the real profile and
+    // every other assertion here becomes meaningless.
+    expect(existsSync(join(root, ".nirvana", "packs", "pack-a.json"))).toBe(true);
+  }, 30_000);
+
+  test("the flag on: nothing is mirrored, and the refusal names the component", () => {
+    const root = home();
+    const r = run(INSTALL_CONTENT, [pack(root, "packed-b"), "--slug", "pack-b"], root, ENFORCE);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("squads/packed-b");
+    expect(r.out).toContain("Nothing was installed");
+    expect(existsSync(join(root, "squads", "packed-b"))).toBe(false);
+    // A refusal happens before the manifest is written: nothing was recorded.
+    expect(existsSync(join(root, ".nirvana", "packs", "pack-b.json"))).toBe(false);
+  }, 30_000);
+
+  test("--skip-validate escapes, and the pack installs whole", () => {
+    const root = home();
+    const r = run(INSTALL_CONTENT, [pack(root, "packed-c"), "--slug", "pack-c", "--skip-validate"], root, ENFORCE);
+    expect(r.code).toBe(0);
+    expect(landedIn(root, "packed-c")).toBe(true);
+  }, 30_000);
+
+  test("a slug already installed at the same hash is not re-judged", () => {
+    // The other half of the contract the shared-slug bug was hiding: the gate
+    // is about what ENTERS, so a second identical overlay of the same pack has
+    // nothing entering and passes even with the flag on. Asserted on purpose,
+    // in one place, instead of leaking into the three cases above.
+    const root = home();
+    const content = pack(root, "packed-d");
+    expect(run(INSTALL_CONTENT, [content, "--slug", "pack-d", "--skip-validate"], root, ENFORCE).code).toBe(0);
+    const second = run(INSTALL_CONTENT, [content, "--slug", "pack-d"], root, ENFORCE);
+    expect(second.code).toBe(0);
+    expect(second.out).not.toContain("surface_missing");
+    expect(second.out).toContain("0 new");
+  }, 30_000);
+});
+
+describe("nrv activate", () => {
+  test("the flag off activates; the flag on refuses before touching dependencies", () => {
+    const root = home();
+    brokenSquad(join(root, "squads", "handmade"), "handmade");
+    // No dependencies.yaml: the activator has nothing to install, so the exit
+    // code carries the gate's answer and nothing else.
+    const off = run(ACTIVATE, ["handmade", "--dry-run"], root);
+    expect(off.out).toContain("surface_missing");
+    expect(off.out).not.toContain("refused");
+
+    const on = run(ACTIVATE, ["handmade", "--dry-run"], root, { NIRVANA_VERIFY_ENFORCE_ON_ACTIVATE: "1" });
+    expect(on.code).toBe(1);
+    expect(on.out).toContain("refused");
+
+    const skipped = run(ACTIVATE, ["handmade", "--dry-run", "--skip-verify"], root, { NIRVANA_VERIFY_ENFORCE_ON_ACTIVATE: "1" });
+    expect(skipped.out).toContain("skipped by --skip-verify");
+    expect(skipped.out).not.toContain("refused");
+  }, 30_000);
+
+  test("the install flag does not activate, and the activate flag does not install", () => {
+    const root = home();
+    const src = brokenSquad(join(root, "source", "handmade"), "handmade");
+    const install = run(INSTALL, [src, "--type=squad", "--skip-reindex"], root, { NIRVANA_VERIFY_ENFORCE_ON_ACTIVATE: "1" });
+    expect(install.code).toBe(0);
+    const activate = run(ACTIVATE, ["handmade", "--dry-run"], root, ENFORCE);
+    expect(activate.out).not.toContain("refused");
+  }, 30_000);
+});

--- a/skills/squads/references/15-creation-wizard.md
+++ b/skills/squads/references/15-creation-wizard.md
@@ -169,18 +169,29 @@ After that the LLM:
 
 ---
 
-## Final validation (loop until it passes)
+## Final validation — the admission gate (BLOCKING, loop until it passes)
 
 ```bash
-bun ~/.nirvana/skills/squads/scripts/validate-squad.ts ${SQUADS_DIR}/<name>
+nrv validate squad ${SQUADS_DIR}/<name> --strict     # --fix applies the mechanical repairs
 ```
+
+This is the gate, not a linter: it carries the whole criteria catalog of
+`SQUAD_PROTOCOL_V6.md` §34 — manifest, capabilities, workflow graph, component
+refs, contract surface, routing metadata. Require exit 0 alongside the
+self-retrieval gate; a squad that does not pass is not created.
+
+`init-squad.ts` already ran it once, in `--fix` mode, over the scaffold it
+wrote, so the engine-owned files (`.nirvana-surface.json`, the component stubs)
+are on disk before you start filling them in. What is left after your edits is
+authorship, which is yours.
 
 If it fails, read the output and fix:
 - capability error → revisit Round 3
 - missing agent/task/workflow file → fill in the skeleton
 - domain outside the catalog → confirm experimental_domains
+- a finding marked `[agentic]` → write it yourself, or `--fix=agentic --yes`
 
-Do not declare the squad ready until validation passes.
+Do not declare the squad ready until the gate passes.
 
 ---
 

--- a/skills/squads/scripts/init-squad.ts
+++ b/skills/squads/scripts/init-squad.ts
@@ -25,10 +25,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { paths, EXIT } from "../../_shared/lib/bun-helpers.ts";
+import { verifyHook } from "../../_shared/lib/verify/index.ts";
 
 const argv = process.argv.slice(2);
 if (argv.length < 1 || argv[0] === "-h" || argv[0] === "--help") {
-  console.error("Usage: init-squad <target-dir> [--name N] [--description D] ...");
+  console.error("Usage: init-squad <target-dir> [--name N] [--description D] [--skip-verify] ...");
   process.exit(argv.length === 0 ? EXIT.INVALID_ARGS : EXIT.OK);
 }
 
@@ -62,6 +63,7 @@ const state: Record<string, string> = {
   TASK_2: env.SQUAD_TASK_2 || "execute",
 };
 let force = false;
+let skipVerify = false;
 
 const flagToKey: Record<string, string> = {
   "--name": "NAME",
@@ -78,6 +80,7 @@ let i = 1;
 while (i < argv.length) {
   const a = argv[i];
   if (a === "--force") { force = true; i++; continue; }
+  if (a === "--skip-verify") { skipVerify = true; i++; continue; }
   if (a === "--example") {
     const v = argv[i + 1];
     if (!state.EXAMPLE_INTENT_1) state.EXAMPLE_INTENT_1 = v;
@@ -170,13 +173,28 @@ if (fs.existsSync(workflowPath) && !force) {
 }
 fs.writeFileSync(workflowPath, substitute(fs.readFileSync(workflowTemplate, "utf8")), "utf8");
 
+// The admission gate at creation (§34). `fix: "mechanical"` first, because a
+// scaffold is authored content minus what the ENGINE owns: the component files
+// the manifest declares and `.nirvana-surface.json`, which is a hash of files
+// that do not exist until this script has written them. Repairing those turns
+// a freshly scaffolded squad from REJECTED into ADMITTED; anything the fixers
+// cannot repair is a broken scaffold, and a broken scaffold is deleted rather
+// than left on disk pretending to be a squad.
+const gate = await verifyHook({ kind: "squad", target: targetDir, gate: "create", fix: "mechanical", skip: skipVerify });
+for (const line of gate.lines) console.error(line);
+if (gate.blocked) {
+  console.error(`[init-squad] FAIL: the scaffold does not pass the admission gate; removing ${targetDir}`);
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  process.exit(EXIT.FAILURES);
+}
+
 console.log(`[init-squad] Wrote ${manifestPath}`);
 console.log(`[init-squad] Wrote ${workflowPath}`);
 console.log("[init-squad] Created skeleton dirs: agents/ tasks/ workflows/ schemas/");
 console.log("");
 console.log("Next steps:");
-console.log(`  1. Fill in agents/${state.AGENT_1}.md and agents/${state.AGENT_2}.md (use templates/agent.md.tmpl)`);
-console.log(`  2. Fill in tasks/${state.TASK_1}.md and tasks/${state.TASK_2}.md`);
+console.log(`  1. Fill in agents/${state.AGENT_1}.md and agents/${state.AGENT_2}.md (stubs written; templates/agent.md.tmpl has the full shape)`);
+console.log(`  2. Fill in tasks/${state.TASK_1}.md and tasks/${state.TASK_2}.md (stubs written)`);
 console.log(`  3. Fill in workflows/${state.WORKFLOW_REF}.md (the graph is scaffolded; the body is yours)`);
 console.log(`  4. Validate: nrv validate squad ${targetDir}   (--fix applies the mechanical repairs)`);
 console.log(`  5. Index:    nrv index`);

--- a/skills/squads/tests/init-squad-gate.test.ts
+++ b/skills/squads/tests/init-squad-gate.test.ts
@@ -1,0 +1,100 @@
+// init-squad-gate.test.ts — the scaffolder hands over an ADMITTED squad.
+//
+// A v6 scaffold declares four components it has not written yet and no
+// `.nirvana-surface.json` (a hash of files that exist only after this script
+// runs), so before the creation hook a brand-new squad was born REJECTED on
+// two errors nobody was told about. The hook repairs what the engine owns and
+// then judges; what it cannot repair, it deletes rather than leave on disk
+// pretending to be a squad.
+//
+// Runs with: bun test skills/squads/tests
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const INIT = join(REPO, "skills", "squads", "scripts", "init-squad.ts");
+const VERIFY = join(REPO, "skills", "_shared", "scripts", "verify.ts");
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) try { rmSync(r, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function home(): string {
+  const root = mkdtempSync(join(tmpdir(), "nrv-init-squad-"));
+  ROOTS.push(root);
+  return root;
+}
+
+function env(root: string): Record<string, string> {
+  return {
+    ...process.env,
+    NIRVANA_HOME: root,
+    NIRVANA_STATE_DIR: join(root, "state"),
+    HARNESS_LOGS_DIR: join(root, "logs"),
+    SQUADS_DIR: join(root, "squads"),
+    BUSINESSES_DIR: join(root, "businesses"),
+    DNA_LIBRARY: join(root, "dna"),
+    NIRVANA_SKILLS_DIR: join(REPO, "skills"),
+    CLAUDE_SKILLS_DIR: join(REPO, "skills"),
+    NIRVANA_SCOPE: "global",
+    NIRVANA_SCOPE_QUIET: "1",
+  } as Record<string, string>;
+}
+
+function init(root: string, dir: string, ...args: string[]) {
+  const r = spawnSync(process.execPath, [INIT, dir, ...args], { cwd: root, env: env(root), encoding: "utf8" });
+  return { code: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("a scaffolded squad passes the gate it was just measured by", () => {
+  test("the engine-owned files are written and the verdict is ADMITTED", () => {
+    const root = home();
+    const dir = join(root, "squads", "fresh-squad");
+    expect(init(root, dir).code).toBe(0);
+
+    for (const f of [".nirvana-surface.json", "agents/orchestrator.md", "agents/specialist.md", "tasks/plan.md", "tasks/execute.md"]) {
+      expect(existsSync(join(dir, f))).toBe(true);
+    }
+    const v = spawnSync(process.execPath, [VERIFY, "squad", dir, "--json", "--no-retrieval"], { cwd: root, env: env(root), encoding: "utf8" });
+    const report = JSON.parse(v.stdout);
+    expect(report.findings.filter((f: any) => f.severity === "error")).toEqual([]);
+    expect(report.verdict).toBe("ADMITTED");
+    expect(v.status).toBe(0);
+  }, 30_000);
+
+  test("--skip-verify leaves the scaffold exactly as the templates wrote it", () => {
+    const root = home();
+    const dir = join(root, "squads", "raw-squad");
+    const r = init(root, dir, "--skip-verify");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("skipped by --skip-verify");
+    expect(existsSync(join(dir, ".nirvana-surface.json"))).toBe(false);
+    expect(existsSync(join(dir, "agents", "orchestrator.md"))).toBe(false);
+  }, 30_000);
+
+  test("a scaffold the fixers cannot repair is deleted, not left half-made", () => {
+    const root = home();
+    const dir = join(root, "squads", "doomed-squad");
+    // Only the two templates are faked — the script itself is the repo's, and
+    // it reads templates from CLAUDE_SKILLS_DIR. The manifest here cannot
+    // parse, which is the one error with no mechanical fixer.
+    const templates = join(root, "fake-skills", "squads", "templates");
+    mkdirSync(templates, { recursive: true });
+    writeFileSync(join(templates, "squad.yaml.tmpl"), 'name: {{SQUAD_NAME}}\ndescription: "unterminated\n  - [\n', "utf8");
+    writeFileSync(join(templates, "workflow.md.tmpl"), "---\nname: {{WORKFLOW_REF}}\nsteps: []\n---\n\n## {{TASK_1}}\n", "utf8");
+    const r = spawnSync(process.execPath, [INIT, dir], {
+      cwd: root, env: { ...env(root), NIRVANA_SKILLS_DIR: join(root, "fake-skills"), CLAUDE_SKILLS_DIR: join(root, "fake-skills") }, encoding: "utf8",
+    });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain("does not pass the admission gate");
+    expect(existsSync(dir)).toBe(false);
+  }, 30_000);
+});
+
+describe("the printed next steps match what is on disk", () => {
+  test("step 4 is the gate itself", () => {
+    const source = readFileSync(INIT, "utf8");
+    expect(source).toContain("nrv validate squad");
+  });
+});


### PR DESCRIPTION
`nrv validate` shipped as a verb nobody called. The criteria catalogs, the debt baseline and the `--fix` loop with backup and rollback all existed, and an entity could still enter the system through four other doors without any of it being asked. This cut wires the four doors to one module, `skills/_shared/lib/verify/hooks.ts`, under a constraint that shapes every decision in it: **turning a gate on must never be the reason a paid pack stops installing on the day it ships.**

## The four hooks

| Moment | Where | Flag off (shipped default) | Flag on |
|---|---|---|---|
| Creation | `init-squad.ts`, `init-business.ts` | mechanical repair, then the verdict is printed | a remaining error deletes the scaffold |
| Install | `installer.ts` (staged copy), `install-content.ts` (per entity, before the first mirror) | warns and installs | refuses; nothing is written |
| Activation | `nrv activate` | warns and activates | refuses before touching a dependency |
| Pack build | `check-entity-admission.ts`, `check-seat-sufficiency.ts` | wrappers over `verifyPack` / `verifyAll`, frozen | — |

Three rules keep a buyer's machine safe:

1. **Flagged off.** `verify.mode` ships `report`; `verify.enforce_on_install` and `verify.enforce_on_activate` ship `false`. `verify.mode: block` turns all three on at once.
2. **Grandfathering.** A machine with no debt baseline gets one **recorded** (`x_verify_baseline_recorded`, `reason: hook_grandfathering`) instead of a refusal of the library it already had. Only `baselineable` criteria become debt; a HARD error never does.
3. **A documented escape.** `--skip-validate` (install) and `--skip-verify` (activate, creation). A hook also never throws: an internal failure is `ran: false` with a reason, and the caller proceeds.

Creation is the one hook that refuses by default, for two reasons: `init-business.ts` already deleted the scaffold when the loader failed, and the hook runs `fix: "mechanical"` **before** it judges. A scaffold is authored content minus what the ENGINE owns — the component files the manifest declares, and `.nirvana-surface.json`, a hash of files that do not exist until the wizard has written them. A fresh business was REJECTED on that single error. Both wizards now hand over an ADMITTED entity.

## The frozen wrappers

`check-entity-admission.ts` and `check-seat-sufficiency.ts` became wrappers with flags, output and exit codes untouched; their tests were **not edited** and `~/nirvana-packs/scripts/build-all-packs.sh` needs no change.

Proof beyond the tests: run against **all 17 pack content dirs** (231 entities in genesis alone), the old implementation and the wrapper produce the same violations, the same debt map and the same counts. Getting there closed two real gaps in the clone catalog — a numbered legacy `category` written at the top level instead of under `manifest:`, and `source_material.primary_works`, the older spelling three of 527 live clones use. The seat gate reports the same 19 thin seats of 581 as before.

## `--fix=agentic`

`skills/_shared/lib/verify/agentic.ts`. Mechanical pass first (never pay a model for what a fixer writes for free), then a staging copy, `runHeadless` with the scope guard in the prompt, a re-check **on the copy**, and acceptance only when errors did not grow **and** at least one targeted finding is gone. Routing metadata must additionally survive the self-retrieval gate, or the backup is restored.

Nothing runs without `--yes`: exit 2 quotes the ceiling (`--budget-usd`, default 3; `--timeout-min`, default 15). The spend leaves a ledger row (`openAgenticRun({ targetKind: "verify-fix" })`) and the pair `x_verify_fix_started` / `x_verify_fix_finished`. Off in `--pack` and off with no runtime on PATH.

## Glance and doctor

`GET /api/v1/verify/<kind>/<slug>` answers a full `nirvana.verify-report/v1` from a **child process** with a wall clock (`NIRVANA_GLANCE_VERIFY_TIMEOUT_MS`, default 20 s). The cockpit answers every panel from one event loop, so a slow entity would freeze all of them; overrun is `504` and the server keeps serving, which the test asserts. Repair is a separate mutating action, `POST /api/actions/verify-fix`, confirmed before it leaves the browser. Squad, business and mind-clone panels gained a **Verificar** button and, when a mechanical fixer exists, **Corrigir (--fix)**.

`nrv doctor` gained a **Protocol** section counting squads by protocol and businesses still on 1.0 or carrying retired fields — **WARN, never FAIL**, because CI reads `doctor >= 2` as a broken machine and a library mid-migration is everyone's normal state.

## Verification

Area suites, per the verification contract (the full suite and `check:all` run once over the whole after integration):

- `test:shared` — 556 pass, 12 skip, 0 fail
- `test:squads` — 79 pass, 0 fail
- `test:businesses` — 88 pass, 0 fail
- `test:harness` — 1304 pass, 4 skip, 1 fail: `buyer-path.test.ts`, the documented worktree failure (`Cannot find package 'yaml' from …/skills/_shared/lib/entity-graph.ts`, `node_modules` is a symlink here). Confirmed environmental: it fails identically in this worktree with `origin/main`'s `install-content.ts` and `installer.ts` checked out, and passes in the main checkout.
- `check:quick` — 0 actionable discrepancies · `check-english-source --strict` clean · `check-changelog-parity --strict` clean · `git diff --check` clean

New tests: `verify-hooks`, `verify-agentic`, `verify-install-hooks`, `glance-verify-route`, `doctor-protocol`, `init-squad-gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
