### PR TITLE
fix(gate): judge the work product, not the state of the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,37 @@ alternatives read and what was harvested go in the reasoning of
 `target_plan_committed`, a field that already exists; no new event, no schema,
 no scoring matrix. Piling procedure on the agent is what makes it stop thinking.
 
+### The gate judges the work product, not the state of the run
+
+A dispatch on 27/08 wrote `backup-before/` inside its own outputs root: a whole
+copy of the squad it was auditing, 276 files. The delivery pipeline listed
+everything under that root and filtered it by size alone, so all 276 went to the
+quality gate next to the nine files the run had really written. Both revision
+rounds were then spent rewriting prose out of another squad's README, and the
+delivery shipped with reservations about files nobody had touched.
+
+The gate surface now drops what the run did not write. Run state comes from
+`skills/_shared/lib/run-state.ts`, the list the installer, the uninstaller and
+the pack builder already read, asked one kind at a time so that `memory/projects`
+never collapses into `memory/`, plus any directory segment opening with `.` or
+`_`. The engine's own `_SUMMARY.md` and `_QA-RESERVATIONS.md` are files rather
+than directories, so they stay under judgement. A captured entity is recognized
+by identity, never by name: a directory holding `squad.yaml`, `business.yaml` or
+`MANIFEST.yaml` is a component this run copied, whatever the folder was called.
+A reserved prefix would have missed `backup-before` completely, because it needs
+the agent that wrote the directory to have known the convention, and that agent
+did not. When the captured entity is all there is, it is judged as usual, so the
+filter can narrow noise and never silence the only signal on disk.
+
+`wiki-lint` implements the Wikipedia "Signs of AI writing" tells, every one of
+them English, and the same run had it fail `README.hi.md` and `README.ar.md` for
+em-dash overuse and hyphen stitching. It now abstains when more than a fifth of
+the letters sit outside the Latin script. Measured on the files from that trace:
+0% for the English and Spanish READMEs, 42% for Chinese, 59% for Hindi, 70% for
+Arabic. Abstention is not approval. It is a skipped rubric, and a file left with
+no unskipped rubric still lands on INDETERMINATE, which withholds delivery.
+Portuguese, Spanish and every other Latin-script language stay under judgement;
+separating those needs language detection, not a script check.
 
 ## 0.10.1 — 2026-08-27
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -36,6 +36,38 @@ alternativos lidos e o que foi aproveitado vão no raciocínio do
 matriz de pontuação. Empilhar procedimento no agente é o que faz ele parar de
 pensar.
 
+### O portão julga o produto do trabalho, não o estado do run
+
+Um dispatch de 27/08 escreveu `backup-before/` dentro do próprio outputs root:
+uma cópia inteira do squad que ele estava auditando, 276 arquivos. O pipeline de
+entrega listava tudo sob aquele root e filtrava só por tamanho, então os 276
+foram ao portão de qualidade ao lado dos nove arquivos que o run tinha de fato
+escrito. As duas rodadas de revisão foram gastas reescrevendo prosa do README de
+outro squad, e a entrega saiu com ressalvas sobre arquivos que ninguém tocou.
+
+A superfície do portão agora descarta o que o run não escreveu. O estado de
+execução vem de `skills/_shared/lib/run-state.ts`, a lista que o instalador, o
+desinstalador e o construtor de packs já leem, consultada um kind por vez para
+que `memory/projects` nunca desabe em `memory/`, mais qualquer segmento de
+diretório que comece com `.` ou `_`. O `_SUMMARY.md` e o `_QA-RESERVATIONS.md`
+do próprio engine são arquivos, não diretórios, e seguem sendo julgados. Uma
+entidade capturada é reconhecida por identidade, nunca por nome: um diretório com
+`squad.yaml`, `business.yaml` ou `MANIFEST.yaml` é um componente que este run
+copiou, qualquer que fosse o nome da pasta. Um prefixo reservado teria passado
+longe de `backup-before`, porque depende de o agente que escreveu o diretório
+conhecer a convenção, e esse agente não conhecia. Quando a entidade capturada é
+tudo o que existe, ela é julgada normalmente, então o filtro consegue estreitar
+ruído e nunca calar o único sinal em disco.
+
+O `wiki-lint` implementa os sinais do guia "Signs of AI writing" da Wikipédia,
+todos eles ingleses, e o mesmo run o fez reprovar `README.hi.md` e `README.ar.md`
+por excesso de travessão e por hifenização. Ele agora se abstém quando mais de um
+quinto das letras está fora da escrita latina. Medido nos arquivos daquele trace:
+0% nos READMEs em inglês e espanhol, 42% no chinês, 59% no híndi, 70% no árabe.
+Abster-se não é aprovar. É uma rubrica pulada, e um arquivo sem nenhuma rubrica
+não pulada continua caindo em INDETERMINATE, o que retém a entrega. Português,
+espanhol e toda língua de escrita latina seguem sendo julgados; separar esses
+casos exige detecção de idioma, não uma checagem de escrita.
 
 ## 0.10.1 — 2026-08-27
 

