### PR TITLE
fix(tests): the disk stops being the default when a test opens the Run Kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,74 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Ten more tests were measuring the disk, and nobody had chosen it
+
+The entry below fixed one file and left a list of ten. What those ten have in
+common is not a mistake anyone made. A new test opens the Run Kernel the way its
+neighbour does, the neighbour opened a real SQLite file under a temp directory,
+and `PRAGMA synchronous = FULL` turns every journalled event into an fsync. The
+disk arrives as an inheritance, never as a decision.
+
+The decision now has somewhere to live. `tests/helpers/test-kernels.ts` sits
+beside `temp-dirs.ts` and `test-budgets.ts` and offers two doors:
+`openTestKernel()`, hermetic, the default; and `openTestKernelFile(path)`, the
+named exception for a test that earns the disk. `closeTestKernels()` releases
+either one in `afterEach`, which is what keeps a leaked handle from turning a
+Windows teardown into EBUSY.
+
+One question sorted the ten. Does this test read the database back through a
+connection that is not the one it writes with? `:memory:` belongs to whichever
+connection opened it, so any other reader — a spawned child, an HTTP server, a
+second handle the code under test opens from a path it was handed — finds an
+empty database and every assertion passes on nothing. A green lie costs more
+than an honest fsync.
+
+Three answers were no, and those journals moved into memory: `gauntlet-store`,
+whose three cases write and read through one handle; the coordinator case in
+`multi-target-dispatch-adapters`, where the fake dispatch children answer through
+files and never open the kernel; and the crash-replay case in
+`glance-multi-target-projection`, the only one in that file that never goes
+through the server.
+
+Two answers were yes, and neither had a budget. `standard-publication` is the
+file that took `main` down in run `33098410397`. `openStandardPublication` is
+handed a path and opens its own handle, so the test's reads reach the journal
+from outside; the collision case then walks all seven terminal states, and each
+one costs a `prepare` plus three reads, twenty-eight openings of the same file
+with the schema initialization re-run on every one of them. `glance-control-plane`
+drives a live server holding its own connections to two databases, both opened
+with `synchronous = FULL`. The disk is the coverage in both, so both keep it and
+both get `KERNEL_BUDGET_MS`.
+
+Five were left exactly as they were. `dispatch-gauntlet-ledger`,
+`dispatch-standard-kernel`, `gauntlet-evaluator-dispatch`, `judge-x-dispatch` and
+`multi-target-cli` spawn a real dispatch and read what the child wrote. A
+database in this process's memory is invisible to a child process, which makes
+them the clearest read-back of all, and they already carry `spawnBudgetMs`
+budgets larger than the kernel one.
+
+The proof is statistical, on a 10-core machine with four fsync loops competing
+for the disk. Forty concurrent copies of the three server-free files, 640 runs
+before the change and 640 after: 18 timeouts became 0. All 18 were the same case,
+"a Run that already ended under the same id is refused before any producer", at
+5,943 ms mean against Bun's 5 s default. The group's wall clock fell from 18.2 s
+mean and 23.4 s at the tail to 15.8 s and 19.9 s. Measured on their own, the two
+files whose journals moved went from 9.0 s mean and 9.9 s max to 8.0 s and 9.0 s
+over 240 runs a side, with no timeout on either side: on macOS they are too cheap
+to cross 5 s, and the exposure they carried was Windows-shaped.
+
+The two Glance files ran sequentially, sixty times a side, against that same
+contention. Neither side timed out, the mean fell from 3.0 s to 2.5 s, and one
+sample in sixty reached 6.9 s against a previous worst of 5.4 s. That tail argues
+for the budget rather than against it: under Bun's default it is a red build, and
+nothing about it is the test's fault.
+
+One finding belongs to the load harness rather than to CI. `startServer` resolves
+`port: 0` by probing with a throwaway `Bun.serve`, stopping it, and letting the
+caller bind the same number, so two copies started in the same instant both pick
+3737 and one dies with EADDRINUSE. Only one copy of a file runs in CI, so it
+never fires there. It is why the Glance files were measured sequentially.
+
 ### A test that failed by lottery, and the fsync that decided the draw
 
 `gauntlet-revision-loop.e2e.test.ts` kept going red on `smoke (windows-latest)`

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,77 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Mais dez testes mediam o disco, e ninguém tinha escolhido isso
+
+A entrada abaixo consertou um arquivo e deixou uma lista de dez. O que esses dez
+têm em comum não é erro de ninguém. Um teste novo abre o Run Kernel como o
+vizinho abre, o vizinho abriu um arquivo SQLite de verdade num diretório
+temporário, e o `PRAGMA synchronous = FULL` transforma cada evento registrado num
+fsync. O disco chega por herança, nunca por decisão.
+
+Agora a decisão tem onde morar. O `tests/helpers/test-kernels.ts` fica ao lado do
+`temp-dirs.ts` e do `test-budgets.ts` e oferece duas portas: `openTestKernel()`,
+hermético, o padrão; e `openTestKernelFile(path)`, a exceção nomeada, para o teste
+que merece o disco. O `closeTestKernels()` solta qualquer uma das duas no
+`afterEach`, que é o que impede um handle vazado de virar EBUSY na limpeza do
+Windows.
+
+Uma pergunta separou os dez. Este teste lê o banco de volta por uma conexão que
+não é a mesma com que escreve? O `:memory:` pertence a quem o abriu, então
+qualquer outro leitor — um filho executado, um servidor HTTP, um segundo handle
+que o código sob teste abre a partir de um caminho recebido — encontra um banco
+vazio e toda asserção passa em cima do nada. Mentira verde custa mais que um
+fsync honesto.
+
+Três respostas foram não, e esses diários foram para a memória: o
+`gauntlet-store`, cujos três casos escrevem e leem pelo mesmo handle; o caso do
+coordenador no `multi-target-dispatch-adapters`, onde os filhos de dispatch falsos
+respondem por arquivos e nunca abrem o kernel; e o caso de replay pós-crash no
+`glance-multi-target-projection`, o único daquele arquivo que não passa pelo
+servidor.
+
+Duas respostas foram sim, e nenhuma das duas tinha orçamento. O
+`standard-publication` é o arquivo que derrubou a `main` na execução
+`33098410397`. O `openStandardPublication` recebe um caminho e abre o próprio
+handle, então as leituras do teste chegam ao diário por fora; o caso de colisão
+então percorre os sete estados terminais, e cada um custa um `prepare` mais três
+leituras, vinte e oito aberturas do mesmo arquivo com a inicialização do esquema
+refeita em cada uma delas. O `glance-control-plane` dirige um servidor vivo que
+segura as próprias conexões com dois bancos, os dois abertos com
+`synchronous = FULL`. Nos dois o disco é a cobertura, então os dois ficam com ele
+e os dois ganham `KERNEL_BUDGET_MS`.
+
+Cinco ficaram exatamente como estavam. O `dispatch-gauntlet-ledger`, o
+`dispatch-standard-kernel`, o `gauntlet-evaluator-dispatch`, o `judge-x-dispatch`
+e o `multi-target-cli` executam um dispatch de verdade e leem o que o filho
+escreveu. Um banco na memória deste processo é invisível para um processo filho, o
+que faz deles o caso mais claro de leitura de volta, e eles já carregam orçamentos
+`spawnBudgetMs` maiores que o do kernel.
+
+A prova é estatística, numa máquina de 10 núcleos com quatro laços de fsync
+disputando o disco. Quarenta cópias concorrentes dos três arquivos sem servidor,
+640 execuções antes da mudança e 640 depois: 18 timeouts viraram 0. Os 18 eram o
+mesmo caso, "a Run that already ended under the same id is refused before any
+producer", com média de 5.943 ms contra o padrão de 5 s do Bun. O relógio do grupo
+caiu de 18,2 s de média e 23,4 s na cauda para 15,8 s e 19,9 s. Medidos sozinhos,
+os dois arquivos cujos diários mudaram foram de 9,0 s de média e 9,9 s de máximo
+para 8,0 s e 9,0 s, em 240 execuções de cada lado, sem nenhum timeout dos dois
+lados: no macOS eles são baratos demais para cruzar os 5 s, e a exposição que
+carregavam tinha formato de Windows.
+
+Os dois arquivos do Glance rodaram sequencialmente, sessenta vezes de cada lado,
+contra a mesma disputa. Nenhum dos lados estourou, a média caiu de 3,0 s para
+2,5 s, e uma amostra em sessenta chegou a 6,9 s contra um pior caso anterior de
+5,4 s. Essa cauda é argumento a favor do orçamento, não contra: sob o padrão do
+Bun ela é um build vermelho, e nada nela é culpa do teste.
+
+Um achado pertence ao arreio de carga, não ao CI. O `startServer` resolve
+`port: 0` sondando com um `Bun.serve` descartável, parando-o e deixando o chamador
+ligar o mesmo número, então duas cópias iniciadas no mesmo instante escolhem 3737
+e uma morre com EADDRINUSE. No CI roda uma cópia só de cada arquivo, então isso
+nunca dispara lá. É por isso que os arquivos do Glance foram medidos
+sequencialmente.
+
 ### Um teste que reprovava por sorteio, e o fsync que decidia o sorteio
 
 O `gauntlet-revision-loop.e2e.test.ts` vinha ficando vermelho no

