### PR TITLE
fix(tests): the gauntlet revision loop stops measuring the runner's disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A test that failed by lottery, and the fsync that decided the draw
+
+`gauntlet-revision-loop.e2e.test.ts` kept going red on `smoke (windows-latest)`
+from branches whose diff touched nothing near it. Three of those failures landed
+on `main`, which only takes code that already passed all three systems, so they
+were intermittency by definition. The case CI named was "a typed agent-x producer
+crosses the revision loop to completed", timing out at 8,415 ms against Bun's 5 s
+default.
+
+The gap is the whole story. That case is one of the cheapest in the file: 14 ms
+on an idle machine. On the very run where it failed, its neighbours finished in
+195 to 490 ms, and the twin leg of its own `test.each`, which executes the
+identical code path, finished in 688 ms. Nothing about the work explains the
+spread. Where the work happened does. Every case in the file opened the Run
+Kernel as a real SQLite database under a temp directory, and the kernel opens
+with `synchronous = FULL`, so each of the 17 events the loop journals costs one
+fsync. The test's wall clock was a measurement of the runner's disk, and Windows
+is the slowest of the three.
+
+The journal now lives in memory. No case in the file ever read that database
+back; they assert projections, event payloads and the files the producers write.
+The disk bought no coverage and charged for durability that `afterEach` deleted
+milliseconds later. The kernel's own on-disk behaviour stays covered where it is
+the subject, in `run-kernel.test.ts` and the cross-process e2e files that share a
+database file with a spawned child.
+
+One finding sits outside the test. `openKernel` used to create the parent
+directory of whatever path it was handed, so `:memory:` worked only because
+`path.dirname(":memory:")` is `"."` on both platforms and creating `"."` is a
+no-op. It is a supported argument now, guarded and documented. Working by
+accident is how the next Windows-only failure gets written.
+
+The proof is statistical. Under 40 concurrent copies of the file on a 10-core
+machine with four fsync loops competing for the disk, 640 runs before the change
+produced 100 timeouts spread over nine different cases, including that twin leg;
+640 runs after, under the same load, produced 5, all in one case. The named case
+went from 1,356 ms mean and 4,518 ms at the tail to 573 ms and 2,212 ms. Two
+hundred consecutive unloaded runs then passed without a failure.
+
+No `retry`, no raised budget, no skip. Each of those hides the draw and keeps
+teaching everyone to re-run without reading, which is what makes the next real
+failure in that file invisible. Worth recording against that: the case CI named
+never had a declared budget at all. The two `KERNEL_BUDGET_MS` budgets in the
+file belong to the two cases that spawn processes.
+
+One case is left alone. "a typed Business crosses the revision loop, the real
+offline gate and the post-gate" is the only one that still crossed 5 s under that
+load, 7 samples in 400 against 65 before, because it runs the delivery pipeline
+and the post-gate on top of the kernel. That cost is not the one this change
+removes, and it carries no budget either. It is a cut of its own.
+
 ## 0.10.2 — 2026-08-27
 
 ### A newline in one argument cut every flag behind it, on Windows

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,57 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Um teste que reprovava por sorteio, e o fsync que decidia o sorteio
+
+O `gauntlet-revision-loop.e2e.test.ts` vinha ficando vermelho no
+`smoke (windows-latest)` a partir de branches cujo diff não encostava em nada
+perto dele. Três dessas falhas caíram na `main`, que só recebe código já aprovado
+nos três sistemas, então eram intermitência por definição. O caso que o CI nomeou
+foi "a typed agent-x producer crosses the revision loop to completed", estourando
+em 8.415 ms contra o padrão de 5 s do Bun.
+
+A distância é a história inteira. Aquele caso é dos mais baratos do arquivo: 14 ms
+numa máquina ociosa. Na mesma execução em que reprovou, os vizinhos terminaram
+entre 195 e 490 ms, e a perna gêmea do próprio `test.each`, que percorre o código
+idêntico, terminou em 688 ms. Nada no trabalho explica a diferença. O lugar onde o
+trabalho acontecia explica. Todo caso do arquivo abria o Run Kernel como um banco
+SQLite real num diretório temporário, e o kernel abre com `synchronous = FULL`,
+então cada um dos 17 eventos que o laço registra custa um fsync. O relógio do
+teste media o disco do runner, e o Windows é o mais lento dos três.
+
+O diário agora vive em memória. Nenhum caso do arquivo lia aquele banco de volta;
+eles verificam projeções, payloads de evento e os arquivos que os produtores
+escrevem. O disco não comprava cobertura nenhuma e cobrava por uma durabilidade
+que o `afterEach` apagava milissegundos depois. O comportamento em disco do kernel
+segue coberto onde ele é o assunto, no `run-kernel.test.ts` e nos arquivos e2e
+entre processos que compartilham um arquivo de banco com um filho executado.
+
+Um achado fica fora do teste. O `openKernel` criava o diretório pai de qualquer
+caminho que recebesse, de modo que `:memory:` só funcionava porque
+`path.dirname(":memory:")` é `"."` nas duas plataformas e criar `"."` não faz
+nada. Agora é um argumento suportado, com guarda e documentado. Funcionar por
+acidente é como se escreve a próxima falha exclusiva do Windows.
+
+A prova é estatística. Sob 40 cópias simultâneas do arquivo numa máquina de 10
+núcleos, com quatro laços de fsync disputando o disco, 640 execuções antes da
+mudança produziram 100 estouros espalhados por nove casos diferentes, inclusive
+aquela perna gêmea; 640 execuções depois, sob a mesma carga, produziram 5, todos
+num caso só. O caso nomeado saiu de 1.356 ms de média e 4.518 ms na cauda para
+573 ms e 2.212 ms. Duzentas execuções seguidas sem carga passaram então sem uma
+falha.
+
+Sem `retry`, sem aumentar orçamento, sem `skip`. Cada um deles esconde o sorteio e
+mantém o treinamento de re-rodar sem ler, que é o que torna invisível a próxima
+falha verdadeira naquele arquivo. Vale registrar contra isso: o caso que o CI
+nomeou nunca teve orçamento declarado. Os dois `KERNEL_BUDGET_MS` do arquivo
+pertencem aos dois casos que executam processos.
+
+Um caso fica de fora. O "a typed Business crosses the revision loop, the real
+offline gate and the post-gate" é o único que ainda cruzou os 5 s sob aquela
+carga, 7 amostras em 400 contra 65 antes, porque roda o pipeline de entrega e o
+pós-gate em cima do kernel. Esse custo não é o que esta mudança remove, e ele
+também não tem orçamento. É um corte próprio.
+
 ## 0.10.2 — 2026-08-27
 
 ### Uma quebra de linha num argumento cortava todas as flags atrás dela, no Windows

