### PR TITLE
O heartbeat que já varre o diretório passa a dizer quais arquivos viu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,55 @@ Arabic. Abstention is not approval. It is a skipped rubric, and a file left with
 no unskipped rubric still lands on INDETERMINATE, which withholds delivery.
 Portuguese, Spanish and every other Latin-script language stay under judgement;
 separating those needs language detection, not a script check.
+### The watcher that was already running learns to say what it saw
+
+A squad ran 418 seconds on Codex on 2026-08-27 and wrote 113 files. The day's
+audit held sixteen events, eleven of them `x_ledger_lease_renewed` — "still
+alive", eleven times, over seven minutes in which the Glance could say nothing
+about where the run was. The disk knew: the files of each pipeline step landed
+in order, each with a timestamp.
+
+A daemon was already sweeping that directory. `runWithLedgerHeartbeat` spawns
+the ledger heartbeat next to every headless child, and it walks the whole
+`--watch` tree on every tick to answer one question, "is anything happening",
+and throws away the answer to the more useful one, "what is happening". The
+sweep now returns both, through the new `scanDir`: the newest mtime, which
+decides the lease, and which files moved since the previous tick. Each new file
+becomes one `artifact_touched` carrying `file_path`, `size_bytes`, `cwd`,
+`source: "ledger-heartbeat"` and the run's `trace_id`. The Glance has been
+reading that event all along, in four places.
+
+No new process joins the run, and that is the point. The obvious move was to
+have the dispatch spawn `nrv watch-fs`, which does exactly this reporting and is
+lit today only by a person who knows the subcommand. It closes on `SIGINT` or
+`SIGTERM` and on nothing else, so a dispatch killed with `SIGKILL` leaves it
+writing to a log forever, and it watches through recursive `fs.watch`, whose
+behavior has never been the same on the three systems. The heartbeat sidecar has
+four independent exits already (the `--done` sentinel, a dead parent pid, a
+missing run row, a run in a terminal state), and it polls rather than subscribes,
+so a run that ends normally and one that dies abruptly close the observer the
+same way. `nrv watch-fs` stays for what never passes through a dispatch: a
+project touched by Cursor, Aider, or any agent without hooks.
+
+Deriving the same progress from the `creates[]` that every v6 workflow step
+declares was the other candidate, and it loses on both coverage and timing. The
+parent is blocked inside one `spawnSync` for the whole run, so nothing evaluates
+that cross while the work is in flight — the answer would arrive when the run
+ends, which is the blind window itself. And `creates[]` exists only for workflow
+squads: the agent-x branch and the business branch would stay dark. Matching the
+reported files against `creates[]` is a good later step, on top of this one.
+
+Volume is bounded by construction. The tick interval is the coalescing window,
+and inside it a ceiling of 25 events applies, plus the per-child ceiling of the
+new `supervisor.touch_events_max` setting (500 by default; `0` turns the
+reporting off without touching the lease). A truncated tick carries `omitted` on
+its last event rather than losing the difference silently. The action is always
+`modify`: a poller sees that a file moved, never that it was born, and claiming
+`create` from an mtime would be the evidence-free assertion this signal exists to
+replace. Noise (`.git`, `node_modules`, `.nirvana`, `dist`, `build`, editor
+tempfiles) is filtered out of the REPORT only — the sweep still descends into
+those directories, because pruning them would change `latestMs` and with it the
+liveness proof the supervisor reads.
 
 ## 0.10.1 — 2026-08-27
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -98,6 +98,54 @@ Abster-se não é aprovar. É uma rubrica pulada, e um arquivo sem nenhuma rubri
 não pulada continua caindo em INDETERMINATE, o que retém a entrega. Português,
 espanhol e toda língua de escrita latina seguem sendo julgados; separar esses
 casos exige detecção de idioma, não uma checagem de escrita.
+### O observador que já estava rodando aprende a dizer o que viu
+
+Um squad rodou 418 segundos no Codex em 27/08/2026 e escreveu 113 arquivos. O
+audit do dia guardou dezesseis eventos, onze deles `x_ledger_lease_renewed` —
+"ainda estou vivo", onze vezes, ao longo de sete minutos em que a Glance não
+conseguia dizer nada sobre onde o run estava. O disco sabia: os arquivos de cada
+passo do pipeline apareceram em ordem, cada um com carimbo de hora.
+
+Um daemon já varria aquele diretório. O `runWithLedgerHeartbeat` lança o
+heartbeat do ledger ao lado de todo filho headless, e ele percorre a árvore
+inteira de `--watch` a cada tick para responder a uma pergunta, "há atividade?",
+e jogava fora a resposta da mais útil, "qual atividade?". A varredura agora
+devolve as duas, pelo novo `scanDir`: a mtime mais nova, que decide o lease, e
+quais arquivos se moveram desde o tick anterior. Cada arquivo novo vira um
+`artifact_touched` com `file_path`, `size_bytes`, `cwd`,
+`source: "ledger-heartbeat"` e o `trace_id` do run. A Glance lê esse evento
+desde sempre, em quatro lugares.
+
+Nenhum processo novo entra no run, e esse é o ponto. O movimento óbvio era o
+despacho lançar o `nrv watch-fs`, que faz exatamente esse relato e hoje só é
+ligado por quem conhece o subcomando. Ele fecha em `SIGINT` ou `SIGTERM` e em
+mais nada, então um despacho morto por `SIGKILL` o deixa escrevendo num log para
+sempre, e ele observa por `fs.watch` recursivo, cujo comportamento nunca foi o
+mesmo nos três sistemas. O sidecar de heartbeat já tem quatro saídas
+independentes (a sentinela `--done`, o pid do pai morto, a linha do run ausente,
+o run em estado terminal), e ele consulta em vez de assinar, então um run que
+termina normalmente e um que morre de repente fecham o observador do mesmo
+jeito. O `nrv watch-fs` fica para o que nunca passa por despacho: um projeto
+tocado por Cursor, Aider ou qualquer agente sem hooks.
+
+Derivar o mesmo progresso do `creates[]` que todo passo de workflow v6 declara
+era o outro candidato, e perde em cobertura e em tempo. O pai fica bloqueado
+dentro de um `spawnSync` durante o run inteiro, então nada avalia esse cruzamento
+enquanto o trabalho acontece — a resposta chegaria quando o run terminasse, que é
+a própria janela cega. E `creates[]` só existe para squads com workflow: a
+branch do agent-x e a de business continuariam no escuro. Casar os arquivos
+relatados com o `creates[]` é um bom passo depois deste, em cima dele.
+
+O volume é limitado por construção. O intervalo do tick é a janela de
+coalescência, e dentro dela vale um teto de 25 eventos, mais o teto por filho da
+nova chave `supervisor.touch_events_max` (500 por padrão; `0` desliga o relato
+sem tocar no lease). Um tick truncado carrega `omitted` no último evento em vez
+de perder a diferença em silêncio. A ação é sempre `modify`: uma varredura vê
+que o arquivo se moveu, nunca que ele nasceu, e afirmar `create` a partir de uma
+mtime seria a alegação sem evidência que esse sinal existe para substituir. O
+ruído (`.git`, `node_modules`, `.nirvana`, `dist`, `build`, tempfiles de editor)
+sai só do RELATO — a varredura continua descendo nesses diretórios, porque
+podá-los mudaria a `latestMs` e com ela a prova de vida que o supervisor lê.
 
 ## 0.10.1 — 2026-08-27
 

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -66,6 +66,7 @@ Gerada a partir do schema. `nrv config explain <chave>` mostra a descrição de 
 | `routing.on_router_failure` | nenhuma | `cascade` | global, projeto | cascade / fail |
 | `supervisor.progress_ping_sec` | `NIRVANA_PROGRESS_PING_SEC` | `1800` | global, projeto | inteiro >= 0 (segundos) |
 | `supervisor.stall_threshold_ms` | `NIRVANA_STALL_THRESHOLD_MS` | `300000` | global, projeto | inteiro > 0 (milissegundos) |