--- a/skills/harness/tests/gauntlet-store.test.ts
+++ b/skills/harness/tests/gauntlet-store.test.ts
@@ -1,20 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import { beginGauntlet, compileGauntletPlan, getGauntlet, listCandidateRevisions, saveCandidateRevision, saveScorecard } from "../lib/gauntlet/index.ts";
-import { createRun, listEvents, openKernel, type KernelHandle } from "../lib/run-kernel/index.ts";
+import { createRun, listEvents } from "../lib/run-kernel/index.ts";
+import { closeTestKernels, openTestKernel } from "./helpers/test-kernels.ts";
 
-const roots: string[] = [];
-const handles: KernelHandle[] = [];
-afterEach(() => {
-  while (handles.length) handles.pop()!.close();
-  while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true });
-});
+afterEach(closeTestKernels);
 
 function fresh() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gauntlet-")); roots.push(root);
-  const handle = openKernel(path.join(root, "kernel.sqlite")); handles.push(handle);
+  // Hermetic journal. The three cases below write and read through this one handle
+  // (getGauntlet, listCandidateRevisions, listEvents); nothing else opens the database, no child
+  // process sees it and no assertion mentions the file. On disk it cost one fsync per event, for
+  // durability the teardown discarded, and the temp directory existed only to hold it.
+  const handle = openTestKernel();
   createRun(handle, { projectId: "prj_1", runId: "run_1", traceId: "trace_1", planId: "plan_1",
     target: { kind: "business", slug: "builder" }, policySnapshotRef: "policy", actor: { kind: "kernel", id: "test" }, correlationId: "cor" });
   return { handle, context: { projectId: "prj_1", runId: "run_1", traceId: "trace_1", actor: { kind: "kernel", id: "test" }, correlationId: "cor" } };

