### PR TITLE
fix(squads): the acceptance fixer renames instead of inventing, and a step ref with `tasks/` resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Two mechanical fixers were lying: one fabricated a criterion, the other repaired nothing
+
+Both turned up in a real audit of `brandcraft` on 27/08/2026, and the first would
+have made that squad worse if anyone had run `--fix` before reading it.
+
+`fix_tasks_acceptance_criteria` tested whether a task carried an acceptance
+heading and, finding none, appended a generic block. The thirty-two tasks of that
+squad wrote the true criterion under `## Postconditions`. The judge's parser,
+`acceptanceCriteriaOf`, matches `## Acceptance Criteria` and nothing else, so the
+fixer would have left every task with the author's contract under one heading and
+a placebo under the heading that is actually scored. It also appended an
+`## Output Schema` block declaring outputs the task never had, which flipped the
+detector's `outputs:` test true and left the finding unable to fire again. A fixer
+that silences its own finding by inventing the answer is worse than the gap it
+closed, because the gap was at least visible.
+
+It renames now, and fabricates nothing. The alias list is measured, not guessed:
+across the 206 installed squads the criteria that are not under
+`## Acceptance Criteria` sit under `Quality criteria` (37 task files),
+`Critérios de Qualidade` (22), `Acceptance` and `Acceptance (binário)` (14), and
+`Postconditions` (9). `Checklist` is deliberately excluded — in this library it
+opens `### Pre` and `### Post` subsections, and renaming it would promote
+preconditions into the contract the judge scores. Of the 291 task files that
+trigger the finding today, 121 carry real criteria that now move under the
+heading the judge reads, in 19 squads. The other 170 stay a finding. v6 §28.3
+already settled that question for the sibling fixer: writing the criterion is
+writing the squad's method, and the author writes it.
+
+`workflow_refs_repair` matched a reference by case and separator alone, never
+stripping the directory an author writes into the path. Nine workflows of
+brandcraft wrote `task: tasks/inspect-quality.md` with every file present; the
+lint compares the value against the stem on disk, so present read as absent and
+twelve of the thirteen pending references survived `--fix` untouched. The
+executor had been reading that shape correctly all along, since `squad-exec.ts`
+strips `^(agents|tasks)/` before loading a component: the gate and the runtime
+disagreed about a file both could open.
+
+Step-reference normalization now strips the component directory the way it
+already stripped the encoding, and the repair strips it before matching, then
+writes the bare stem back. Accepting the written form is not adopting it as
+canonical: §28.6 keeps a reference free of directory and extension, and that is
+what `--fix` writes. Measured over the installed library, unresolved step
+references fall from 1021 to 829, and the squads carrying the finding from 78
+to 62.
+
 ### The cockpit read `0 running` while two dispatches were writing to disk
 
 On 27/08/2026 the owner opened Glance with two dispatches alive and the Runs

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,52 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Dois reparos mecânicos mentiam: um fabricava critério, o outro não reparava nada
+
+Os dois apareceram numa auditoria real do `brandcraft` em 27/08/2026, e o
+primeiro teria piorado aquela squad se alguém tivesse rodado `--fix` antes de
+olhar.
+
+O `fix_tasks_acceptance_criteria` testava se a task tinha cabeçalho de aceitação
+e, não tendo, acrescentava um bloco genérico. As trinta e duas tasks daquela
+squad escreviam o critério verdadeiro sob `## Postconditions`. O parser que o
+juiz lê, `acceptanceCriteriaOf`, casa `## Acceptance Criteria` e mais nada, então
+o fixer teria deixado cada task com o contrato do autor sob um cabeçalho e um
+placebo sob o cabeçalho que de fato é cobrado. Ele ainda acrescentava um bloco
+`## Output Schema` declarando outputs que a task nunca teve, o que virava o teste
+de `outputs:` do detector para verdadeiro e deixava a constatação sem poder
+disparar de novo. Um fixer que cala a própria constatação inventando a resposta é
+pior que a lacuna que ele fechou, porque a lacuna pelo menos era visível.
+
+Agora ele renomeia, e não fabrica nada. A lista de sinônimos foi medida, não
+chutada: nas 206 squads instaladas, os critérios que não estão sob
+`## Acceptance Criteria` vivem sob `Quality criteria` (37 arquivos de task),
+`Critérios de Qualidade` (22), `Acceptance` e `Acceptance (binário)` (14) e
+`Postconditions` (9). O `Checklist` ficou de fora de propósito — nesta biblioteca
+ele abre subseções `### Pre` e `### Post`, e renomeá-lo promoveria pré-condições
+ao contrato que o juiz cobra. Dos 291 arquivos de task que hoje disparam a
+constatação, 121 carregam critério real que passa a ficar sob o cabeçalho que o
+juiz lê, em 19 squads. Os outros 170 continuam constatação. A v6 §28.3 já tinha
+resolvido essa pergunta para o fixer irmão: escrever o critério é escrever o
+método da squad, e quem escreve isso é o autor.
+
+O `workflow_refs_repair` casava a referência só por caixa e separador, sem nunca
+tirar o diretório que o autor escreve no caminho. Nove workflows do brandcraft
+escreviam `task: tasks/inspect-quality.md` com todos os arquivos presentes; o
+lint compara o valor com o stem em disco, então presente virava ausente e doze
+das treze referências pendentes sobreviveram intactas ao `--fix`. O executor
+sempre leu essa forma corretamente, porque o `squad-exec.ts` tira
+`^(agents|tasks)/` antes de carregar um componente: o portão e o runtime
+discordavam sobre um arquivo que os dois conseguiam abrir.
+
+A normalização da referência de passo passa a tirar o diretório do componente do
+mesmo jeito que já tirava a codificação, e o reparo tira o diretório antes de
+casar e escreve o stem puro de volta. Aceitar a forma escrita não é adotá-la como
+canônica: a §28.6 mantém a referência sem diretório e sem extensão, e é isso que
+o `--fix` grava. Medido sobre a biblioteca instalada, as referências de passo
+pendentes caem de 1021 para 829, e as squads que carregam a constatação, de 78
+para 62.
+
 ### O cockpit lia `0 running` enquanto dois despachos escreviam no disco
 
 Em 27/08/2026 o dono abriu o Glance com dois despachos vivos e o painel de Runs