+| `supervisor.touch_events_max` | `NIRVANA_TOUCH_EVENTS_MAX` | `500` | global, projeto | inteiro >= 0 (eventos); 0 = não relata arquivos |
 | `updates.check` | `NIRVANA_NO_UPDATE_CHECK` (opt-out: `1` = não verificar) | `true` | global | true / false |
 | `budget.default_max_cost_usd` | nenhuma | `0` | global, projeto | número >= 0 (USD); 0 = ilimitado |
 | `budget.default_max_tokens` | nenhuma | `0` | global, projeto | inteiro >= 0 |
@@ -107,6 +108,7 @@ Cada interruptor do schema tem exatamente um caminho de leitura, `resolveSetting
 | `routing.mode` | `_shared/lib/routing-mode.ts` |
 | `routing.dense`, `on_router_failure`, `quality_gate.*` | `harness/lib/harness-config.ts` (`loadHarnessConfig`, `denseRoutingMode`, `setRoutingDense`) e, por ele, `router.js`, `dispatch.ts`, `revise.ts`, `supervisor.ts`, `embeddings.ts` |
 | `supervisor.progress_ping_sec`, `stall_threshold_ms` | `harness/scripts/supervisor.ts`; o limiar também é o `stallBudgetMs` padrão do heartbeat em `host-agent-driver.ts` |
+| `supervisor.touch_events_max` | `_shared/lib/host-agent-driver.ts`, que passa o teto ao sidecar como `--touch-max` |
 | `updates.check` | `harness/scripts/update-check.ts` |
 | `budget.*`, `baselines.*` | `harness/lib/budget.js` |
 

--- a/docs/architecture/glance-settings.md
+++ b/docs/architecture/glance-settings.md
@@ -23,7 +23,7 @@ Não há segundo lugar para a mesma coisa. As variáveis que viraram chave do sc
 | Glance | `glance.execution`, `maestro_max_budget_usd` |
 | Runtime | `runtime.provider_catalog_dir`, `allow_stale_catalog` |
 | Roteamento | `routing.mode`, `dense`, `on_router_failure` |
-| Supervisor | `supervisor.progress_ping_sec`, `stall_threshold_ms` |
+| Supervisor | `supervisor.progress_ping_sec`, `stall_threshold_ms`, `touch_events_max` |
 | Atualizações | `updates.check` |
 | Orçamento | `budget.default_max_cost_usd`, `default_max_tokens`, `default_max_handoffs`, `default_max_duration_seconds`, `on_budget_exceeded`, `auto_invoke_budget_usd` |
 | Baselines de custo | `baselines.squad_capability_usd`, `business_usd`, `per_handoff_usd` |

--- a/docs/architecture/run-kernel-operations.md
+++ b/docs/architecture/run-kernel-operations.md
@@ -119,6 +119,16 @@ Com vida, a linha ganha mais um lease e o audit recebe `x_ledger_grace_extended`
 
 A medição que motivou a regra (26/08/2026, `~/.nirvana/run-ledger.sqlite`): de 39 runs de empresa retidos desde 01/08, 35 tinham esse `last_error`, em 15 empresas e 10 dias, sem falha de gate. A empresa delegava a um squad e escrevia fora do próprio `outputs_root`. O limiar `supervisor.stall_threshold_ms` e o `AGENTIC_LEASE_SEC` não mudaram.
 
+## O que o heartbeat relata
+
+O sidecar de heartbeat (`heartbeatMain` em `skills/harness/lib/run-ledger.ts`, lançado desanexado por `runWithLedgerHeartbeat` em `skills/_shared/lib/host-agent-driver.ts`) já varria o diretório de `--watch` a cada tick para responder "há atividade?". A varredura agora devolve as duas respostas de uma vez, por `scanDir`: a mtime mais nova, que decide o lease, e **quais** arquivos se moveram desde o tick anterior. Cada arquivo novo vira um `artifact_touched` com `file_path`, `size_bytes`, `cwd`, `source: "ledger-heartbeat"` e o `trace_id` da linha do run, que é o que a Glance lê para dizer onde o run está.
+
+A medição que motivou isso (27/08/2026, trace `70341260-ff80-4c9b-9dd4-6925a36c6b99`): um squad rodou 418 s no Codex escrevendo 113 arquivos e o audit do dia guardou dezesseis eventos, onze deles `x_ledger_lease_renewed`. O disco sabia a ordem exata dos passos; o log dizia "vivo", onze vezes.
+
+Três limites nascem com a regra. O intervalo do tick (15 s por padrão) é a janela de coalescência, e dentro dela valem um teto de 25 eventos e o teto por execução de `supervisor.touch_events_max` (500; `0` desliga o relato sem tocar no lease). Um tick truncado carrega `omitted` no último evento em vez de sumir com a diferença. A ação é sempre `modify`: uma varredura por mtime vê que o arquivo se moveu, nunca que ele nasceu, e afirmar `create` a partir disso seria a alegação sem evidência que o sinal existe para substituir. E a lista de ruído (`.git`, `node_modules`, `.nirvana`, `dist`, `build`, tempfiles de editor) filtra só o **relato**: a varredura continua descendo nesses diretórios, porque podá-los mudaria a `latestMs` e com ela a prova de vida da seção anterior.
+
+Nenhum processo novo entra em cena, e é o ponto: o ciclo de vida do sidecar já tem quatro saídas independentes (sentinela `--done`, pid do pai morto, linha do run ausente, run em estado terminal), então um despacho que termina normalmente e um que morre de `SIGKILL` fecham o observador do mesmo jeito. `nrv watch-fs` continua existindo para o que não passa por despacho: um projeto tocado por Cursor, Aider ou qualquer agente sem hooks.
+
 ## Limites conhecidos
 
 Esta fundação não altera Gauntlet, runtime providers nem supervisor; o dispatch escreve no kernel apenas pela publicação do modo `standard` descrita acima. A outbox oferece entrega pelo menos uma vez, com identidade estável para deduplicação, porque exatamente uma vez entre SQLite e um side effect externo exige cooperação do consumer. A publicação atômica de artifacts além da verificação de `ArtifactRef` fica para o marco próprio previsto no plano incremental.

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -789,8 +789,13 @@ export interface LedgerHeartbeatOpts {
   /** Ledger run id (run-ledger.ts openRun). */
   runId: string;
   /** Directory watched for activity (the run's output dir). Activity = newest
-   * mtime under it advanced — activity-based, not existence-based. */
+   * mtime under it advanced — activity-based, not existence-based. Every file
+   * the sweep finds is also NAMED in an `artifact_touched` audit event, which
+   * is what the Glance reads to say where a run is. */
   watchDir?: string;
+  /** Ceiling on those `artifact_touched` events for this child; 0 reports none.
+   * Default: the supervisor.touch_events_max setting. */
+  touchEventsMax?: number;
   /** Ledger DB path override (tests). Default: resolveLedgerDbPath(). */
   dbPath?: string;
   /** Heartbeat check interval in ms (default 15s; tests shrink it). */
@@ -924,7 +929,10 @@ function runWithLedgerHeartbeat(opts: RunHeadlessOpts, runner: (o: RunHeadlessOp
     "--lease", String(led.leaseSec ?? 600),
     "--parent", String(process.pid),
   ];
-  if (led.watchDir) sidecarArgs.push("--watch", led.watchDir);
+  if (led.watchDir) {
+    sidecarArgs.push("--watch", led.watchDir);
+    sidecarArgs.push("--touch-max", String(led.touchEventsMax ?? resolveSetting("supervisor.touch_events_max").value));
+  }
   if (led.dbPath) sidecarArgs.push("--db", led.dbPath);
 
   let sidecarPid: number | null = null;

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -249,6 +249,9 @@ export const SETTINGS = {
   "supervisor.stall_threshold_ms": numberSetting("supervisor.stall_threshold_ms",
     "Milissegundos sem atividade até um run ser tratado como travado (supervisor e heartbeat do driver).",
     { default: 300_000, env: "NIRVANA_STALL_THRESHOLD_MS", type: z.number().int().positive(), expects: "inteiro > 0 (milissegundos)" }),
+  "supervisor.touch_events_max": numberSetting("supervisor.touch_events_max",
+    "Teto de eventos artifact_touched que o heartbeat emite por execução headless; 0 desliga o relato de arquivos.",
+    { default: 500, env: "NIRVANA_TOUCH_EVENTS_MAX", type: nonNegativeInt, expects: "inteiro >= 0 (eventos)" }),
 
   "updates.check": booleanSetting("updates.check",
     "Verifica se há release nova do engine (cache diário); false desliga.",

--- a/skills/harness/lib/run-ledger.ts
+++ b/skills/harness/lib/run-ledger.ts
@@ -406,11 +406,52 @@ export function pidAlive(pid: number): boolean {
   catch (e) { return (e as NodeJS.ErrnoException)?.code === "EPERM"; }
 }
 
-/** Newest mtime (ms) under dir, recursive, capped so a sweep never crawls a
- *  runaway tree. 0 when the dir is missing/empty. */
-export function latestMtimeMs(dir: string, cap = 5000): number {
+/** One file the sweep found newer than the mark it was given. */
+export interface TouchedFile { path: string; mtimeMs: number; sizeBytes: number }
+
+export interface DirScan {
+  /** Newest mtime (ms) anywhere under dir, noise included. 0 when missing/empty. */
+  latestMs: number;
+  /** Files newer than `sinceMs`, noise excluded, oldest first, at most `limit`. */
+  changed: TouchedFile[];
+  /** Files that qualified and were dropped by `limit`. */
+  omitted: number;
+}
+
+// Names that are never a deliverable. Same rules as scripts/watch-fs.ts, kept
+// here as a copy on purpose: this list decides what gets REPORTED, and the
+// walk still descends into every one of them, because pruning the traversal
+// would change `latestMs` and with it the liveness signal the supervisor
+// reads. Noise counts as "the run is alive"; it never counts as progress.
+const NOISE_DIR_SEGMENTS: readonly string[] = [".git", "node_modules", "__pycache__", ".idea", ".vscode", ".harness-logs", ".bun", "dist", "build"];
+const NOISE_FILE_PATTERNS: readonly RegExp[] = [/\.swp$/, /~$/, /^\.#/, /\.tmp$/, /\.pyc$/, /^\.DS_Store$/];
+
+function isNoise(root: string, full: string): boolean {
+  const base = path.basename(full);
+  for (const re of NOISE_FILE_PATTERNS) if (re.test(base)) return true;
+  const rel = path.relative(root, full);
+  const segments = rel.split(/[\\/]/).slice(0, -1);
+  if (segments.some(s => NOISE_DIR_SEGMENTS.includes(s))) return true;
+  // .nirvana/ under the outputs root is the harness's own scaffolding (state,
+  // briefs, logs) — written by the dispatcher, not by the agent being watched.
+  return segments.includes(".nirvana");
+}
+
+/**
+ * One recursive sweep of `dir`, capped so it never crawls a runaway tree.
+ *
+ * Returns both answers the heartbeat needs from a single walk: the newest
+ * mtime (is anything happening at all?) and WHICH files moved (what is
+ * happening). The second answer is the whole reason this exists — the sidecar
+ * used to compute the first and throw the rest away, so seven minutes of a run
+ * writing 113 files reported "still alive", eleven times, and nothing else.
+ */
+export function scanDir(dir: string, sinceMs: number, opts: { cap?: number; limit?: number } = {}): DirScan {
+  const cap = opts.cap ?? 5000;
+  const limit = Math.max(0, opts.limit ?? 0);
   let latest = 0;
   let seen = 0;
+  const qualified: TouchedFile[] = [];
   const stack = [dir];
   while (stack.length && seen < cap) {
     const d = stack.pop()!;
@@ -422,11 +463,23 @@ export function latestMtimeMs(dir: string, cap = 5000): number {
       try {
         const st = fs.statSync(full);
         if (st.mtimeMs > latest) latest = st.mtimeMs;
-        if (e.isDirectory()) stack.push(full);
+        if (e.isDirectory()) { stack.push(full); continue; }
+        if (limit > 0 && st.mtimeMs > sinceMs && !isNoise(dir, full)) {
+          qualified.push({ path: full, mtimeMs: st.mtimeMs, sizeBytes: st.size });
+        }
       } catch { /* raced deletion */ }
     }
   }
-  return latest;
+  // Oldest first: the order the files appeared IS the progress, and when the
+  // tick overflows the cap it is the FIRST touches that survive the slice.
+  qualified.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  return { latestMs: latest, changed: qualified.slice(0, limit), omitted: Math.max(0, qualified.length - limit) };
+}
+
+/** Newest mtime (ms) under dir, recursive, capped so a sweep never crawls a
+ *  runaway tree. 0 when the dir is missing/empty. */
+export function latestMtimeMs(dir: string, cap = 5000): number {
+  return scanDir(dir, Number.POSITIVE_INFINITY, { cap }).latestMs;
 }
 
 // ── mutations ───────────────────────────────────────────────────────────
@@ -924,8 +977,21 @@ export function setSupervisorMeta(handle: LedgerHandle, key: string, value: stri
 // over) and record the heartbeat gap once per stall episode. If activity
 // resumes, renewal resumes.
 //
+// It also NAMES what it saw. The same sweep that answers "is anything
+// happening" already knows which files moved, so every tick with activity
+// emits one `artifact_touched` per new file (--touch-max caps the run; 0 turns
+// the reporting off). Before this, a squad writing 113 files over 418s left
+// sixteen audit events, eleven of them a content-free "still alive", and the
+// Glance — which has read `artifact_touched` all along — had nothing to show
+// for seven minutes.
+//
 // Exit conditions (no dangling process, ever): done-sentinel written by the
 // parent, parent pid gone, run row missing, or run reached a terminal state.
+
+/** Ceiling per tick. The poll interval is the coalescing window; this is the
+ *  ceiling INSIDE one window, so a step that unpacks a tarball cannot turn a
+ *  single sweep into ten thousand audit lines. */
+const TOUCH_EVENTS_PER_TICK = 25;
 
 function heartbeatArg(name: string): string | undefined {
   const i = process.argv.indexOf(name);
@@ -948,6 +1014,9 @@ export function heartbeatMain(): void {
   const stallMs = Math.max(500, parseInt(heartbeatArg("--stall") || String(5 * 60_000), 10));
   const leaseSec = Math.max(5, parseInt(heartbeatArg("--lease") || "600", 10));
   const parentPid = parseInt(heartbeatArg("--parent") || "0", 10);
+  // Absent flag = 0 = report nothing, so a caller that never asked for file
+  // reporting keeps the old event stream byte for byte.
+  let touchBudget = Math.max(0, parseInt(heartbeatArg("--touch-max") || "0", 10));
 
   const handle = openLedger(dbPath);
   let lastBytes = fileSize(outFile) + fileSize(errFile);
@@ -963,7 +1032,12 @@ export function heartbeatMain(): void {
     if (!row || isTerminal(row.state)) break;
 
     const bytes = fileSize(outFile) + fileSize(errFile);
-    const mtime = watchDir ? latestMtimeMs(watchDir) : 0;
+    // `sinceMs` is the PREVIOUS high-water mark, so the sweep reports only what
+    // moved since the last tick and never re-reports a file it already named.
+    const scan = watchDir
+      ? scanDir(watchDir, lastMtime, { limit: Math.min(TOUCH_EVENTS_PER_TICK, touchBudget) })
+      : { latestMs: 0, changed: [], omitted: 0 };
+    const mtime = scan.latestMs;
     const activity = bytes !== lastBytes || mtime > lastMtime;
     lastBytes = bytes;
     if (mtime > lastMtime) lastMtime = mtime;
@@ -973,6 +1047,20 @@ export function heartbeatMain(): void {
       lastActivityAt = now;
       stallRecorded = false;
       renewLease(handle, runId, leaseSec);
+      for (let i = 0; i < scan.changed.length; i++) {
+        const f = scan.changed[i];
+        // Always "modify": a poller sees that a file moved, never that it was
+        // born. Claiming "create" from an mtime would be exactly the kind of
+        // assertion-without-evidence this signal exists to replace.
+        emitLedgerAudit("artifact_touched", {
+          run_id: runId, action: "modify", file_path: f.path, size_bytes: f.sizeBytes,
+          cwd: watchDir, source: "ledger-heartbeat",
+          // The overflow rides on the last event of the tick rather than
+          // disappearing: a truncated sweep says so.
+          ...(i === scan.changed.length - 1 && scan.omitted > 0 ? { omitted: scan.omitted } : {}),
+        }, row);
+        touchBudget--;
+      }
     } else if (now - lastActivityAt >= stallMs && !stallRecorded) {
       stallRecorded = true;
       emitLedgerAudit("x_ledger_stall_observed", {

--- a/skills/harness/scripts/watch-fs.ts
+++ b/skills/harness/scripts/watch-fs.ts
@@ -20,6 +20,18 @@
  * Ignores: .git/, node_modules/, .nirvana/state/, *.swp, .DS_Store, ~ tempfiles.
  *
  * Failure mode: log to stderr, don't crash. Survives single-file errors.
+ *
+ * WHY A DISPATCH DOES NOT SPAWN THIS. It would be the obvious way to give the
+ * Glance file-level progress, and it is the wrong one twice over: this daemon
+ * exits on SIGINT/SIGTERM and on nothing else, so a dispatch killed with
+ * SIGKILL leaves it appending to a log forever, and recursive fs.watch is not
+ * the same feature on the three systems (see the comment on the watcher
+ * below). A ledgered run gets that progress from the heartbeat sidecar
+ * instead, which already sweeps the outputs root every tick, already has four
+ * independent exits, and now emits the same `artifact_touched` from what the
+ * sweep found (run-ledger.ts heartbeatMain). This command stays for what never
+ * passes through a dispatch: a project being worked on by Cursor, Aider, or
+ * any agent with no hooks and no ledger row.
  */
 
 import * as fs from "node:fs";

--- a/skills/harness/tests/driver-ledger-heartbeat.test.ts
+++ b/skills/harness/tests/driver-ledger-heartbeat.test.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-driver-hb-test-"));
 process.env.HARNESS_LOGS_DIR = path.join(TMP, "harness-logs");
@@ -16,7 +16,7 @@ process.env.NIRVANA_SKILLS_DIR = path.resolve(import.meta.dir, "..", "..");
 process.env.NIRVANA_RUN_LEDGER_DB = path.join(TMP, "ledger.sqlite");
 
 import { runHeadless, resolveLedgerTimeoutMs, LEDGER_DEFAULT_TIMEOUT_MS } from "../lib/host-agent-driver.ts";
-import { openLedger, openRun, getRun } from "../lib/run-ledger.ts";
+import { openLedger, openRun, getRun, markState, pidAlive } from "../lib/run-ledger.ts";
 
 const DB = path.join(TMP, "ledger.sqlite");
 
@@ -135,4 +135,215 @@ describe("driver — heartbeat sidecar", () => {
     expect(res.sessionId).toBe("fake-session-123");
     expect(res.result).toBe("done");
   }, 20_000);
+});
+
+// ── the sidecar NAMES what it saw ────────────────────────────────────────
+//
+// The defect this covers, measured on 2026-08-27 (trace 70341260): a squad ran
+// 418s on Codex and wrote 113 files, and the audit held sixteen events, eleven
+// of them a content-free `x_ledger_lease_renewed`. The sidecar was already
+// sweeping the outputs root every tick to answer "alive?"; it threw away WHICH
+// files moved. The Glance has consumed `artifact_touched` all along.
+
+/** A second fake `claude`, in its own bin dir, so the module-level fake above
+ *  keeps its exact behaviour for the tests that already depend on it. */
+function withWritingFake<T>(name: string, body: string, run: () => T): T {
+  const bin = path.join(TMP, `bin-${name}`);
+  writeFakeCli(bin, "claude", body);
+  const saved = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${saved}`;
+  try { return run(); } finally { process.env.PATH = saved; }
+}
+
+function touchEvents(runId: string): Array<Record<string, unknown>> {
+  return readAuditEvents().filter(e => e.event === "artifact_touched" && e.run_id === runId);
+}
+
+/**
+ * The orphan probe. Poke the watched directory AFTER the dispatch returned and
+ * prove nobody answers: a live sidecar would renew the lease and append an
+ * `artifact_touched`; a dead one leaves both exactly where they were. The run
+ * row is deliberately left non-terminal, so "the sidecar is gone" can only be
+ * explained by the parent's teardown.
+ */
+function proveNoOrphan(handle: ReturnType<typeof openLedger>, runId: string, watchDir: string, intervalMs: number): void {
+  Bun.sleepSync(intervalMs * 2);
+  const before = getRun(handle, runId)!;
+  const touchesBefore = touchEvents(runId).length;
+  expect(isTerminalState(before.state)).toBe(false);
+  fs.writeFileSync(path.join(watchDir, "poke-after-the-run-ended.md"), "anybody home?", "utf8");
+  Bun.sleepSync(intervalMs * 5);
+  expect(getRun(handle, runId)!.heartbeat_at).toBe(before.heartbeat_at);
+  expect(touchEvents(runId).length).toBe(touchesBefore);
+}
+
+const isTerminalState = (s: string): boolean => ["delivered", "withheld", "abandoned"].includes(s);
+
+describe("driver — the heartbeat reports files, not just liveness", () => {
+  test("every file the child writes is named in an artifact_touched; noise never is", () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { traceId: "trace-touch", projectId: "proj-touch", targetSlug: "fake", targetKind: "squad", initialLeaseSec: 120 });
+    const watch = path.join(TMP, "watch-happy");
+    fs.mkdirSync(watch, { recursive: true });
+
+    const res = withWritingFake("touch", `
+      import * as fs from "node:fs";
+      import * as path from "node:path";
+      const dir = ${JSON.stringify(watch)};
+      fs.mkdirSync(path.join(dir, "node_modules", "pkg"), { recursive: true });
+      for (const name of ["step-1.md", "step-2.md", "step-3.md"]) {
+        await Bun.sleep(400);
+        fs.writeFileSync(path.join(dir, name), "content of " + name);
+        fs.writeFileSync(path.join(dir, "node_modules", "pkg", name + ".js"), "vendored noise");
+      }
+      await Bun.sleep(900);
+      console.log(JSON.stringify({ type: "result", result: "done", session_id: "touch-session", total_cost_usd: 0 }));
+      process.exit(0);
+    `, () => runHeadless({
+      runtime: "claude-code", prompt: "write three files", cwd: TMP, yolo: true,
+      ledger: { runId: row.run_id, dbPath: DB, intervalMs: 250, leaseSec: 120, watchDir: watch, touchEventsMax: 100 },
+    }));
+    expect(res.ok).toBe(true);
+
+    const named = touchEvents(row.run_id).map(e => path.basename(String(e.file_path)));
+    expect(named).toContain("step-1.md");
+    expect(named).toContain("step-2.md");
+    expect(named).toContain("step-3.md");
+    expect(named.some(n => n.endsWith(".js"))).toBe(false);
+    const first = touchEvents(row.run_id)[0];
+    expect(first.trace_id).toBe("trace-touch");
+    expect(first.action).toBe("modify");
+    expect(Number(first.size_bytes)).toBeGreaterThan(0);
+    expect(first.source).toBe("ledger-heartbeat");
+
+    proveNoOrphan(h, row.run_id, watch, 250);
+  }, 30_000);
+
+  test("touchEventsMax 0 keeps the old event stream: liveness renewed, nothing named", () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { traceId: "trace-off", targetSlug: "fake", targetKind: "squad", initialLeaseSec: 120 });
+    const watch = path.join(TMP, "watch-off");
+    fs.mkdirSync(watch, { recursive: true });
+    const lease = Date.parse(row.lease_expires_at!);
+
+    const res = withWritingFake("off", `
+      import * as fs from "node:fs";
+      import * as path from "node:path";
+      for (const name of ["a.md", "b.md"]) { await Bun.sleep(400); fs.writeFileSync(path.join(${JSON.stringify(watch)}, name), name); }
+      await Bun.sleep(600);
+      console.log(JSON.stringify({ type: "result", result: "done", session_id: "off-session", total_cost_usd: 0 }));
+      process.exit(0);
+    `, () => runHeadless({
+      runtime: "claude-code", prompt: "write two files", cwd: TMP, yolo: true,
+      ledger: { runId: row.run_id, dbPath: DB, intervalMs: 250, leaseSec: 120, watchDir: watch, touchEventsMax: 0 },
+    }));
+    expect(res.ok).toBe(true);
+    expect(touchEvents(row.run_id)).toEqual([]);
+    // The switch silences the REPORT, never the liveness the supervisor reads.
+    expect(Date.parse(getRun(h, row.run_id)!.lease_expires_at!)).toBeGreaterThan(lease);
+  }, 30_000);
+
+  test("a run that FAILS leaves no sidecar behind either", () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { traceId: "trace-fail", targetSlug: "fake", targetKind: "squad", initialLeaseSec: 120 });
+    const watch = path.join(TMP, "watch-fail");
+    fs.mkdirSync(watch, { recursive: true });
+
+    const res = withWritingFake("fail", `
+      import * as fs from "node:fs";
+      import * as path from "node:path";
+      await Bun.sleep(400);
+      fs.writeFileSync(path.join(${JSON.stringify(watch)}, "half-written.md"), "the run dies here");
+      await Bun.sleep(400);
+      process.stderr.write("boom\\n");
+      process.exit(1);
+    `, () => runHeadless({
+      runtime: "claude-code", prompt: "fail halfway", cwd: TMP, yolo: true,
+      ledger: { runId: row.run_id, dbPath: DB, intervalMs: 250, leaseSec: 120, watchDir: watch, touchEventsMax: 100 },
+    }));
+    expect(res.ok).toBe(false);
+    // It reported the work the run DID do before dying — evidence survives failure.
+    expect(touchEvents(row.run_id).map(e => path.basename(String(e.file_path)))).toContain("half-written.md");
+    proveNoOrphan(h, row.run_id, watch, 250);
+  }, 30_000);
+});
+
+// ── the sidecar's own exit conditions, without a cooperative parent ──────
+//
+// The two paths above are torn down by a parent that reaches its `finally`.
+// A watcher whose only exit is a signal from a parent that never sends one is
+// worse than no watcher, so these spawn the sidecar directly and take the
+// parent's cooperation away.
+
+const RUN_LEDGER = path.resolve(import.meta.dir, "..", "lib", "run-ledger.ts");
+const sidecars: ChildProcess[] = [];
+
+/** Spawned the way the driver spawns it (detached, stdio ignored). NOT
+ *  unref'd, and observed through the `exit` event rather than the pid: a
+ *  detached child of a process that is still running stays a zombie until it
+ *  is reaped, and a zombie answers `kill(pid, 0)` — polling the pid would
+ *  report every one of these as alive forever. */
+function spawnSidecar(runId: string, extra: string[]): ChildProcess {
+  const child = spawn(process.execPath, [
+    RUN_LEDGER, "heartbeat", "--run-id", runId, "--db", DB,
+    "--interval", "200", "--lease", "120", ...extra,
+  ], { detached: true, stdio: "ignore", env: { ...process.env } });
+  sidecars.push(child);
+  return child;
+}
+
+const stillRunning = (c: ChildProcess): boolean => c.exitCode === null && c.signalCode === null;
+
+function exitedWithin(child: ChildProcess, ms: number): Promise<boolean> {
+  if (!stillRunning(child)) return Promise.resolve(true);
+  return new Promise<boolean>(resolve => {
+    const timer = setTimeout(() => resolve(false), ms);
+    child.once("exit", () => { clearTimeout(timer); resolve(true); });
+  });
+}
+
+afterAll(() => {
+  for (const c of sidecars) { try { if (stillRunning(c)) c.kill("SIGKILL"); } catch { /* already gone */ } }
+});
+
+describe("driver — the sidecar dies on its own", () => {
+  test("the parent is SIGKILLed mid-run: no sentinel, no SIGTERM, and the sidecar still exits", async () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { targetSlug: "fake", targetKind: "squad", initialLeaseSec: 300 });
+    // A stand-in parent that will never write a done file and never signal.
+    const parent = spawn(process.execPath, ["-e", "await Bun.sleep(60000)"], { detached: true, stdio: "ignore" });
+    const sidecar = spawnSidecar(row.run_id, ["--parent", String(parent.pid)]);
+    await Bun.sleep(700);
+    expect(stillRunning(sidecar)).toBe(true);          // it really was running
+
+    parent.kill("SIGKILL");
+    expect(await exitedWithin(sidecar, 8_000)).toBe(true);
+    // The RUN outlives its watcher: losing observability must never terminate work.
+    expect(isTerminalState(getRun(h, row.run_id)!.state)).toBe(false);
+  }, 30_000);
+
+  test("the run reaching a terminal state ends the sidecar even with the parent still alive", async () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { targetSlug: "fake", targetKind: "squad", initialLeaseSec: 300 });
+    const sidecar = spawnSidecar(row.run_id, ["--parent", String(process.pid)]);
+    await Bun.sleep(700);
+    expect(stillRunning(sidecar)).toBe(true);
+
+    markState(h, row.run_id, "running");
+    markState(h, row.run_id, "delivered");
+    expect(await exitedWithin(sidecar, 8_000)).toBe(true);
+  }, 30_000);
+
+  test("the done sentinel ends it, and a run row that never existed ends it immediately", async () => {
+    const h = openLedger(DB);
+    const row = openRun(h, { targetSlug: "fake", targetKind: "squad", initialLeaseSec: 300 });
+    const done = path.join(TMP, "done-sentinel");
+    const sidecar = spawnSidecar(row.run_id, ["--parent", String(process.pid), "--done", done]);
+    await Bun.sleep(700);
+    expect(stillRunning(sidecar)).toBe(true);
+    fs.writeFileSync(done, "done", "utf8");
+    expect(await exitedWithin(sidecar, 8_000)).toBe(true);
+
+    expect(await exitedWithin(spawnSidecar("run-that-never-existed", ["--parent", String(process.pid)]), 8_000)).toBe(true);
+  }, 30_000);
 });

