### PR TITLE
fix(verify): order backup retention by mtime, not by name sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Backup retention orders by time, not by the shape of the name
+
+`prune` keeps the five newest backups of an entity and finds them by sorting the
+directory names as strings. Nothing declared that assumption, and nothing forces
+an outside writer to honor it. It broke a second time on 27/08: an agent wrote
+its own backup of `nirvana-crypto-trading` next to the engine's, stamping local
+time in basic ISO (`.20260827T152722`) where the engine stamps UTC in extended
+ISO (`.2026-08-27T18-27-22-440Z`). Same second, opposite sort, because `-`
+(0x2D) comes before `0` (0x30) at the fourth character of the stamp. The
+engine's newer copy read as the oldest and went first in the deletion queue,
+which is the failure the collision comment in `backup.ts` was written to
+prevent, arriving through a different door.
+
+`listBackups` now orders by the directory's mtime and uses the name only to
+break ties. mtime is the one clock every writer sets, including writers whose
+stamp format does not exist yet; parsing the name can only cover formats already
+known, which is the shape of both failures, and it would leave an unparseable
+directory in a bucket with no good policy — deleting it is destructive, keeping
+it forever leaks disk, counting it against the cap without knowing its age
+brings the bug back. What mtime does not cover is now written in the file: mtime
+is writable, so a `touch`, or a copy that does not preserve times, can buy an
+old backup a slot the newest one then loses. Restore is unaffected. It takes the
+path `createBackup` returned, never a path this order picked.
+
+The regression test carries both real directory names and was run against the
+old code first, where `prune` deletes the engine's backup and keeps the agent's.
+`createBackup`, `restoreBackup` and `BACKUP_KEEP` are unchanged.
+
 ### Overlap between entities is normal, and the loser's work is harvested rather than discarded
 
 The creation pipelines told an author that a new squad or business "that steals

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,36 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A retenção de backups ordena por tempo, não pelo formato do nome
+
+O `prune` mantém os cinco backups mais novos de uma entidade e os encontra
+ordenando os nomes dos diretórios como string. Essa suposição não estava
+declarada em lugar nenhum, e nada obriga um escritor externo a respeitá-la. Ela
+quebrou pela segunda vez em 27/08: um agente gravou o próprio backup de
+`nirvana-crypto-trading` ao lado do backup do engine, carimbando hora local em
+ISO básico (`.20260827T152722`) onde o engine carimba UTC em ISO estendido
+(`.2026-08-27T18-27-22-440Z`). Mesmo segundo, ordem invertida, porque `-` (0x2D)
+vem antes de `0` (0x30) no quarto caractere do carimbo. A cópia mais nova, a do
+engine, foi lida como a mais antiga e entrou primeiro na fila de exclusão — a
+falha que o comentário de colisão do `backup.ts` existe para evitar, chegando
+por outra porta.
+
+O `listBackups` passa a ordenar pelo mtime do diretório e usa o nome só para
+desempatar. O mtime é o único relógio que todo escritor grava, inclusive os
+escritores cujo formato de carimbo ainda não existe; parsear o nome só cobre os
+formatos que já conhecemos, que é justamente o formato das duas falhas, e ainda
+deixaria o diretório inparseável num balde sem política boa — apagá-lo é
+destrutivo, mantê-lo para sempre vaza disco, contá-lo no teto sem saber a idade
+traz o defeito de volta. O que o mtime não cobre está escrito no arquivo: mtime
+é gravável, então um `touch`, ou uma cópia que não preserva horários, compra
+para um backup velho a vaga que o mais novo perde. O restore não muda. Ele usa o
+caminho que o `createBackup` devolveu, nunca um caminho escolhido por essa
+ordem.
+
+O teste de regressão carrega os dois nomes reais de diretório e foi rodado antes
+contra o código antigo, onde o `prune` apaga o backup do engine e mantém o do
+agente. `createBackup`, `restoreBackup` e `BACKUP_KEEP` não mudam.
+
 ### Sobreposição entre entidades é normal, e o que o perdedor tem de bom é aproveitado
 
 Os pipelines de criação diziam ao autor que um squad ou empresa "que rouba o

--- a/skills/_shared/lib/verify/backup.ts
+++ b/skills/_shared/lib/verify/backup.ts
@@ -3,7 +3,7 @@
 // `fs.cpSync`, never rsync: the CI matrix runs Windows, where rsync does not
 // exist (improve-squad.ts:104 was the precedent to avoid). Backups go to
 // `$NIRVANA_HOME/.nirvana/verify-backups/<kind>/<slug>.<ts>/`; the last five
-// per entity are kept. Restore is rm + cpSync, so a rolled-back entity is
+// per entity are kept, newest by filesystem mtime. Restore is rm + cpSync, so a rolled-back entity is
 // byte-identical to the moment before the fixers ran.
 
 import * as fs from "node:fs";