--- a/skills/_shared/lib/verify/kinds/squad.ts
+++ b/skills/_shared/lib/verify/kinds/squad.ts
@@ -719,7 +719,10 @@ const workflowRefsRepair: Fixer = ({ dir, finding }) => withDigest(dir, "workflo
   const text = fs.readFileSync(file, "utf8");
   const rewritten = text.replace(/^(\s*-?\s*)(agent|task)(:\s*["']?)([\w./-]+)(["']?\s*)$/gim, (whole, lead, key, sep, value, tail) => {
     const kind = key as "agent" | "task";
-    const bare = value.replace(/\.(md|markdown)$/i, "");
+    // The directory and the extension are how the path is written; the step
+    // names the component. Strip both before matching, and write the bare stem
+    // back — §28.6's canonical form, and the fixed point of a second `--fix`.
+    const bare = value.replace(/^(?:agents|tasks)\//i, "").replace(/\.(md|markdown)$/i, "");
     if (known[kind].has(bare)) return whole;
     const candidates = byKey[kind].get(bare.toLowerCase().replace(/_/g, "-")) ?? [];
     if (candidates.length !== 1) return whole;

--- a/skills/_shared/tests/verify-squad.test.ts
+++ b/skills/_shared/tests/verify-squad.test.ts
@@ -19,6 +19,7 @@ import { CANONICAL_WORKFLOW, rmrf, runCli, squadFixture, tempRoot, treeDigest, w
 import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 import { criteria as squadCriteria, squadModule } from "../lib/verify/kinds/squad.ts";
 import { WORKFLOW_LINT_IDS } from "../../squads/lib/workflow-reader.ts";
+import { acceptanceCriteriaOf } from "../../harness/lib/gauntlet/success-requirements.ts";
 
 const require_ = createRequire(import.meta.url);
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
@@ -379,6 +380,33 @@ describe("--fix", () => {
     expect(idsOf(findings(r, "renames"))).toContain("workflow_ref_unresolved");
   });
 
+  test("a step reference written `tasks/<stem>.md` resolves: the file is on disk", () => {
+    const r = root();
+    // brandcraft, 27/08/2026: nine workflows wrote the directory into the ref,
+    // every file present, and the gate reported thirteen dangling references.
+    // The executor already reads this shape (`squad-exec.ts` strips
+    // `^(agents|tasks)/` before loading the document); only the lint disagreed.
+    const graph = [
+      "name: main", "steps:",
+      "  - id: plan", "    agent: planner", "    task: tasks/plan.md",
+      "  - id: build", "    agent: builder", "    task: tasks/build", "    requires: [plan]",
+      "",
+    ].join("\n");
+    squadFixture(r, "dir-prefixed-refs", { workflows: { "main.yaml": graph } });
+    expect(idsOf(findings(r, "dir-prefixed-refs"))).not.toContain("workflow_ref_unresolved");
+  }, spawnBudgetMs(2));
+
+  test("workflow_refs_repair strips the directory prefix before matching, and writes the bare stem", () => {
+    const r = root();
+    const graph = "name: main\nsteps:\n  - id: plan\n    agent: planner\n    task: tasks/PLAN.md\n";
+    const dir = squadFixture(r, "prefixed-rename", { workflows: { "main.yaml": graph } });
+    expect(idsOf(findings(r, "prefixed-rename"))).toContain("workflow_ref_unresolved");
+    runCli(r, ["squad", "prefixed-rename", "--no-retrieval", "--fix"]);
+    // §28.6: the canonical reference carries neither directory nor extension.
+    expect(fs.readFileSync(path.join(dir, "workflows", "main.yaml"), "utf8")).toContain("task: plan\n");
+    expect(idsOf(findings(r, "prefixed-rename"))).not.toContain("workflow_ref_unresolved");
+  }, spawnBudgetMs(3));
+
   test("requires_by_output_name rewrites a dependency that named an output", () => {
     const r = root();
     const graph = "name: main\nsteps:\n  - id: plan\n    agent: planner\n    task: plan\n    creates: [plan.md]\n  - id: build\n    agent: builder\n    task: build\n    requires: [plan.md]\n";
@@ -453,5 +481,38 @@ describe("the audit scorer after `humanize`", () => {
     const front = /^---\n([\s\S]*?)\n---/.exec(text)![1];
     expect(parseYaml(front).tools).toEqual(["Read", "Write", "Edit", "Bash", "Grep", "Glob"]);
     expect(parseYaml(front).maxTurns).toBe(12);
+  }, spawnBudgetMs(2));
+
+  test("tasks_acceptance_criteria renames the criteria the author wrote, and fabricates none", () => {
+    const r = root();
+    const dir = squadFixture(r, "ac-postconditions");
+    // brandcraft, 27/08/2026: thirty-two tasks carried the real contract under
+    // `## Postconditions`, which neither the gate's detector nor the judge's
+    // parser reads. Appending a generic block would have left the true
+    // criterion under one heading and a placebo under the heading the judge
+    // scores against.
+    fs.writeFileSync(path.join(dir, "tasks", "plan.md"), [
+      "# plan", "", "Plan the artifact.", "",
+      "## Postconditions", "",
+      "- `plan.md` exists and names every section the brief asked for.",
+      "- Every open question of the brief is answered or listed as a risk.",
+      "",
+    ].join("\n"), "utf8");
+    // Nothing to rename. Writing a criterion here would hand the judge a
+    // contract the author never agreed to (v6 §28.3: fixers never invent).
+    const barren = "# build\n\nBuild it.\n";
+    fs.writeFileSync(path.join(dir, "tasks", "build.md"), barren, "utf8");
+
+    const [res] = fixers.applyMechanicalFixes(dir, { patches: [{ kind: "tasks_acceptance_criteria" }] });
+    expect(res.result.ok).toBe(true);
+
+    const plan = fs.readFileSync(path.join(dir, "tasks", "plan.md"), "utf8");
+    expect(acceptanceCriteriaOf(plan)).toEqual([
+      "`plan.md` exists and names every section the brief asked for.",
+      "Every open question of the brief is answered or listed as a risk.",
+    ]);
+    expect(plan).not.toContain("## Postconditions");
+    expect(plan).not.toContain("matches the declared schema");
+    expect(fs.readFileSync(path.join(dir, "tasks", "build.md"), "utf8")).toBe(barren);
   }, spawnBudgetMs(2));
 });

--- a/skills/squads/lib/mechanical-fixers.js
+++ b/skills/squads/lib/mechanical-fixers.js
@@ -291,42 +291,62 @@ function fix_domain_realign(squadDir, patch) {
 
 // ─── structural fixers (tasks, agents, readme, workflows) ───
 
+/**
+ * Headings the library writes acceptance criteria under when it does not write
+ * `## Acceptance Criteria`. Measured over the 206 installed squads on
+ * 27/08/2026: `Quality criteria` (37 task files), `Critérios de Qualidade` (22),
+ * `Acceptance` / `Acceptance (binário)` (14), `Postconditions` (9 — the
+ * brandcraft case). Nothing here is invented: a heading nobody writes only
+ * widens what a rename can damage.
+ *
+ * `Checklist` is deliberately absent. In the library it opens `### Pre` and
+ * `### Post` subsections, so renaming it would promote preconditions into the
+ * contract the judge scores against — the same lie by a different route.
+ */
+const AC_ALIAS_RE = /^(#{2,6})[ \t]+(?:Postconditions|P[óo]s[- ]?condi[çc][õo]es|Quality criteria|Crit[ée]rios? de Qualidade|Acceptance(?:[ \t]*\([^)\n]*\))?)[ \t]*$/im;
+
+/**
+ * Rename first, and never fabricate.
+ *
+ * The parser the judge reads (`acceptanceCriteriaOf`) matches
+ * `## Acceptance Criteria` and nothing else. A task whose real contract sits
+ * under another heading is therefore invisible to the judge — and appending a
+ * generic block, as this fixer used to, left the true criterion under one
+ * heading and a placebo under the one that is scored. That is worse than the
+ * finding it closed, because it closes silently.
+ *
+ * So: move the author's criteria under the heading the judge reads. When there
+ * is nothing to move, decline and name the tasks. v6 §28.3 — "os fixers nunca
+ * inventam" — and §35.2 both draw the line here: writing the criterion would
+ * be writing the squad's method.
+ */
 function fix_tasks_acceptance_criteria(squadDir) {
   const dir = path.join(squadDir, 'tasks');
   if (!fs.existsSync(dir)) return { ok: false, reason: 'tasks/ missing' };
   const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
-  let patched = 0;
+  let renamed = 0;
+  const unwritten = [];
   for (const f of files) {
     const fp = path.join(dir, f);
-    let body = fs.readFileSync(fp, 'utf8');
+    const body = fs.readFileSync(fp, 'utf8');
     const hasACHeader = /^##+\s+(Acceptance Criteria|Critérios de Aceita[çc]ão|Success Criteria)/im.test(body);
     const hasOutputs = /^outputs\s*:/m.test(body);
     const hasACField = /^acceptance_criteria\s*:/m.test(body);
     if (hasACHeader || hasOutputs || hasACField) continue;
-    const slug = f.replace(/\.md$/, '');
-    const block = [
-      '',
-      '## Acceptance Criteria',
-      '',
-      `- [ ] Output produced for task \`${slug}\` is non-empty and matches the declared schema.`,
-      '- [ ] All inputs referenced in the task body are consumed; no orphan placeholders remain.',
-      '- [ ] Resulting handoff artifact is valid against \`_shared/schemas/handoff.schema.json\`.',
-      '',
-      '## Output Schema',
-      '',
-      '```yaml',
-      'outputs:',
-      `  - name: ${slug}_result`,
-      '    type: object',
-      `    description: Deliverable produced by the ${slug} task.`,
-      '```',
-      '',
-    ].join('\n');
-    if (!body.endsWith('\n')) body += '\n';
-    fs.writeFileSync(fp, body + block, 'utf8');
-    patched++;
+    const alias = AC_ALIAS_RE.exec(body);
+    if (!alias) { unwritten.push(f.replace(/\.md$/, '')); continue; }
+    const head = `${alias[1]} Acceptance Criteria`;
+    fs.writeFileSync(fp, body.slice(0, alias.index) + head + body.slice(alias.index + alias[0].length), 'utf8');
+    renamed++;
   }
-  return { ok: true, patched, total: files.length };
+  if (renamed === 0) {
+    if (unwritten.length === 0) return { ok: false, reason: 'every task already declares acceptance criteria or outputs' };
+    return {
+      ok: false,
+      reason: `${unwritten.length} task(s) declare no criteria under any heading (${unwritten.slice(0, 5).join(', ')}) — the author writes them; a fabricated one would be scored as a contract`,
+    };
+  }
+  return { ok: true, renamed, unwritten: unwritten.length, total: files.length };
 }
 
 function fix_agents_frontmatter_repair(squadDir) {

--- a/skills/squads/lib/workflow-reader.ts
+++ b/skills/squads/lib/workflow-reader.ts
@@ -44,6 +44,9 @@ export const WORKFLOW_EXTS = [".md", ".yaml", ".yml"] as const;
 const WORKFLOW_EXT_RE = /\.(ya?ml|md)$/i;
 const COMPONENT_EXT_RE = /\.(ya?ml|md|markdown)$/i;
 
+/** The component directory an author writes into a step reference. */
+const COMPONENT_DIR_RE = /^(?:agents|tasks)\//i;
+
 /** `^[a-z][a-z0-9_-]*$` — the canonical form of a workflow name and a step id. */
 export const CANONICAL_ID = /^[a-z][a-z0-9_-]*$/;
 
@@ -266,7 +269,7 @@ function normalizeStep(raw: unknown, index: number, out: NormalizeResult): Canon
   // task: a reference, never a paragraph. Prose moves to the body verbatim.
   const proseParts: string[] = [];
   if (typeof src.task === "string") {
-    if (isRefShaped(src.task)) step.task = stripComponentExt(src.task.trim());
+    if (isRefShaped(src.task)) step.task = componentStem(src.task.trim());
     else { proseParts.push(src.task); out.inlineProse.push(id); }
   } else if (src.task !== undefined) {
     step.meta.task = src.task;
@@ -274,7 +277,7 @@ function normalizeStep(raw: unknown, index: number, out: NormalizeResult): Canon
   for (const key of ["action", "prompt"] as const) {
     const v = src[key];
     if (typeof v === "string" && v.trim()) {
-      if (key === "action" && isRefShaped(v) && !step.task) { step.task = stripComponentExt(v.trim()); continue; }
+      if (key === "action" && isRefShaped(v) && !step.task) { step.task = componentStem(v.trim()); continue; }
       proseParts.push(v);
       if (v.includes("\n")) out.inlineProse.push(id);
     } else if (v !== undefined) {
@@ -305,8 +308,23 @@ function normalizeStep(raw: unknown, index: number, out: NormalizeResult): Canon
   return step;
 }
 
-function stripComponentExt(s: string): string {
-  return s.replace(COMPONENT_EXT_RE, "");
+/**
+ * A component reference → the stem the graph names.
+ *
+ * The directory and the encoding are how an author writes a path; the step
+ * names the component, the same way §28.6 has a capability name the workflow
+ * and not its file. The executor already reads a reference this way —
+ * `squad-exec.ts` strips `^(agents|tasks)/` and the extension before loading
+ * the document — so a lint that compared the raw value against the stems on
+ * disk reported a file it could open as missing. Nine workflows of brandcraft
+ * wrote `task: tasks/inspect-quality.md`, every file present, and the gate
+ * called thirteen references dangling.
+ *
+ * Accepting the written form is not making it canonical: `workflow_refs_repair`
+ * still writes the bare stem back whenever it renames.
+ */
+function componentStem(s: string): string {
+  return s.replace(COMPONENT_DIR_RE, "").replace(COMPONENT_EXT_RE, "");
 }
 
 /**


### PR DESCRIPTION
Two mechanical fixers that lied, both found in a real audit of `brandcraft` on 27/08/2026. The first would have made that squad **worse** if anyone had run `--fix` before reading it.

## 1. `fix_tasks_acceptance_criteria` fabricated a criterion the judge then scored

`skills/squads/lib/mechanical-fixers.js`. It tested for an acceptance heading and, finding none, appended a generic block plus an `## Output Schema` declaring outputs the task never had.

The thirty-two tasks of `brandcraft` wrote the true criterion under `## Postconditions`. The judge's parser, `acceptanceCriteriaOf`, matches `## Acceptance Criteria` and nothing else. So `--fix` would have left the author's contract under one heading and a placebo under the heading that is actually scored — and the fabricated `outputs:` flipped the detector's own test true, leaving the finding unable to fire again. A fixer that silences its own finding by inventing the answer is worse than the gap it closed, because the gap was at least visible.

**It renames now, and fabricates nothing.** The alias list is measured over the 206 installed squads, not guessed:

| Heading | Task files |
|---|---|
| `Quality criteria` | 37 |
| `Critérios de Qualidade` | 22 |
| `Acceptance` / `Acceptance (binário)` | 14 |
| `Postconditions` | 9 |

`Checklist` is excluded on purpose: in this library it opens `### Pre` and `### Post` subsections, so renaming it would promote preconditions into the contract the judge scores — the same lie by another route.

When nothing can be renamed the fixer declines and names the tasks. v6 §28.3 already settled that question for the sibling fixer ("os fixers nunca inventam"), and §35.2 repeats it for the migration: writing the criterion is writing the squad's method. Of the 291 task files that trigger the finding today, **121 carry real criteria that now reach the judge, in 19 squads**; the other 170 stay a visible finding for their author.

## 2. `workflow_refs_repair` never stripped the directory prefix

`skills/_shared/lib/verify/kinds/squad.ts:711` matched by case and separator alone. Nine `brandcraft` workflows wrote `task: tasks/inspect-quality.md` with every file on disk; the lint compares the value against the stem, so present read as absent and **twelve of the thirteen pending references survived `--fix` untouched**.

The executor had been reading that shape correctly all along — `squad-exec.ts` strips `^(agents|tasks)/` before loading a component — so the gate and the runtime disagreed about a file both could open.

Step-reference normalization now strips the component directory the way it already stripped the encoding, and the repair strips it before matching, then writes the bare stem back. Accepting the written form is not adopting it as canonical: §28.6 keeps the reference free of directory and extension, and that is what `--fix` writes.

Measured over the installed library: unresolved step references **1021 → 829**, squads carrying the finding **78 → 62**.

## Verification

Both defects are pinned by tests written first and observed failing against the previous code (`workflow_ref_unresolved` present where every file existed; `acceptanceCriteriaOf` returning the three fabricated bullets instead of the author's two).

- `bun test skills/_shared/tests skills/squads/tests` plus the four harness files that read `workflow-reader` / `success-requirements` / `squad-exec`: **741 pass, 0 fail**
- `bun scripts/check-english-source.ts --strict` — clean
- `bun scripts/check-changelog-parity.ts --strict` — clean (58 versions, 182 sections)
- `git diff --check` — clean

Changelog in both languages.