### PR TITLE
protocol: overlap between entities is normal, and the comparison harvests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Overlap between entities is normal, and the loser's work is harvested rather than discarded
+
+The creation pipelines told an author that a new squad or business "that steals
+an existing one's territory is born wrong", and that the finding "dictates the
+`not_for` of both". That doctrine predates agentic routing being the default,
+and under it the instruction is backwards: the maestro reads the registries and
+compares candidates against the brief it is actually holding, which is more
+information than either author had when writing their manifest. A defensive
+`not_for` removes an entity from a comparison it might have won, permanently and
+invisibly — and it is a ×0.4 penalty in the router, so it reads as a demotion
+while working as removal.
+
+Both texts now say the opposite: overlap is legitimate, an owner may keep two
+entities covering the same ground on purpose — to name one when they want it and
+let the system choose when they do not — and what a new entity must earn is not
+exclusivity but being **visibly better at** something nameable. `not_for` carries
+genuine refusals only.
+
+The maestro's contract gains the method, in three sentences rather than a
+procedure: read the candidates that overlap, decide which one executes, and put
+what the others do better into the brief the winner receives. A step one
+workflow had and the other lacks is not lost when you pick — you are writing the
+brief. The dispatch that follows is better than either candidate alone. The
+alternatives read and what was harvested go in the reasoning of
+`target_plan_committed`, a field that already exists; no new event, no schema,
+no scoring matrix. Piling procedure on the agent is what makes it stop thinking.
+
+
 ## 0.10.1 — 2026-08-27
 
 ### A field that reads as data stops being able to run a command

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,35 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Sobreposição entre entidades é normal, e o que o perdedor tem de bom é aproveitado
+
+Os pipelines de criação diziam ao autor que um squad ou empresa "que rouba o
+território de outro nasce errado", e que o achado "dita o `not_for` dos dois".
+Essa doutrina é anterior ao roteamento agêntico ser o padrão, e sob ele a
+instrução está invertida: o maestro lê os registries e compara os candidatos
+contra o brief que tem na mão — mais informação do que qualquer um dos dois
+autores tinha ao escrever o manifesto. Uma cerca defensiva tira a entidade de
+uma comparação que ela poderia ganhar, de forma permanente e invisível — e como
+é penalidade de ×0,4 no roteador, ela se lê como rebaixamento e funciona como
+remoção.
+
+Os dois textos agora dizem o contrário: sobreposição é legítima, o dono pode
+querer duas entidades cobrindo o mesmo terreno de propósito — para nomear uma
+quando quiser e deixar o sistema escolher quando não quiser — e o que uma
+entidade nova precisa ganhar não é exclusividade, e sim ser **visivelmente
+melhor** em algo que se possa nomear. `not_for` carrega só recusa genuína.
+
+O contrato do maestro ganha o método, em três frases em vez de um procedimento:
+leia os candidatos que se sobrepõem, decida qual executa, e ponha no briefing do
+escolhido aquilo que os outros fazem melhor. Um passo que um workflow tinha e o
+outro não tem não se perde na escolha — quem escreve o briefing é você. O
+despacho que sai daí é melhor do que qualquer um dos candidatos sozinho. Os
+alternativos lidos e o que foi aproveitado vão no raciocínio do
+`target_plan_committed`, campo que já existe; sem evento novo, sem schema, sem
+matriz de pontuação. Empilhar procedimento no agente é o que faz ele parar de
+pensar.
+
+
 ## 0.10.1 — 2026-08-27
 
 ### Um campo que se lê como dado deixa de poder rodar um comando

--- a/skills/businesses/SKILL.md
+++ b/skills/businesses/SKILL.md
@@ -194,9 +194,11 @@ When intent = CREATE, follow this sequence without skipping steps.
 **Round 0 — Archaeology + research (before asking anything)**
 - Intent archaeology: which recurring pain the business serves, who consumes
   the outputs, and what already exists in the portfolio that covers part of it
-  (`nrv find --no-amplify` with 3-5 hypothetical briefs — a new business that
-  steals an existing business's territory is born wrong; the result dictates
-  `auto_routes` and boundaries).
+  (`nrv find --no-amplify` with 3-5 hypothetical briefs). Overlap is legitimate
+  — the owner may want two organisations covering the same sector, to name one
+  when they want it and let the maestro choose when they do not. What the
+  search tells you is what this business must be visibly better at. Never fence
+  a neighbour off; boundaries carry genuine refusals only.
 - Domain research (web, mandatory): CURRENT practices, tools, and services of
   the sector, with date and source — they become the employees' knowledge and
   the real vocabulary of `domains`/`example_briefs`/keywords (PT and EN).

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -253,6 +253,10 @@ For **mind-clones**, search by NEED, never by name: `nrv find-clone` runs BM25 o
 
 Pick a **shortlist of 5–10 candidates** across all three pillars with rough rationale.
 
