### PR TITLE
fix(dispatch): one answer for the project, and the runtime runs inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,109 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A newline in one argument cut every flag behind it, on Windows
+
+Found while chasing a Windows-only CI failure on the dispatch cut above, and it
+is the more serious half of what that failure was pointing at.
+
+An agent CLI installed through npm is a `.cmd` on Windows, and a `.cmd` can only
+be started through the command interpreter — Node has refused to spawn one
+without a shell since CVE-2024-27980, which is why `resolveExecutable` routes it
+through `cmd.exe`. What nothing accounted for: **cmd.exe ends the command line at
+the first CR/LF**, quoted or not. `quoteForCmd` solves spaces and metacharacters
+and can do nothing about this one, because the limit is the parser rather than
+the quoting.
+
+The claude runner pushed `--append-system-prompt` second, and the autonomy
+directive it carries is 5,875 characters of multi-line prose whose first newline
+lands at character 183. Everything after that was discarded before the child ever
+saw it. On the squad dispatch that meant both `--add-dir` grants and
+`--dangerously-skip-permissions` — a headless child left without its permission
+mode, and a directory grant dropped in silence — out of a 6,251-character command
+line, well under cmd.exe's 8,191 limit. This was never a length problem, which is
+why the existing ARG_MAX machinery never caught it.
+
+The cure already existed in this repository and the driver had not been told:
+`control-plane/maestro-turn.ts` diagnosed the same defect and fixed it by sending
+the directive as `--append-system-prompt-file <temp file>` whenever the CLI is
+started through a shell. The headless driver every dispatched child goes through
+had been left out of it. It now uses the same rule (`claudeDirectiveArgs`): under
+a shell the directive travels as a file, without one it stays inline, and the temp
+file is removed when the child closes. The command line for the squad dispatch
+goes from 6,251 characters with a cut at 183 to 407 characters with no newline in
+it at all — every flag delivered, and the whole 5,875-character directive
+delivered too, instead of its first line.
+
+Pushing the directive last is kept as well. It costs nothing, flag order being
+irrelevant to the CLI, and it means a runtime whose build predates the file flag
+can still only lose the tail of the directive rather than a directory grant or
+the permission mode. Three tests pin it: both delivery branches, the argv of a
+real child, and the constraint underneath — that quoting cannot neutralize a
+newline.
+
+Runtimes whose Windows install is a real `.exe` take the no-shell branch and were
+never affected, and the eight other adapters still carry the untreated shape;
+this is the pattern for them, and their fix is now a replication rather than a
+design. The light layer (`buildCall`) already happened to push its directive
+last, so it lost no flags; its own directive still truncates under a shell.
+
+### One answer to "which project is this?", and the dispatched runtime runs inside it
+
+`dispatch.ts` answered the question twice. Once from the environment
+(`NIRVANA_PROJECT_ROOT`, else the invocation cwd) and twice more by arithmetic —
+`resolve(projDir, "..", "..")` — climbing two levels out of the scaffold the run
+had just created. The arithmetic is only right when the layout is exactly
+`<project>/outputs/<pid>`, and the outputs root is a flag the user sets.
+
+A squad dispatch on 27/08 with `--outputs-root` outside the project tree split
+one trace's audit chain across three files: the routing events under the
+project, the scaffold events under `<outputs>/<pid>` (the dispatch kernel
+creates a `.nirvana/` there, so the walk-up reads the scaffold as its own
+project), and every `gate_passed` under `~/.harness-logs`, because
+`quality-gate.ts` anchors its audit on the artifact it was handed and an
+artifact outside any project has no root to find. `nrv validate-chain` reads one
+place. That chain could not be audited. The child had been handed `addDirs: [~]`
+— the user's whole home as "the project" — with its cwd inside the scaffold.
+
+Now the project is resolved once, by the rule `_shared/lib/paths.js` already
+gives the supervisor, the config, multi-target and the runtime snapshot:
+`NIRVANA_PROJECT_ROOT` when named, else the invocation cwd walked up to its
+marker. It is never derived from the outputs root. Where a path really is
+scaffold-shaped — `brief.md`, the dispatch kernel, the Gauntlet's candidate and
+evaluation directories — the variable is called `scaffoldRoot` and the Gauntlet
+inputs take it as `workspaceRoot`, so nothing moved on disk and `nrv clean
+<pid>` still takes the scratch with it.
+
+That answer is the OS's canonical form: `resolveProjectRoot` normalizes through
+`realpathSync.native`, which expands a Windows 8.3 short path
+(`C:\Users\RUNNER~1\…` into `C:\Users\runneradmin\…`) and resolves `/var` to
+`/private/var` on macOS. So `meta.project_root`, the ledger's `project_root`
+column, the audit anchor, the kernel path and the child's cwd are now one
+spelling of one directory. They were not before — the dispatch echoed whatever
+spelling the invocation happened to use while the ledger stored the canonical
+one, which is the same project splitting in two through a narrower door.
+
+The second half is the owner's decision: the dispatched runtime runs INSIDE the
+project, on every path — business single-shot and Gauntlet canary, squad, team
+step, agent-x, judge-x, the report publisher, the revision run, `nrv revise` and
+the supervisor's auto-redispatch. `cwd` is the project root; the scaffold and
+the outputs root are granted as additional directories, so the outputs root
+stays writable and the agent finally sees the project's `.nirvana/`, its local
+config, its own trace's logs and the code-base. The gate and verify children are
+told which project they belong to (`HARNESS_LOGS_DIR`, still overridable)
+instead of re-deriving it from the file they are judging.
+
+Two paths deliberately do NOT run in the project, and stayed as they were: the
+team director (`team-orchestrator.ts`, `cwd: os.tmpdir()`) is a text-only
+planning call with no file access, and the agentic verifier
+(`_shared/lib/verify/agentic.ts`) runs in an isolated staging directory on
+purpose — seeing the project would defeat the isolation.
+
+The regression test is the real run: a squad dispatch with the outputs root
+outside the project tree, asserting every event of the trace lands in one log
+and the child's cwd is the project root. Run against the old code it fails on
+all three counts.
+
 ### Backup retention orders by time, not by the shape of the name
 
 `prune` keeps the five newest backups of an entity and finds them by sorting the

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,111 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Uma quebra de linha num argumento cortava todas as flags atrás dela, no Windows
+
+Achado enquanto eu perseguia uma falha de CI exclusiva do Windows no corte de
+despacho acima, e é a metade mais séria do que aquela falha apontava.
+
+Uma CLI de agente instalada por npm é um `.cmd` no Windows, e um `.cmd` só pode
+ser iniciado pelo interpretador de comandos — o Node se recusa a executar um sem
+shell desde a CVE-2024-27980, por isso o `resolveExecutable` o encaminha pelo
+`cmd.exe`. O que ninguém tinha previsto: **o cmd.exe encerra a linha de comando na
+primeira CR/LF**, com ou sem aspas. O `quoteForCmd` resolve espaços e
+metacaracteres e não pode fazer nada quanto a isso, porque o limite é do parser,
+não do escape.
+
+O runner do claude empurrava o `--append-system-prompt` em segundo lugar, e a
+diretiva de autonomia que ele carrega tem 5.875 caracteres de prosa multilinha
+cuja primeira quebra cai no caractere 183. Tudo depois disso era descartado antes
+de o filho ver. No despacho de squad isso significava as duas concessões
+`--add-dir` e o `--dangerously-skip-permissions` — um filho headless sem o próprio
+modo de permissão, e uma concessão de diretório derrubada em silêncio — numa linha
+de 6.251 caracteres, bem abaixo do limite de 8.191 do cmd.exe. Nunca foi problema
+de tamanho, e é por isso que a maquinaria de ARG_MAX existente nunca pegou.
+
+A cura já existia neste repositório e ninguém tinha contado ao driver: o
+`control-plane/maestro-turn.ts` diagnosticou o mesmo defeito e o resolveu mandando
+a diretiva como `--append-system-prompt-file <arquivo temporário>` sempre que a CLI
+é iniciada por um shell. O driver headless por onde passa todo filho despachado
+ficou de fora. Agora ele usa a mesma regra (`claudeDirectiveArgs`): sob shell a
+diretiva viaja por arquivo, sem shell segue inline, e o temporário é removido
+quando o filho fecha. A linha de comando do despacho de squad cai de 6.251
+caracteres com corte no 183 para 407 caracteres sem nenhuma quebra de linha —
+todas as flags entregues, e a diretiva inteira de 5.875 caracteres entregue
+também, em vez da primeira linha dela.
+
+A diretiva continua sendo empurrada por último. Não custa nada, já que a ordem das
+flags é irrelevante para a CLI, e garante que um runtime cuja build seja anterior à
+flag de arquivo ainda só consiga perder a cauda da diretiva, nunca uma concessão de
+diretório nem o modo de permissão. Três testes fixam isso: os dois ramos de
+entrega, o argv de um filho real, e a restrição por baixo — que o escape não
+neutraliza uma quebra de linha.
+
+Runtimes cuja instalação no Windows é um `.exe` de verdade pegam o ramo sem shell e
+nunca foram afetados, e os outros oito adaptadores seguem com a forma não tratada;
+este é o padrão para eles, e a correção deles agora é replicação, não desenho. A
+camada leve (`buildCall`) já empurrava a diretiva por último por acaso, então não
+perdia flags; a diretiva dela ainda trunca sob shell.
+
+### Uma resposta só para "qual é o projeto?", e o runtime despachado roda dentro dele
+
+O `dispatch.ts` respondia à pergunta duas vezes. Uma pelo ambiente
+(`NIRVANA_PROJECT_ROOT`, senão o cwd da invocação) e outras duas por aritmética
+de caminho — `resolve(projDir, "..", "..")` — subindo dois níveis a partir do
+scaffold que a própria execução acabara de criar. A aritmética só acerta quando
+o layout é exatamente `<projeto>/outputs/<pid>`, e o outputs root é uma flag que
+o usuário escolhe.
+
+Um despacho de squad em 27/08 com `--outputs-root` fora da árvore do projeto
+partiu a cadeia de auditoria de um único trace em três arquivos: os eventos de
+roteamento sob o projeto, os eventos de scaffold sob `<outputs>/<pid>` (o kernel
+do despacho cria um `.nirvana/` ali, então a subida de diretórios lê o scaffold
+como se fosse um projeto) e todos os `gate_passed` sob `~/.harness-logs`, porque
+o `quality-gate.ts` ancora a auditoria no artefato que recebeu e um artefato fora
+de qualquer projeto não tem raiz para encontrar. O `nrv validate-chain` olha um
+lugar só. Aquela cadeia era inauditável. E o filho tinha recebido `addDirs: [~]`
+— a pasta pessoal inteira como "o projeto" — com o cwd dentro do scaffold.
+
+Agora o projeto é resolvido uma vez, pela regra que o `_shared/lib/paths.js` já
+dá ao supervisor, à configuração, ao multi-target e ao snapshot de runtime:
+`NIRVANA_PROJECT_ROOT` quando nomeado, senão o cwd da invocação subindo até o
+marcador. Nunca derivado do outputs root. Onde o caminho é mesmo do scaffold —
+`brief.md`, o kernel do despacho, os diretórios de candidates e evaluations do
+Gauntlet — a variável se chama `scaffoldRoot` e as entradas do Gauntlet a
+recebem como `workspaceRoot`, então nada mudou de lugar em disco e o `nrv clean
+<pid>` continua levando o rascunho junto.
+
+Essa resposta vem na forma canônica do sistema operacional: o
+`resolveProjectRoot` normaliza com `realpathSync.native`, que expande o caminho
+curto 8.3 do Windows (`C:\Users\RUNNER~1\…` vira `C:\Users\runneradmin\…`) e
+resolve `/var` para `/private/var` no macOS. Assim o `meta.project_root`, a
+coluna `project_root` do ledger, a âncora da auditoria, o caminho do kernel e o
+cwd do filho passam a ser uma grafia só de um diretório só. Não eram antes — o
+despacho repetia a grafia que a invocação usou enquanto o ledger guardava a
+canônica, que é o mesmo projeto se partindo em dois por uma porta mais estreita.
+
+A segunda metade é a decisão do dono: o runtime despachado roda DENTRO do
+projeto, em todo caminho — empresa em disparo único e canário do Gauntlet,
+squad, passo de time, agent-x, judge-x, o publicador do relatório, a rodada de
+revisão, o `nrv revise` e o redespacho automático do supervisor. O `cwd` é a
+raiz do projeto; o scaffold e o outputs root entram como diretórios adicionais,
+então o outputs root segue gravável e o agente enfim enxerga o `.nirvana/` do
+projeto, a configuração local, os logs do próprio trace e o código-base. Os
+filhos do gate e do verify são informados a que projeto pertencem
+(`HARNESS_LOGS_DIR`, ainda sobrescrevível) em vez de rededuzir isso do arquivo
+que estão julgando.
+
+Dois caminhos deliberadamente NÃO rodam no projeto, e ficaram como estavam: o
+diretor do time (`team-orchestrator.ts`, `cwd: os.tmpdir()`) é uma chamada de
+planejamento só de texto, sem acesso a arquivos, e o verificador agêntico
+(`_shared/lib/verify/agentic.ts`) roda de propósito num diretório de staging
+isolado — enxergar o projeto derrubaria o isolamento.
+
+O teste de regressão é a execução real: um despacho de squad com o outputs root
+fora da árvore do projeto, afirmando que todos os eventos do trace caem num log
+só e que o cwd do filho é a raiz do projeto. Contra o código antigo ele reprova
+nos três pontos.
+
 ### A retenção de backups ordena por tempo, não pelo formato do nome
 
 O `prune` mantém os cinco backups mais novos de uma entidade e os encontra

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -118,8 +118,8 @@ export function salientError(stderr: string, fallback: string, max = 500): strin
   return chosen.length <= max ? chosen : chosen.slice(0, max - 1) + "…";
 }
 