--- a/skills/harness/tests/glance-control-plane.test.ts
+++ b/skills/harness/tests/glance-control-plane.test.ts
@@ -3,8 +3,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { GauntletController, compileGauntletPlan } from "../lib/gauntlet/index.ts";
-import { openKernel } from "../lib/run-kernel/index.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
+import { closeTestKernels, openTestKernelFile } from "./helpers/test-kernels.ts";
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-glance-control-"));
 let instance: any;
@@ -22,8 +23,17 @@ beforeAll(async () => {
 afterAll(() => {
   try { instance?.close(); } catch {}
   delete process.env.NIRVANA_PROJECT_ROOT;
+  closeTestKernels();
   removeDir(root);
 });
+
+// Every case here goes through the running server, so both of its databases stay on disk and both
+// open with `PRAGMA synchronous = FULL`: the control plane's (projects, conversations, messages)
+// and the Run Kernel's. That is the read-back the file exists to prove — the last case writes a
+// Gauntlet through a second connection and asks the server to project it, which a `:memory:`
+// database cannot do, since it belongs to whichever connection opened it. The cost is legitimate,
+// so it gets the budget instead: an fsync-bound case measured up to 5.5 s on the slowest runner
+// against Bun's 5 s default, which is a red build decided by the disk, not by the code.
 
 describe("Glance project control plane", () => {
   test("legacy discovery is read-only and adoption is explicit", async () => {
@@ -35,7 +45,7 @@ describe("Glance project control plane", () => {
     expect(response.status).toBe(201);
     projectId = ((await response.json()) as any).project_id;
     expect(projectId).toStartWith("prj_");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("requires idempotency and rejects foreign origins and traversal", async () => {
     expect((await fetch(`${base}/api/v1/projects`, { method: "POST", headers: { "content-type": "application/json", origin: base }, body: "{}" })).status).toBe(400);
@@ -44,7 +54,7 @@ describe("Glance project control plane", () => {
     expect((await fetch(`${base}/api/actions/chat-shell`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ command: "pwd" }) })).status).toBe(404);
     const capabilities = await fetch(`${base}/api/v1/capabilities`).then(r => r.json()) as any;
     expect(capabilities.permissions["tool.execute.shell"]).toBe(false);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("persists conversation messages and keeps entities separate", async () => {
     const conversation = await fetch(`${base}/api/v1/projects/${projectId}/conversations`, { method: "POST", headers: headers(), body: JSON.stringify({ title: "Workspace" }) }).then(r => r.json()) as any;
@@ -53,7 +63,7 @@ describe("Glance project control plane", () => {
     expect(message.message.sequence).toBe(1);
     const opened = await fetch(`${base}/api/v1/conversations/${conversation.conversation_id}`).then(r => r.json()) as any;
     expect(opened.messages.map((item: any) => item.content)).toEqual(["Brief persistente"]);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("returns journal events in sequence and resumes SSE after cursor", async () => {
     const target = { kind: "squad", slug: "systems-atelier", capabilityId: "software.project-control-plane.implement" };
@@ -70,7 +80,7 @@ describe("Glance project control plane", () => {
     expect(chunk).toContain("id: 2");
     expect(chunk).not.toContain(`id: 1\n`);
     expect((await fetch(`${base}/api/v1/runs/${first.runId}?project_id=${projectId}`).then(r => r.json()) as any).target.kind).toBe("squad");
-    const kernel = openKernel(path.join(root, ".nirvana", "run-kernel.sqlite"));
+    const kernel = openTestKernelFile(path.join(root, ".nirvana", "run-kernel.sqlite"));
     const gauntlet = new GauntletController(kernel, { projectId, runId: first.runId, traceId: first.traceId,
       actor: { kind: "test", id: "glance" }, correlationId: "cor_glance" });
     gauntlet.begin(compileGauntletPlan({ brief: "Test Glance projection", intensity: "light" }));
@@ -79,5 +89,5 @@ describe("Glance project control plane", () => {
     expect(gauntletView.projection.plan.intensity).toBe("light");
     expect(gauntletView.candidates).toEqual([]);
     expect(gauntletView.scorecards).toEqual([]);
-  });
+  }, KERNEL_BUDGET_MS);
 });

--- a/skills/harness/tests/glance-multi-target-projection.test.ts
+++ b/skills/harness/tests/glance-multi-target-projection.test.ts
@@ -8,8 +8,9 @@ import { projectMultiTargetRun } from "../lib/gauntlet/index.ts";
 import { coordinateMultiTargetPlan, type MultiTargetAdapterInput, type MultiTargetCoordinatorSnapshot } from "../lib/gauntlet/multi-target-coordinator.ts";
 import { createRunKernelMultiTargetPorts } from "../lib/gauntlet/run-kernel-multi-target-ports.ts";
 import { compileMultiTargetGauntletPolicy } from "../lib/plan-compiler.ts";
-import { createRun, listEvents, openKernel, type KernelHandle } from "../lib/run-kernel/store.ts";
+import { createRun, listEvents, type KernelHandle } from "../lib/run-kernel/store.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { closeTestKernels, openTestKernel, openTestKernelFile } from "./helpers/test-kernels.ts";
 
 const roots: string[] = [];
 const projectId = "prj_multi-target";
@@ -69,7 +70,11 @@ beforeAll(async () => {
   const root = tempRoot();
   process.env.NIRVANA_PROJECT_ROOT = root;
   fs.mkdirSync(path.join(root, ".nirvana"), { recursive: true });
-  const kernel = openKernel(path.join(root, ".nirvana", "run-kernel.sqlite"));
+  // On disk by necessity: the four cases below read this journal back through the Glance server,
+  // which opens its own connection to <NIRVANA_PROJECT_ROOT>/.nirvana/run-kernel.sqlite. A
+  // `:memory:` database belongs to one connection, so the server would answer from an empty one and
+  // every assertion here would pass on nothing.
+  const kernel = openTestKernelFile(path.join(root, ".nirvana", "run-kernel.sqlite"));
   seedRun(kernel, multiRunId);
   seedRun(kernel, plainRunId);
   completed = await coordinateMultiTargetPlan({ ...plan(), ports: ports(kernel, multiRunId) });
@@ -81,6 +86,7 @@ beforeAll(async () => {
 afterAll(() => {
   try { instance?.close(); } catch {}
   delete process.env.NIRVANA_PROJECT_ROOT;
+  closeTestKernels();
   while (roots.length) removeDir(roots.pop()!);
 });
 
@@ -117,7 +123,11 @@ describe("Glance multi-target projection", () => {
   });
 
   test("projectMultiTargetRun replays node events recorded after the last snapshot", async () => {
-    const kernel = openKernel(path.join(tempRoot(), "kernel.sqlite"));
+    // Hermetic: this case never goes through the server. It crashes the coordinator, then reads the
+    // journal back through this same handle (listEvents, projectMultiTargetRun, state.load) to prove
+    // the replay. It is also the only case here that drives a full plan, so it journalled the most
+    // events and paid the most fsyncs.
+    const kernel = openTestKernel();
     const runId = "run_crash";
     seedRun(kernel, runId);
     const kernelPorts = ports(kernel, runId);

--- a/skills/harness/tests/helpers/test-kernels.ts
+++ b/skills/harness/tests/helpers/test-kernels.ts
@@ -1,0 +1,45 @@
+// test-kernels.ts — how a harness test opens the Run Kernel, and why the hermetic one is the default.
+//
+// The kernel opens with `PRAGMA synchronous = FULL`, so every event it journals costs one fsync. A
+// test that opens it as a file under a temp directory stops measuring the code it exercises and
+// starts measuring the runner's disk. PR #146 measured the size of that: in
+// `gauntlet-revision-loop.e2e.test.ts` a case that costs 14 ms on an idle machine timed out at
+// 8,415 ms on `smoke (windows-latest)` while the twin leg of its own `test.each` — the identical
+// code path — finished in 688 ms. Under 40 concurrent copies, 640 runs on disk produced 100
+// timeouts; the same 640 in memory produced 5.
+//
+// The reason the disk kept winning is that nobody chose it. A new test copies its neighbour, the
+// neighbour opened a file, and the fsync arrives without a decision. So the default here is
+// `openTestKernel()` and the file is the named exception.
+//
+// Take `openTestKernelFile(path)` only when the test READS THE DATABASE BACK through a connection
+// that is not the one it writes with: a spawned child process, an HTTP server the test drives, or a
+// second handle the code under test opens from a path it was given. `:memory:` is private to a
+// single connection — every other reader opens an empty database — so those tests would go green on
+// nothing at all. That failure is silent, and a green lie costs more than an honest fsync.
+//
+// Both register the handle with `closeTestKernels()`, which belongs in `afterEach`. A handle left
+// open holds the file on Windows and turns the temp-root cleanup into EBUSY, where it hides the
+// real failure (see temp-dirs.ts).
+import { openKernel, type KernelHandle } from "../../lib/run-kernel/index.ts";
+
+const opened: KernelHandle[] = [];
+
+/** The default: a Run Kernel whose journal never reaches the disk. */
+export function openTestKernel(): KernelHandle {
+  const handle = openKernel(":memory:");
+  opened.push(handle);
+  return handle;
+}
+
+/** The exception: a Run Kernel on disk, for a test whose database another connection reads back. */
+export function openTestKernelFile(dbPath: string): KernelHandle {
+  const handle = openKernel(dbPath);
+  opened.push(handle);
+  return handle;
+}
+
+/** Close every handle these helpers opened. A handle the test already closed absorbs this as a no-op. */
+export function closeTestKernels(): void {
+  while (opened.length) opened.pop()!.close();
+}

--- a/skills/harness/tests/multi-target-dispatch-adapters.test.ts
+++ b/skills/harness/tests/multi-target-dispatch-adapters.test.ts
@@ -8,16 +8,16 @@ import { coordinateMultiTargetPlan, type MultiTargetAdapterInput } from "../lib/
 import { costMatcher, createDispatchMultiTargetAdapters, MULTI_TARGET_RESULT_MARKER, nodeRunId, type DispatchSpawn } from "../lib/gauntlet/multi-target-dispatch-adapters.ts";
 import { createRunKernelMultiTargetPorts } from "../lib/gauntlet/run-kernel-multi-target-ports.ts";
 import { compileMultiTargetGauntletPolicy, type CompiledMultiTargetPlan } from "../lib/plan-compiler.ts";
-import { createRun, listEvents, openKernel, type KernelHandle } from "../lib/run-kernel/store.ts";
+import { createRun, listEvents } from "../lib/run-kernel/store.ts";
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
 import { SCOPE_GUARD_EN } from "../../_shared/lib/scope-guard.ts";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { closeTestKernels, openTestKernel } from "./helpers/test-kernels.ts";
 
 const roots: string[] = [];
-const handles: KernelHandle[] = [];
 afterEach(() => {
-  while (handles.length) handles.pop()!.close();
+  closeTestKernels();
   for (const root of roots.splice(0)) removeDir(root);
 });
 
@@ -338,8 +338,11 @@ describe("multi-target dispatch adapters", () => {
     const setup = fixture();
     const { plan, reservation } = compile();
     const ws = setup.workspaceRoot;
-    const kernel = openKernel(join(setup.root, "kernel.sqlite"));
-    handles.push(kernel);
+    // Hermetic journal. The subprocesses this case spawns are fake dispatches that answer through
+    // files (the spawn log, dispatch-capture.json, _SUMMARY.md); none of them opens the kernel, and
+    // the leases and lease_released events are read back below through this same handle. The disk
+    // only bought fsyncs — this is the wave-and-resume case, the heaviest journal in the file.
+    const kernel = openTestKernel();
     createRun(kernel, {
       projectId: setup.projectId, runId: "run-multi", traceId: setup.projectId, planId: "plan-multi",
       target: { kind: "agent-x", slug: "agent-x" }, policySnapshotRef: "pending", actor: { kind: "test", id: "fixture" },

--- a/skills/harness/tests/standard-publication.test.ts
+++ b/skills/harness/tests/standard-publication.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../lib/run-kernel/standard-publication.ts";
 import { transitionsTo } from "./helpers/run-states.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const roots: string[] = [];
 afterEach(() => { while (roots.length) removeDir(roots.pop()!); });
@@ -24,6 +25,16 @@ const TARGET = { kind: "squad" as const, slug: "brandcraft", capabilityId: "squa
 type AuditEntry = { event: string; payload: Record<string, any> };
 const typeOf = (event: RunEvent) => event.type === "run.transitioned" ? `run.transitioned:${(event.payload as { to: string }).to}` : event.type;
 
+// On disk by necessity, and this is the file where that costs the most. `openStandardPublication`
+// is given a PATH and opens its own handle, so `read` and `prepare` below reach the journal through
+// connections that are not the writer's — the exact thing a `:memory:` database cannot serve, since
+// it belongs to whichever connection opened it. One case even asserts the file was never created.
+// The kernel opens with `PRAGMA synchronous = FULL`, so every event is an fsync, and the collision
+// case walks all seven terminal states: each costs a `prepare` plus three reads, twenty-eight
+// openings of one file with the schema initialization re-run on every one, on top of the events.
+// That is why it timed out: 18 times in 640 runs under a busy disk, always that one case, at 5.9 s
+// mean against Bun's 5 s default, while the cheap cases beside it finished in milliseconds. The
+// cost is real coverage, so it is budgeted rather than moved.
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-standard-publication-")); roots.push(root);
   const kernelPath = path.join(root, ".nirvana", "run-kernel.sqlite");
@@ -91,7 +102,7 @@ describe("openStandardPublication", () => {
     expect(events.at(-1)!.payload).toEqual({ from: "verifying", to: "completed", exitCode: 0, gateOutcome: "pass", outputsRoot: "/out/deliverables" });
     expect(fx.audit).toEqual([]);
     expect(fx.warnings).toEqual([]);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("every delivery result lands as its own terminal state, with the error on a failed Run", () => {
     const fx = fixture();
@@ -110,7 +121,7 @@ describe("openStandardPublication", () => {
         ...(verdict.error ? { error: verdict.error } : {}) });
     }
     expect((fx.read("run_withheld").events.at(-1)!.payload as { error?: string }).error).toBeUndefined();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("adopts a Run prepared with --run-id: no second run.prepared, the prepared trace and reference are kept", () => {
     const fx = fixture();
@@ -125,7 +136,7 @@ describe("openStandardPublication", () => {
     expect(events.map(typeOf)).toEqual(["run.prepared", "runtime.selection_snapshot", "run.transitioned:running", "run.transitioned:verifying", "run.transitioned:completed"]);
     expect(events[1].payload).toEqual({ ref: policySnapshotRefFor(SNAPSHOT), snapshot: SNAPSHOT });
     expect(fx.audit).toEqual([]);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("re-opening the same Run adds no duplicate events", () => {
     const fx = fixture();
@@ -140,7 +151,7 @@ describe("openStandardPublication", () => {
     expect(fx.read().events.map(typeOf)).toEqual(["run.prepared", "runtime.selection_snapshot",
       "run.transitioned:running", "run.transitioned:verifying", "run.transitioned:completed"]);
     expect(fx.audit).toEqual([]);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("an unavailable kernel is fail-open: x_run_kernel_unavailable, no exception, every later call a no-op", () => {
     const fx = fixture();
@@ -159,7 +170,7 @@ describe("openStandardPublication", () => {
     expect(() => { publication.start(); publication.verify(); publication.finish({ exitCode: 0, gateOutcome: "pass" }, "/out"); }).not.toThrow();
     expect(fx.audit).toHaveLength(1);
     expect(fs.existsSync(fx.kernelPath)).toBe(false);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a transition the kernel refuses turns the publication inert without touching the legacy flow", () => {
     const fx = fixture();
@@ -171,7 +182,7 @@ describe("openStandardPublication", () => {
     expect(fx.audit[0].payload).toMatchObject({ run_id: "run_live", stage: "running" });
     expect(fx.audit[0].payload.error).toContain("illegal transition running -> running");
     expect(fx.read("run_live").run?.state).toBe("running");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a Run that already ended under the same id is refused before any producer: x_run_id_collision, collided, nothing appended", () => {
     const fx = fixture();
@@ -192,7 +203,7 @@ describe("openStandardPublication", () => {
     expect(fx.audit[0].payload).toEqual({ trace_id: "trace_std", project_id: "prj_std", run_id: "run_abandoned", state: "abandoned",
       kernel_path: fx.kernelPath, target_kind: "squad", run_target: { kind: "agent-x", slug: "agent-x" }, mode: "standard" });
     expect(fx.audit.some(entry => entry.event === "x_run_kernel_unavailable")).toBe(false);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("broker errors in the frozen snapshot end the Run rolled_back before any producer (RT-002)", () => {
     const fx = fixture();
@@ -208,5 +219,5 @@ describe("openStandardPublication", () => {
     publication.start();
     expect(fx.read().events).toHaveLength(3);
     expect(fx.audit).toEqual([]);
-  });
+  }, KERNEL_BUDGET_MS);
 });


### PR DESCRIPTION
PR #146 fixed one file and left a list of ten. What the ten have in common is not a mistake anyone made: a new test opens the Run Kernel the way its neighbour does, the neighbour opened a real SQLite file under a temp directory, and `PRAGMA synchronous = FULL` turns every journalled event into an fsync. The disk arrives as an inheritance, never as a decision.

## The helper

`skills/harness/tests/helpers/test-kernels.ts` sits beside `temp-dirs.ts` and `test-budgets.ts` and gives the decision somewhere to live:

- `openTestKernel()` — hermetic, the default.
- `openTestKernelFile(path)` — the named exception, for a test that earns the disk.
- `closeTestKernels()` — releases either in `afterEach`, so a leaked handle never turns a Windows teardown into EBUSY.

## The ten, one question each

**Does this test read the database back through a connection that is not the one it writes with?** `:memory:` belongs to whichever connection opened it, so any other reader finds an empty database and every assertion passes on nothing. A green lie costs more than an honest fsync.

| File | Reads it back? | Decision |
|---|---|---|
| `gauntlet-store` | no, one handle writes and reads | `:memory:` |
| `multi-target-dispatch-adapters` | no, the fake dispatch children answer through files | `:memory:` |
| `glance-multi-target-projection` | split: the server reads the `beforeAll` journal; the crash-replay case never goes through the server | file for the first, `:memory:` for the second |
| `standard-publication` | yes, `openStandardPublication` is handed a path and opens its own handle | file + `KERNEL_BUDGET_MS` |
| `glance-control-plane` | yes, a live server holds its own connections to two `synchronous = FULL` databases | file + `KERNEL_BUDGET_MS` |
| `dispatch-gauntlet-ledger` | yes, a spawned dispatch writes it | unchanged, already `spawnBudgetMs` |
| `dispatch-standard-kernel` | yes, a spawned dispatch writes it | unchanged, already budgeted |
| `gauntlet-evaluator-dispatch` | yes, a spawned evaluator child writes it | unchanged, already `spawnBudgetMs` |
| `judge-x-dispatch` | yes, a spawned judge writes it | unchanged, already `spawnBudgetMs` |
| `multi-target-cli` | yes, a spawned `nrv` writes it, and the file's existence is asserted | unchanged, already `spawnBudgetMs` |

A database in this process's memory is invisible to a child process, which makes the last five the clearest read-back of all. None of them moved.

## The proof, statistical

10-core machine, four fsync loops competing for the disk, identical parameters both sides.

| Measurement | Before | After |
|---|---|---|
| 40 concurrent copies of the three server-free files, 640 runs a side: timeouts | **18** | **0** |
| the same group's wall clock, mean / p95 / max | 18.2 s / 22.2 s / 23.4 s | 15.8 s / 19.4 s / 19.9 s |
| the two files whose journals moved, alone, 240 runs a side: mean / max | 9.0 s / 9.9 s | 8.0 s / 9.0 s |
| the two Glance files, 60 sequential runs a side under that contention: mean / max | 3.0 s / 5.4 s | 2.5 s / 6.9 s |

All 18 timeouts were the same case, `a Run that already ended under the same id is refused before any producer`, at 5,943 ms mean against Bun's 5 s default. The two files that moved to memory never timed out on macOS on either side — they are too cheap to cross 5 s here, and the exposure they carried was Windows-shaped. The Glance pair's 6.9 s outlier, one sample in sixty, is the tail `KERNEL_BUDGET_MS` now absorbs; under Bun's default it is a red build.

## Verified

`bun test` over the five touched files (36 pass), plus `gauntlet-revision-loop.e2e` and `run-kernel.test.ts` as neighbours; `check-english-source --strict`; `check-changelog-parity --strict`; `check-engine-purity`; `git diff --check`. The full suite and the 14 gates run once over the whole, in CI.

## Out of scope, recorded

`startServer` resolves `port: 0` by probing with a throwaway `Bun.serve`, stopping it, and letting the caller bind the same number, so two copies started in the same instant both pick 3737 and one dies with EADDRINUSE. Only one copy of a file runs in CI, so it never fires there; it is why the Glance files were measured sequentially. Not touched.

Four more files open the kernel on disk with a single in-process handle and no read-back — `agent-x-gauntlet-cutover`, `gauntlet-controller`, `gauntlet-evaluator-adapter`, `run-kernel-multi-target-ports`. They are exposed the same way, but they already carry budgets, so they are listed rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