--- a/skills/harness/tests/run-ledger.test.ts
+++ b/skills/harness/tests/run-ledger.test.ts
@@ -23,7 +23,7 @@ process.env.NIRVANA_RUN_LEDGER_DB = path.join(TMP, "default-ledger.sqlite");
 import {
   openLedger, openRun, getRun, markState, renewLease, abandon, incrementRetries,
   findExpired, findNonTerminal, countNonTerminal, resumeInfo, canTransition,
-  isTerminal, resolveLedgerDbPath, patchMeta, TERMINAL_STATES,
+  isTerminal, resolveLedgerDbPath, patchMeta, scanDir, latestMtimeMs, TERMINAL_STATES,
   type LedgerHandle,
 } from "../lib/run-ledger.ts";
 
@@ -243,5 +243,74 @@ describe("run-ledger — abandon and resume info", () => {
     expect(info.maxRetries).toBe(5);
     expect(info.meta.outputs_root).toBe("/tmp/x");
     expect(resumeInfo(h, "nope")).toBeNull();
+  });
+});
+
+describe("run-ledger — scanDir (what the heartbeat reports)", () => {
+  let dirSeq = 0;
+  /** A tree whose files are written with EXPLICIT mtimes, so the assertions
+   *  never depend on how fast the filesystem's clock ticks. */
+  function tree(files: Record<string, number>): string {
+    const dir = path.join(TMP, `scan-${dirSeq++}`);
+    for (const [rel, mtimeMs] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, rel, "utf8");
+      const when = new Date(mtimeMs);
+      fs.utimesSync(full, when, when);
+    }
+    return dir;
+  }
+  const rel = (dir: string, scan: ReturnType<typeof scanDir>) => scan.changed.map(f => path.relative(dir, f.path).split(path.sep).join("/"));
+
+  test("reports only what moved after the mark, oldest first, with size", () => {
+    const dir = tree({ "old.md": 1_000_000, "a/first.md": 2_000_000, "b/second.md": 3_000_000 });
+    const scan = scanDir(dir, 1_500_000, { limit: 10 });
+    expect(rel(dir, scan)).toEqual(["a/first.md", "b/second.md"]);
+    expect(scan.omitted).toBe(0);
+    expect(scan.changed[0].sizeBytes).toBe("a/first.md".length);
+    expect(scan.latestMs).toBeGreaterThanOrEqual(3_000_000);
+  });
+
+  test("noise is never progress: .git, node_modules, .nirvana, dist and editor tempfiles are excluded", () => {
+    const dir = tree({
+      "report.md": 3_000_000,
+      ".git/index": 3_000_000,
+      "node_modules/pkg/index.js": 3_000_000,
+      ".nirvana/state/run.json": 3_000_000,
+      "dist/bundle.js": 3_000_000,
+      "notes.md.swp": 3_000_000,
+      ".DS_Store": 3_000_000,
+    });
+    expect(rel(dir, scanDir(dir, 1_000_000, { limit: 50 }))).toEqual(["report.md"]);
+  });
+
+  test("noise still counts as liveness: latestMtimeMs sees what the report hides", () => {
+    const dir = tree({ "node_modules/pkg/index.js": 4_000_000 });
+    // Nothing to report, but the supervisor must still read the tree as alive —
+    // pruning the traversal would have silently changed that signal.
+    expect(scanDir(dir, 1_000_000, { limit: 50 }).changed).toEqual([]);
+    expect(latestMtimeMs(dir)).toBeGreaterThanOrEqual(4_000_000);
+  });
+
+  test("the limit keeps the FIRST touches and names how many it dropped", () => {
+    const dir = tree({ "s1.md": 2_000_000, "s2.md": 3_000_000, "s3.md": 4_000_000, "s4.md": 5_000_000 });
+    const scan = scanDir(dir, 1_000_000, { limit: 2 });
+    expect(rel(dir, scan)).toEqual(["s1.md", "s2.md"]);
+    expect(scan.omitted).toBe(2);
+  });
+
+  test("limit 0 reports nothing and still answers the liveness question", () => {
+    const dir = tree({ "x.md": 2_000_000 });
+    const scan = scanDir(dir, 1_000_000, { limit: 0 });
+    expect(scan.changed).toEqual([]);
+    expect(scan.omitted).toBe(0);
+    expect(scan.latestMs).toBeGreaterThanOrEqual(2_000_000);
+  });
+
+  test("a missing directory is empty, never a throw", () => {
+    const scan = scanDir(path.join(TMP, "nope-not-here"), 0, { limit: 10 });
+    expect(scan).toEqual({ latestMs: 0, changed: [], omitted: 0 });
+    expect(latestMtimeMs(path.join(TMP, "nope-not-here"))).toBe(0);
   });
 });