-function writePromptFile(prompt: string): string {
-  const f = path.join(os.tmpdir(), `nrv-prompt-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
+function writePromptFile(prompt: string, prefix = "nrv-prompt"): string {
+  const f = path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}.md`);
   fs.writeFileSync(f, prompt, "utf8");
   return f;
 }
@@ -999,7 +999,6 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
   const args: string[] = ["-p", "--output-format", "json"];
 
   if (opts.sessionId) args.push("--resume", opts.sessionId);
-  if (opts.appendSystemPrompt) args.push("--append-system-prompt", opts.appendSystemPrompt);
   // Model: caller's explicit value > system model (what the user's session
   // runs) > CLI default. Without this, the child `claude -p` falls to the
   // default (sonnet) instead of inheriting the interactive session's fable/opus.
@@ -1033,13 +1032,26 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
   if (typeof opts.maxBudgetUsd === "number") args.push("--max-budget-usd", String(opts.maxBudgetUsd));
   for (const d of opts.addDirs ?? []) args.push("--add-dir", d);
 
-  const r = driverSpawnSync("claude", args, {
-    cwd: opts.cwd,
-    input: opts.prompt,
-    encoding: "utf8",
-    ...(typeof opts.timeoutMs === "number" ? { timeout: opts.timeoutMs } : {}),
-    maxBuffer: 64 * 1024 * 1024,
-  });
+  // The directive goes LAST, and under a shell it does not go through argv at all
+  // (claudeDirectiveArgs). Defence in depth: the file delivery is the cure, and last
+  // position means that even a runtime whose CLI lacks the file flag can only ever lose
+  // the tail of the directive — never an `--add-dir` grant or the permission mode, which
+  // is what a 6251-character command line silently dropped before this.
+  const directive = claudeDirectiveArgs(opts.appendSystemPrompt ?? "", resolveExecutable("claude").shell);
+  args.push(...directive.args);
+
+  let r!: SpawnSyncReturns<string>;
+  try {
+    r = driverSpawnSync("claude", args, {
+      cwd: opts.cwd,
+      input: opts.prompt,
+      encoding: "utf8",
+      ...(typeof opts.timeoutMs === "number" ? { timeout: opts.timeoutMs } : {}),
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } finally {
+    removeTmpFiles(directive.tmpFiles);
+  }
 
   const durationMs = Date.now() - started;
   const exitCode = r.status ?? (r.signal ? 124 : 1);
@@ -1771,6 +1783,26 @@ export function runtimeAvailable(runtime: Runtime): boolean {
   // perfectly invocable. Same reason in whichSync below.
   const r = spawnSync(probe, [bin], { encoding: "utf8", env: process.env });
   return r.status === 0;
+}
+
+/**
+ * How the multi-line system directive reaches `claude`, per start path.
+ *
+ * A `.cmd`/`.bat` runtime — every npm-installed CLI — can only be started through the
+ * command interpreter (resolveExecutable), and cmd.exe ends the command line at the first
+ * CR/LF of an argument however it is quoted: quoteForCmd cannot help, because the limit is
+ * the parser and not the escaping. The directive is the one argument here that spans lines,
+ * so under a shell it travels as `--append-system-prompt-file <temp file>` and the command
+ * line stays single-line. Without a shell it stays inline, exactly as before.
+ *
+ * The same defect and the same cure already live in control-plane/maestro-turn.ts; the
+ * headless driver every dispatched child goes through had been left out of it.
+ */
+export function claudeDirectiveArgs(directive: string, shell: boolean): { args: string[]; tmpFiles?: string[] } {
+  if (!directive) return { args: [] };
+  if (!shell) return { args: ["--append-system-prompt", directive] };
+  const file = writePromptFile(directive, "nrv-directive");
+  return { args: ["--append-system-prompt-file", file], tmpFiles: [file] };
 }
 
 /** TEST-ONLY seams. Not part of the public driver contract. */

--- a/skills/harness/lib/business-post-gate.ts
+++ b/skills/harness/lib/business-post-gate.ts
@@ -96,7 +96,7 @@ export function runBusinessPostGate(input: BusinessPostGateInput): { zipPath: st
         else input.warn("⚠ report-publisher prompt failed; using the generic publisher");
       }
       const publisher = deps.runPublisher({
-        runtime: input.runtime, prompt: publisherPrompt, cwd: input.projectDir, addDirs: [input.projectRoot],
+        runtime: input.runtime, prompt: publisherPrompt, cwd: input.projectRoot, addDirs: [input.projectDir, reportDir],
         appendSystemPrompt: AUTONOMOUS_DIRECTIVE + input.rulesDirective,
         maxBudgetUsd: input.maxBudgetUsd, timeoutMs: input.timeoutMs, yolo: input.yolo,
       });

--- a/skills/harness/lib/delivery-pipeline.ts
+++ b/skills/harness/lib/delivery-pipeline.ts
@@ -45,6 +45,7 @@ import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
 import { isRunStatePath } from "../../_shared/lib/run-state.ts";
 import { detectKind } from "../../_shared/lib/surface.ts";
 import { GATEABLE_EXTS } from "../scripts/quality-gate.ts";
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import type { HarnessConfig } from "./harness-config.ts";
 import * as runLedger from "./run-ledger.ts";
 
@@ -358,9 +359,17 @@ export function runDelivery(args: DeliveryArgs): DeliveryResult {
   const mark = (state: runLedger.RunState, extra?: runLedger.MarkStateExtra) => {
     if (led) ledgerTry(() => runLedger.markState(led.handle, led.runId, state, extra ?? {}), warn);
   };
+  // quality-gate.ts and verify-deliverable.ts each anchor their audit on the artifact they
+  // were handed. With an outputs root outside the project tree that walk finds no project and
+  // lands in `~/.harness-logs`, which is how one trace's `gate_passed` ended up in a different
+  // file from its own `dispatch_squad`. The run already knows which project it belongs to, so
+  // it says so — an explicit HARNESS_LOGS_DIR the caller can still override.
   const gateEnv = {
     NIRVANA_TRACE_ID: args.pid,
     NIRVANA_PROJECT_ID: args.pid,
+    // Resolved from the project root the same way the dispatch resolves its own — walking up
+    // from it — so the two answers cannot disagree even when the root carries no marker.
+    HARNESS_LOGS_DIR: harnessLogsDir({ cwd: args.projectRoot }),
     ...(args.slug ? { NIRVANA_BUSINESS_SLUG: args.slug } : {}),
   };
   let sessionId: string | null = args.sessionId ?? null;
@@ -458,7 +467,7 @@ export function runDelivery(args: DeliveryArgs): DeliveryResult {
       "Não imprima resumo: entregue os arquivos corrigidos.",
     ].join("\n");
     const rr = runHeadlessImpl({
-      runtime: args.runtime, prompt: fixPrompt, cwd: args.projectDir, addDirs: [args.projectRoot],
+      runtime: args.runtime, prompt: fixPrompt, cwd: args.projectRoot, addDirs: [args.projectDir, args.outputsRoot],
       sessionId: sessionId || undefined,
       appendSystemPrompt: AUTONOMOUS_DIRECTIVE + (args.rulesDirective ?? ""),
       maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs, yolo: args.yolo,

--- a/skills/harness/lib/dispatch-cascade.ts
+++ b/skills/harness/lib/dispatch-cascade.ts
@@ -388,7 +388,7 @@ export function runAgentX(args: RunAgentXArgs): AgentXResult {
 
   const cascadeImpl = args.runWithCascadeImpl ?? runWithCascade;
   const res = cascadeImpl({
-    runtime: args.runtime, prompt, cwd: args.projectDir, addDirs: [args.projectRoot],
+    runtime: args.runtime, prompt, cwd: args.projectRoot, addDirs: [args.projectDir, args.outputsRoot],
     appendSystemPrompt: args.appendSystemPrompt,
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs, yolo: args.yolo,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: args.outputsRoot,

--- a/skills/harness/lib/gauntlet/agent-x-cutover.ts
+++ b/skills/harness/lib/gauntlet/agent-x-cutover.ts
@@ -62,7 +62,12 @@ export interface AgentXGauntletInput {
   runId: string;
   traceId: string;
   brief: string;
+  /** The project this Run belongs to. One answer, never derived from the outputs root. */
   projectRoot: string;
+  /** Where the Run's scratch lives — `<workspaceRoot>/.nirvana/gauntlet/<runId>/candidates/`.
+   *  The dispatch scaffold (`<outputs>/<pid>`), so `nrv clean <pid>` still takes it with it.
+   *  Absent = the project root, which is what every caller passed before the split. */
+  workspaceRoot?: string;
   outputsRoot: string;
   /** Cost reserved per round: the per-candidate estimate times `candidateStrategy.count`. */
   expectedCostUsd: number;
@@ -194,7 +199,7 @@ function mediaType(filePath: string): string {
 }
 
 function candidateRootFor(input: AgentXGauntletInput, candidateId: string, revision: number): string {
-  return path.join(input.projectRoot, ".nirvana", "gauntlet", input.runId, "candidates", candidateId, `rev_${revision}`);
+  return path.join(input.workspaceRoot ?? input.projectRoot, ".nirvana", "gauntlet", input.runId, "candidates", candidateId, `rev_${revision}`);
 }
 
 function revisionIdFor(runId: string, candidateId: string, revision: number): string {

--- a/skills/harness/lib/gauntlet/evaluator-adapter.ts
+++ b/skills/harness/lib/gauntlet/evaluator-adapter.ts
@@ -72,8 +72,12 @@ export interface DispatchEvaluatorInput {
   plan: GauntletPlan;
   /** The original brief, reproduced in the evaluation brief. */
   brief: string;
-  /** Root of the Run: evaluations live under `.nirvana/gauntlet/<runId>/evaluations/<revisionId>/`. */
+  /** The project the Run belongs to: the evaluator dispatch runs here (cwd + NIRVANA_PROJECT_ROOT),
+   *  and its audit joins the parent's chain under this root's harness logs. */
   projectRoot: string;
+  /** Where evaluations live — `<workspaceRoot>/.nirvana/gauntlet/<runId>/evaluations/<revisionId>/`,
+   *  beside the candidates they judge. Absent = the project root (the pre-split behaviour). */
+  workspaceRoot?: string;
   projectId: string;
   runtime?: string;
   /** Defaults to NIRVANA_DISPATCH_SCRIPT, then the repository's dispatch.ts. */
@@ -145,6 +149,7 @@ export function createDispatchEvaluator(input: DispatchEvaluatorInput): AgentXGa
       + "the evaluator must be a different target (evaluator-registry.ts targetsAreIndependent)");
   }
   const projectRoot = path.resolve(input.projectRoot);
+  const workspaceRoot = path.resolve(input.workspaceRoot ?? input.projectRoot);
   const dispatchScript = path.resolve(input.dispatchScriptPath ?? process.env.NIRVANA_DISPATCH_SCRIPT ?? DEFAULT_DISPATCH_SCRIPT);
   const spawn = input.spawn ?? defaultSpawn;
   const now = input.now ?? (() => new Date().toISOString());
@@ -153,7 +158,7 @@ export function createDispatchEvaluator(input: DispatchEvaluatorInput): AgentXGa
   const gauntletId = scorecardGauntletId(plan);
 
   const evaluate = (evaluation: AgentXGauntletEvaluationInput): EvaluationScorecard[] => {
-    const evaluationDir = evaluationDirFor(projectRoot, evaluation.runId, evaluation.revisionId);
+    const evaluationDir = evaluationDirFor(workspaceRoot, evaluation.runId, evaluation.revisionId);
     // The subprocess gets its own outputs root under the evaluation directory, empty before the
     // spawn. The request and the brief stay one level up, so the child dispatch never counts the
     // adapter's files as artifacts, and a scorecard left by an earlier attempt is never read as
@@ -205,6 +210,9 @@ export function createDispatchEvaluator(input: DispatchEvaluatorInput): AgentXGa
     for (const [key, value] of Object.entries({ ...process.env, ...input.env })) if (value !== undefined) env[key] = value;
     // The effective settings, as the variables the child reads (settings.ts settingsEnvForChild).
     Object.assign(env, settingsEnvForChild({ env, projectRoot }));
+    // The evaluator is a dispatch like any other: it runs INSIDE the project, and it is told so
+    // rather than left to infer it from a cwd that may sit under the scaffold.
+    env.NIRVANA_PROJECT_ROOT = projectRoot;
     // The child writes its audit where this adapter reads the cost from.
     const logsDir = env.HARNESS_LOGS_DIR ? path.resolve(env.HARNESS_LOGS_DIR) : harnessLogsDir({ projectRoot });
     env.HARNESS_LOGS_DIR = logsDir;

--- a/skills/harness/lib/gauntlet/judge-x.ts
+++ b/skills/harness/lib/gauntlet/judge-x.ts
@@ -132,8 +132,8 @@ export function runJudgeX(args: RunJudgeXArgs): JudgeXResult {
   emit("x_dispatch_judge_x", { trace_id: args.projectId, project_id: args.projectId, runtime: args.runtime, persona_file: promptPath,
     outputs_root: args.outputsRoot, scorecard_path: args.scorecardPath, prompt_chars: prompt.length, max_budget_usd: args.maxBudgetUsd ?? null });
   const res = (args.runWithCascadeImpl ?? runWithCascade)({
-    runtime: args.runtime, prompt, cwd: args.projectDir,
-    addDirs: [args.projectRoot, ...(args.candidateRoot ? [args.candidateRoot] : [])],
+    runtime: args.runtime, prompt, cwd: args.projectRoot,
+    addDirs: [args.projectDir, args.outputsRoot, ...(args.candidateRoot ? [args.candidateRoot] : [])],
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs, yolo: args.yolo,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: args.outputsRoot,
     taskHint: "judge-x (Gauntlet evaluation)", projectId: args.projectId,

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -446,7 +446,10 @@ export function runSquadHeadless(args: SquadExecArgs): SquadExecResult {
 
   const cascadeImpl = args.runWithCascadeImpl ?? runWithCascade;
   const cascadeArgs: Parameters<typeof runWithCascade>[0] = {
-    runtime: args.runtime, prompt, cwd: args.projectDir, addDirs: [args.projectRoot],
+    // The dispatched runtime runs INSIDE the project — it needs the project's .nirvana/,
+    // its config, its logs and its code-base — with the scaffold and the outputs dir handed
+    // to it as additional directories so both stay writable.
+    runtime: args.runtime, prompt, cwd: args.projectRoot, addDirs: [args.projectDir, outDir],
     appendSystemPrompt: args.autonomousDirective + (args.rulesDirective ?? ""),
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: outDir,

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -226,7 +226,7 @@ function runStep(step: ChainStep, idx: number, total: number, args: TeamRunArgs,
   appendAudit({ event: "dispatch_business", trace_id: args.projectId, project_id: args.projectId, business_slug: args.slug, employee: step.employee, mode: "team-step", step: idx + 1, total }, args.projectRoot);
 
   const res = runWithSession("employee", step.employee, args, {
-    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectDir, addDirs: [args.projectRoot],
+    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectRoot, addDirs: [args.projectDir, employeeOutDir],
     appendSystemPrompt: AUTONOMOUS_DIRECTIVE + (args.rulesDirective ?? ""),
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: employeeOutDir,

--- a/skills/harness/scripts/dispatch.ts
+++ b/skills/harness/scripts/dispatch.ts
@@ -180,6 +180,24 @@ export async function explicitTargetPlan(target: Exclude<ExplicitTarget, { kind:
   return resolveDispatchPlan(NO_ROUTER_DECISION, { explicitTarget: target });
 }
 
+// ── the one answer to "which project is this?" ────────────────────────────
+// NIRVANA_PROJECT_ROOT when the caller named it, else the invocation cwd walked
+// up to its marker — the rule _shared/lib/paths.js gives every other consumer
+// (supervisor, config, multi-target, runtime-snapshot). run-ledger owns the TS
+// half of it and memoizes the walk.
+//
+// It is NEVER derived from the outputs root. This file used to answer twice:
+// from the environment on one line and by `resolve(projDir, "..", "..")` on two
+// others. With an outputs root outside the project tree the arithmetic climbed
+// out of the project (as far as $HOME), so ONE trace wrote its dispatch events
+// under the project, its scaffold events under `<outputs>/<pid>` and its
+// `gate_passed` under `~/.harness-logs` — three files, an unauditable chain, and
+// a child runtime told its project was the user's home directory.
+//
+// Where a path still has to be scaffold-shaped (brief.md, the dispatch kernel,
+// the Gauntlet workspace) the variable is called `scaffoldRoot` and says so.
+const PROJECT_ROOT = runLedger.resolveProjectRoot() ?? path.resolve(process.cwd());
+
 const positional = extractPositional(process.argv.slice(2));
 // --auto: no business is named; the router picks the best one for the brief.
 // In that mode the first positional is the brief itself, as it is when an
@@ -201,9 +219,8 @@ const projectId = arg("--project");
 // canaries open that kernel; without it each dispatch keeps its own under
 // outputs/<pid>, byte-for-byte the previous behaviour.
 const runIdFlag = arg("--run-id");
-function canaryKernelPath(dispatchRoot: string): string {
-  const root = runIdFlag ? path.resolve(process.env.NIRVANA_PROJECT_ROOT || process.cwd()) : dispatchRoot;
-  return path.join(root, ".nirvana", "run-kernel.sqlite");
+function canaryKernelPath(scaffoldRoot: string): string {
+  return path.join(runIdFlag ? PROJECT_ROOT : scaffoldRoot, ".nirvana", "run-kernel.sqlite");
 }
 const runtime = arg("--runtime", "claude-code");
 // Was the --runtime flag GIVEN by the user? (arg() can't tell flag from default;
@@ -765,8 +782,7 @@ const prepScriptEnv = { ...process.env, ...settingsEnvForChild(), NIRVANA_DISPAT
 // explained here and end the Run before the producer inside runAgentXGauntlet
 // (RT-002): no silent switch, no legacy fallback.
 function frozenExecutionSnapshot(pid: string, rt: Runtime, targetKind: "business" | "squad" | "agent-x") {
-  const snapshot = freezeExecutionSnapshot({ runtimeId: rt, runtimeSource: runtimeDecision.source,
-    projectRoot: path.resolve(process.env.NIRVANA_PROJECT_ROOT || process.cwd()) });
+  const snapshot = freezeExecutionSnapshot({ runtimeId: rt, runtimeSource: runtimeDecision.source, projectRoot: PROJECT_ROOT });
   if (snapshot.errors?.length) {
     console.error(c("red", `✗ runtime '${rt}' is incompatible with the provider catalog; the Run ends before the producer:`));
     for (const error of snapshot.errors) console.error(c("red", `    ${error}`));
@@ -788,7 +804,12 @@ function heuristicGauntletEvaluator(env: Record<string, string>): AgentXGauntlet
     target,
     evaluate({ candidateId, revisionId, candidateRoot, artifactRefs }) {
       const files = gateableFiles(candidateRoot, new Set());
-      const gate = files.length ? runGateOnce(files, { gateScript: gateScriptPath, offline: true, env }) : { pass: false, fails: [] };
+      const gate = files.length
+        ? runGateOnce(files, { gateScript: gateScriptPath, offline: true,
+            // Same reason as the delivery pipeline's gateEnv: the gate child must not
+            // re-derive the project from the candidate it is judging.
+            env: { HARNESS_LOGS_DIR: harnessLogsDir({ cwd: PROJECT_ROOT }), ...env } })
+        : { pass: false, fails: [] };
       return [{ evaluationId: `evl_${revisionId}`, candidateId, revisionId,
         gauntletId: "brief-conformance", rubricVersion: "harness-quality-gate/v1", verdict: gate.pass ? "pass" : "revise",
         dimensions: [{ id: "brief-conformance", score: files.length ? (files.length - gate.fails.length) / files.length : 0,
@@ -881,7 +902,7 @@ function producesForDelivery(read: () => string[]): string[] | undefined {
 // the Run rolled back as `evaluator_unavailable` and exit 4. A real evaluator runs through
 // lib/gauntlet/evaluator-adapter.ts with the evaluation budget (share or floor) as its cap; a
 // slice the floor consumes entirely rolls the Run back as `max_cost` before the producer.
-function gauntletEvaluatorFor(args: { pid: string; producer: TargetRef; plan: GauntletPlan; projectRoot: string; rt: Runtime;
+function gauntletEvaluatorFor(args: { pid: string; producer: TargetRef; plan: GauntletPlan; projectRoot: string; workspaceRoot: string; rt: Runtime;
   kernelPath: string; runId: string; heuristicEnv: Record<string, string> }): { evaluator: AgentXGauntletEvaluator; budget: GauntletRoundBudget } {
   const judge = judgeXAvailability(args.rt);
   // The gauntlet.evaluator setting: the variable, else the project or global config.
@@ -941,7 +962,7 @@ function gauntletEvaluatorFor(args: { pid: string; producer: TargetRef; plan: Ga
     process.exit(1);
   }
   const evaluator = createDispatchEvaluator({ target: selection.target, producer: args.producer, plan: args.plan, brief: brief!,
-    projectRoot: args.projectRoot, projectId: args.pid, runtime: args.rt, budgetUsd: budget.evaluationBudgetUsd,
+    projectRoot: args.projectRoot, workspaceRoot: args.workspaceRoot, projectId: args.pid, runtime: args.rt, budgetUsd: budget.evaluationBudgetUsd,
     timeoutMs: timeoutMin ? parseInt(timeoutMin, 10) * 60 * 1000 : undefined, audit: emit });
   return { evaluator, budget };
 }
@@ -981,7 +1002,7 @@ function deliveryArgs(opts: DeliverOpts): DeliveryArgs {
     runtime: opts.rt,
     projectDir: opts.projDir,
     projectRoot: opts.projectRoot,
-    workingDir: process.cwd(),
+    workingDir: PROJECT_ROOT,
     sessionId: opts.sessionId,
     maxRevisions,
     maxBudgetUsd: effectiveBudgetUsd(),
@@ -1071,8 +1092,12 @@ if (pendingCascade?.kind === "squad-only") {
     console.error(c("red", "✗ could not parse the Project dir from brief-squad"));
     process.exit(1);
   }
-  const projectRoot = path.resolve(projDir, "..", "..");   // <outputs>/<pid>
-  dispatchAudit.bindProjectRoot(projDir);
+  // brief-squad scaffolds at <outputs>/<pid>/squads/<slug>; its two parents are the
+  // run's WORKSPACE (brief.md, the dispatch kernel, the Gauntlet scratch), never the
+  // project — deriving one from the other is the defect this cut closed.
+  const scaffoldRoot = path.resolve(projDir, "..", "..");
+  const projectRoot = PROJECT_ROOT;
+  dispatchAudit.bindProjectRoot(projectRoot);
 
   if (!wantExec) {
     console.log("");
@@ -1090,7 +1115,7 @@ if (pendingCascade?.kind === "squad-only") {
     emit("agent_exec_failed", { trace_id: pid, project_id: pid, squad_slug: squads[0], runtime: rt, reason: "runtime not on PATH" });
     process.exit(1);
   }
-  const oroot = outputsRoot || path.join(projectRoot, "deliverables");
+  const oroot = outputsRoot || path.join(scaffoldRoot, "deliverables");
   fs.mkdirSync(oroot, { recursive: true });
   // The capability each squad of the chain actually runs (lib/capability-resolver.ts):
   // the id the user named, the squad's only capability, the best one for this brief
@@ -1115,8 +1140,9 @@ if (pendingCascade?.kind === "squad-only") {
     const requirements = gauntletRequirements(pid, producerTarget, squadContract);
     const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: producerTarget,
       plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }),
-      projectRoot, rt, kernelPath: canaryKernelPath(projectRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
-    const kernel = openKernel(canaryKernelPath(projectRoot));
+      projectRoot, workspaceRoot: scaffoldRoot, rt, kernelPath: canaryKernelPath(scaffoldRoot), runId: canonicalRunId,
+      heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
+    const kernel = openKernel(canaryKernelPath(scaffoldRoot));
     const legacy = runLedger.openLedger();
     let finalDelivery: DeliveryResult | null = null;
     // One producer for the first candidate and for every revision: same squad, same runtime.
@@ -1132,8 +1158,8 @@ if (pendingCascade?.kind === "squad-only") {
     const executionSnapshot = frozenExecutionSnapshot(pid, rt, "squad");
     try {
       const result = runAgentXGauntlet({
-        kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: projDir }), producerTarget,
-        projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot, outputsRoot: oroot,
+        kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: projectRoot }), producerTarget,
+        projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot, workspaceRoot: scaffoldRoot, outputsRoot: oroot,
         intensity: executionOptions.intensity, requirements, executionSnapshot, audit: emit,
         expectedCostUsd: budget.roundBudgetUsd,
         executeCandidate: candidateRoot => produce(candidateRoot, brief),
@@ -1157,7 +1183,7 @@ if (pendingCascade?.kind === "squad-only") {
   }
   // Standard mode publishes the same canonical Run the Gauntlet canary would (dual-write through
   // lib/run-kernel/standard-publication.ts, fail-open); a chain of squads publishes under its first squad.
-  const publication = openStandardPublication({ kernelPath: canaryKernelPath(projectRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
+  const publication = openStandardPublication({ kernelPath: canaryKernelPath(scaffoldRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
     traceId: pid, target: { kind: "squad", slug: squads[0], capabilityId }, snapshot: frozenExecutionSnapshot(pid, rt, "squad"),
     audit: emit, warn: line => console.error(c("yellow", line)) });
   if (publication.incompatible || publication.collided) process.exit(1);
@@ -1166,7 +1192,8 @@ if (pendingCascade?.kind === "squad-only") {
     const row = runLedger.openRun(ledgerHandle, {
       traceId: pid, projectId: pid, targetSlug: squads.join(","), targetKind: "squad",
       runtime: rt, childPid: process.pid,
-      meta: { project_dir: projDir, project_root: projectRoot, outputs_root: oroot, mode: "squad-only" },
+      meta: { project_dir: projDir, project_root: projectRoot, scaffold_root: scaffoldRoot,
+        brief_path: path.join(scaffoldRoot, "brief.md"), outputs_root: oroot, mode: "squad-only" },
     });
     ledgerRunId = row.run_id;
   });
@@ -1234,10 +1261,10 @@ if (pendingCascade?.kind === "judge-x") {
   const rt = runtimeDecision.runtime;
   const ts = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "");
   const pid = projectId || `proj-${ts}-judge-x`;
-  const base = path.join(process.cwd(), "outputs", pid);
-  const projDir = path.join(base, "judge-x");
+  const scaffoldRoot = path.join(PROJECT_ROOT, "outputs", pid);
+  const projDir = path.join(scaffoldRoot, "judge-x");
   fs.mkdirSync(projDir, { recursive: true });
-  dispatchAudit.bindProjectRoot(projDir);
+  dispatchAudit.bindProjectRoot(PROJECT_ROOT);
   emit("brief_received", { trace_id: pid, project_id: pid, target: "judge-x", brief_chars: brief.length });
 
   if (!wantExec) {
@@ -1246,7 +1273,7 @@ if (pendingCascade?.kind === "judge-x") {
     console.log(c("dim", "  (exit 3 — nothing dispatched, nothing judged)"));
     process.exit(3);
   }
-  const oroot = outputsRoot || path.join(base, "deliverables");
+  const oroot = outputsRoot || path.join(scaffoldRoot, "deliverables");
   fs.mkdirSync(oroot, { recursive: true });
   const requestFile = path.join(path.dirname(oroot), EVALUATION_REQUEST_FILE);
   let request: EvaluationRequest;
@@ -1263,7 +1290,7 @@ if (pendingCascade?.kind === "judge-x") {
     process.exit(1);
   }
   const scorecardPath = path.join(oroot, SCORECARD_FILE);
-  const publication = openStandardPublication({ kernelPath: canaryKernelPath(base), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
+  const publication = openStandardPublication({ kernelPath: canaryKernelPath(scaffoldRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
     traceId: pid, target: JUDGE_X_TARGET, snapshot: frozenExecutionSnapshot(pid, rt, "agent-x"),
     audit: emit, warn: line => console.error(c("yellow", line)) });
   if (publication.incompatible) process.exit(1);
@@ -1271,7 +1298,7 @@ if (pendingCascade?.kind === "judge-x") {
   console.log(c("lime", "▶") + c("bold", ` Judge-x — exec headless (${rt})`));
   publication.start();
   const maxBudgetUsd = effectiveBudgetUsd();
-  const r = runJudgeX({ brief, runtime: rt, projectId: pid, projectDir: projDir, projectRoot: base, outputsRoot: oroot, scorecardPath,
+  const r = runJudgeX({ brief, runtime: rt, projectId: pid, projectDir: projDir, projectRoot: PROJECT_ROOT, outputsRoot: oroot, scorecardPath,
     candidateRoot: request.candidateRoot, maxBudgetUsd, timeoutMs: timeoutMin ? parseInt(timeoutMin, 10) * 60 * 1000 : undefined, yolo, audit: emit });
   console.log(c("dim", `  session: ${r.sessionId || "(none)"} · ${r.durationMs}ms${r.costUsd != null ? ` · $${r.costUsd.toFixed(4)}` : ""} · prompt ${r.promptChars} chars`));
   publication.verify();
@@ -1298,12 +1325,12 @@ if (pendingCascade?.kind === "agent-x") {
   const rt = runtimeDecision.runtime;
   const ts = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "");
   const pid = projectId || `proj-${ts}-agent-x`;
-  const base = path.join(process.cwd(), "outputs", pid);
-  const projDir = path.join(base, "agent-x");
+  const scaffoldRoot = path.join(PROJECT_ROOT, "outputs", pid);
+  const projDir = path.join(scaffoldRoot, "agent-x");
   fs.mkdirSync(projDir, { recursive: true });
-  const briefPath = path.join(base, "brief-enriched.md");
+  const briefPath = path.join(scaffoldRoot, "brief-enriched.md");
   fs.writeFileSync(briefPath, brief, "utf8");
-  dispatchAudit.bindProjectRoot(projDir);
+  dispatchAudit.bindProjectRoot(PROJECT_ROOT);
   emit("brief_received", { trace_id: pid, project_id: pid, target: "agent-x", brief_chars: brief.length });
 
   if (!wantExec) {
@@ -1323,7 +1350,7 @@ if (pendingCascade?.kind === "agent-x") {
     emit("agent_exec_failed", { trace_id: pid, project_id: pid, employee: "agent-x", runtime: rt, reason: "runtime not on PATH" });
     process.exit(1);
   }
-  const oroot = outputsRoot || path.join(base, "deliverables");
+  const oroot = outputsRoot || path.join(scaffoldRoot, "deliverables");
   fs.mkdirSync(oroot, { recursive: true });
   if (shouldRunAgentXGauntlet({ targetKind: "agent-x", wantExec, resolvedMode: executionOptions.resolvedMode })) {
     const canonicalRunId = canonicalRunIdFor(pid, runIdFlag);
@@ -1331,15 +1358,16 @@ if (pendingCascade?.kind === "agent-x") {
     // setting — the array still travels to both compile sites, which is what keeps them equal.
     const requirements = gauntletRequirements(pid, { kind: "agent-x", slug: "agent-x" });
     const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: { kind: "agent-x", slug: "agent-x" },
-      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }), projectRoot: base, rt,
-      kernelPath: canaryKernelPath(base), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
-    const kernel = openKernel(canaryKernelPath(base));
+      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }),
+      projectRoot: PROJECT_ROOT, workspaceRoot: scaffoldRoot, rt,
+      kernelPath: canaryKernelPath(scaffoldRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid } });
+    const kernel = openKernel(canaryKernelPath(scaffoldRoot));
     const legacy = runLedger.openLedger();
     let finalDelivery: DeliveryResult | null = null;
     // One producer for the first candidate and for every revision: same persona, same runtime.
     const produce = (candidateRoot: string, candidateBrief: string, candidateBriefPath: string) => {
       const candidate = runAgentX({ brief: candidateBrief, briefPath: candidateBriefPath, runtime: rt, projectId: pid, projectDir: projDir,
-        projectRoot: base, outputsRoot: candidateRoot, reason: pendingCascade.reason, appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
+        projectRoot: PROJECT_ROOT, outputsRoot: candidateRoot, reason: pendingCascade.reason, appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
         maxBudgetUsd: budget.candidateBudgetUsd, timeoutMs: timeoutMin ? parseInt(timeoutMin, 10) * 60 * 1000 : undefined,
         yolo, ledger: { runId: canonicalRunId, watchDir: candidateRoot }, audit: emit });
       if (candidate.sessionId) runLedger.recordSession(legacy, canonicalRunId, candidate.sessionId);
@@ -1351,8 +1379,8 @@ if (pendingCascade?.kind === "agent-x") {
     const executionSnapshot = frozenExecutionSnapshot(pid, rt, "agent-x");
     try {
       const result = runAgentXGauntlet({
-        kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: projDir }),
-        projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot: base, outputsRoot: oroot,
+        kernel, legacy: createHarnessLegacyAdapter({ ledger: legacy, auditCwd: PROJECT_ROOT }),
+        projectId: pid, runId: canonicalRunId, traceId: pid, brief, projectRoot: PROJECT_ROOT, workspaceRoot: scaffoldRoot, outputsRoot: oroot,
         intensity: executionOptions.intensity, requirements, executionSnapshot, audit: emit,
         expectedCostUsd: budget.roundBudgetUsd,
         executeCandidate: candidateRoot => produce(candidateRoot, brief, briefPath),
@@ -1363,7 +1391,7 @@ if (pendingCascade?.kind === "agent-x") {
         evaluator,
         finalGate({ sessionId }) {
           finalDelivery = runDelivery({ ...deliveryArgs({ pid, slugOrNull: null, targetKind: "agent-x", rt, oroot,
-            projDir, projectRoot: base, sessionId, withManifest: false }), ledger: null, maxRevisions: 0 });
+            projDir, projectRoot: PROJECT_ROOT, sessionId, withManifest: false }), ledger: null, maxRevisions: 0 });
           return { exitCode: finalDelivery.exitCode, gateOutcome: finalDelivery.gateOutcome };
         },
       });
@@ -1378,7 +1406,7 @@ if (pendingCascade?.kind === "agent-x") {
     }
   }
   // Standard mode publishes the same canonical Run the Gauntlet canary would (dual-write, fail-open).
-  const publication = openStandardPublication({ kernelPath: canaryKernelPath(base), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
+  const publication = openStandardPublication({ kernelPath: canaryKernelPath(scaffoldRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag),
     traceId: pid, target: { kind: "agent-x", slug: "agent-x" }, snapshot: frozenExecutionSnapshot(pid, rt, "agent-x"),
     audit: emit, warn: line => console.error(c("yellow", line)) });
   if (publication.incompatible || publication.collided) process.exit(1);
@@ -1387,7 +1415,8 @@ if (pendingCascade?.kind === "agent-x") {
     const row = runLedger.openRun(ledgerHandle, {
       traceId: pid, projectId: pid, targetSlug: "agent-x", targetKind: "agent-x",
       runtime: rt, childPid: process.pid,
-      meta: { project_dir: projDir, project_root: base, outputs_root: oroot, mode: "agent-x" },
+      meta: { project_dir: projDir, project_root: PROJECT_ROOT, scaffold_root: scaffoldRoot,
+        brief_path: briefPath, outputs_root: oroot, mode: "agent-x" },
     });
     ledgerRunId = row.run_id;
   });
@@ -1397,7 +1426,7 @@ if (pendingCascade?.kind === "agent-x") {
   publication.start();
   const r = runAgentX({
     brief, briefPath, runtime: rt, projectId: pid,
-    projectDir: projDir, projectRoot: base, outputsRoot: oroot,
+    projectDir: projDir, projectRoot: PROJECT_ROOT, outputsRoot: oroot,
     reason: pendingCascade.reason,
     appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
     maxBudgetUsd: effectiveBudgetUsd(),
@@ -1409,7 +1438,7 @@ if (pendingCascade?.kind === "agent-x") {
   if (ledgerRunId) ledgerTry(() => runLedger.recordSession(ledgerHandle!, ledgerRunId!, r.sessionId));
   const agentXDeliverOpts = {
     pid, slugOrNull: null, targetKind: "agent-x" as const, rt, oroot,
-    projDir, projectRoot: base, sessionId: r.sessionId, withManifest: false,
+    projDir, projectRoot: PROJECT_ROOT, sessionId: r.sessionId, withManifest: false,
   };
   publication.verify();
   if (!r.ok) {
@@ -1474,8 +1503,10 @@ const businessProduces = producesForDelivery(() => businessEntry.produces);
 
 // Step 2 — build employee prompt
 console.log(c("lime", "▶") + c("bold", ` Step 2/4 — buildEmployeePrompt (${intake}@${slug})`));
-// brief-business writes brief.md at the project root (parent of businesses/<slug>/), not inside the business subdir
-const projectRoot = path.resolve(projDir, "..", "..");
+// brief-business writes brief.md at the WORKSPACE root (parent of businesses/<slug>/), not
+// inside the business subdir. That root is the scaffold's, never the project's — see PROJECT_ROOT.
+const scaffoldRoot = path.resolve(projDir, "..", "..");
+const projectRoot = PROJECT_ROOT;
 // In exec mode the agent writes deliverables here (a clean subfolder export
 // includes but the scaffold dirs handoffs/tickets/employees are excluded).
 const execOutputsRoot = outputsRoot || (wantExec ? path.join(projDir, "deliverables") : undefined);
@@ -1485,7 +1516,7 @@ const businessCanaryDecision = decideBusinessCanary({ businessSlug: slug, wantEx
   // The gauntlet.business_allowlist and gauntlet.business_kill_switch settings (variables, else config).
   intensity: executionOptions.intensity, allowlist: resolveSetting("gauntlet.business_allowlist").value,
   killSwitch: resolveSetting("gauntlet.business_kill_switch").value ? "1" : undefined });
-const tmpBriefFile = path.join(projectRoot, "brief.md");
+const tmpBriefFile = path.join(scaffoldRoot, "brief.md");
 if (!fs.existsSync(tmpBriefFile)) {
   console.error(c("red", `✗ brief.md not found at ${tmpBriefFile}`));
   process.exit(1);
@@ -1507,10 +1538,12 @@ const dnaCount = (r2.stdout.match(/^--- MIND-CLONE:/gm) || []).length;
 console.log(c("dim", `  Prompt: ${promptSize.toLocaleString()} chars · ${dnaCount} mind-clones injected`));
 console.log(c("dim", `  Saved to: ${outputPath}`));
 
-// Step 3 — dispatch_business audit event. From here on we know projDir:
-// bind the audit facade to the project root (pre-projDir events are replayed
-// there, flagged replayed_from_global — the split-root fix).
-dispatchAudit.bindProjectRoot(projDir);
+// Step 3 — dispatch_business audit event. Bind the audit facade to the project
+// (pre-scaffold events are replayed there, flagged replayed_from_global — the
+// split-root fix). The bind takes the PROJECT, never the scaffold: the scaffold
+// grows its own `.nirvana/` for the dispatch kernel, so a walk-up anchored there
+// reads it as a project of its own and the trace ends up in two files.
+dispatchAudit.bindProjectRoot(projectRoot);
 // Dispatch ledger — open the run BEFORE exec, so a crash anywhere between
 // here and delivery leaves a non-terminal row the supervisor can recover.
 // Scaffold-only mode opens nothing (there is no execution to supervise).
@@ -1526,7 +1559,7 @@ if (wantExec && !businessCanaryDecision.enabled) {
         ? Math.floor(((timeoutMin ? parseInt(timeoutMin, 10) * 60_000 : LEDGER_DEFAULT_TIMEOUT_MS) + 5 * 60_000) / 1000)
         : 900,
       meta: {
-        project_dir: projDir, project_root: projectRoot,
+        project_dir: projDir, project_root: projectRoot, scaffold_root: scaffoldRoot,
         outputs_root: execOutputsRoot ?? null,
         prompt_path: outputPath, brief_path: tmpBriefFile,
         mode: wantTeam ? "team" : "single",
@@ -1558,7 +1591,7 @@ if (executionOptions.requestedMode === "gauntlet") {
     requested_mode: executionOptions.requestedMode, intensity: executionOptions.intensity,
   });
 }
-console.log(c("dim", `  ✓ dispatch_business written to ${path.join(harnessLogsDir({ cwd: projDir }), new Date().toISOString().slice(0, 10))}/audit.jsonl`));
+console.log(c("dim", `  ✓ dispatch_business written to ${path.join(harnessLogsDir({ cwd: projectRoot }), new Date().toISOString().slice(0, 10))}/audit.jsonl`));
 
 // ── EXEC MODE — actually run the runtime headless, then verify+gate+deliver ─
 if (wantExec) {
@@ -1578,9 +1611,9 @@ if (wantExec) {
     const canonicalRunId = canonicalRunIdFor(pid, runIdFlag);
       const requirements = gauntletRequirements(pid, { kind: "business", slug }, { requirements: businessAcceptance.requirements });
     const { evaluator, budget } = gauntletEvaluatorFor({ pid, producer: { kind: "business", slug },
-      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }), projectRoot, rt,
-      kernelPath: canaryKernelPath(projectRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid, NIRVANA_BUSINESS_SLUG: slug } });
-    const kernel = openKernel(canaryKernelPath(projectRoot));
+      plan: compileGauntletPlan({ brief, intensity: executionOptions.intensity, requirements }), projectRoot, workspaceRoot: scaffoldRoot, rt,
+      kernelPath: canaryKernelPath(scaffoldRoot), runId: canonicalRunId, heuristicEnv: { NIRVANA_TRACE_ID: pid, NIRVANA_PROJECT_ID: pid, NIRVANA_BUSINESS_SLUG: slug } });
+    const kernel = openKernel(canaryKernelPath(scaffoldRoot));
     const canaryLedger = runLedger.openLedger();
     let finalDelivery: DeliveryResult | null = null;
     let canarySessionId: string | null = null;
@@ -1595,8 +1628,8 @@ if (wantExec) {
     const produce = (candidateRoot: string, briefFile: string, candidateBrief: string) => {
       const prompt = employeePromptFor(briefFile, candidateRoot);
       attempt.markProductionStarted();
-      const candidate = runWithCascade({ runtime: rt, prompt, cwd: projDir,
-        addDirs: [projectRoot], appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
+      const candidate = runWithCascade({ runtime: rt, prompt, cwd: projectRoot,
+        addDirs: [projDir, candidateRoot], appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
         maxBudgetUsd: budget.candidateBudgetUsd, timeoutMs: timeoutMin ? parseInt(timeoutMin, 10) * 60 * 1000 : undefined,
         yolo, brief: candidateBrief, projectRoot, outputsRoot: candidateRoot, taskHint: `business Gauntlet canary · ${slug}/${intake}`,
         projectId: pid, ledger: { runId: canonicalRunId, watchDir: candidateRoot } });
@@ -1610,9 +1643,9 @@ if (wantExec) {
       markProductionStarted() {},
       run() {
         return runAgentXGauntlet({
-          kernel, legacy: createHarnessLegacyAdapter({ ledger: canaryLedger, auditCwd: projDir }),
+          kernel, legacy: createHarnessLegacyAdapter({ ledger: canaryLedger, auditCwd: projectRoot }),
           producerTarget: { kind: "business", slug }, projectId: pid, runId: canonicalRunId, traceId: pid,
-          brief, projectRoot, outputsRoot: oroot, expectedCostUsd: budget.roundBudgetUsd, intensity: executionOptions.intensity,
+          brief, projectRoot, workspaceRoot: scaffoldRoot, outputsRoot: oroot, expectedCostUsd: budget.roundBudgetUsd, intensity: executionOptions.intensity,
           requirements, executionSnapshot, audit: emit,
           executeCandidate: candidateRoot => produce(candidateRoot, tmpBriefFile, brief),
           reviseCandidate(request) {
@@ -1658,7 +1691,7 @@ if (wantExec) {
       ledgerTry(() => {
         ledgerHandle = runLedger.openLedger();
         const row = runLedger.openRun(ledgerHandle, { traceId: pid, projectId: pid, targetSlug: slug, targetKind: "business",
-          runtime: rt, childPid: process.pid, meta: { project_dir: projDir, project_root: projectRoot,
+          runtime: rt, childPid: process.pid, meta: { project_dir: projDir, project_root: projectRoot, scaffold_root: scaffoldRoot,
             outputs_root: oroot, prompt_path: outputPath, brief_path: tmpBriefFile, mode: "single" } });
         ledgerRunId = row.run_id;
       });
@@ -1673,7 +1706,7 @@ if (wantExec) {
   // Standard mode publishes the canonical Run (dual-write, fail-open). After a canary rollback the
   // kernel already holds this Run's terminal state, so the legacy fallback publishes nothing new.
   const publication = businessCanaryDecision.enabled ? inertStandardPublication(canonicalRunIdFor(pid, runIdFlag))
-    : openStandardPublication({ kernelPath: canaryKernelPath(projectRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag), traceId: pid,
+    : openStandardPublication({ kernelPath: canaryKernelPath(scaffoldRoot), projectId: pid, runId: canonicalRunIdFor(pid, runIdFlag), traceId: pid,
       target: { kind: "business", slug }, snapshot: frozenExecutionSnapshot(pid, rt, "business"), audit: emit, warn: line => console.error(c("yellow", line)) });
   if (publication.incompatible || publication.collided) {
     const error = publication.collided ? `run ${publication.runId} is already terminal` : "runtime incompatible with the provider catalog";
@@ -1719,8 +1752,8 @@ if (wantExec) {
     res = runWithCascade({
       runtime: rt,
       prompt: agentPrompt,
-      cwd: projDir,
-      addDirs: [projectRoot],
+      cwd: projectRoot,
+      addDirs: [projDir, oroot],
       appendSystemPrompt: AUTONOMOUS_DIRECTIVE + rulesDirective,
       maxBudgetUsd: effectiveBudgetUsd(),
       timeoutMs: timeoutMin ? parseInt(timeoutMin, 10) * 60 * 1000 : undefined,

--- a/skills/harness/scripts/revise.ts
+++ b/skills/harness/scripts/revise.ts
@@ -144,8 +144,8 @@ appendAudit({ event: "revision_requested", trace_id: projectId, project_id: proj
 const res = runHeadless({
   runtime: rt,
   prompt: revisePrompt,
-  cwd: projDir,
-  addDirs: [projectRoot],
+  cwd: projectRoot,
+  addDirs: [projDir, oroot],
   sessionId,
   appendSystemPrompt: AUTONOMOUS_DIRECTIVE,
   maxBudgetUsd: maxBudget ? parseFloat(maxBudget) : undefined,

--- a/skills/harness/scripts/supervisor.ts
+++ b/skills/harness/scripts/supervisor.ts
@@ -339,11 +339,16 @@ const CONTINUE_PROMPT = [
 function reviseCwdFor(meta: Record<string, unknown>): string {
   const pr = typeof meta.project_root === "string" ? (meta.project_root as string) : null;
   if (pr) {
+    // Rows written before the dispatch had one answer for "which project is this?" stored the
+    // SCAFFOLD here (`<project>/outputs/<pid>`, or `<project>/.nirvana/outputs/<pid>`), so those
+    // are still walked back. A row written since already names the project: take it as it is,
+    // instead of falling through to HOME because it does not look like an outputs path.
     let d = path.dirname(pr);                       // …/outputs
     if (path.basename(d) === "outputs") {
       d = path.dirname(d);                          // base or base/.nirvana
       return path.basename(d) === ".nirvana" ? path.dirname(d) : d;
     }
+    return pr;
   }
   return os.homedir();
 }
@@ -470,8 +475,8 @@ export function redispatchRun(h: LedgerHandle, row: RunRow, overrides: Redispatc
   const res = runCascade({
     runtime: (row.runtime as any) || "claude-code",
     prompt,
-    cwd: projectDir,
-    addDirs: [projectRoot],
+    cwd: projectRoot,
+    addDirs: [projectDir, outputsRoot],
     appendSystemPrompt: AUTONOMOUS_DIRECTIVE,
     yolo: true,
     brief: brief || prompt.slice(0, 4000),

--- a/skills/harness/tests/dispatch-project-root.e2e.test.ts
+++ b/skills/harness/tests/dispatch-project-root.e2e.test.ts
@@ -1,0 +1,155 @@
+// dispatch-project-root.e2e.test.ts — one answer to "which project is this?".
+//
+// Reproduces the real squad dispatch of 2026-08-27 (trace ce1bd81c): the outputs
+// root lived OUTSIDE the project tree, dispatch.ts derived the project by path
+// arithmetic (`resolve(projDir, "..", "..")`) instead of asking the canonical
+// resolver, and the audit chain of ONE trace was split across two files —
+// 28 events under the project, the 9 `gate_passed` under `~/.harness-logs`.
+// `nrv validate-chain` reads one place, so that chain was unauditable.
+//
+// Two invariants are pinned here, both the owner's decision:
+//   1. every event of a trace lands in ONE audit log — the project's;
+//   2. the dispatched runtime runs INSIDE the project (cwd = project root),
+//      with the outputs root reachable as an additional directory.
+//
+// Hermetic: a fake `claude` on PATH, a squad fixture under a temporary HOME, no
+// LLM and no network. HARNESS_LOGS_DIR is deliberately NOT set — pinning it
+// would force one root and hide the very defect this suite exists to catch.
+// Runs with: bun test skills/harness/tests
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { writeFakeCli } from "./helpers/fake-cli.ts";
+import { makeTempRoot } from "./helpers/temp-dirs.ts";
+
+const REPO = path.resolve(import.meta.dir, "..", "..", "..");
+const SKILLS = path.join(REPO, "skills");
+const DISPATCH = path.join(SKILLS, "harness", "scripts", "dispatch.ts");
+
+// Passes the offline quality gate (same fixture the other dispatch e2e suites use).
+const PASSING_HTML = [
+  "<!doctype html><html><head><title>Delivery</title></head><body><main>",
+  "<h1>Final delivery</h1><p>This local fixture contains enough structured content for deterministic validation.</p>",
+  "<p>The manifest, quality gate and publication stages all run without network access or an external runtime.</p>",
+  "</main></body></html>",
+].join("");
+
+// Records the working directory and the argv it was launched with, then delivers.
+const FAKE_CLAUDE = String.raw`
+import * as fs from "node:fs";
+import * as path from "node:path";
+const capture = process.env.FAKE_CAPTURE_DIR;
+const argv = Bun.argv.slice(2);
+await Bun.stdin.text();
+fs.writeFileSync(path.join(capture, "child.json"), JSON.stringify({ cwd: process.cwd(), argv }), "utf8");
+const outputsRoot = process.env.FAKE_CLAUDE_OUTPUTS_ROOT;
+fs.mkdirSync(outputsRoot, { recursive: true });
+fs.writeFileSync(path.join(outputsRoot, "report.html"), ${JSON.stringify(PASSING_HTML)}, "utf8");
+console.log(JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "delivered", session_id: "sess-fake", total_cost_usd: 0.01 }));
+`;
+
+const roots: string[] = [];
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+function writeSquad(dir: string): void {
+  fs.mkdirSync(path.join(dir, "agents"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "agents", "fixture.md"), "# fixture agent\n", "utf8");
+  fs.writeFileSync(path.join(dir, "squad.yaml"), [
+    "name: fixture-squad", "version: 1.0.0", 'protocol: "5.0"', "description: A fixture squad for the project-root proof.",
+    "experimental_domains: true", "components:", "  agents: [fixture.md]", "  tasks: []", "  workflows: []", "capabilities:",
+    "  - id: general.fixture.run", "    description: Do the fixture thing.", "    domains: [fixture]", "    produces: [report]",
+    '    examples: ["rode o fixture"]', "    invoke:", "      type: agent", "      ref: fixture", "",
+  ].join("\n"), "utf8");
+}
+
+/** Every harness audit log under `dir`: the daily files, wherever they were anchored.
+ *  The per-scaffold `audit.jsonl` the prep scripts write is a different artifact
+ *  and is excluded — this is about the DAILY chain validate-chain reads. */
+function harnessAuditFiles(dir: string): string[] {
+  const found: string[] = [];
+  const walk = (current: string): void => {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(current, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name === "audit.jsonl" && (full.includes(path.join("logs", "harness")) || full.includes(".harness-logs"))) found.push(full);
+    }
+  };
+  walk(dir);
+  return found.sort();
+}
+
+function readEvents(file: string): Array<Record<string, unknown>> {
+  return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+function fixture() {
+  const root = makeTempRoot("nrv-projroot-"); roots.push(root);
+  const home = path.join(root, "home");
+  const projectRoot = path.join(root, "project");
+  const bin = path.join(root, "bin");
+  const capture = path.join(root, "capture");
+  // The outputs root of the real run: a sibling of the project, under no project at all.
+  const outputs = path.join(root, "audits", "trace-outside");
+  fs.mkdirSync(path.join(projectRoot, ".nirvana"), { recursive: true });
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(capture, { recursive: true });
+  fs.mkdirSync(outputs, { recursive: true });
+  writeFakeCli(bin, "claude", FAKE_CLAUDE);
+  writeSquad(path.join(home, "squads", "fixture-squad"));
+  const briefFile = path.join(root, "brief.md");
+  fs.writeFileSync(briefFile, "Produza o relatório final em report.html", "utf8");
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined || /^(NIRVANA_|HARNESS_|FAKE_|NRV_|LLM_CASCADE|SQUADS_DIR|BUSINESSES_DIR)/.test(key)) continue;
+    env[key] = value;
+  }
+  Object.assign(env, {
+    // USERPROFILE too: os.homedir() follows it on Windows, not HOME. Without it the
+    // `~/.harness-logs` fallback resolves to the REAL home, outside the tree this test
+    // scans — so a trace leaking there would go unseen and the test would pass for the
+    // wrong reason on exactly the system the split is hardest to spot.
+    HOME: home, USERPROFILE: home, NIRVANA_HOME: home, SQUADS_DIR: path.join(home, "squads"), NIRVANA_SKILLS_DIR: SKILLS, NIRVANA_PROJECT_ROOT: projectRoot,
+    NIRVANA_HOST_RUNTIME: "claude-code", NIRVANA_RUN_LEDGER_DB: path.join(root, "ledger.sqlite"), NIRVANA_STATE_DB: path.join(root, "state.db"),
+    NIRVANA_NO_UPDATE_CHECK: "1", NIRVANA_SCOPE_QUIET: "1", NRV_PREFLIGHT: "0",
+    FAKE_CAPTURE_DIR: capture, FAKE_CLAUDE_OUTPUTS_ROOT: outputs, PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+  });
+  const dispatch = (args: string[]) =>
+    spawnSync(process.execPath, [DISPATCH, ...args], { cwd: projectRoot, encoding: "utf8", env });
+  const child = () => JSON.parse(fs.readFileSync(path.join(capture, "child.json"), "utf8")) as { cwd: string; argv: string[] };
+  return { root, home, projectRoot, outputs, briefFile, capture, env, dispatch, child };
+}
+
+describe("a dispatch whose outputs root is outside the project", () => {
+  test("squad --exec: one audit log for the whole trace, the child runs in the project, the outputs root stays writable", () => {
+    const fx = fixture();
+    const pid = "proj-outside";
+    const result = fx.dispatch(["--squad", "fixture-squad", "--brief-file", fx.briefFile, "--exec", "--project", pid,
+      "--outputs-root", fx.outputs, "--max-revisions", "0"]);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+
+    // No write regression: the child still delivered into the outputs root, and it was
+    // handed to the runtime as an additional directory (the cwd no longer contains it).
+    expect(fs.existsSync(path.join(fx.outputs, "report.html"))).toBe(true);
+    const child = fx.child();
+    const addDirs = child.argv.filter((_, index) => child.argv[index - 1] === "--add-dir");
+    expect(addDirs).toContain(fx.outputs);
+
+    // Decision 1 — the dispatched runtime runs INSIDE the project.
+    expect(child.cwd).toBe(fx.projectRoot);
+
+    // Decision 2 — one trace, one audit log: the project's.
+    const projectLog = path.join(fx.projectRoot, ".nirvana", "logs", "harness", new Date().toISOString().slice(0, 10), "audit.jsonl");
+    const logs = harnessAuditFiles(fx.root);
+    const withTrace = logs.filter(file => readEvents(file).some(event => event.trace_id === pid));
+    expect(withTrace).toEqual([projectLog]);
+
+    // And it is the COMPLETE chain: the gate verdict is in the same file as the dispatch.
+    const events = readEvents(projectLog).filter(event => event.trace_id === pid).map(event => event.event);
+    for (const name of ["dispatch_squad", "verify_passed", "gate_passed", "delivered"]) {
+      expect(events, name).toContain(name);
+    }
+  }, 120000);
+});

--- a/skills/harness/tests/dispatch-standard-kernel.e2e.test.ts
+++ b/skills/harness/tests/dispatch-standard-kernel.e2e.test.ts
@@ -8,13 +8,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { createDispatchExecutionRunner, glanceRunDir } from "../lib/control-plane/index.ts";
 import { createRun, getRun, listEvents, openKernel, type RunEvent, type TargetRef } from "../lib/run-kernel/index.ts";
 import { openLedger } from "../lib/run-ledger.ts";
 import { canonicalRunIdFor } from "../scripts/dispatch.ts";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
+import { makeTempRoot } from "./helpers/temp-dirs.ts";
 import { pidAlive, waitUntil } from "./helpers/fake-glance-child.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
@@ -69,7 +69,7 @@ function writeSquad(dir: string): void {
 }
 
 function fixture() {
-  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "nrv-standard-kernel-"))); roots.push(root);
+  const root = makeTempRoot("nrv-standard-kernel-"); roots.push(root);
   const home = path.join(root, "home");
   const projectRoot = path.join(root, "project");
   const bin = path.join(root, "bin");

--- a/skills/harness/tests/driver-autonomy-flags.test.ts
+++ b/skills/harness/tests/driver-autonomy-flags.test.ts
@@ -15,7 +15,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-  HEADLESS_SKIP_PERMISSIONS_ENV, __testables, headlessSkipPermissions, runHeadless, type Runtime,
+  HEADLESS_SKIP_PERMISSIONS_ENV, __testables, claudeDirectiveArgs, headlessSkipPermissions, resolveExecutable,
+  runHeadless, type Runtime,
 } from "../../_shared/lib/host-agent-driver.ts";
 import { CAPTURE_PRELUDE, readCapturedArgs, writeFakeCli } from "./helpers/fake-cli.ts";
 
@@ -133,6 +134,52 @@ describe("headless layer — runHeadless argv per runtime", () => {
     expect(restricted).not.toContain("--dangerously-skip-permissions");
     expect(hasPair(restricted, ["--permission-mode", "acceptEdits"])).toBeTrue();
     expect(restricted).toContain("--allowedTools");
+  });
+
+  // A `.cmd`/`.bat` runtime — every npm-installed CLI — can only be started through cmd.exe
+  // (resolveExecutable), and cmd.exe ends the command line at the first CR/LF of an argument
+  // whatever the quoting. The directive is the only argument that spans lines, so everything
+  // pushed after it used to vanish: the squad dispatch lost both `--add-dir` grants AND
+  // `--dangerously-skip-permissions` from a 6251-character line, far under cmd.exe's 8191
+  // limit — a grant dropped in silence and a headless child with no permission mode.
+  // The cure is the one control-plane/maestro-turn.ts already used: under a shell the
+  // directive travels as a FILE, so the command line never contains a newline at all.
+  test("claude-code: the directive travels by file under a shell, inline without one — both branches", () => {
+    const directive = "line one\nline two";
+
+    const inline = claudeDirectiveArgs(directive, false);
+    expect(inline.args).toEqual(["--append-system-prompt", directive]);
+    expect(inline.tmpFiles).toBeUndefined();
+
+    const viaFile = claudeDirectiveArgs(directive, true);
+    expect(viaFile.args[0]).toBe("--append-system-prompt-file");
+    expect(viaFile.args).toHaveLength(2);
+    // The whole point: what reaches the command line carries no newline for cmd.exe to cut on.
+    expect(viaFile.args[1]).not.toContain("\n");
+    expect(fs.readFileSync(viaFile.args[1], "utf8")).toBe(directive);
+    expect(viaFile.tmpFiles).toEqual([viaFile.args[1]]);
+    fs.rmSync(viaFile.args[1], { force: true });
+
+    expect(claudeDirectiveArgs("", true).args).toEqual([]);
+  });
+
+  test("claude-code: no grant and no permission flag is ever pushed behind the directive", () => {
+    try { fs.rmSync(path.join(CAP, "claude-args.json"), { force: true }); } catch { /* ignore */ }
+    const result = runHeadless({
+      runtime: "claude-code", prompt: "do the task", cwd: TMP, timeoutMs: 20_000,
+      appendSystemPrompt: "line one\nline two", addDirs: ["/tmp/grant-a", "/tmp/grant-b"],
+    });
+    expect(result.ok, result.error ?? result.stderr).toBe(true);
+    const args = readCapturedArgs(CAP, "claude");
+    // Which channel carried it is the platform's decision, read from the same resolver the
+    // driver used — not guessed, and not skipped on the system where it differs.
+    const flag = resolveExecutable("claude").shell ? "--append-system-prompt-file" : "--append-system-prompt";
+    const at = args.indexOf(flag);
+    expect(at).toBeGreaterThanOrEqual(0);
+    expect(args).toHaveLength(at + 2);   // the directive pair is last: nothing behind it to lose
+    expect(args.lastIndexOf("--add-dir")).toBeLessThan(at);
+    expect(args.indexOf("--dangerously-skip-permissions")).toBeLessThan(at);
+    expect(hasPair(args, ["--add-dir", "/tmp/grant-b"])).toBeTrue();
   });
 
   test("codex: --dangerously-bypass-approvals-and-sandbox by default; the workspace-write sandbox under =0", () => {

--- a/skills/harness/tests/gauntlet-evaluator-dispatch.e2e.test.ts
+++ b/skills/harness/tests/gauntlet-evaluator-dispatch.e2e.test.ts
@@ -11,7 +11,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
 import { EVALUATION_OUTPUTS_DIR, EVALUATION_RUBRIC_VERSION } from "../lib/gauntlet/evaluation-contract.ts";
@@ -23,7 +22,7 @@ import type { TargetRef } from "../lib/run-kernel/types.ts";
 import { canonicalRunIdFor } from "../scripts/dispatch.ts";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
-import { removeDir } from "./helpers/temp-dirs.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
@@ -73,7 +72,7 @@ const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) removeDir(root); });
 
 function fixture(installed: Record<string, string[]>) {
-  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gauntlet-evaluator-e2e-"))); roots.push(root);
+  const root = makeTempRoot("nrv-gauntlet-evaluator-e2e-"); roots.push(root);
   const home = path.join(root, "home");
   const projectRoot = path.join(root, "project");
   const bin = path.join(root, "bin");
@@ -134,15 +133,17 @@ describe("dispatch.ts selects and runs the Gauntlet evaluator", () => {
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({ verdict: "pass", costUsd: 0.2, gauntletId: "brief-conformance", rubricVersion: EVALUATION_RUBRIC_VERSION,
       evaluator: { kind: "squad", slug: "fixture-evaluator", capabilityId: CONFORMANCE } });
-    const projectRoot = path.join(fx.projectRoot, "outputs", "proj-env");
-    const evaluationDir = evaluationDirFor(projectRoot, canonicalRunIdFor("proj-env"), "crv_run_proj-env_can_1_1");
+    // Evaluations stay beside the candidates they judge, in the Run's WORKSPACE…
+    const workspaceRoot = path.join(fx.projectRoot, "outputs", "proj-env");
+    const evaluationDir = evaluationDirFor(workspaceRoot, canonicalRunIdFor("proj-env"), "crv_run_proj-env_can_1_1");
     expect(fs.existsSync(path.join(evaluationDir, EVALUATION_OUTPUTS_DIR, "scorecard.json"))).toBeTrue();
     expect(fs.readFileSync(path.join(evaluationDir, "evaluation-brief.md"), "utf8")).toContain("Produza o relatório final em report.html");
     const captured = JSON.parse(fs.readFileSync(path.join(evaluationDir, EVALUATION_OUTPUTS_DIR, "dispatch-capture.json"), "utf8")) as { argv: string[]; cwd: string };
     expect(captured.argv.slice(0, 2)).toEqual(["--squad", "fixture-evaluator"]);
     expect(captured.argv).toContain("--execution-mode=standard");
     expect(captured.argv[captured.argv.indexOf("--project") + 1]).toBe("proj-env-evl-crv_run_proj-env_can_1_1");
-    expect(captured.cwd).toBe(projectRoot);
+    // …while the evaluator dispatch itself runs in the PROJECT, like every other dispatch.
+    expect(captured.cwd).toBe(fx.projectRoot);
     const audit = fx.audit();
     expect(audit.filter(entry => entry.event === "x_gauntlet_evaluator_fallback")).toEqual([]);
     expect(audit.find(entry => entry.event === "x_gauntlet_evaluator_selected")).toMatchObject({ trace_id: "proj-env", source: "env",

--- a/skills/harness/tests/helpers/temp-dirs.ts
+++ b/skills/harness/tests/helpers/temp-dirs.ts
@@ -8,6 +8,8 @@
 // departing child the moment it needs to release its handles; a leak that
 // never resolves still throws, so nothing is masked.
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 const RETRYABLE = new Set(["EBUSY", "EPERM", "EACCES", "ENOTEMPTY"]);
 
@@ -20,4 +22,27 @@ export function removeDir(dir: string, attempts = 10, delayMs = 100): void {
       Bun.sleepSync(delayMs);
     }
   }
+}
+
+/**
+ * Create a temporary root and return it in the OS's CANONICAL form — the same
+ * form the engine answers with.
+ *
+ * `fs.realpathSync` is NOT enough, and the difference is invisible on macOS and
+ * Ubuntu. On Windows `os.tmpdir()` answers with an 8.3 SHORT path
+ * (`C:\Users\RUNNER~1\...` on the CI runner) and the JS resolver hands it
+ * straight back, while every project root inside the engine goes through
+ * `realpathSync.native` (run-ledger.ts `normalizeRoot`, paths.js `canonical`) —
+ * which is the resolver that expands 8.3. A fixture built on the short form then
+ * compares `C:\Users\RUNNER~1\…` against the engine's
+ * `C:\Users\runneradmin\…`: one directory, two strings, and an assertion that
+ * is green on two systems and red on the third.
+ *
+ * The macOS analogue is `/var` vs `/private/var`, which is why the fixtures
+ * already resolved at all — they just used the resolver that stops short of
+ * Windows. Both sides go through the same function here.
+ */
+export function makeTempRoot(prefix: string): string {
+  const created = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return fs.realpathSync.native ? fs.realpathSync.native(created) : fs.realpathSync(created);
 }

--- a/skills/harness/tests/judge-x-dispatch.e2e.test.ts
+++ b/skills/harness/tests/judge-x-dispatch.e2e.test.ts
@@ -8,7 +8,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { compileGauntletPlan } from "../lib/gauntlet/compiler.ts";
 import { EVALUATION_BRIEF_FILE, EVALUATION_REQUEST_FILE, SCORECARD_FILE, renderEvaluationBrief, type EvaluationRequest } from "../lib/gauntlet/evaluation-contract.ts";
@@ -16,7 +15,7 @@ import { JUDGE_X_BUDGET_EXHAUSTED_MARK } from "../lib/gauntlet/judge-x.ts";
 import { getRun, openKernel } from "../lib/run-kernel/index.ts";
 import { canonicalRunIdFor } from "../scripts/dispatch.ts";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
-import { removeDir } from "./helpers/temp-dirs.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
@@ -50,7 +49,7 @@ const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) removeDir(root); });
 
 function fixture() {
-  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "nrv-judge-x-e2e-"))); roots.push(root);
+  const root = makeTempRoot("nrv-judge-x-e2e-"); roots.push(root);
   const home = path.join(root, "home");
   const projectRoot = path.join(root, "project");
   const bin = path.join(root, "bin");
@@ -123,8 +122,10 @@ describe("dispatch.ts --judge-x", () => {
     const args = fx.judgeArgs();
     expect(args).not.toContain("--append-system-prompt");
     expect(args[args.indexOf("--max-budget-usd") + 1]).toBe("1.5");
-    expect(args.filter(arg => arg === "--add-dir")).toHaveLength(2);
-    expect(args).toContain(fx.candidateRoot);
+    // The judge's cwd is the PROJECT; its scaffold, its outputs root and the candidate it
+    // reads are the three granted directories.
+    const addDirs = args.filter((_, index) => args[index - 1] === "--add-dir");
+    expect(addDirs).toEqual([path.join(fx.projectRoot, "outputs", fx.projectId, "judge-x"), fx.outputsRoot, fx.candidateRoot]);
     // The candidate was only read; the outputs root holds the scorecard alone.
     expect(fs.readdirSync(fx.candidateRoot)).toEqual(["report.md"]);
     expect(fs.readdirSync(fx.outputsRoot)).toEqual([SCORECARD_FILE]);

--- a/skills/harness/tests/judge-x.test.ts
+++ b/skills/harness/tests/judge-x.test.ts
@@ -143,7 +143,9 @@ describe("runJudgeX", () => {
     });
     expect(result).toMatchObject({ ok: true, sessionId: "s-judge", costUsd: 0.8, budgetExhausted: false, promptPath: path.join(AGENTS_DIR, "judge-x.claude-code.md"), finalRuntime: "claude-code" });
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({ runtime: "claude-code", cwd: "/tmp/e/judge-x", addDirs: ["/tmp/e", "/tmp/cand"], maxBudgetUsd: 1.5, timeoutMs: 1000, yolo: true, projectId: "prj-evl", taskHint: "judge-x (Gauntlet evaluation)" });
+    // The judge runs INSIDE the project, with its scaffold, its outputs root and the
+    // candidate it reads granted as additional directories.
+    expect(calls[0]).toMatchObject({ runtime: "claude-code", cwd: "/tmp/e", addDirs: ["/tmp/e/judge-x", "/tmp/e/outputs", "/tmp/cand"], maxBudgetUsd: 1.5, timeoutMs: 1000, yolo: true, projectId: "prj-evl", taskHint: "judge-x (Gauntlet evaluation)" });
     expect(calls[0].appendSystemPrompt).toBeUndefined();
     expect(calls[0].ledger).toBeUndefined();
     expect(calls[0].prompt).toContain("# JUDGE-X DISPATCH");

--- a/skills/harness/tests/windows-spawn.test.ts
+++ b/skills/harness/tests/windows-spawn.test.ts
@@ -126,6 +126,19 @@ describe("quoteForCmd", () => {
     expect(quoteForCmd("")).toBe('""');
   });
 
+  test("a newline survives the quoting — which is exactly why it cannot be passed through cmd.exe", () => {
+    // quoteForCmd solves spaces and metacharacters. It cannot solve a newline, and nothing
+    // can: cmd.exe ends the command line at the first CR/LF whether or not the argument is
+    // quoted, so the limit is the parser, not the quoting. That is why the driver keeps its
+    // one multi-line argument OFF the command line entirely on this path — the directive
+    // travels as `--append-system-prompt-file <temp file>` (claudeDirectiveArgs), the same
+    // cure control-plane/maestro-turn.ts already used. This test states the constraint that
+    // cure exists to obey; pushing the directive last is only the belt to its braces.
+    const quoted = quoteForCmd("line one\nline two");
+    expect(quoted.startsWith('"')).toBe(true);
+    expect(quoted).toContain("\n");
+  });
+
   test("escapes embedded quotes instead of ending the argument early", () => {
     expect(quoteForCmd('say "hi"')).toBe('"say \\"hi\\""');
   });


### PR DESCRIPTION
## The defect, on a real run

`dispatch.ts` answered "which project is this?" **twice**: from the environment
on one line (`NIRVANA_PROJECT_ROOT`, else the invocation cwd) and by arithmetic
on two others — `resolve(projDir, "..", "..")`, climbing two levels out of the
scaffold the run had just created. The arithmetic is only right when the layout
is exactly `<project>/outputs/<pid>`, and the outputs root is a flag the user sets.

A squad dispatch on 27/08 with `--outputs-root` outside the project tree split
one trace's audit chain across **three** files:

| where | what landed there | why |
|---|---|---|
| `<project>/.nirvana/logs/harness/` | routing / brief events | emitted before the bind, from the launch cwd |
| `<project>/outputs/<pid>/.nirvana/logs/harness/` | dispatch + scaffold events | the bind used `projDir`, and the dispatch kernel creates a `.nirvana/` there, so the walk-up reads the scaffold as its own project |
| `~/.harness-logs/` | every `gate_passed` | `quality-gate.ts` anchors its audit on the artifact it was handed; an artifact outside any project has no root to find |

`nrv validate-chain` reads one place. That chain could not be audited. The child
runtime had been handed `addDirs: [~]` — the user's whole home as "the project" —
with its cwd inside the scaffold.

## What changed

**One resolver.** The project is resolved once, by the rule `_shared/lib/paths.js`
already gives the supervisor, the config, multi-target and the runtime snapshot:
`NIRVANA_PROJECT_ROOT` when named, else the invocation cwd walked up to its
marker. Never derived from the outputs root. Where a path really is
scaffold-shaped — `brief.md`, the dispatch kernel, the Gauntlet's candidate and
evaluation directories — the variable is `scaffoldRoot` and the Gauntlet inputs
take it as `workspaceRoot`, so **nothing moved on disk** and `nrv clean <pid>`
still takes the scratch with it.

**The runtime runs inside the project**, on every dispatch path: business
single-shot and Gauntlet canary, squad, team step, agent-x, judge-x, the report
publisher, the revision run, `nrv revise`, and the supervisor's auto-redispatch.
`cwd` is the project root; the scaffold and the outputs root are granted as
additional directories, so the outputs root stays writable and the agent finally
sees the project's `.nirvana/`, its local config, its own trace's logs and the
code-base. The gate and verify children are told which project they belong to
(`HARNESS_LOGS_DIR`, still overridable) instead of re-deriving it from the file
they are judging.

**Two paths deliberately stay outside the project**, and were left alone: the
team director (`team-orchestrator.ts`, `cwd: os.tmpdir()`) is a text-only
planning call with no file access, and the agentic verifier
(`_shared/lib/verify/agentic.ts`) runs in an isolated staging directory on
purpose — seeing the project would defeat the isolation.

## The test

`skills/harness/tests/dispatch-project-root.e2e.test.ts` is the real run: a squad
dispatch with the outputs root outside the project tree, asserting every event of
the trace lands in one log, the child's cwd is the project root, and the outputs
root still receives the deliverable and arrives as `--add-dir`. Against the old
code it fails on all three counts (the diagnostic run reproduced the three-way
split verbatim).

## Verification

- `bun test skills/harness/tests` — 1384 pass · 4 skip · 1 fail, the fail being
  `buyer-path.test.ts` (`Cannot find package 'yaml'`), the known worktree
  `node_modules`-symlink failure.
- `bun test skills/businesses/tests skills/squads/tests` — 194 pass · 0 fail.
- Gates green: `check-audit-parity --strict`, `check-dispatch-contract`,
  `check-english-source --strict`, `check-changelog-parity --strict`,
  `check-engine-purity`, `check-scope-guard --strict`, `git diff --check`.
- Three contract tests were updated because they pinned the behaviour the owner
  decided to change (`judge-x.test.ts`, `judge-x-dispatch.e2e.test.ts`,
  `gauntlet-evaluator-dispatch.e2e.test.ts`). `dispatch-standard-kernel.e2e`'s
  exit codes 0/1/2/3 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)