+**Two candidates covering the same ground is normal, and it is an opportunity, not a tie to break.** Read both. Decide which one executes — then take what the other does better and put it into the brief you hand the winner. A step the loser's workflow had and the winner's lacks, a check only one of them makes, a sharper way of framing the output: none of that is lost when you pick, because you are writing the brief. The dispatch that follows is better than either candidate would have been alone.
+
+That is the whole method. Do not run a scoring procedure, do not fill in a matrix: read the code of the ones that overlap, judge which fits **this** brief, and carry the rest forward. When you commit the plan, say in the reasoning which alternatives you read and what you harvested — the field already exists, and one sentence there is worth more than a schema.
+
 **Pass 2 — deep confirmation (~10–20k tokens).** Read the full content of each shortlisted candidate: businesses (`business.yaml` + `org-chart.yaml` + selected `employees/<name>.md`), squads (`squad.yaml` + selected `agents/` + `workflows/`), mind-clones (`agent/AGENT.md` + relevant `dna/`). The deep read confirms or rules out.
 
 **Closure check (optional, multi-entity dispatches).** Before dispatching a business, `nrv graph closure --business <slug> --json` returns the exact entity closure the execution needs — employees, the mind-clones they embody, squads — with missing dependencies named instead of silently absent. The graph is derived from the prose declarations on disk, never a second source of truth. Opt-in by construction: single-target dispatch never needs it and pays no graph cost.

--- a/skills/squads/references/02-creation.md
+++ b/skills/squads/references/02-creation.md
@@ -38,9 +38,14 @@ request into the right squad:
    to serve what they NEED. Extract: which recurring pain motivates the squad,
    who consumes the outputs, which deliverable format closes the loop, and what
    ALREADY exists in the portfolio that covers part of it (`nrv find --no-amplify`
-   with 3-5 hypothetical briefs from the domain — a new squad that steals an
-   existing squad's territory is born wrong; the result dictates the `not_for`
-   of both). On a clean engine install (zero squads — the engine installs no
+   with 3-5 hypothetical briefs from the domain). Overlap is not a problem to
+   solve here: two squads may cover the same ground, and the maestro compares
+   them at dispatch with the brief in hand. What the search tells you is what
+   this squad must be **visibly better at** — sharpen its description,
+   `produces` and `example_briefs` until a reader could say which of the two
+   fits a given brief. Never fence a neighbour off in `not_for`: that carries
+   genuine refusals only, and a defensive entry removes this squad from a
+   comparison it might have won.) On a clean engine install (zero squads — the engine installs no
    content), the search comes back empty and this step degrades to nothing:
    move on.
 2. **Domain research (web, mandatory).** The squad has to be born at the state


### PR DESCRIPTION
Removes the exclusive-territory doctrine from the squad and business creation pipelines, and gives the maestro the comparison method as a principle rather than a procedure.

**Why.** `references/02-creation.md` and `businesses/SKILL.md` told an author that an entity overlapping an existing one is "born wrong" and that the finding "dictates the `not_for` of both". Agentic routing has been the default since; under it the maestro reads the registries and compares candidates against the brief it is actually holding — more information than either author had when writing their manifest. A defensive `not_for` removes an entity from a comparison it might have won, and since it is a ×0.4 penalty in `router.js` it reads as a demotion while working as removal.

**What the owner wants instead**, and has already done by hand: when two entities cover the same ground, read both, pick the one that executes, and carry what the weaker one does better into the brief the winner receives. The dispatch is then better than either candidate alone.

**Deliberately small.** Three text edits, +17/−6. No new audit event, no schema, no scoring matrix: the alternatives read and what was harvested go in the reasoning field of `target_plan_committed`, which already exists. Piling procedure on the agent is the failure this change is trying not to commit.

Gates: `check-english-source --strict`, `check-skillmd-command-parity --strict`, `check-changelog-parity --strict` (171 sections), `git diff --check` — all clean. No test reads these documents; full suite and `check:all` not run, per the verification contract.