### PR DESCRIPTION
## O achado

Numa execução real de 27/08/2026 (trace `70341260-ff80-4c9b-9dd4-6925a36c6b99`), um squad rodou 418 s no Codex escrevendo 113 arquivos, e o log de auditoria guardou dezesseis eventos — onze deles `x_ledger_lease_renewed`. Sete minutos de trabalho, e tudo o que a Glance conseguia dizer era "vivo", onze vezes.

## A escolha, e por que não é a do brief

O brief propunha o despacho lançar `skills/harness/scripts/watch-fs.ts`. Não implementei isso, e também não implementei o cruzamento com `creates[]`. Implementei uma terceira coisa, que é estritamente menor que as duas.

**Um daemon já estava varrendo aquele diretório.** O `runWithLedgerHeartbeat` lança o heartbeat do ledger ao lado de *todo* filho headless — business, squad, agent-x, canário — e ele percorre a árvore inteira de `--watch` a cada tick. Ele já sabia quais arquivos se moveram; calculava a mtime máxima e jogava o resto fora. Os onze `x_ledger_lease_renewed` da medição são *dele*: ele estava olhando para os 113 arquivos e reportando "vivo".

A varredura agora devolve as duas respostas de um walk só (`scanDir`): a mtime mais nova, que decide o lease, e quais arquivos se moveram desde o tick anterior. Cada arquivo novo vira um `artifact_touched` com `file_path`, `size_bytes`, `cwd`, `source: "ledger-heartbeat"` e o `trace_id` do run — o evento que a Glance lê em quatro lugares desde sempre. Nenhum evento novo, nenhuma view mexida.

