### PR TITLE
An event router is a shape, not a defect; the invocation keys nothing reads stop being invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A workflow written as an event router stopped being reported as broken
+
+`nirvana-crypto-trading` carried a permanent warning. Its
+`event-driven-reactive.yaml` declares 23 event routes, each with its own channel,
+condition, priority and agent chain, and a capability invokes it for real. The
+gate answered `workflow_unnormalizable` on every run, saying no step order could
+be derived from the document, and under `--strict` that one warning was enough to
+print REJECTED against a squad that had done nothing wrong.
+
+A document whose graph cannot be derived because it is not a graph is not a
+malformed workflow. It is a workflow of another kind. The finding is now
+`workflow_event_router` at severity `info`, and it counts toward nothing: not the
+verdict, not the warning total, not the number of criteria passed. Every squad's
+`PASS n criteria` line drops by one for that reason, because an `info` criterion
+is not one an entity can pass or fail. It still appears, because the empty `steps[]` it produces would otherwise go unexplained,
+and it now says what the document is instead of what could not be done to it:
+`an event router: 23 event_routes entries, each with its own channel and chain`.
+
+No canonical shape for routers was added, and that was the decision rather than
+an omission. Two files in 629 carry `event_routes`, both named
+`event-driven-reactive.yaml`, in `nirvana-crypto-trading` and
+`nirvana-ai-trading`. Two instances do not pay for a second form that the reader,
+the lint, the migration, the prompt builder, the graph and the catalog would each
+have to learn. `nrv migrate` still refuses those two without `--force`, and the
+refusal is the honest half: forcing `steps[]` would invent an order between
+events that arrive independently.
+
+### The doctor names the invocation keys that nothing reads
+
+`triggers:` and `trigger_threshold:` name a command (`*full-tutoring`, `*wiki`,
+`*followup {jid}`) and how many must match before a workflow fires. Measured on
+the installed library on 27/08/2026: 302 of 629 workflows, across 101 of 206
+squads, declare one of them. `trigger_threshold` appears in 256, `triggers` in 46.
+
+No version of the protocol ever defined either key. v4 does not, v5 mentions them
+zero times, and v6 mentions them once, in the line that preserves legacy
+top-level keys verbatim inside `extensions`. No code reads them either. Routing is
+decided by `produces`, `keywords` and `example_briefs`, weighed by a maestro
+comparing candidates, which makes those commands a convention from before the
+agentic router.
+
+`nrv doctor` now reports the count as a warning, beside the protocol dashboard it
+already prints. Nothing deletes them, and nothing will. That is authored text, the
+normalizer keeps it on purpose, and erasing an author's content to clear a
+diagnostic line is the opposite of what a fixer does. The point is for dead
+surface to stop being invisible, not to stop existing.
+
+The count comes from the normalizer, not from a grep, which is why it exceeds
+what a search for a top-level key finds: 24 of those workflows are already on v6
+and carry the key inside their `extensions:` block.
+
 ### Two mechanical fixers were lying: one fabricated a criterion, the other repaired nothing
 
 Both turned up in a real audit of `brandcraft` on 27/08/2026, and the first would

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,60 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Um workflow escrito como roteador de eventos deixou de ser reportado como quebrado
+
+O `nirvana-crypto-trading` carregava um aviso permanente. O
+`event-driven-reactive.yaml` dele declara 23 rotas de evento, cada uma com canal,
+condição, prioridade e cadeia de agentes própria, e uma capability o invoca de
+verdade. O portão respondia `workflow_unnormalizable` a cada rodada, dizendo que
+nenhuma ordem de passos podia ser derivada do documento, e sob `--strict` aquele
+único aviso bastava para imprimir REJECTED contra uma squad que não tinha feito
+nada de errado.
+
+Um documento cujo grafo não se deriva porque ele não é um grafo não é um workflow
+malformado. É um workflow de outra natureza. A constatação agora é
+`workflow_event_router`, severidade `info`, e não conta para nada: nem para o
+veredito, nem para o total de avisos, nem para o número de critérios passados. A
+linha `PASS n criteria` de toda squad cai em um por causa disso, porque um
+critério `info` não é critério que uma entidade passe ou reprove. Ela continua
+aparecendo, porque o `steps[]` vazio que o documento produz ficaria
+sem explicação, e agora diz o que o documento é em vez de dizer o que não deu
+para fazer com ele: `an event router: 23 event_routes entries, each with its own
+channel and chain`.
+
+Nenhuma forma canônica de roteador foi criada, e isso foi decisão, não
+esquecimento. São dois arquivos em 629 com `event_routes`, os dois chamados
+`event-driven-reactive.yaml`, no `nirvana-crypto-trading` e no
+`nirvana-ai-trading`. Duas instâncias não pagam uma segunda forma que leitor,
+lint, migração, construtor de prompt, grafo e catálogo teriam cada um de
+aprender. O `nrv migrate` continua recusando os dois sem `--force`, e a recusa é a
+metade honesta: forçar `steps[]` inventaria uma ordem entre eventos que chegam
+independentes.
+
+### O doctor passa a nomear as chaves de invocação que ninguém lê
+
+`triggers:` e `trigger_threshold:` nomeiam um comando (`*full-tutoring`, `*wiki`,
+`*followup {jid}`) e quantos precisam casar para o workflow disparar. Medido na
+biblioteca instalada em 27/08/2026: 302 de 629 workflows, em 101 das 206 squads,
+declaram uma das duas. `trigger_threshold` aparece em 256, `triggers` em 46.
+
+Nenhuma versão do protocolo jamais definiu qualquer uma delas. A v4 não define, a
+v5 tem zero menções e a v6 tem uma, na linha que preserva chaves de topo legadas
+verbatim dentro de `extensions`. Código nenhum lê as duas. O roteamento é decidido
+por `produces`, `keywords` e `example_briefs`, pesados por um maestro que compara
+candidatos, o que faz daqueles comandos uma convenção anterior ao roteador
+agêntico.
+
+O `nrv doctor` passa a reportar a contagem como aviso, ao lado do painel de
+protocolo que ele já imprime. Nada apaga aquilo, e nada vai apagar. É texto
+autoral, o normalizador o preserva de propósito, e destruir conteúdo do autor
+para limpar uma linha de diagnóstico é o oposto do que um fixer faz. O objetivo é
+a superfície morta parar de ser invisível, não parar de existir.
+
+A contagem sai do normalizador, não de um grep, e é por isso que ela passa do que
+uma busca por chave de topo encontra: 24 daqueles workflows já estão em v6 e
+carregam a chave dentro do bloco `extensions:` deles.
+
 ### Dois reparos mecânicos mentiam: um fabricava critério, o outro não reparava nada
 
 Os dois apareceram numa auditoria real do `brandcraft` em 27/08/2026, e o

