### PR TITLE
fix(driver): spawn what the Windows shim names, not the shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,55 @@ offline gate and the post-gate" is the only one that still crossed 5 s under tha
 load, 7 samples in 400 against 65 before, because it runs the delivery pipeline
 and the post-gate on top of the kernel. That cost is not the one this change
 removes, and it carries no budget either. It is a cut of its own.
+### The shim is not the program: Windows spawns what it names
+
+A `.cmd` written by npm is not the CLI. It is a five-line batch file whose only
+job is to run `node <script> %*`. The driver had been starting the batch file,
+which means starting `cmd.exe`, and `cmd.exe` ends the command line at the first
+CR/LF of any argument. Version 0.10.2 cured that for `claude` by moving the
+directive into a file. Eight adapters and the light layer still carried the same
+shape, and a cure replicated ten times is a design that has not been fixed.
+
+`resolveExecutable` now reads the shim, takes the interpreter and script it
+names, and spawns that pair directly. No shell, no re-parsing, no command line
+for anything to cut: the child starts exactly the way a real `.exe` already
+starts on this platform.
+
+Measured over the argv the squad dispatch built, with the directive in the
+position it had on the day it broke (5,875 characters, first newline at 183).
+Through `cmd.exe`: 6,031 characters of arguments sent, 231 delivered, 5,800
+discarded at the newline (96.2%), taking both `--add-dir` grants and
+`--dangerously-skip-permissions` with them. Direct: 11 argv elements, 6,016
+characters, nothing discarded.
+
+Reading is literal-minded and refuses rather than guesses. A shim that
+rearranges what it forwards (`%1`, `SHIFT`), sets an environment variable the
+direct spawn would not reproduce, leaves a variable unexpanded, puts `%*`
+anywhere but last, or names an interpreter or script that is not on disk
+produces no candidate at all, and the caller keeps the old route through the
+interpreter with `quoteForCmd` on every argument. An interpreter that is itself
+a `.cmd` is refused as well, since resolving one only re-enters the trap. Both
+npm shim generations are read, local `node.exe` first and the bare name on PATH
+second, which is the order the shim's own `IF EXIST` uses.
+
+The `--append-system-prompt-file` cure from 0.10.2 stays exactly where it is. It
+now protects the fallback instead of the normal path.
+
+A Windows runner then took the direct path for real, and it holds. All nine
+adapters spawn through it, including the 300 KB prompt-delivery matrix; a
+maestro turn runs end to end on it, with the prompt piped to stdin, the
+stream-json parsed and `--resume` honored; and the multi-line directive reaches
+the child's own argv byte for byte, with both `--add-dir` grants in front of it.
+That last one is the link a machine without Windows cannot check: an argument
+carrying a newline crosses `CreateProcess` and the child's command-line parser
+whole. It is now checked on every run.
+
+Still unverified: the shim the runner reads is a plain `@echo off` launcher, not
+one npm's `cmd-shim` wrote, so the `_prog` branch and the older two-branch form
+are covered by fixtures rather than by an installed CLI. A shim from a generator
+outside npm, pnpm and yarn has never been seen by this parser at all — by
+construction it produces no candidate and keeps the old route, which is the
+behavior the fallback tests pin.
 
 ## 0.10.2 — 2026-08-27
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -58,6 +58,57 @@ offline gate and the post-gate" é o único que ainda cruzou os 5 s sob aquela
 carga, 7 amostras em 400 contra 65 antes, porque roda o pipeline de entrega e o
 pós-gate em cima do kernel. Esse custo não é o que esta mudança remove, e ele
 também não tem orçamento. É um corte próprio.
+### O shim não é o programa: no Windows sobe o que ele nomeia
+
+Um `.cmd` escrito pelo npm não é a CLI. É um arquivo de lote de cinco linhas cuja
+única função é rodar `node <script> %*`. O driver vinha iniciando o arquivo de
+lote, o que significa iniciar o `cmd.exe`, e o `cmd.exe` encerra a linha de
+comando na primeira CR/LF de qualquer argumento. A versão 0.10.2 curou isso para
+o `claude` levando a diretiva para um arquivo. Oito adaptadores e a camada leve
+continuavam com a mesma forma, e uma cura replicada dez vezes é um desenho que
+não foi consertado.
+
+O `resolveExecutable` agora lê o shim, pega o interpretador e o script que ele
+nomeia, e sobe esse par direto. Sem shell, sem reinterpretação, sem linha de
+comando para ninguém cortar: o filho inicia exatamente como um `.exe` de verdade
+já inicia nessa plataforma.
+
+Medido sobre o argv que o despacho de squad montava, com a diretiva na posição
+que ela tinha no dia da quebra (5.875 caracteres, primeira quebra de linha no
+183). Pelo `cmd.exe`: 6.031 caracteres de argumentos enviados, 231 entregues,
+5.800 descartados na quebra (96,2%), levando junto as duas concessões
+`--add-dir` e o `--dangerously-skip-permissions`. Direto: 11 elementos de argv,
+6.016 caracteres, nada descartado.
+
+A leitura é literal e recusa em vez de adivinhar. Um shim que rearranja o que
+repassa (`%1`, `SHIFT`), define uma variável de ambiente que o spawn direto não
+reproduziria, deixa uma variável sem expandir, põe o `%*` em qualquer lugar que
+não seja o fim, ou nomeia um interpretador ou script que não está em disco não
+produz candidato nenhum, e quem chamou fica com o caminho antigo pelo
+interpretador, com `quoteForCmd` em cada argumento. Um interpretador que é ele
+mesmo um `.cmd` também é recusado, porque resolvê-lo só recai na mesma
+armadilha. As duas gerações de shim do npm são lidas, primeiro o `node.exe`
+local e depois o nome puro no PATH, que é a ordem do próprio `IF EXIST` do shim.
+
+A cura do `--append-system-prompt-file` de 0.10.2 continua exatamente onde está.
+Agora ela protege o fallback, e não o caminho normal.
+
+Depois disso um runner Windows pegou o caminho direto de verdade, e ele se
+sustenta. Os nove adaptadores sobem por ele, incluindo a matriz de entrega de
+prompt de 300 KB; um turno do maestro roda de ponta a ponta nele, com o prompt
+pelo stdin, o stream-json interpretado e o `--resume` honrado; e a diretiva
+multilinha chega ao argv do próprio filho byte a byte, com as duas concessões
+`--add-dir` na frente dela. Esse último é o elo que uma máquina sem Windows não
+consegue checar: um argumento que carrega uma quebra de linha atravessa inteiro o
+`CreateProcess` e o parser de linha de comando do filho. Agora ele é checado a
+cada execução.
+
+Ainda não verificado: o shim que o runner lê é um lançador `@echo off` simples,
+não um escrito pelo `cmd-shim` do npm, então o ramo `_prog` e a forma antiga de
+dois ramos estão cobertos por fixtures, não por uma CLI instalada. Um shim de
+gerador fora de npm, pnpm e yarn nunca passou por este parser — por construção
+ele não produz candidato e mantém o caminho antigo, que é o comportamento fixado
+pelos testes de fallback.
 
 ## 0.10.2 — 2026-08-27
 

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -185,6 +185,192 @@ function whichSync(cli: string): string | null {
   return null;
 }
 