@@ -39,9 +39,10 @@ export function createBackup(dir: string, kind: Kind, slug: string, root: string
   fs.mkdirSync(parent, { recursive: true });
   // One stamp per call. Re-stamping inside the loop below produced names whose
   // lexicographic order was not their creation order (`<t>-1` minted at t+1ms
-  // sorts after `<t>` minted later), and `prune` keeps the newest by that very
-  // order — so a collision could delete the newest backup and keep an older one.
-  // With the stamp fixed, `<t>`, `<t>-1`, `<t>-2` sort exactly as they were made.
+  // sorts after `<t>` minted later). Retention no longer reads chronology off
+  // the names (see `listBackups`), so that alone can no longer delete the newest
+  // backup; the fixed stamp stays because `<t>`, `<t>-1`, `<t>-2` is the tie
+  // order the filesystem falls back on when it cannot separate them in time.
   const at = stamp();
   let dst = path.join(parent, `${slug}.${at}`);
   let n = 0;
@@ -57,13 +58,46 @@ export function restoreBackup(backupDir: string, dir: string): void {
   copyTree(backupDir, dir);
 }
 
+/** mtime in ms; 0 for a directory that vanished under us (a parallel prune). */
+function mtimeOf(p: string): number {
+  try { return fs.statSync(p).mtimeMs; } catch { return 0; }
+}
+
+/**
+ * The backups of one entity, **oldest first**. `prune` deletes off the front of
+ * this list, so the order is the retention rule and has to be real time.
+ *
+ * It used to be `.sort()` on the names — which reads chronology out of a string
+ * and so assumes every writer stamps the way `stamp()` does. The assumption has
+ * broken twice. First from inside: a re-stamp in the collision loop of
+ * `createBackup` minted `<t>-1` at t+1ms, sorting it after a later `<t>`. Then
+ * from outside, on 2026-08-27: an agent wrote its own backup of
+ * `nirvana-crypto-trading` beside the engine's, stamping local time in basic ISO
+ * (`.20260827T152722`) against the engine's UTC extended ISO
+ * (`.2026-08-27T18-27-22-440Z`). Same second, opposite sort — `-` (0x2D) < `0`
+ * (0x30) at the fourth character — so the engine's newer copy read as the oldest
+ * and was first in line to be deleted.
+ *
+ * mtime is the only clock every writer sets, including writers whose stamp
+ * format does not exist yet; parsing the name can only ever cover the formats we
+ * already know, which is the shape of both failures. Names break ties, so
+ * backups the filesystem cannot separate in time still list in a stable,
+ * reproducible order — never as a claim about which is newer.
+ *
+ * What this does not cover: mtime is writable. A `touch`, or a copy that does
+ * not preserve times, can make an old backup look new and buy it a slot the
+ * newest backup then loses. Restores are unaffected — they take the path
+ * `createBackup` returned, never a path this order picked.
+ */
 export function listBackups(kind: Kind, slug: string, root: string = defaultBackupRoot()): string[] {
   const parent = path.join(root, kind);
   if (!fs.existsSync(parent)) return [];
   return fs.readdirSync(parent)
     .filter((n) => n.startsWith(`${slug}.`))
-    .sort()
-    .map((n) => path.join(parent, n));
+    .map((n) => path.join(parent, n))
+    .map((p) => ({ p, at: mtimeOf(p) }))
+    .sort((a, b) => a.at - b.at || (a.p < b.p ? -1 : a.p > b.p ? 1 : 0))
+    .map((e) => e.p);
 }
 
 /** Keeps the newest BACKUP_KEEP backups of an entity, removes the rest. */

--- a/skills/_shared/tests/verify-backup.test.ts
+++ b/skills/_shared/tests/verify-backup.test.ts
@@ -5,7 +5,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { BACKUP_KEEP, createBackup, listBackups, mindCloneModule, verifyEntity, type KindModule } from "../lib/verify/index.ts";
+import { BACKUP_KEEP, createBackup, listBackups, prune, mindCloneModule, verifyEntity, type KindModule } from "../lib/verify/index.ts";
 import { cloneFixture, rmrf, runCli, tempRoot, treeDigest } from "./helpers/verify-fixture.ts";
 import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
@@ -131,6 +131,46 @@ describe("idempotence and retention", () => {
     expect(kept).toEqual(made.slice(-BACKUP_KEEP));
     expect(fs.existsSync(made[0])).toBe(false);
   }, spawnBudgetMs(2));
+
+  test("a backup stamped by another writer, in another format, does not invert retention", () => {
+    // Both names are real. On 2026-08-27 an agent wrote its own backup of
+    // `nirvana-crypto-trading` next to the engine's: the engine stamps UTC in
+    // extended ISO, the agent stamped local time in basic ISO. The two are the
+    // same second — 15:27:22 local is 18:27:22Z — and the engine's copy is the
+    // newer of the pair by its own 440 ms. Sorted as strings the engine's name
+    // comes FIRST, because `-` (0x2D) < `0` (0x30) at the fourth character of
+    // the stamp, so a `prune` reading chronology off the names deletes the
+    // newest backup and keeps the oldest: the exact failure the collision
+    // comment in backup.ts exists to remember, arriving through a second door.
+    const r = root();
+    const parent = path.join(r, "backups", "squad");
+    fs.mkdirSync(parent, { recursive: true });
+    const seed = (name: string, at: string): string => {
+      const d = path.join(parent, name);
+      fs.mkdirSync(d);
+      fs.writeFileSync(path.join(d, "MANIFEST.yaml"), `name: ${name}\n`, "utf8");
+      fs.utimesSync(d, new Date(at), new Date(at));
+      return d;
+    };
+    const AGENT = seed("nirvana-crypto-trading.20260827T152722", "2026-08-27T18:27:22.000Z");
+    const ENGINE = seed("nirvana-crypto-trading.2026-08-27T18-27-22-440Z", "2026-08-27T18:27:22.440Z");
+    // Enough later backups to put the population one over the cap, so `prune`
+    // drops exactly one and the choice is unambiguous.
+    const later = [
+      seed("nirvana-crypto-trading.2026-08-27T18-30-22-878Z", "2026-08-27T18:30:22.878Z"),
+      seed("nirvana-crypto-trading.2026-08-27T18-33-41-102Z", "2026-08-27T18:33:41.102Z"),
+      seed("nirvana-crypto-trading.2026-08-27T18-36-05-517Z", "2026-08-27T18:36:05.517Z"),
+      seed("nirvana-crypto-trading.2026-08-27T18-39-58-004Z", "2026-08-27T18:39:58.004Z"),
+    ];
+    expect(listBackups("squad", "nirvana-crypto-trading", path.join(r, "backups")))
+      .toEqual([AGENT, ENGINE, ...later]);
+
+    const dropped = prune("squad", "nirvana-crypto-trading", path.join(r, "backups"));
+    expect(dropped).toEqual([AGENT]);
+    expect(fs.existsSync(ENGINE)).toBe(true);
+    expect(listBackups("squad", "nirvana-crypto-trading", path.join(r, "backups")))
+      .toEqual([ENGINE, ...later]);
+  });
 
   test("a same-millisecond collision keeps listing order equal to creation order", () => {
     // The retention rule is "the newest BACKUP_KEEP", and it reads that order off


### PR DESCRIPTION
## The defect

`prune` keeps the five newest backups of an entity and finds them by sorting the directory names as strings — chronology read out of a string, which assumes every writer stamps the way `stamp()` does. The assumption was never declared, and it has now broken twice.

The first time was from inside: a re-stamp in the collision loop of `createBackup` minted `<t>-1` at t+1ms, so it sorted after a later `<t>`. That cause was fixed in `backup.ts:40-44`; the assumption stayed. Second round, 27/08, from outside — an agent wrote its own backup of `nirvana-crypto-trading` beside the engine's:

```
nirvana-crypto-trading.2026-08-27T18-27-22-440Z   engine, UTC extended ISO
nirvana-crypto-trading.20260827T152722            agent, local time, basic ISO
```

Same second (15:27:22 local is 18:27:22Z), opposite sort, because `-` (0x2D) precedes `0` (0x30) at the fourth character of the stamp. The engine's copy — the newer of the two by its own 440 ms — read as the oldest and went first in the deletion queue. That is the failure mode the collision comment exists to remember, arriving through a different door.

## The choice

`listBackups` orders by the directory's mtime, with the name as tiebreak only.

mtime is the one clock every writer sets, **including writers whose stamp format does not exist yet**. Parsing the name can only ever cover the formats already enumerated, which is precisely the shape of both failures — and it would leave the unparseable directory in a bucket with no good policy: deleting it is destructive, keeping it forever leaks disk, counting it against the cap without knowing its age brings the bug straight back. The name tiebreak is not a chronology claim; it only makes the order of backups the filesystem cannot separate in time stable and reproducible (`<t>` before `<t>-1`).

**What it does not cover**, now written in the file: mtime is writable. A `touch`, or a copy that does not preserve times, can make an old backup look new and buy it a slot the newest backup then loses. Restore is unaffected — it takes the path `createBackup` returned, never a path this order picked.

## The proof

The regression test carries both real directory names and was run against the old code before the fix. It fails twice over there:

- listing order inverts — the agent's older copy sorts last;
- `prune` returns `[…2026-08-27T18-27-22-440Z]` as the dropped directory, deleting the newest and keeping the oldest.

After the fix it drops the agent's older copy and keeps the engine's.

## Contracts held

`createBackup`, `restoreBackup` and `BACKUP_KEEP` are unchanged. `listBackups` keeps its signature and its oldest-first direction.

## Verification run

- `bun test` over the whole verify area (8 files): 159 pass / 0 fail
- `bun scripts/check-english-source.ts --strict`: clean
- `bun scripts/check-changelog-parity.ts --strict`: clean
- `git diff --check`: clean

Full suite and the 14 gates run once over the integrated whole, per the verification contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)