--- a/docs/architecture/validate-gate.md
+++ b/docs/architecture/validate-gate.md
@@ -163,7 +163,7 @@ O manifesto da biblioteca é são; o workflow não é. Medido em 26/08/2026 sobr
 | `outputs_pollution` | erro | — |
 | `evaluator_missing` | erro em 6.0 · aviso em 5.0 | agêntico |
 | `surface_stale` | aviso | `surface_regen` |
-| `workflow_unnormalizable` | aviso | — |
+| `workflow_event_router` | informativo | — |
 | `workflow_orphan` | aviso | — |
 | `workflow_body_too_long` | aviso | — |
 | `produces_untyped` | aviso | — |
@@ -184,7 +184,7 @@ Quem for estender o catálogo precisa de quatro detalhes:
 - **Um leitor só.** `skills/squads/lib/workflow-reader.ts` é a única derivação do grafo: `readWorkflow` aceita as duas codificações (YAML v5, Markdown v6 = frontmatter + corpo), `normalizeWorkflow` mapeia cada dialeto sobre a forma canônica da §28.1, `lintWorkflow` decide a severidade pelo protocolo. Validador, auditor, fixer e migração partem daqui para que nenhum deles discorde sobre o que é o grafo de um squad.
 - **Nada se perde.** Uma chave de topo desconhecida vai para `extensions`, uma chave de passo desconhecida vai para `step.meta`. Um dialeto atravessa `normalizeWorkflow` → `renderCanonicalMarkdown` → `normalizeWorkflow` e volta ao mesmo objeto, com todo campo ainda lá. Essa é também a razão de a segunda rodada de `--fix` não mexer num byte: a forma canônica é ponto fixo da normalização.
 - **Nada se inventa.** Os fixers renomeiam, movem e reformam o que já existe: uma extensão retirada de um ref, a prosa de `task: |` transportada verbatim para `## <step.id>` no corpo, um `depends_on` que nomeava um output reescrito para o passo que o cria, um `output` singular promovido a `outputs[]`. `workflow_refs_repair` **renomeia** quando exatamente um componente casa por caixa ou por `_`↔`-` (o caso `enterprise-dashboard`) e **nunca cria stub**: escrever a task que falta seria fabricar o método do squad. Um `.yaml` também nunca vira `.md` num fixer — trocar a codificação é migração, com backup e relatório (`nrv migrate --to 6`), e o fixer diz isso em vez de agir.