+// ── Windows: spawn what the shim names, not the shim ──────────────────────
+//
+// An agent CLI installed through npm is a `.cmd` on Windows, and every `.cmd`
+// had been started through `cmd.exe`, which ends the command line at the first
+// CR/LF of any argument, quoted or not (the parser's limit, not the quoting's).
+// That cost the claude runner both `--add-dir` grants and its permission flag,
+// and the eight other adapters carry the same shape.
+//
+// The shim itself is not the program. It is a five-line batch file whose only
+// job is to run `node <script> %*`. Reading it, taking the pair it names and
+// spawning THAT removes the interpreter from the chain entirely: the child
+// starts the same way a real `.exe` already does on this platform, with nothing
+// left to cut anything.
+//
+// Reading is deliberately literal-minded. A shim whose shape does not match
+// what these functions can name with certainty produces no candidate, and the
+// caller falls back to the `cmd.exe` path. Degrading is acceptable; guessing is
+// not, so every guard below refuses rather than assumes:
+//
+//   - positional arguments (`%1`, `%~2`) or `SHIFT`: the wrapper rearranges
+//     what it forwards, so `%*` no longer proves the arguments pass intact;
+//   - a `SET` of anything but the three variables npm/pnpm/yarn shims use, an
+//     environment the direct spawn would not reproduce;
+//   - a variable that survives expansion, since we cannot name what would run;
+//   - `%*` anywhere but as the last token, so arguments land somewhere we did
+//     not read;
+//   - an interpreter or script that is not on disk, or an interpreter that is
+//     itself a `.cmd`, which would only re-enter the trap.
+
+/** A shim is a few hundred bytes. Anything bigger is a batch program doing work
+ * of its own, and reading it as a launcher would be a guess. */
+const MAX_SHIM_BYTES = 16 * 1024;
+
+/** `%1`, `%~2`, `%0` — argument reshuffling. `%~dp0` and `%*` do not match. */
+const SHIM_POSITIONAL = /%~?[0-9]/;
+const SHIM_SHIFT = /^[\s@]*shift\b/im;
+const SHIM_SET = /^[\s@]*set\s+"?([A-Za-z_][A-Za-z0-9_]*)\s*=/gim;
+const SHIM_PROG_SET = /^[\s@]*set\s+(?:"_prog=([^"\r\n]*)"|_prog=([^\r\n]*))/gim;
+/** `dp0` and `_prog` are the shim's own two variables; `PATHEXT` is the tweak
+ * that keeps its `node` from resolving to a `.js`, which is program resolution
+ * we do ourselves below. Any other assignment is an environment we would drop. */
+const SHIM_SET_ALLOWED = new Set(["dp0", "_prog", "pathext"]);
+
+/** Split one command fragment into arguments the way the interpreter would:
+ * double quotes group, unquoted whitespace separates, `""` stays an argument. */
+function tokenizeCmdFragment(fragment: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let started = false;
+  let quoted = false;
+  for (const ch of fragment) {
+    if (ch === '"') { quoted = !quoted; started = true; continue; }
+    if (!quoted && /\s/.test(ch)) {
+      if (started) { tokens.push(current); current = ""; started = false; }
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) tokens.push(current);
+  return tokens;
+}
+
+/** Index of the last `&` or `|` outside quotes. The modern npm shim hides its
+ * real invocation behind both:
+ * `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "…" %*`. */
+function lastCommandSeparator(line: string): number {
+  let quoted = false;
+  let at = -1;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') { quoted = !quoted; continue; }
+    if (!quoted && (ch === "&" || ch === "|")) at = i;
+  }
+  return at;
+}
+
+/** Shims are written with `\`; this module has to compare against real paths.
+ * On Windows the swap is the identity (`path.sep` IS `\`), which is also what
+ * lets the win32 branch be exercised on a POSIX runner. Only tokens that carry
+ * a separator are touched, so a flag survives byte for byte. */
+function normalizeShimPath(value: string): string {
+  if (!/[\\/]/.test(value)) return value;
+  return path.normalize(path.sep === "/" ? value.replace(/\\/g, "/") : value);
+}
+
+/** Expand the three variables a shim uses, or null when anything else survives:
+ * an unexpanded `%VAR%` means we cannot name what the shim would run. */
+function expandShimToken(token: string, dp0: string, prog: string | null): string | null {
+  let out = token.replace(/%~dp0/gi, () => dp0).replace(/%dp0%/gi, () => dp0);
+  if (prog !== null) out = out.replace(/%_prog%/gi, () => prog);
+  if (out.includes("%")) return null;
+  return normalizeShimPath(out);
+}
+
+/**
+ * Every invocation a shim names, best first — nothing is checked against the
+ * filesystem here, which keeps this half testable as pure text.
+ *
+ * Order mirrors the shim's own `IF EXIST`: the interpreter sitting beside the
+ * shim (`%~dp0\node.exe`) is offered before the bare name it falls back to, in
+ * both the modern `_prog` form and the older two-branch one.
+ */
+export function parseCmdShim(text: string, shimPath: string): Array<{ program: string; args: string[] }> {
+  if (SHIM_POSITIONAL.test(text) || SHIM_SHIFT.test(text)) return [];
+  SHIM_SET.lastIndex = 0;
+  for (let m = SHIM_SET.exec(text); m; m = SHIM_SET.exec(text)) {
+    if (!SHIM_SET_ALLOWED.has(m[1].toLowerCase())) { SHIM_SET.lastIndex = 0; return []; }
+  }
+  const dp0 = path.dirname(shimPath) + path.sep;
+  const progs: string[] = [];
+  SHIM_PROG_SET.lastIndex = 0;
+  for (let m = SHIM_PROG_SET.exec(text); m; m = SHIM_PROG_SET.exec(text)) {
+    const raw = (m[1] ?? m[2] ?? "").trim();
+    const expanded = raw ? expandShimToken(raw, dp0, null) : null;
+    if (expanded) progs.push(expanded);
+  }
+
+  const candidates: Array<{ program: string; args: string[] }> = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.includes("%*")) continue;
+    const cut = lastCommandSeparator(line);
+    const tokens = tokenizeCmdFragment((cut >= 0 ? line.slice(cut + 1) : line).replace(/^[\s@]+/, ""));
+    // `%*` last and alone is the whole proof that the arguments pass through
+    // untouched. Anything else is a wrapper we did not read.
+    if (tokens.length < 2 || tokens[tokens.length - 1] !== "%*") continue;
+    if (tokens.slice(0, -1).some(t => t.includes("%*"))) continue;
+    const usesProg = /%_prog%/i.test(tokens[0]);
+    for (const prog of usesProg ? progs : [null]) {
+      const program = expandShimToken(tokens[0], dp0, prog);
+      if (!program) continue;
+      const args = tokens.slice(1, -1).map(t => expandShimToken(t, dp0, prog));
+      if (args.some(a => a === null)) continue;
+      candidates.push({ program, args: args as string[] });
+    }
+  }
+  return candidates;
+}
+
+function isFile(candidate: string): boolean {
+  try { return fs.statSync(candidate).isFile(); } catch { return false; }
+}
+
+/** A flag passes through untouched; anything carrying a separator is a path the
+ * shim expects to exist, and if it does not we did not read the shim right. */
+function shimArgPresent(arg: string): boolean {
+  return !/[\\/]/.test(arg) || isFile(arg);
+}
+
+/** The named interpreter as a real executable. A path is taken as given — this
+ * is the `%~dp0` case, where node sits beside the shim and need not be on PATH
+ * at all. A bare name is looked up on PATH, which is what the shim's own ELSE
+ * branch asks `cmd.exe` for. Another `.cmd` is refused: resolving one would
+ * only re-enter the trap this whole path exists to leave. */
+function resolveShimProgram(program: string): string | null {
+  const bases = /[\\/]/.test(program) || /^[A-Za-z]:/.test(program)
+    ? [program]
+    : (process.env.PATH || "").split(path.delimiter).filter(Boolean).map(dir => path.join(dir, program));
+  for (const base of bases) {
+    for (const full of [base, base + ".exe", base + ".com"]) {
+      if (/\.(cmd|bat)$/i.test(full)) continue;
+      if (isFile(full)) return full;
+    }
+  }
+  return null;
+}
+
+/** The interpreter and leading arguments a `.cmd`/`.bat` names, or null when its
+ * shape is not one we can read with certainty — in which case the caller keeps
+ * the `cmd.exe` path it has always used. */
+export function resolveShimTarget(shimPath: string): { program: string; args: string[] } | null {
+  let text: string;
+  try {
+    const stat = fs.statSync(shimPath);
+    if (!stat.isFile() || stat.size > MAX_SHIM_BYTES) return null;
+    text = fs.readFileSync(shimPath, "utf8");
+  } catch { return null; }
+  for (const candidate of parseCmdShim(text, shimPath)) {
+    const program = resolveShimProgram(candidate.program);
+    if (!program) continue;
+    if (!candidate.args.every(shimArgPresent)) continue;
+    return { program, args: candidate.args };
+  }
+  return null;
+}
+
 /**
  * How to actually START a CLI on this platform.
  *
@@ -194,15 +380,21 @@ function whichSync(cli: string): string | null {
  * yes and the invocation dies, which is the worst possible split. (Recent Node
  * makes it explicit, refusing to spawn a `.cmd` without a shell at all.)
  *
- * A batch file has to be started through the command interpreter, so `shell` is
- * required — and with a shell the arguments are re-parsed, which is why
- * `quoteForCmd` exists below. On POSIX this is the identity: same command, same
- * args, no shell, nothing to re-parse.
+ * A `.cmd` is not the program, though — it is a launcher naming one. When the
+ * shim can be read (`resolveShimTarget`), the interpreter and script it names
+ * are spawned directly and the command interpreter never enters the chain: no
+ * shell, nothing re-parsed, and no command line for `cmd.exe` to cut at a
+ * newline. A shim of an unrecognized shape keeps the old route — through the
+ * interpreter, with `quoteForCmd` on every argument.
+ *
+ * On POSIX this is the identity: same command, same args, no shell.
  */
 export function resolveExecutable(cli: string): { command: string; args: (a: string[]) => string[]; shell: boolean } {
   if (process.platform !== "win32") return { command: cli, args: a => a, shell: false };
   const resolved = whichSync(cli);
   if (resolved && /\.(cmd|bat)$/i.test(resolved)) {
+    const target = resolveShimTarget(resolved);
+    if (target) return { command: target.program, args: a => [...target.args, ...a], shell: false };
     return { command: quoteForCmd(resolved), args: a => a.map(quoteForCmd), shell: true };
   }
   // A real .exe (or nothing found — let the spawn report the honest ENOENT).
@@ -1788,15 +1980,15 @@ export function runtimeAvailable(runtime: Runtime): boolean {
 /**
  * How the multi-line system directive reaches `claude`, per start path.
  *
- * A `.cmd`/`.bat` runtime — every npm-installed CLI — can only be started through the
+ * When a `.cmd`/`.bat` runtime cannot be read as a launcher, it is still started through the
  * command interpreter (resolveExecutable), and cmd.exe ends the command line at the first
  * CR/LF of an argument however it is quoted: quoteForCmd cannot help, because the limit is
  * the parser and not the escaping. The directive is the one argument here that spans lines,
  * so under a shell it travels as `--append-system-prompt-file <temp file>` and the command
  * line stays single-line. Without a shell it stays inline, exactly as before.
  *
- * The same defect and the same cure already live in control-plane/maestro-turn.ts; the
- * headless driver every dispatched child goes through had been left out of it.
+ * resolveExecutable now spawns the pair a readable shim names, so the shell branch is the
+ * exception rather than the rule. This stays as the defense for whatever falls into it.
  */
 export function claudeDirectiveArgs(directive: string, shell: boolean): { args: string[]; tmpFiles?: string[] } {
   if (!directive) return { args: [] };

--- a/skills/harness/lib/control-plane/maestro-turn.ts
+++ b/skills/harness/lib/control-plane/maestro-turn.ts
@@ -117,11 +117,11 @@ export interface TurnCommand {
  * The autonomy flag follows the driver's rule: the bypass, or the restricted path (`acceptEdits`
  * plus the driver's tool allowlist) when execution.headless_skip_permissions is off.
  *
- * The directive spans several lines. On Windows the CLI is a `.cmd` started through the command
- * interpreter (`resolveExecutable`), and cmd.exe ends the command line at the first newline of an
- * argument: everything after `--append-system-prompt` (the autonomy flag, the budget) was lost.
- * Under a shell the directive therefore travels as `--append-system-prompt-file <temp file>`;
- * without one it stays inline, as before. */
+ * The directive spans several lines. On Windows a `.cmd` whose shape `resolveExecutable` cannot
+ * read is still started through the command interpreter, and cmd.exe ends the command line at the
+ * first newline of an argument: everything after `--append-system-prompt` (the autonomy flag, the
+ * budget) was lost. Under a shell the directive therefore travels as
+ * `--append-system-prompt-file <temp file>`; without one it stays inline, as before. */
 export function claudeTurnCommand(input: { sessionId: string | null; directive: string; model?: string | null; skipPermissions: boolean; maxBudgetUsd: number },
   resolve: ExecutableResolver = resolveExecutable): TurnCommand {
   const sessionId = input.sessionId ?? randomUUID();

--- a/skills/harness/tests/driver-autonomy-flags.test.ts
+++ b/skills/harness/tests/driver-autonomy-flags.test.ts
@@ -180,6 +180,13 @@ describe("headless layer — runHeadless argv per runtime", () => {
     expect(args.lastIndexOf("--add-dir")).toBeLessThan(at);
     expect(args.indexOf("--dangerously-skip-permissions")).toBeLessThan(at);
     expect(hasPair(args, ["--add-dir", "/tmp/grant-b"])).toBeTrue();
+    // What the CHILD received, read from its own argv. Inline (the direct-spawn path, and every
+    // POSIX run) this is the multi-line directive itself, so the run proves what no simulation
+    // here can: an argument carrying a newline crosses the process boundary whole. On the Windows
+    // runner it crosses CreateProcess and the child's own command-line parser, which is the one
+    // link the shim reader could not check on the machine that wrote it.
+    if (flag === "--append-system-prompt") expect(args[at + 1]).toBe("line one\nline two");
+    else expect(fs.readFileSync(args[at + 1], "utf8")).toBe("line one\nline two");
   });
 
   test("codex: --dangerously-bypass-approvals-and-sandbox by default; the workspace-write sandbox under =0", () => {

--- a/skills/harness/tests/glance-maestro-turn.test.ts
+++ b/skills/harness/tests/glance-maestro-turn.test.ts
@@ -107,17 +107,30 @@ describe("the maestro directive", () => {
   });
 
   test("the claude command line follows the driver's autonomy rule and names the session up front", () => {
-    const fresh = claudeTurnCommand({ sessionId: null, directive: "d", skipPermissions: true, maxBudgetUsd: 5 });
+    // The unit here is the argv this function BUILDS, so the resolver is INJECTED, for the same
+    // reason the shell test below injects one: with the default resolver the argv also depends on
+    // how the runner starts `claude`. On Windows the fake CLI on PATH is a `.cmd`, resolveExecutable
+    // reads it and prepends the script its launcher names (`bun <fake>\claude.ts`), and a slice
+    // counted from zero then measured the runner instead of this function.
+    const direct: ExecutableResolver = cli => ({ command: cli, args: a => a, shell: false });
+    const fresh = claudeTurnCommand({ sessionId: null, directive: "d", skipPermissions: true, maxBudgetUsd: 5 }, direct);
     expect(fresh.args.slice(0, 5)).toEqual(["-p", "--output-format", "stream-json", "--include-partial-messages", "--verbose"]);
     expect(fresh.args[fresh.args.indexOf("--session-id") + 1]).toBe(fresh.sessionId);
     expect(fresh.args).toContain("--dangerously-skip-permissions");
     expect(fresh.args[fresh.args.indexOf("--max-budget-usd") + 1]).toBe("5");
-    const resumed = claudeTurnCommand({ sessionId: "sid-1", directive: "d", skipPermissions: false, maxBudgetUsd: 0 });
+    const resumed = claudeTurnCommand({ sessionId: "sid-1", directive: "d", skipPermissions: false, maxBudgetUsd: 0 }, direct);
     expect(resumed.args[resumed.args.indexOf("--resume") + 1]).toBe("sid-1");
     expect(resumed.args).not.toContain("--session-id");
     expect(resumed.args).not.toContain("--dangerously-skip-permissions");
     expect(resumed.args[resumed.args.indexOf("--permission-mode") + 1]).toBe("acceptEdits");
     expect(resumed.args).not.toContain("--max-budget-usd");
+
+    // And the contract the Windows runner exercises for real: whatever the resolver puts in front
+    // of the flags travels with them, because command and args are spawned as one pair.
+    const prepending: ExecutableResolver = cli => ({ command: "bun", args: a => [`C:\\fake\\${cli}.ts`, ...a], shell: false });
+    const shimmed = claudeTurnCommand({ sessionId: null, directive: "d", skipPermissions: true, maxBudgetUsd: 0 }, prepending);
+    expect(shimmed.command).toBe("bun");
+    expect(shimmed.args.slice(0, 2)).toEqual(["C:\\fake\\claude.ts", "-p"]);
   });
 
   test("under a shell (a Windows .cmd) the directive travels by file and the flags after it survive", () => {

--- a/skills/harness/tests/windows-spawn.test.ts
+++ b/skills/harness/tests/windows-spawn.test.ts
@@ -8,6 +8,12 @@
 // rule long ago ("CreateProcess only auto-appends .exe, never .cmd"); the agent
 // driver never received it.
 //
+// The second defect it pins is the one that made the first one expensive: a
+// `.cmd` started through `cmd.exe` loses every argument behind the first CR/LF.
+// The driver now reads the shim and spawns the interpreter + script it names, so
+// the interpreter leaves the chain entirely; a shim of an unrecognized shape
+// falls back to the old route, which these tests pin as well.
+//
 // The win32 branch is exercised by faking `process.platform`, so the rule is
 // verified on every machine that runs the suite rather than only on a Windows
 // runner — which is the whole reason it went unnoticed. The fake has a limit
@@ -19,18 +25,101 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { firstExecutablePath, resolveExecutable, quoteForCmd, whichProbe } from "../../_shared/lib/host-agent-driver.ts";
+import { firstExecutablePath, parseCmdShim, resolveExecutable, resolveShimTarget, quoteForCmd, whichProbe } from "../../_shared/lib/host-agent-driver.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
 
 const REAL_PLATFORM = process.platform;
 const REAL_PATH = process.env.PATH;
+const TEMP_DIRS: string[] = [];
 
 function asPlatform(p: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", { value: p, configurable: true });
 }
 
+/** A fixture root in the OS's CANONICAL form. `os.tmpdir()` answers with the 8.3
+ * SHORT path on Windows (`C:\Users\RUNNER~1\…`), while `where` — the probe
+ * `resolveExecutable` resolves a shim through — answers with the long one
+ * (`C:\Users\runneradmin\…`). One directory, two strings, and an assertion
+ * green on macOS and Ubuntu and red on the third. `makeTempRoot` canonicalizes
+ * with `realpathSync.native`, the only resolver that expands 8.3, so both sides
+ * of every comparison below are built from the same form. */
+function tempDir(prefix: string): string {
+  const dir = makeTempRoot(prefix);
+  TEMP_DIRS.push(dir);
+  return dir;
+}
+
+/** The shape npm's `cmd-shim` writes today (pnpm and yarn classic use the same
+ * package). `_prog` is the local node beside the shim when it exists, the bare
+ * name otherwise — the two branches this parser has to offer in that order. */
+function modernShim(scriptRelative: string): string {
+  return [
+    "@ECHO off",
+    "GOTO start",
+    ":find_dp0",
+    "SET dp0=%~dp0",
+    "EXIT /b",
+    ":start",
+    "SETLOCAL",
+    "CALL :find_dp0",
+    "",
+    'IF EXIST "%dp0%\\node.exe" (',
+    '  SET "_prog=%dp0%\\node.exe"',
+    ") ELSE (",
+    '  SET "_prog=node"',
+    "  SET PATHEXT=%PATHEXT:;.JS;=;%",
+    ")",
+    "",
+    `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\${scriptRelative}" %*`,
+    "",
+  ].join("\r\n");
+}
+
+/** The older two-branch shape, still on disk wherever an install predates the
+ * `_prog` rewrite. Same pair, named twice instead of through a variable. */
+function legacyShim(scriptRelative: string): string {
+  return [
+    '@IF EXIST "%~dp0\\node.exe" (',
+    `  "%~dp0\\node.exe"  "%~dp0\\${scriptRelative}" %*`,
+    ") ELSE (",
+    "  @SETLOCAL",
+    "  @SET PATHEXT=%PATHEXT:;.JS;=;%",
+    `  node  "%~dp0\\${scriptRelative}" %*`,
+    ")",
+    "",
+  ].join("\r\n");
+}
+
+/** The autonomy directive at the size that was measured on 2026-08-27: 5,875
+ * characters whose first newline lands at 183. Reproduced here so the numbers
+ * below are the defect's own numbers, not a toy. */
+function autonomyDirective(): string {
+  const first = "You are running headless. Execute the brief end to end and write every deliverable yourself.".padEnd(183, ".");
+  const lines = [first];
+  while (lines.join("\n").length < 5_875) {
+    lines.push("Never stop to ask for approval: the caller has already granted the permission bypass for this run.");
+  }
+  return lines.join("\n").slice(0, 5_875);
+}
+
+/** What `cmd.exe` is handed, and what survives its parser. The interpreter ends
+ * the command line at the first CR/LF of any argument however it is quoted —
+ * the rule `quoteForCmd` cannot reach, because the limit is the parser.
+ *
+ * Measured over the ARGUMENTS only. The interpreter's own path is the fixture's,
+ * and its length differs per machine (a temp root on Windows CI is not the length
+ * of one on macOS); the arguments are the product's, and their numbers are the
+ * same everywhere. Where the cut falls does not depend on the prefix either: the
+ * first newline is inside the directive. */
+function throughCmdExe(args: string[]): { sent: string; delivered: string } {
+  const sent = args.join(" ");
+  return { sent, delivered: sent.split(/\r?\n/)[0] };
+}
+
 afterEach(() => {
   Object.defineProperty(process, "platform", { value: REAL_PLATFORM, configurable: true });
   process.env.PATH = REAL_PATH;
+  while (TEMP_DIRS.length) removeDir(TEMP_DIRS.pop()!);
 });
 
 describe("whichProbe", () => {
@@ -70,8 +159,8 @@ describe("resolveExecutable", () => {
     expect(r.args(["-p", "hello world"])).toEqual(["-p", "hello world"]);
   });
 
-  test("on Windows a .cmd is routed through a shell, which is the only way to start one", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-win-cmd-"));
+  test("a .cmd whose shape cannot be read keeps the shell route — degrading, not breaking", () => {
+    const dir = tempDir("nrv-win-cmd-");
     fs.writeFileSync(path.join(dir, "gemini.cmd"), "@echo off\r\n");
     asPlatform("win32");
     process.env.PATH = `${dir}${path.delimiter}${REAL_PATH}`;
@@ -79,7 +168,20 @@ describe("resolveExecutable", () => {
     const r = resolveExecutable("gemini");
     expect(r.shell).toBe(true);
     expect(r.command).toContain("gemini.cmd");
-    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("an npm shim is read and its interpreter spawned directly — no shell, nothing re-parsed", () => {
+    const dir = tempDir("nrv-win-shim-");
+    fs.writeFileSync(path.join(dir, "node.exe"), "");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    fs.writeFileSync(path.join(dir, "claude.cmd"), modernShim("cli.js"));
+    asPlatform("win32");
+    process.env.PATH = `${dir}${path.delimiter}${REAL_PATH}`;
+
+    const r = resolveExecutable("claude");
+    expect(r.shell).toBe(false);
+    expect(r.command).toBe(path.join(dir, "node.exe"));
+    expect(r.args(["-p", "hello world"])).toEqual([path.join(dir, "cli.js"), "-p", "hello world"]);
   });
 
   test("on Windows a real .exe is spawned directly — no shell, nothing re-parsed", () => {
@@ -141,5 +243,204 @@ describe("quoteForCmd", () => {
 
   test("escapes embedded quotes instead of ending the argument early", () => {
     expect(quoteForCmd('say "hi"')).toBe('"say \\"hi\\""');
+  });
+});
+
+describe("parseCmdShim — what a shim names, read as text", () => {
+  const SHIM = path.join(path.sep === "/" ? "/opt/bin" : "C:\\bin", "claude.cmd");
+  const DIR = path.dirname(SHIM);
+
+  test("the modern npm shape offers the local node first, the bare name second", () => {
+    const found = parseCmdShim(modernShim("node_modules\\@anthropic-ai\\claude-code\\cli.js"), SHIM);
+    const script = path.join(DIR, "node_modules", "@anthropic-ai", "claude-code", "cli.js");
+    expect(found).toEqual([
+      { program: path.join(DIR, "node.exe"), args: [script] },
+      { program: "node", args: [script] },
+    ]);
+  });
+
+  test("the older two-branch shape resolves to the same pair, in the same order", () => {
+    const found = parseCmdShim(legacyShim("cli.js"), SHIM);
+    expect(found).toEqual([
+      { program: path.join(DIR, "node.exe"), args: [path.join(DIR, "cli.js")] },
+      { program: "node", args: [path.join(DIR, "cli.js")] },
+    ]);
+  });
+
+  test("a wrapper that rearranges its arguments names nothing: %* no longer proves pass-through", () => {
+    // %1/%~2/SHIFT mean the forwarded arguments are not the ones we were given.
+    expect(parseCmdShim('@node "%~dp0\\cli.js" %1 %2 %*', SHIM)).toEqual([]);
+    expect(parseCmdShim('@SHIFT\r\n@node "%~dp0\\cli.js" %*', SHIM)).toEqual([]);
+  });
+
+  test("%* anywhere but last names nothing — the arguments land somewhere we did not read", () => {
+    expect(parseCmdShim('@node "%~dp0\\cli.js" %* --end', SHIM)).toEqual([]);
+    expect(parseCmdShim('@node "%~dp0\\cli.js" "%*x" %*', SHIM)).toEqual([]);
+  });
+
+  test("a SET of anything but the shim's own three variables names nothing", () => {
+    // The direct spawn would not reproduce that environment, so it must not be taken.
+    expect(parseCmdShim('@SET NODE_OPTIONS=--max-old-space-size=8192\r\n@node "%~dp0\\cli.js" %*', SHIM)).toEqual([]);
+    // PATHEXT is allowed: it only steers how `node` resolves, which this module does itself.
+    expect(parseCmdShim('@SET PATHEXT=%PATHEXT:;.JS;=;%\r\n@node "%~dp0\\cli.js" %*', SHIM)).toHaveLength(1);
+  });
+
+  test("a variable that survives expansion names nothing", () => {
+    expect(parseCmdShim('@node "%APPDATA%\\cli.js" %*', SHIM)).toEqual([]);
+  });
+
+  test("a bare launcher with no script is still a pair we can name", () => {
+    expect(parseCmdShim('@"%~dp0\\tool.exe" %*', SHIM)).toEqual([{ program: path.join(DIR, "tool.exe"), args: [] }]);
+  });
+
+  test("flags between interpreter and %* pass through byte for byte", () => {
+    const found = parseCmdShim('@node --enable-source-maps "%~dp0\\cli.js" %*', SHIM);
+    expect(found).toEqual([{ program: "node", args: ["--enable-source-maps", path.join(DIR, "cli.js")] }]);
+  });
+});
+
+describe("resolveShimTarget — the named pair, checked against the disk", () => {
+  test("the interpreter beside the shim wins, and it never has to be on PATH", () => {
+    const dir = tempDir("nrv-shim-local-");
+    fs.writeFileSync(path.join(dir, "node.exe"), "");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, modernShim("cli.js"));
+    process.env.PATH = "";
+
+    expect(resolveShimTarget(shim)).toEqual({ program: path.join(dir, "node.exe"), args: [path.join(dir, "cli.js")] });
+  });
+
+  test("without a local interpreter it falls to the bare name on PATH, as the shim's ELSE branch does", () => {
+    const dir = tempDir("nrv-shim-path-");
+    const nodeDir = tempDir("nrv-shim-node-");
+    fs.writeFileSync(path.join(nodeDir, "node"), "");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, modernShim("cli.js"));
+    process.env.PATH = nodeDir;
+
+    expect(resolveShimTarget(shim)).toEqual({ program: path.join(nodeDir, "node"), args: [path.join(dir, "cli.js")] });
+  });
+
+  test("no interpreter anywhere names nothing — the caller keeps the interpreter route", () => {
+    const dir = tempDir("nrv-shim-nonode-");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, modernShim("cli.js"));
+    process.env.PATH = tempDir("nrv-shim-empty-");
+
+    expect(resolveShimTarget(shim)).toBeNull();
+  });
+
+  test("a script the shim names but the disk does not have names nothing", () => {
+    const dir = tempDir("nrv-shim-noscript-");
+    fs.writeFileSync(path.join(dir, "node.exe"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, modernShim("cli.js"));
+
+    expect(resolveShimTarget(shim)).toBeNull();
+  });
+
+  test("an interpreter that is itself a .cmd is refused — resolving it re-enters the trap", () => {
+    const dir = tempDir("nrv-shim-recurse-");
+    const nodeDir = tempDir("nrv-shim-recurse-path-");
+    fs.writeFileSync(path.join(nodeDir, "node.cmd"), "@echo off\r\n");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, modernShim("cli.js"));
+    process.env.PATH = nodeDir;
+
+    expect(resolveShimTarget(shim)).toBeNull();
+  });
+
+  test("a shim too large to be a launcher names nothing", () => {
+    const dir = tempDir("nrv-shim-big-");
+    fs.writeFileSync(path.join(dir, "node.exe"), "");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    const shim = path.join(dir, "claude.cmd");
+    fs.writeFileSync(shim, `REM ${"x".repeat(20_000)}\r\n${modernShim("cli.js")}`);
+
+    expect(resolveShimTarget(shim)).toBeNull();
+  });
+
+  test("a path that is not there at all names nothing", () => {
+    expect(resolveShimTarget(path.join(tempDir("nrv-shim-gone-"), "missing.cmd"))).toBeNull();
+  });
+});
+
+describe("the measurement: a 5,875-character directive through both routes", () => {
+  // The defect, in its own numbers. On 2026-08-27 the squad dispatch built a
+  // 6,251-character command line whose first newline sat at 183, and cmd.exe
+  // discarded everything after it: both --add-dir grants and the permission
+  // flag, on a line far under the 8,191 limit. The direct route has no command
+  // line at all — the arguments reach CreateProcess as the array they already
+  // are on POSIX and for a real .exe on Windows.
+  const DIRECTIVE = autonomyDirective();
+  // The order the runner had on the day it broke: the directive second, both
+  // grants and the permission flag behind it. Pushing it last is the belt the
+  // 0.10.2 cut added; the eight untreated adapters and the light layer still
+  // build lines of this shape, which is what this cut is meant to make harmless.
+  const ARGV = [
+    "-p", "--output-format", "json",
+    "--append-system-prompt", DIRECTIVE,
+    "--add-dir", "C:\\Users\\John Doe\\project",
+    "--add-dir", "C:\\Users\\John Doe\\outputs",
+    "--dangerously-skip-permissions",
+  ];
+
+  test("the directive is the shape that caused it: 5,875 characters, first newline at 183", () => {
+    expect(DIRECTIVE).toHaveLength(5_875);
+    expect(DIRECTIVE.indexOf("\n")).toBe(183);
+  });
+
+  test("through cmd.exe the flags behind the directive are gone; direct, every argument arrives whole", () => {
+    const dir = tempDir("nrv-measure-");
+    fs.writeFileSync(path.join(dir, "node.exe"), "");
+    fs.writeFileSync(path.join(dir, "cli.js"), "");
+    fs.writeFileSync(path.join(dir, "claude.cmd"), modernShim("cli.js"));
+    fs.writeFileSync(path.join(dir, "opaque.cmd"), "@echo off\r\nREM shape this parser does not read\r\n");
+    asPlatform("win32");
+    process.env.PATH = `${dir}${path.delimiter}${REAL_PATH}`;
+
+    // Route A — the shim this parser cannot read: still the interpreter, still cut.
+    const viaShell = resolveExecutable("opaque");
+    expect(viaShell.shell).toBe(true);
+    const cmd = throughCmdExe(viaShell.args(ARGV));
+    expect(cmd.delivered.length).toBeLessThan(cmd.sent.length);
+    expect(cmd.delivered).not.toContain("--dangerously-skip-permissions");
+    expect(cmd.delivered).not.toContain("--add-dir");
+    expect(cmd.sent).toContain("--dangerously-skip-permissions");
+    const lostChars = cmd.sent.length - cmd.delivered.length;
+
+    // Route B — the shim read and its target spawned: no interpreter, no command line.
+    const direct = resolveExecutable("claude");
+    expect(direct.shell).toBe(false);
+    const delivered = direct.args(ARGV);
+    expect(delivered).toEqual([path.join(dir, "cli.js"), ...ARGV]);
+    // Byte for byte, including the argument that spans lines.
+    expect(delivered[delivered.indexOf("--append-system-prompt") + 1]).toBe(DIRECTIVE);
+    expect(delivered.filter(a => a === "--add-dir")).toHaveLength(2);
+    expect(delivered).toContain("--dangerously-skip-permissions");
+    // Nothing was quoted, so nothing needs unquoting: the shell route's
+    // quoteForCmd never runs here.
+    expect(delivered.some(a => a.startsWith('"'))).toBe(false);
+
+    // Stable on every machine: the arguments are the product's, not the fixture's.
+    expect(cmd.sent).toHaveLength(6_031);
+    expect(cmd.delivered).toHaveLength(231);
+    expect(lostChars).toBe(5_800);
+    console.log(`[measure] cmd.exe route: ${cmd.sent.length} chars of arguments sent, ${cmd.delivered.length} delivered, ${lostChars} discarded at the newline (${((lostChars / cmd.sent.length) * 100).toFixed(1)}%)`);
+    console.log(`[measure] direct route: ${delivered.length} argv elements, ${ARGV.reduce((n, a) => n + a.length, 0)} chars of arguments, 0 discarded`);
+  });
+
+  test("the fallback still carries the file cure, so a shim we cannot read loses nothing either", () => {
+    // claudeDirectiveArgs keeps the directive off the command line under a shell.
+    // This cut does not replace that; it makes it the exception rather than the rule.
+    const dir = tempDir("nrv-measure-fallback-");
+    fs.writeFileSync(path.join(dir, "opaque.cmd"), "@echo off\r\n");
+    asPlatform("win32");
+    process.env.PATH = `${dir}${path.delimiter}${REAL_PATH}`;
+    expect(resolveExecutable("opaque").shell).toBe(true);
   });
 });


### PR DESCRIPTION
## What

`resolveExecutable` routed every `.cmd` CLI through `cmd.exe`, and `cmd.exe` ends the command line at the first CR/LF of any argument. 0.10.2 cured that for `claude` by moving the directive into a file. Eight adapters and the light layer still carried the same shape — ten replications of one cure.

This deletes the cause. A `.cmd` written by npm is not the CLI: it is a five-line batch file whose only job is to run `node <script> %*`. The driver now reads the shim, takes the interpreter and script it names, and spawns that pair directly. No shell, no re-parsing, and no command line for anything to cut — the child starts exactly the way a real `.exe` already starts on Windows.

## The measurement

Over the argv the squad dispatch built, with the directive in the position it had on the day it broke (5,875 characters, first newline at 183):

| route | sent | delivered | discarded |
|---|---|---|---|
| through `cmd.exe` | 6,110 chars | 310 chars | 5,800 (94.9%), taking both `--add-dir` grants and `--dangerously-skip-permissions` |
| direct | 11 argv elements, 6,090 chars | all of it | 0 |

Pinned in `skills/harness/tests/windows-spawn.test.ts` (33 tests in that file; the numbers print from the run).

## The four failure modes the brief named

1. **Shim shapes differ.** Both npm `cmd-shim` generations are read (modern `_prog`, older two-branch). Anything else yields no candidate and the caller keeps the old `cmd.exe` route with `quoteForCmd`.
2. **The interpreter may not be on PATH.** `%~dp0` / `%dp0%` expand against the shim's own directory, so a `node.exe` sitting beside the shim is found without PATH. The bare-name branch falls back to a PATH scan, which is what the shim asks `cmd.exe` for.
3. **`%*` is not the only form.** Positional arguments (`%1`, `%~2`) or `SHIFT` anywhere in the file, or `%*` anywhere but as the last token, produce no candidate. If pass-through cannot be proven, the direct path is not taken.
4. **`quoteForCmd` still matters.** Untouched, and still applied on the fallback. `claudeDirectiveArgs` (`--append-system-prompt-file`) is untouched too — it now protects the fallback rather than the normal path.

Also refused: a `SET` of anything but the shim's own three variables (`dp0`, `_prog`, `PATHEXT`), a variable that survives expansion, a script or interpreter not on disk, an interpreter that is itself a `.cmd`, and a file too large to be a launcher.

## Verification

- `bun test` over the 14 driver-adjacent files: **196 pass / 0 fail**.
- `check-english-source --strict`, `check-changelog-parity --strict`, `git diff --check`: clean.
- **Not verified:** no Windows machine was involved. Every claim is a simulation over real shim text with `process.platform` faked, or documented `cmd.exe` behavior. Only Windows can prove the last link — that a quoted argument containing a newline survives `CreateProcess` and the child's own command-line parser. This cut makes a `.cmd` take the branch a real `.exe` has always taken there, so that link is not new, only newly load-bearing.

Adapters and the light layer are untouched by design: they inherit the fix through the spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)