--- a/skills/harness/lib/run-kernel/store.ts
+++ b/skills/harness/lib/run-kernel/store.ts
@@ -116,7 +116,10 @@ function initialize(db: Database): void {
 }
 
 export function openKernel(dbPath: string): KernelHandle {
-  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  // `:memory:` is a supported argument rather than a path: a journal that never outlives the
+  // process has no directory to create. Hermetic tests pass it to keep their wall clock off the
+  // disk, so the guard is the contract, not a convenience.
+  if (dbPath !== ":memory:") fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   const db = new Database(dbPath);
   try {
     initialize(db);

--- a/skills/harness/tests/gauntlet-revision-loop.e2e.test.ts
+++ b/skills/harness/tests/gauntlet-revision-loop.e2e.test.ts
@@ -53,7 +53,16 @@ function writeReport(candidateRoot: string, marker: string): void {
 /** Hermetic loop: deterministic producers write markers, the evaluator grades by (candidate, revision). */
 function scenario(options: Scenario) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gauntlet-revision-")); roots.push(root);
-  const handle = openKernel(path.join(root, ".nirvana", "run-kernel.sqlite")); handles.push(handle);
+  // The journal stays in memory. Every case here asserts projections, event payloads and the files
+  // the producers write; none of them reads the database the kernel keeps. On disk that database
+  // bought no coverage and cost one fsync per journalled event, 17 per case, because
+  // `synchronous = FULL` makes every append durable. That is what tied the wall clock of this whole
+  // file to the runner's disk: measured on a busy disk, 1.4 s per case on average and 6.0 s at the
+  // tail, against Bun's 5 s default. A red build decided that way lands on an arbitrary case. The
+  // two `test.each` legs below measured 1356 ms and 1366 ms, and only one of them ever failed CI.
+  // The kernel's own on-disk behaviour is covered where it is the subject: run-kernel.test.ts and
+  // the cross-process e2e files, which share a real database file with a spawned child.
+  const handle = openKernel(":memory:"); handles.push(handle);
   const outputsRoot = path.join(root, "deliverables");
   const calls = { executions: 0, revisions: [] as AgentXRevisionRequest[], finalGates: 0, holdouts: [] as boolean[] };
   const write = options.write ?? writeReport;


### PR DESCRIPTION
## The finding

`gauntlet-revision-loop.e2e.test.ts`, case **"a typed agent-x producer crosses the revision loop to completed"**, timed out at **8,415 ms** on `smoke (windows-latest)` against Bun's 5 s default, on a branch whose diff touched nothing near it. Three such failures reached `main`, which only takes code that passed all three systems.

That case is one of the cheapest in the file: **14 ms** on an idle machine. On the very run where it failed, its neighbours finished in 195-490 ms and the twin leg of its own `test.each`, which executes the identical code path, finished in 688 ms. Nothing about the work explains the spread.

Where the work happened does. Every case opened the Run Kernel as a real SQLite database under a temp directory, and the kernel opens with `synchronous = FULL`, so each of the 17 events the loop journals costs one fsync. The test's wall clock was a measurement of the runner's disk, and Windows is the slowest of the three.

## The fix

The journal lives in memory. No case in the file reads that database back; they assert projections, event payloads and the files the producers write. The disk bought no coverage and charged for durability that `afterEach` deleted milliseconds later. The kernel's on-disk behaviour stays covered where it is the subject: `run-kernel.test.ts` and the cross-process e2e files that share a database file with a spawned child.

**Outside the test:** `openKernel` created the parent directory of whatever path it was handed, so `:memory:` worked only because `path.dirname(":memory:")` is `"."` on both platforms and creating `"."` is a no-op. It is a supported argument now, guarded and documented.

## The proof (statistical)

40 concurrent copies of the file on a 10-core machine, four fsync loops competing for the disk, 640 runs each side:

| | timeouts | cases affected |
|---|---|---|
| before | 100 | 9 |
| after | 5 | 1 |

| case | before mean / tail | after mean / tail |
|---|---|---|
| a typed agent-x producer (the one CI named) | 1,356 ms / 4,518 ms | 573 ms / 2,212 ms |
| a typed squad producer (twin leg) | 1,366 ms / 5,986 ms | 598 ms / 1,976 ms |

The two legs measured 1,356 ms and 1,366 ms before: which one CI reddened was a coin flip. Then **200 consecutive unloaded runs, all green**.

No `retry`, no raised budget, no `skip`.

## Left alone, on purpose

- **"a typed Business crosses the revision loop, the real offline gate and the post-gate"** is the only case still able to cross 5 s under that load (7 in 400, down from 65). It runs the delivery pipeline and post-gate on top of the kernel, a cost this change does not remove, and it carries no declared budget. Its own cut.
- **`glance-maestro-turn.test.ts`** fails on CI as `(fail) (unnamed)` with *"a beforeEach/afterEach hook timed out for this test"* (run 33077949858, 8,098 ms). Same smell, different cause. Its own cut.
- Correcting the brief's premise: the named case **never had a declared budget**. The two `KERNEL_BUDGET_MS + spawnBudgetMs(2)` budgets in the file belong to the two cases that spawn processes.

## Verification

- `bun test skills/harness/tests` — 1387 pass / 4 skip / 1 fail; the fail is the worktree-environmental `buyer-path.test.ts` (`Cannot find package 'yaml'`, symlinked `node_modules`) named in the verification contract.
- `bun scripts/check-english-source.ts --strict` — 0
- `bun scripts/check-changelog-parity.ts --strict` — 0
- `git diff --check` — 0

Changelog in both languages.