**Por que não o `watch-fs.ts`:** ele fecha em `SIGINT`/`SIGTERM` e em mais nada, então um despacho morto por `SIGKILL` o deixa escrevendo num log para sempre; e ele observa por `fs.watch` recursivo, que não é a mesma feature nos três sistemas. Ligá-lo pelo despacho significaria dois daemons observando o mesmo diretório, um deles com um ciclo de vida frágil. O `watch-fs` continua existindo para o que nunca passa por despacho: um projeto tocado por Cursor, Aider ou qualquer agente sem hooks nem linha no ledger. Deixei essa justificativa no cabeçalho dele, onde a próxima pessoa vai perguntar.

**Por que não o `creates[]`:** o pai fica bloqueado dentro de um único `spawnSync` durante o run inteiro (o workflow v6 vai para o runtime headless de uma vez só, como tabela no prompt — `squad-exec.ts:317`). Nada avalia esse cruzamento enquanto o trabalho acontece; a resposta chegaria quando o run terminasse, que é exatamente a janela cega que se quer fechar. E `creates[]` só existe para squads com workflow: a branch do agent-x e a de business continuariam no escuro. Casar os arquivos relatados com o `creates[]` declarado é um bom passo *depois* deste, em cima dele.

## Os três riscos

**Órfão** — dissolvido, não mitigado: nenhum processo novo entra em cena. O sidecar já tem quatro saídas independentes (sentinela `--done`, pid do pai morto, linha do run ausente, run em estado terminal). Os testes provam as três que não dependem de um pai cooperativo, incluindo `SIGKILL` no pai sem sentinela e sem sinal.