--- a/skills/harness/lib/delivery-pipeline.ts
+++ b/skills/harness/lib/delivery-pipeline.ts
@@ -42,6 +42,8 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { runHeadless, runtimeAvailable, AUTONOMOUS_DIRECTIVE, type Runtime } from "./host-agent-driver.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
+import { isRunStatePath } from "../../_shared/lib/run-state.ts";
+import { detectKind } from "../../_shared/lib/surface.ts";
 import { GATEABLE_EXTS } from "../scripts/quality-gate.ts";
 import type { HarnessConfig } from "./harness-config.ts";
 import * as runLedger from "./run-ledger.ts";
@@ -85,12 +87,71 @@ export function nonStubText(dir: string, named: Set<string>): string[] {
   return listFiles(dir).filter(f => /\.(md|txt|json)$/i.test(f) && isDeliverable(f, named));
 }
 
+/**
+ * True when a path under an outputs root holds RUN STATE rather than work
+ * product. Two sources, neither of them a name list invented here:
+ *
+ *  - `isRunStatePath` (skills/_shared/lib/run-state.ts) — the canonical list
+ *    the installer, the uninstaller and the pack builder already read. An
+ *    outputs root may belong to a squad or to a business, so every kind is
+ *    asked. Asked ONE KIND AT A TIME, never kindless: the kindless branch
+ *    matches bare first segments, and run-state.ts documents what that cost
+ *    the last time — `memory/projects` collapsing to `memory` took
+ *    `memory/permanent.md` out of forty-six businesses.
+ *  - a DIRECTORY segment opening with `.` or `_` — the two namespaces the
+ *    engine reserves for itself. Only directories: the basename is never
+ *    tested, so `_SUMMARY.md` and `_QA-RESERVATIONS.md`, which the run really
+ *    does author, stay under judgement.
+ */
+const RUN_STATE_KINDS = ["squads", "businesses", "mind-clones"] as const;
+
+function isRunStateUnderOutputs(rel: string): boolean {
+  if (RUN_STATE_KINDS.some(kind => isRunStatePath(rel, kind))) return true;
+  const segs = rel.split(/[\\/]/).filter(Boolean);
+  return segs.slice(0, -1).some(s => s.startsWith(".") || s.startsWith("_"));
+}
+
+/**
+ * True when a path sits inside a CAPTURED ENTITY — a squad, business or
+ * mind-clone copied whole into the outputs root (`detectKind` finds its
+ * manifest there). The run put those bytes on disk; it did not write them.
+ *
+ * Why identity and not the name: in trace 70341260 the directory was called
+ * `backup-before`, so a reserved-prefix convention would have missed it — a
+ * rule that needs the offending agent's cooperation is a request, not a rule.
+ * A copied squad carries `squad.yaml` whatever the directory is called.
+ */
+function insideCapturedEntity(root: string, rel: string, memo: Map<string, boolean>): boolean {
+  const dirs = rel.split(/[\\/]/).filter(Boolean).slice(0, -1);
+  let acc = "";
+  for (const seg of dirs) {
+    acc = acc ? `${acc}/${seg}` : seg;
+    let hit = memo.get(acc);
+    if (hit === undefined) {
+      hit = detectKind(path.join(root, acc)) !== null;
+      memo.set(acc, hit);
+    }
+    if (hit) return true;
+  }
+  return false;
+}
+
 /** The Phase 4 gate surface: every non-stub artifact whose extension the
  * quality gate knows how to judge (quality-gate.ts GATEABLE_EXTS — includes
- * .html, .yaml/.yml, code and images). */
+ * .html, .yaml/.yml, code and images), minus what the run did not write.
+ *
+ * Run state is dropped outright — it is never a deliverable, and if dropping
+ * it empties the surface the outcome is INDETERMINATE, which is the honest
+ * answer. A captured entity is dropped only while the run has work of its own
+ * left to judge: when the entity IS the deliverable (a run asked to build a
+ * squad) it stays, so this filter can narrow noise and never silence signal. */
 export function gateableFiles(dir: string, named: Set<string>): string[] {
-  return listFiles(dir).filter(f =>
+  const all = listFiles(dir).filter(f =>
     GATEABLE_EXTS.has(path.extname(f).toLowerCase()) && isDeliverable(f, named));
+  const own = all.filter(f => !isRunStateUnderOutputs(path.relative(dir, f)));
+  const memo = new Map<string, boolean>();
+  const authored = own.filter(f => !insideCapturedEntity(dir, path.relative(dir, f), memo));
+  return authored.length > 0 ? authored : own;
 }
 
 /** Non-stub artifacts under `outputsRoot` — the SAME discovery runDelivery

--- a/skills/harness/rubrics/wiki-lint.ts
+++ b/skills/harness/rubrics/wiki-lint.ts
@@ -14,8 +14,52 @@ const PROBLEMATIC_PATTERNS: { regex: RegExp; label: string; severity: number }[]
   { regex: /\bIt'?s (?:worth (?:noting|mentioning)|important to (?:note|remember|understand))\b/gi, label: "hedging filler", severity: 0.4 },
 ];
 
+// Every signal above is a signal of ENGLISH prose: English filler openers,
+// English passive attribution, and dash/hyphen densities calibrated on Latin
+// punctuation. Run over Devanagari or Arabic they measure nothing — in trace
+// 70341260 (27/08/2026) this rubric failed README.hi.md and README.ar.md for
+// "em-dash overuse" and "hyphen-as-clause-stitching", and the delivery spent
+// its whole revision budget on the complaint.
+//
+// The rubric therefore abstains when the writing is predominantly non-Latin.
+// Script, not filename: a locale suffix (`.hi.md`) is a stronger signal when
+// it is there, and absent from every Hindi document not named that way.
+// Measured on the files from that trace: en/es READMEs score 0% non-Latin
+// letters, zh 42%, hi 59%, ar 70% — the two clusters are far apart, so the
+// threshold sits between them with room on both sides.
+//
+// WHAT THIS DOES NOT COVER: Portuguese, Spanish, French and every other
+// Latin-script language stay under judgement, and the English-specific
+// patterns still do not apply to them. Narrowing that needs real language
+// detection, not a script check; this cut buys the gross case only.
+const NON_LATIN_ABSTAIN_SHARE = 0.2;
+
+function nonLatinLetterShare(content: string): number {
+  const letters = content.match(/\p{L}/gu) ?? [];
+  if (letters.length === 0) return 0;
+  let nonLatin = 0;
+  for (const ch of letters) if (!/\p{Script=Latin}/u.test(ch)) nonLatin++;
+  return nonLatin / letters.length;
+}
+
 export async function evaluate(args: { artifact: string; content: string; offline?: boolean }) {
   const { content } = args;
+
+  const share = nonLatinLetterShare(content);
+  if (share > NON_LATIN_ABSTAIN_SHARE) {
+    // `skipped` — not a pass. quality-gate.ts drops skipped rubrics from the
+    // verdict on both sides: they never carry a PASS, and a file left with no
+    // unskipped rubric lands on INDETERMINATE (exit 1), never on a silent 0.
+    return {
+      name: "wiki-lint",
+      passed: false,
+      score: 0,
+      skipped: true,
+      reasoning: `Not applicable: ${(share * 100).toFixed(0)}% of the letters are outside the Latin script, and these signals describe English prose.`,
+      fix_list: [],
+    };
+  }
+
   const findings: { label: string; count: number; severity: number; sample?: string }[] = [];
   let severityTotal = 0;
 

--- a/skills/harness/tests/delivery-pipeline.test.ts
+++ b/skills/harness/tests/delivery-pipeline.test.ts
@@ -117,6 +117,60 @@ describe("gateableFiles — the Phase 4 gate surface", () => {
     expect(decideGateOutcome([], true)).toBe("indeterminate");
     expect(decideGateOutcome(["/tmp/a.md"], false)).toBe("fail");
   });
+
+  // Reproduction of trace 70341260-ff80-4c9b-9dd4-6925a36c6b99 (27/08/2026): an
+  // audit squad copied the entity it was auditing into its own outputs root as
+  // `backup-before/`, and the pipeline sent all 276 files of that copy to the
+  // gate — including the audited squad's README.*.md. Two revision rounds were
+  // spent on prose nobody had written.
+  test("a captured entity under the outputs root is NOT gated (backup-before)", () => {
+    const oroot = path.join(tmp, "surface-backup");
+    fs.mkdirSync(path.join(oroot, "backup-before", "agents"), { recursive: true });
+    fs.mkdirSync(path.join(oroot, "backup-before", ".squad-state"), { recursive: true });
+    // what the run actually wrote
+    fs.writeFileSync(path.join(oroot, "changes.md"), PASSING_MD);
+    // what the run only COPIED: a squad root, its prose, and its run state
+    fs.writeFileSync(path.join(oroot, "backup-before", "squad.yaml"), "name: audited-squad\nversion: 1.0.0\n");
+    fs.writeFileSync(path.join(oroot, "backup-before", "README.hi.md"), FAILING_MD);
+    fs.writeFileSync(path.join(oroot, "backup-before", "agents", "writer.md"), FAILING_MD);
+    fs.writeFileSync(path.join(oroot, "backup-before", ".squad-state", "runs.json"), JSON.stringify({ runs: [] }) + " ".repeat(300));
+
+    const gated = gateableFiles(oroot, new Set()).map(f => path.relative(oroot, f)).sort();
+    expect(gated).toEqual(["changes.md"]);
+  });
+
+  test("canonical run state under the outputs root is NOT gated (run-state.ts list)", () => {
+    const oroot = path.join(tmp, "surface-runstate");
+    fs.mkdirSync(path.join(oroot, ".squad-state"), { recursive: true });
+    fs.mkdirSync(path.join(oroot, "projects", "old"), { recursive: true });
+    fs.mkdirSync(path.join(oroot, "_internal"), { recursive: true });
+    fs.writeFileSync(path.join(oroot, "relatorio.md"), PASSING_MD);
+    fs.writeFileSync(path.join(oroot, "_SUMMARY.md"), PASSING_MD);
+    fs.writeFileSync(path.join(oroot, ".squad-state", "state.md"), FAILING_MD);
+    fs.writeFileSync(path.join(oroot, "projects", "old", "draft.md"), FAILING_MD);
+    fs.writeFileSync(path.join(oroot, "_internal", "notes.md"), FAILING_MD);
+    // `memory/projects` is run state; bare `memory/` is a business's permanent
+    // knowledge, and run-state.ts documents what collapsing the two once cost.
+    fs.mkdirSync(path.join(oroot, "memory", "projects"), { recursive: true });
+    fs.writeFileSync(path.join(oroot, "memory", "permanent.md"), PASSING_MD);
+    fs.writeFileSync(path.join(oroot, "memory", "projects", "old.md"), FAILING_MD);
+
+    const gated = gateableFiles(oroot, new Set()).map(f => path.relative(oroot, f)).sort();
+    // `_SUMMARY.md` is a FILE the run authored — the reserved prefix marks
+    // directories, never the engine's own root-level handoff files.
+    expect(gated).toEqual(["_SUMMARY.md", path.join("memory", "permanent.md"), "relatorio.md"]);
+  });
+
+  test("when the captured entity is ALL there is, it IS gated (never silence the only signal)", () => {
+    const oroot = path.join(tmp, "surface-only-entity");
+    fs.mkdirSync(path.join(oroot, "novo-squad", "agents"), { recursive: true });
+    fs.writeFileSync(path.join(oroot, "novo-squad", "squad.yaml"), "name: novo-squad\nversion: 1.0.0\n");
+    fs.writeFileSync(path.join(oroot, "novo-squad", "README.md"), PASSING_MD);
+    fs.writeFileSync(path.join(oroot, "novo-squad", "agents", "writer.md"), PASSING_MD);
+
+    const gated = gateableFiles(oroot, new Set()).map(f => path.relative(oroot, f)).sort();
+    expect(gated).toEqual([path.join("novo-squad", "README.md"), path.join("novo-squad", "agents", "writer.md")]);
+  });
 });
 
 describe("runDelivery — outcomes", () => {

--- a/skills/harness/tests/wiki-lint-script.test.ts
+++ b/skills/harness/tests/wiki-lint-script.test.ts
@@ -1,0 +1,73 @@
+// wiki-lint-script.test.ts — the wiki-lint rubric only opines on prose it can
+// read. Reproduction of trace 70341260-ff80-4c9b-9dd4-6925a36c6b99 (27/08/2026),
+// where an English-prose rubric failed README.hi.md and README.ar.md for
+// "em-dash overuse" and "hyphen-as-clause-stitching" and burned the delivery's
+// revision budget on the complaint.
+// Runs with: bun test skills/harness/tests
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { evaluate } from "../rubrics/wiki-lint.ts";
+
+const GATE = path.join(import.meta.dir, "..", "scripts", "quality-gate.ts");
+const SKILLS_DIR = path.join(import.meta.dir, "..", "..");
+
+// The tell wiki-lint punishes hardest: " - " stitching, severity 1.0.
+const stitched = (sentence: string, times: number) =>
+  `# ${sentence}\n\n` + `${sentence} - ${sentence} `.repeat(times) + "\n";
+
+const HINDI = stitched("यह दस्तावेज़ एक परीक्षण के लिए लिखा गया है", 20);
+const ARABIC = stitched("هذا المستند مكتوب لأغراض الاختبار فقط", 20);
+const PORTUGUESE = stitched("Este documento foi escrito para teste", 20);
+
+describe("wiki-lint — abstains outside the Latin script", () => {
+  test("Devanagari prose is NOT judged (skipped, and skipped is not a pass)", async () => {
+    const r = await evaluate({ artifact: "README.hi.md", content: HINDI });
+    expect(r.skipped).toBe(true);
+    expect(r.passed).toBe(false);
+    expect(r.fix_list).toEqual([]);
+    expect(r.reasoning).toContain("Latin");
+  });
+
+  test("Arabic prose is NOT judged", async () => {
+    const r = await evaluate({ artifact: "README.ar.md", content: ARABIC });
+    expect(r.skipped).toBe(true);
+  });
+
+  test("Portuguese with the SAME tell is still judged, and still fails", async () => {
+    const r = await evaluate({ artifact: "README.md", content: PORTUGUESE });
+    expect(r.skipped).toBeUndefined();
+    expect(r.passed).toBe(false);
+    expect(r.fix_list.join(" ")).toContain("hyphen-as-clause-stitching");
+  });
+
+  test("clean English prose still passes", async () => {
+    const clean = "# Delivery note\n\nThe report covers the agreed scope and the files produced.\n" +
+      "Every decision taken during the run is recorded next to its justification.\n";
+    const r = await evaluate({ artifact: "README.md", content: clean });
+    expect(r.skipped).toBeUndefined();
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("quality-gate — an abstaining rubric never becomes a silent PASS", () => {
+  test("wiki-lint alone over Hindi → INDETERMINATE, exit non-zero", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-wikilint-"));
+    try {
+      const artifact = path.join(tmp, "README.hi.md");
+      fs.writeFileSync(artifact, HINDI);
+      const g = spawnSync("bun", [GATE, artifact, "--rubrics=wiki-lint", "--offline"], {
+        encoding: "utf8",
+        env: { ...process.env, NIRVANA_SKILLS_DIR: SKILLS_DIR, HARNESS_LOGS_DIR: path.join(tmp, "logs") },
+      });
+      const verdict = JSON.parse(g.stdout);
+      expect(verdict.status).toBe("INDETERMINATE");
+      expect(verdict.results[0].skipped).toBe(true);
+      expect(g.status).not.toBe(0);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Two defects found in a real run on 27/08/2026 (trace `70341260-ff80-4c9b-9dd4-6925a36c6b99`), with one cause: the delivery gate judges files the run did not write.

## 1. The gate judged the backup

The audit squad copied the entity it was auditing into its own outputs root as `backup-before/` — a whole squad, 276 files — and parked removed run state next to it as `runtime-state-removed/`. `listFiles()` walked everything under the root and `isDeliverable()` filtered by size alone, so 306 files went to the gate beside the 9 the run had written. Both revision rounds went on prose from another squad's README, and the delivery shipped with reservations about files nobody had touched.

`gateableFiles()` now drops what the run did not write, in two tiers:

- **Run state, dropped outright.** From `skills/_shared/lib/run-state.ts` — the canonical list `migrate-squad.ts`, `uninstall-pack.ts` and `install-content.ts` already read — asked **one kind at a time**, never kindless, so `memory/projects` stays run state while `memory/permanent.md` stays judged (the kindless branch's documented cost). Plus any **directory** segment opening with `.` or `_`. The basename is never tested, so `_SUMMARY.md` and `_QA-RESERVATIONS.md` remain under judgement. If this empties the surface the outcome is `INDETERMINATE`, which withholds — the honest answer.
- **A captured entity, dropped while there is other work.** A directory where `detectKind()` finds `squad.yaml`, `business.yaml` or `MANIFEST.yaml` is a component this run copied. **Identity, not name:** a reserved `_` prefix would have missed `backup-before` outright, since it needs the agent that wrote the directory to have known the convention, and that agent did not. When the captured entity is *all* there is (a run asked to build a squad), it is judged as usual — so this tier can narrow noise and never silence the only signal on disk.

`produced` / `candidateArtifacts` / `verify-deliverable` are untouched: what counts as *delivered* answers a different question, and its tests are frozen.

## 2. An English rubric judged Hindi and Arabic

`wiki-lint` implements the Wikipedia "Signs of AI writing" tells, every one of them English, and it failed `README.hi.md` and `README.ar.md` for em-dash overuse and hyphen stitching. It now abstains when more than a fifth of the letters sit outside the Latin script. Measured on the files from that trace: 0% for the English and Spanish READMEs, 42% zh, 59% hi, 70% ar — the clusters are far apart, so the threshold has room on both sides.

Script, not filename: a locale suffix is a stronger signal when present and absent from every Hindi document not named that way. **Abstention is not approval** — it is a skipped rubric, and a file left with no unskipped rubric lands on `INDETERMINATE` (exit 1), pinned by a test that spawns the gate with `--rubrics=wiki-lint` over Devanagari.

**Not covered:** Portuguese, Spanish and every other Latin-script language stay under judgement. Separating those needs language detection, not a script check.

## Verification

The reproduction tests were written first and **run against the pre-fix code**: 2 fail in `delivery-pipeline.test.ts` (`backup-before` and run state both reaching the gate), 3 fail in `wiki-lint-script.test.ts` (Hindi/Arabic judged; the gate returning `FAIL` where it should return `INDETERMINATE`).

- `bun test skills/harness/tests` — 1371 pass / 4 skip / 1 fail. The one failure is `buyer-path.test.ts` (`Cannot find package 'yaml' from .../.nirvana/skills/_shared/lib/entity-graph.ts`), the known worktree `node_modules`-symlink failure; confirmed identical with the diff stashed.
- `dispatch-standard-kernel.e2e` — green, exit-code verdicts unchanged.
- `check-english-source --strict`, `check-changelog-parity --strict`, `check-dispatch-contract`, `git diff --check` — clean.

Not run per the verification contract: the full `bun test skills` and `check:all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)