-- **`event_routes` não é um DAG.** É um roteador: nenhuma ordem de passos sai dele. O lint marca `unnormalizable` como aviso e para por aí; adivinhar a ordem seria pior que não ter nenhuma.
+- **`event_routes` não é um DAG.** É um roteador: nenhuma ordem de passos sai dele. O lint emite `workflow_event_router` como **informativo** — conta as rotas, explica o `steps[]` vazio, e não entra em veredito nem em `passed`. Era aviso até 27/08/2026, o que dava constatação permanente e REJECTED sob `--strict` a duas squads corretas. Adivinhar a ordem continua pior que não ter nenhuma, e a migração continua recusando o arquivo sem `--force`.
 
 O `humanize` saiu junto. Era a contradição documentada no inventário: os docs mandavam declarar, o schema estrito rejeitava, e o fixer **escrevia** o campo — de modo que `fix-squad --apply` podia transformar um manifesto válido em inválido. Os seis pontos do critério 9 da auditoria passam a medir o contrato que o juiz de fato lê (`c9_acceptance`: parcela de capabilities com `acceptance[]` ou com task invocada declarando `## Acceptance Criteria`), o total continua 100, e a metade útil do fixer virou `outputs_shape_repair`.
 

--- a/skills/_shared/lib/verify/kinds/squad.ts
+++ b/skills/_shared/lib/verify/kinds/squad.ts
@@ -42,7 +42,7 @@ import {
 import { checkPortability } from "../../../../squads/lib/squad-doctor.ts";
 import { classify } from "../../../lib/corpus-language.ts";
 import { editYaml, fixResult, listEntities, resolveEntityDir, surfaceFindings, surfaceRegenFixer } from "../common.ts";
-import type { CheckContext, Criterion, Finding, FixResult, Fixer, KindModule } from "../types.ts";
+import type { CheckContext, Criterion, Finding, FixResult, Fixer, KindModule, Severity } from "../types.ts";
 
 const require_ = createRequire(import.meta.url);
 const SQUAD_LIB = path.join(import.meta.dir, "..", "..", "..", "..", "squads", "lib");
@@ -94,7 +94,9 @@ export const criteria: Criterion[] = [
   // ── S13 + W01–W13: advice ─────────────────────────────────────────────────
   { id: "evaluator_missing", severity: "error", autofix: "agentic", baselineable: false, title: "an evaluator capability declares its `evaluator` block (v6 §30)" },
   { id: "surface_stale", severity: "warning", autofix: "mechanical", baselineable: false, title: ".nirvana-surface.json matches the files on disk", fixer: "surface_regen" },
-  { id: "workflow_unnormalizable", severity: "warning", autofix: "none", baselineable: false, title: "a step order can be derived from every workflow" },
+  // Never counted: a router is a shape, not a defect. See ALWAYS_INFO in
+  // squads/lib/workflow-reader.ts for why this one is `info` and not advice.
+  { id: "workflow_event_router", severity: "info", autofix: "none", baselineable: false, title: "an `event_routes` document is read as a router, and its empty graph is explained" },
   { id: "workflow_orphan", severity: "warning", autofix: "none", baselineable: false, title: "every workflow is invoked by a capability" },
   { id: "workflow_body_too_long", severity: "warning", autofix: "none", baselineable: false, title: "the workflow body stays under the word ceiling" },
   { id: "produces_untyped", severity: "warning", autofix: "none", baselineable: false, title: "produces reaches a rubric or the capability types its outputs" },
@@ -113,7 +115,7 @@ export const criteria: Criterion[] = [
 
 const BY_ID = new Map(criteria.map((c) => [c.id, c]));
 
-function mk(id: string, message: string, evidence: string, where?: string, severity?: "error" | "warning"): Finding {
+function mk(id: string, message: string, evidence: string, where?: string, severity?: Severity): Finding {
   const c = BY_ID.get(id);
   if (!c) throw new Error(`unknown squad criterion: ${id}`);
   return {

--- a/skills/_shared/lib/verify/types.ts
+++ b/skills/_shared/lib/verify/types.ts
@@ -9,7 +9,12 @@
 export type Kind = "squad" | "business" | "mind-clone";
 export const KINDS: readonly Kind[] = ["squad", "business", "mind-clone"] as const;
 
-/** `info` never counts: it reports a check that could not run (no registry). */
+/**
+ * `info` never counts, toward the verdict or toward `passed`. Two things wear
+ * it: a check that could not run (a clone outside the registry), and a fact
+ * about a correct entity that the report would be poorer without (a workflow
+ * written as an event router, whose graph is empty on purpose).
+ */
 export type Severity = "error" | "warning" | "info";
 export type Autofix = "mechanical" | "agentic" | "none";
 

--- a/skills/_shared/tests/verify-squad.test.ts
+++ b/skills/_shared/tests/verify-squad.test.ts
@@ -115,15 +115,24 @@ describe("the dialect corpus, judged by protocol", () => {
     expect(runCli(r, ["squad", "clean-v6", "--no-retrieval"]).code).toBe(0);
   });
 
-  test("`event_routes` is advice under either protocol: reported, never guessed at", () => {
+  // A router is a correct file. Reporting it as a defect cost two squads a
+  // permanent warning and, under --strict, a REJECTED verdict they had done
+  // nothing to earn. It is still reported — the empty graph needs explaining —
+  // but as `info`, which counts toward nothing.
+  test("`event_routes` is reported as information under either protocol, never as a defect", () => {
     const r = root();
     for (const protocol of ["5.0", "6.0"]) {
       const slug = `router-${protocol.replace(".", "")}`;
       const ref = protocol === "6.0" ? "main" : "main.yaml";
       squadFixture(r, slug, { protocol, workflows: { "main.yaml": "name: main\nevent_routes:\n  on_push: rebuild\n" }, workflowComponent: ref, invokeRef: `workflows/${ref}` });
       const f = findings(r, slug);
-      expect(severityOf(f, "workflow_unnormalizable")).toBe("warning");
+      expect(severityOf(f, "workflow_event_router")).toBe("info");
+      expect(idsOf(f)).not.toContain("workflow_unnormalizable");
+      expect(idsOf(f)).not.toContain("workflow_shape_legacy");
       expect(runCli(r, ["squad", slug, "--no-retrieval"]).code).toBe(0);
+      // The whole point: the router contributes no error and no warning, so it
+      // cannot reject the squad and cannot strict-fail it either.
+      expect(f.filter((x) => x.severity !== "info" && x.id.startsWith("workflow_")).map((x) => x.id)).toEqual([]);
     }
   }, spawnBudgetMs(2));
 

--- a/skills/_shared/tests/workflow-reader.test.ts
+++ b/skills/_shared/tests/workflow-reader.test.ts
@@ -411,12 +411,17 @@ describe("lint: severity follows the protocol", () => {
     }
   });
 
-  test("`event_routes` is advice too: the gate reports it, the migration decides", () => {
+  test("`event_routes` is not advice and not a defect: it is information, and it counts the routes", () => {
     const r = norm(EVENT_ROUTES, "router");
-    const f = lintWorkflow(r.canonical, lintCtx({ stem: "router", file: "router.yaml", unnormalizable: true, dialects: r.dialects }));
-    expect(f.find((x) => x.id === "workflow_unnormalizable")!.severity).toBe("warning");
-    // Unnormalizable replaces the shape finding: there is no shape to fix.
-    expect(f.map((x) => x.id)).not.toContain("workflow_shape_legacy");
+    for (const protocol of ["5.0", "6.0"]) {
+      const f = lintWorkflow(r.canonical, lintCtx({ protocol, stem: "router", file: "router.yaml", unnormalizable: true, dialects: r.dialects }));
+      const router = f.find((x) => x.id === "workflow_event_router")!;
+      expect(router.severity).toBe("info");
+      // It says what the document IS, not what could not be done to it.
+      expect(router.message).toContain("2 `event_routes` entries");
+      // The router replaces the shape finding: there is no shape to fix.
+      expect(f.map((x) => x.id)).not.toContain("workflow_shape_legacy");
+    }
   });
 });
 

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -800,6 +800,54 @@ try {
   add("routing: aliases", "WARN", `cannot read alias groups: ${(e as Error).message}`);
 }
 
+// Invocation keys nothing reads. `triggers:` and `trigger_threshold:` name a
+// command (`*full-tutoring`, `*wiki`) and how many must match before a workflow
+// fires — a convention from before the agentic router, and one NO version of
+// the protocol ever defined: v4 does not, v5 mentions it zero times, and v6
+// mentions it once, in the line that preserves it verbatim in `extensions`.
+// No code reads either key. Routing is decided by produces, keywords and
+// example_briefs, weighed by a maestro comparing candidates.
+//
+// So this reports and stops. There is no fixer, and there will not be one:
+// those commands are text the author wrote, the normalizer keeps them on
+// purpose, and deleting an author's content to clear a diagnostic line is the
+// opposite of what the fixers do. The goal is for dead surface to stop being
+// INVISIBLE, not to stop existing. WARN, never FAIL — same contract as the
+// Protocol section above.
+if (fs.existsSync(homeSquads)) {
+  try {
+    const { readSquadWorkflows } = await import("../../squads/lib/workflow-reader.ts");
+    const VESTIGIAL = ["triggers", "trigger_threshold"] as const;
+    const perKey = new Map<string, number>(VESTIGIAL.map((k) => [k, 0]));
+    let files = 0, squads = 0, workflows = 0;
+    for (const slug of fs.readdirSync(homeSquads)) {
+      if (slug.startsWith(".")) continue;
+      let hit = false;
+      for (const w of readSquadWorkflows(path.join(homeSquads, slug))) {
+        if (!w.normalized) continue;
+        workflows++;
+        const ext = w.normalized.canonical.extensions;
+        const found = VESTIGIAL.filter((k) => ext[k] !== undefined);
+        if (!found.length) continue;
+        files++; hit = true;
+        for (const k of found) perKey.set(k, (perKey.get(k) ?? 0) + 1);
+      }
+      if (hit) squads++;
+    }
+    const spread = VESTIGIAL.filter((k) => (perKey.get(k) ?? 0) > 0).map((k) => `${perKey.get(k)}× \`${k}\``).join(" · ");
+    if (files === 0) {
+      add("routing: vestigial triggers", "PASS", `${workflows} workflow(s) read, none declares an invocation key the router ignores`);
+    } else {
+      add("routing: vestigial triggers", "WARN",
+        `${files} of ${workflows} workflow(s) in ${squads} squad(s) declare ${spread} — decorative. `
+        + `No protocol version defines those keys and no code reads them; routing goes by produces, keywords and example_briefs. `
+        + `They are preserved verbatim in \`extensions\` and no fixer removes them: this line exists so the dead surface is visible, not so it gets deleted.`);
+    }
+  } catch (e) {
+    add("routing: vestigial triggers", "WARN", `could not read the workflow library: ${(e as Error).message}`);
+  }
+}
+
 // Corpus language, because it decides how good `fast` mode can be.
 //
 // The agentic router (the default) reads the digest and reasons, so it routes a

--- a/skills/harness/tests/doctor-vestigial-triggers.test.ts
+++ b/skills/harness/tests/doctor-vestigial-triggers.test.ts
@@ -1,0 +1,130 @@
+// doctor-vestigial-triggers.test.ts — the dead invocation surface, counted.
+//
+// `triggers:` and `trigger_threshold:` name a command and how many must match
+// before a workflow fires. No version of the protocol ever defined them (v4
+// does not, v5 mentions them zero times, v6 mentions them once — the line that
+// preserves them in `extensions`) and no code reads them. Measured on the
+// installed library on 2026-08-27: 302 of 629 workflows in 101 squads.
+//
+// Two things these cases hold in place. First, the count comes from the
+// normalizer, not from a grep for a top-level key: 24 of those 302 files are
+// already on v6 and carry the key INSIDE `extensions:`, where a column-0 grep
+// misses it. Second, the check reports and stops — it is WARN, it names the
+// keys as decorative, and it says out loud that nothing deletes them, because
+// the next agent to read the line is the one who would write that fixer.
+//
+// Runs with: bun test skills/harness/tests
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const DOCTOR = join(REPO, "skills", "harness", "scripts", "doctor-system.ts");
+const ROOTS: string[] = [];
+afterAll(() => { for (const r of ROOTS) try { removeDir(r); } catch { /* best effort */ } });
+
+/** A library of squads, each `[slug, { workflowFile: contents }]`. */
+function library(squads: Array<[string, Record<string, string>]>): string {
+  const home = makeTempRoot("nrv-doctor-triggers-");
+  ROOTS.push(home);
+  for (const [slug, workflows] of squads) {
+    mkdirSync(join(home, "squads", slug, "workflows"), { recursive: true });
+    writeFileSync(join(home, "squads", slug, "squad.yaml"),
+      `name: ${slug}\nversion: 1.0.0\nprotocol: "5.0"\ndescription: fixture\n`, "utf8");
+    for (const [file, body] of Object.entries(workflows)) {
+      writeFileSync(join(home, "squads", slug, "workflows", file), body, "utf8");
+    }
+  }
+  return home;
+}
+
+function check(home: string): { status: string; note: string } {
+  const r = spawnSync(process.execPath, [DOCTOR, "--json"], {
+    cwd: home, encoding: "utf8",
+    env: {
+      ...process.env, HOME: home, NIRVANA_HOME: home,
+      NIRVANA_SKILLS_DIR: join(REPO, "skills"), CLAUDE_SKILLS_DIR: join(REPO, "skills"),
+      NIRVANA_SCOPE: "global", NIRVANA_SCOPE_QUIET: "1", NIRVANA_NO_UPDATE_CHECK: "1",
+    } as Record<string, string>,
+  });
+  const checks: Array<{ name: string; status: string; note: string }> = JSON.parse(r.stdout).checks;
+  const found = checks.find((c) => c.name === "routing: vestigial triggers");
+  expect(found).toBeDefined();
+  return { status: found!.status, note: found!.note };
+}
+
+/** v5 dialect: the keys sit at the top level of the YAML document. */
+const V5_WITH_BOTH = [
+  "workflow_name: alpha",
+  "agent_sequence:",
+  "  - planner",
+  "triggers:",
+  "  commands:",
+  '    - "*alpha"',
+  "trigger_threshold: 1",
+  "",
+].join("\n");
+
+/** v6 Markdown: already migrated, the key preserved inside `extensions`. A
+ *  grep for `^trigger_threshold:` never sees this one. */
+const V6_IN_EXTENSIONS = [
+  "---",
+  "name: beta",
+  "steps:",
+  "  - id: plan",
+  "    agent: planner",
+  "extensions:",
+  "  key_commands:",
+  '    - "*beta"',
+  "  trigger_threshold: 2",
+  "---",
+  "",
+  "## plan",
+  "",
+  "Read the brief first.",
+  "",
+].join("\n");
+
+const CLEAN = "name: gamma\nsteps:\n  - id: plan\n    agent: planner\n";
+
+describe("the doctor counts the invocation keys nothing reads", () => {
+  test("a library that declares them is WARN, with the spread and the two facts about them", () => {
+    const out = check(library([
+      ["one", { "alpha.yaml": V5_WITH_BOTH, "gamma.yaml": CLEAN }],
+      ["two", { "beta.md": V6_IN_EXTENSIONS }],
+    ]));
+    expect(out.status).toBe("WARN");
+    // Three workflows read, two of them carrying a key, across two squads.
+    expect(out.note).toContain("2 of 3 workflow(s) in 2 squad(s)");
+    expect(out.note).toContain("1× `triggers`");
+    expect(out.note).toContain("2× `trigger_threshold`");
+    // Decorative, and nothing deletes it. Both halves are the point of the cut.
+    expect(out.note).toContain("no code reads them");
+    expect(out.note).toContain("no fixer removes them");
+  }, spawnBudgetMs(1));
+
+  test("the v6 form counts too: the key inside `extensions` is the same dead surface", () => {
+    const grepBlind = check(library([["only-v6", { "beta.md": V6_IN_EXTENSIONS }]]));
+    expect(grepBlind.status).toBe("WARN");
+    expect(grepBlind.note).toContain("1 of 1 workflow(s) in 1 squad(s)");
+    expect(grepBlind.note).toContain("1× `trigger_threshold`");
+    expect(grepBlind.note).not.toContain("`triggers`");
+  }, spawnBudgetMs(1));
+
+  test("a library without them passes and says how much it read", () => {
+    const out = check(library([["clean", { "gamma.yaml": CLEAN }]]));
+    expect(out.status).toBe("PASS");
+    expect(out.note).toContain("1 workflow(s) read");
+  }, spawnBudgetMs(1));
+
+  // CI reads a doctor exit >= 2 as "this machine is broken". A workflow key the
+  // author wrote and the engine ignores is not that, under any count.
+  test("it is never a FAIL — the keys are authored text, not a broken machine", () => {
+    for (const home of [library([["one", { "alpha.yaml": V5_WITH_BOTH }]]), library([["clean", { "gamma.yaml": CLEAN }]])]) {
+      expect(check(home).status).not.toBe("FAIL");
+    }
+  }, spawnBudgetMs(2));
+});

--- a/skills/squads/SQUAD_PROTOCOL_V6.md
+++ b/skills/squads/SQUAD_PROTOCOL_V6.md
@@ -122,11 +122,13 @@ O lint vive em `skills/squads/lib/workflow-reader.ts` (`lintWorkflow`) e o port�
 | `workflow_cycle` | o grafo de passos tem ciclo | erro | aviso | — |
 | `workflow_shape_legacy` | o grafo está em dialeto legado (§28.4) | erro | aviso | `workflow_normalize_shape` |
 | `workflow_stem_case` | o stem não é `^[a-z][a-z0-9_-]*$` | erro | aviso | — |
-| `workflow_unnormalizable` | nenhuma ordem de passos pode ser derivada (`event_routes`) | aviso | aviso | — |
+| `workflow_event_router` | o documento é um roteador `event_routes`, e roteador não tem ordem de passos | informativo | informativo | — |
 | `workflow_body_too_long` | o corpo passou do teto de §28.2 | aviso | aviso | — |
 | `workflow_orphan` | nenhuma capability invoca este workflow | aviso | aviso | — |
 
-As três últimas são conselho sob qualquer protocolo. Um corpo longo e um workflow sem dono são fatos sobre autoria; um documento que não vira DAG é um fato sobre o documento, e transformá-lo em erro obrigaria alguém a inventar uma ordem que o autor não escreveu.
+As duas últimas são conselho sob qualquer protocolo: um corpo longo e um workflow sem dono são fatos sobre autoria, não sobre o contrato.
+
+`workflow_event_router` não é nem conselho. Um documento com `event_routes` declara rotas que chegam independentes — canal, condição, prioridade e cadeia própria em cada uma —, então não existe ordem entre elas para derivar, e não derivar nenhuma é a leitura certa de um arquivo certo. Ele continua no relatório porque o `steps[]` vazio que ele produz ficaria sem explicação, e sai como `info`, que não conta para veredito nem para o número de critérios passados. Antes era aviso, e o custo apareceu na biblioteca: duas squads corretas carregavam uma constatação permanente e, sob `--strict`, um veredito REJECTED que não tinham feito nada para merecer. São **dois arquivos em 629** (`nirvana-crypto-trading` e `nirvana-ai-trading`, ambos `event-driven-reactive.yaml`, medido em 27/08/2026) — poucos demais para pagar uma segunda forma canônica que leitor, lint, migração, construtor de prompt, grafo e catálogo passariam a tratar. Por isso a resposta é reconhecer a forma no relatório, não canonizá-la no protocolo.
 
 Os fixers **nunca inventam**. Eles renomeiam, movem e reformatam o que já está lá: uma extensão que sobrou numa ref, prosa saindo de `task: |` para o corpo verbatim, um `depends_on` que nomeava um output virando o passo que o cria. Uma referência que não resolve para nada continua sendo constatação: escrever a task faltante seria fabricar o método da squad.
 

--- a/skills/squads/lib/workflow-reader.ts
+++ b/skills/squads/lib/workflow-reader.ts
@@ -28,8 +28,9 @@
  * Severity is decided by the manifest's protocol, not by the shape: what is an
  * error under `protocol: "6.0"` is a warning under `"5.0"`, so the 204 installed
  * squads keep validating exactly as they do today while a v6 squad enters
- * clean. The exceptions are the body ceiling, the orphan workflow and the
- * unnormalizable document, which are advice under either protocol.
+ * clean. The body ceiling and the orphan workflow are advice under either
+ * protocol, and an `event_routes` document is not a finding against the squad
+ * at all: it is a router, and a router has no step order to withhold.
  */
 
 import * as fs from "node:fs";
@@ -565,7 +566,7 @@ export function renderProseBody(result: NormalizeResult): string {
 
 // ── lint ────────────────────────────────────────────────────────────────────
 
-export type LintSeverity = "error" | "warning";
+export type LintSeverity = "error" | "warning" | "info";
 
 export interface LintFinding {
   id: string;
@@ -608,7 +609,7 @@ export const WORKFLOW_LINT_IDS = [
   "workflow_cycle",
   "workflow_shape_legacy",
   "workflow_stem_case",
-  "workflow_unnormalizable",
+  "workflow_event_router",
   "workflow_body_too_long",
   "workflow_orphan",
 ] as const;
@@ -616,7 +617,18 @@ export type WorkflowLintId = (typeof WORKFLOW_LINT_IDS)[number];
 
 /** Advice under either protocol: a long body and an unused workflow are facts
  *  about authorship, not about the contract. */
-const ALWAYS_WARNING = new Set<string>(["workflow_body_too_long", "workflow_orphan", "workflow_unnormalizable"]);
+const ALWAYS_WARNING = new Set<string>(["workflow_body_too_long", "workflow_orphan"]);
+
+/**
+ * Never counted, under any protocol. A document that declares `event_routes`
+ * is a router: each route names a channel, a condition and its own chain, and
+ * the routes arrive independently. There is no order between them to derive,
+ * so deriving none is the correct reading of a correct file — not a defect.
+ * It stays in the report because the empty `steps[]` it produces would
+ * otherwise be unexplained, and it is `info` because the alternative was a
+ * permanent warning against two squads that are right.
+ */
+const ALWAYS_INFO = new Set<string>(["workflow_event_router"]);
 
 export function bodyWordCount(body: string): number {
   const t = body.trim();
@@ -632,7 +644,9 @@ export function lintWorkflow(canonical: CanonicalWorkflow, ctx: LintContext): Li
   const v6 = String(ctx.protocol).trim() === "6.0";
   const findings: LintFinding[] = [];
   const add = (id: WorkflowLintId, message: string, evidence: string) => {
-    findings.push({ id, severity: ALWAYS_WARNING.has(id) || !v6 ? "warning" : "error", message, evidence, where: ctx.file });
+    const severity: LintSeverity = ALWAYS_INFO.has(id) ? "info"
+      : ALWAYS_WARNING.has(id) || !v6 ? "warning" : "error";
+    findings.push({ id, severity, message, evidence, where: ctx.file });
   };
 
   if (ctx.inlineProse.length) {
@@ -685,7 +699,9 @@ export function lintWorkflow(canonical: CanonicalWorkflow, ctx: LintContext): Li
   }
 
   if (ctx.unnormalizable) {
-    add("workflow_unnormalizable", "no step order can be derived from this document (`event_routes` is a router, not a DAG)", ctx.file);
+    const routes = canonical.extensions.event_routes;
+    const n = isMapping(routes) ? Object.keys(routes).length : Array.isArray(routes) ? routes.length : 0;
+    add("workflow_event_router", `an event router: ${n} \`event_routes\` entr${n === 1 ? "y" : "ies"}, each with its own channel and chain — there is no step order between them, so none is derived`, ctx.file);
   } else if (ctx.dialects.length) {
     add("workflow_shape_legacy", `${ctx.dialects.length} legacy dialect(s) — the canonical shape is \`steps[]\` with \`requires\``,
       ctx.dialects.join(", "));


### PR DESCRIPTION
Two small cuts, both measured against the installed library on 27/08/2026.

## Part 1 — `event_routes` stops being reported as a defect

`nirvana-crypto-trading/workflows/event-driven-reactive.yaml` declares 23 event routes, each with its own channel, condition, priority and agent chain, and a capability invokes it. The gate answered `workflow_unnormalizable` at severity `warning` on every run, and under `--strict` that single warning printed `REJECTED` against a squad that had done nothing wrong.

The finding is now **`workflow_event_router` at severity `info`**. It counts toward no verdict, no warning total and no `passed` count. It still appears, because the empty `steps[]` the document produces would otherwise go unexplained, and it now names what the document *is*:

```
INFO  workflow_event_router:event-driven-reactive.yaml   an event router: 23 `event_routes` entries,
      each with its own channel and chain — there is no step order between them, so none is derived
```

Proven against the real file:

| | before | after |
|---|---|---|
| verdict | ADMITTED | ADMITTED |
| errors · warnings · debt | 0 · 2 · 0 | 0 · **1** · 0 |
| findings | `workflow_unnormalizable` (warn), `protocol_below_6` (warn) | `workflow_event_router` (**info**), `protocol_below_6` (warn) |
| passed | 36 | 36 |

Nothing else in that squad's verdict moved. `nrv migrate nirvana-crypto-trading --to 6` still refuses the file without `--force`, with the same refusal text.

**No canonical router shape was added, deliberately.** Measured: `event_routes` appears in **2 workflow files out of 629** in the whole library (`nirvana-crypto-trading` and `nirvana-ai-trading`, both `event-driven-reactive.yaml`). Two instances do not pay for a second form that the reader, the lint, the migration, the prompt builder, the graph and the catalog would each have to learn.

## Part 2 — `nrv doctor` names the dead invocation surface

New check `routing: vestigial triggers`, beside the protocol dashboard:

```
WARN | routing: vestigial triggers | 302 of 629 workflow(s) in 101 squad(s) declare
       46× `triggers` · 256× `trigger_threshold` — decorative. No protocol version defines
       those keys and no code reads them; routing goes by produces, keywords and
       example_briefs. They are preserved verbatim in `extensions` and no fixer removes
       them: this line exists so the dead surface is visible, not so it gets deleted.
```

Verified: v4 does not define either key (its only hit is the word "trigger" in a sentence about compaction), v5 has zero mentions, v6 has one — the line that preserves legacy top-level keys in `extensions`. No code reads them; the only `triggers` in a Zod schema is the business org-chart `antagonist_invocation.triggers`, unrelated.

**There is no fixer and there will not be one.** Those commands are text the author wrote, the normalizer preserves them on purpose, and erasing an author's content to clear a diagnostic line is the opposite of what the fixers do.

The count comes from the normalizer rather than a grep, so it also catches the **24 already-migrated v6 workflows** that carry the key inside their `extensions:` block, where a column-0 grep misses it. That is why 302/101 and not 278/87.

## Verification

Areas only, per the verification contract:

- `bun test skills/_shared/tests skills/squads/tests` + the six `doctor-*` tests + `squad-exec` + `gauntlet-success-requirements` → **703 pass · 0 fail · 12 skip**
- `bun scripts/check-english-source.ts --strict` → exit 0
- `bun scripts/check-changelog-parity.ts --strict` → exit 0
- `bun scripts/check-skillmd-command-parity.ts --strict` → exit 0
- `git diff --check` → clean

Not run: `bun test skills` in full and `check:all`, by contract.