**Volume** — limitado por construção. O intervalo do tick é a janela de coalescência; dentro dela vale um teto de 25 eventos, mais o teto por filho de `supervisor.touch_events_max` (500 por padrão). Um tick truncado carrega `omitted` no último evento em vez de perder a diferença em silêncio. Ordenação por mtime crescente: quando o tick estoura, quem sobrevive é o *primeiro* toque.

**Portabilidade** — dissolvida também: nenhum `fs.watch`. É `readdirSync` + `statSync`, o mesmo walk que o `latestMtimeMs` já rodava nos três sistemas.

## Ligado por padrão

Sim, com `supervisor.touch_events_max: 0` para desligar. O custo marginal é reunir caminhos num walk que já acontecia e escrever no máximo 25 linhas por tick; o valor é justamente para quem não sabe que a peça existe. Um teto configurável serve de teto *e* de chave, então é uma chave só em vez de duas.

Detalhe honesto: a ação é sempre `modify`. Uma varredura por mtime vê que o arquivo se moveu, nunca que ele nasceu, e afirmar `create` a partir disso seria a alegação sem evidência que esse sinal existe para substituir. A conta de `artifactsCreated` da Glance continua zerada para esses eventos; `filesTouched`, o rótulo do swimlane e o stage rank funcionam.

## Verificação

- `bun test` nas áreas do diff: 308 pass / 0 fail em 20 arquivos (ledger, driver, supervisor, liveness, settings, glance-settings, audit-events).
- `check-changelog-parity --strict`, `check-english-source --strict`, `check-audit-parity --strict`, `gen-json-schemas --check`, `check-engine-purity`, `sync-agent-docs --check`, `git diff --check` — todos limpos.
- Ciclo de vida testado nos dois caminhos: um despacho que termina normalmente e um que **falha** (filho sai 1) não deixam nada vivo, provado por uma sonda que cutuca o diretório observado *depois* do run e mostra que ninguém responde (lease intocado, nenhum `artifact_touched` novo), com a linha do run deixada de propósito em estado não terminal.

Não rodei `bun test skills` inteiro nem `check:all`, por contrato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)