### PR TITLE
fix(routing,gate): a route is indexed by what it can match, and a route under the wrong key says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A route under the wrong key says so, instead of blaming a seat
+
+`investigation-bureau` was audited on 28/08/2026 and the gate answered nine times
+with `route_to (empty) names no seat of this business`. Every one of those routes
+named a real seat. They were written under the key `employee:`, so the message
+printed a placeholder where a seat name belongs, and the audit spent its effort
+discovering that the routes were not empty at all.
+
+`auto_route_unknown_employee` now separates the two cases. When `route_to` is
+absent and another key of the same route holds an existing seat, the finding
+names that key, names the seat, and states that the route is dead on both sides:
+`route_to is absent: the key employee holds ib-chief-detective, a seat of this
+business.` When two keys hold a seat name, it lists both and picks neither. When
+`route_to` is genuinely empty, it says `route_to is empty` and stops printing
+`(empty)` in the position where a seat name goes.
+
+No alias was added and no fixer was written. `employee:` is not a second spelling
+of `route_to`: this module reads `r.route_to`, `router.js` skips any entry whose
+`route_to` is not a string, and a second accepted key would be one more thing
+every future reader has to handle. The mechanical rewrite lost on the library's
+own numbers. Across 63 businesses and 691 routes on 28/08/2026, no route carries
+a seat under another key, while 66 routes hold a seat name under
+`requires_escalation_to`, which §13.2 defines as an escalation target and never a
+destination. Those 66 declare a valid `route_to` as well, so a fixer would not
+touch them today; they are the evidence that a key holding a seat name does not
+mean `route_to`, and rewriting on that heuristic is a fixer inventing intent
+(v6 §28.3). The message is the fix.
+
 ## 0.10.4 — 2026-08-28
 
 ### A workflow written as an event router stopped being reported as broken

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,35 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Uma rota sob a chave errada diz isso, em vez de culpar um cargo
+
+O `investigation-bureau` foi auditado em 28/08/2026 e o portão respondeu nove
+vezes com `route_to (empty) names no seat of this business`. Cada uma dessas
+rotas nomeava um cargo real. Estavam escritas sob a chave `employee:`, então a
+mensagem imprimia um marcador onde vai um nome de cargo, e a auditoria gastou o
+esforço dela descobrindo que as rotas não estavam vazias coisa nenhuma.
+
+O `auto_route_unknown_employee` agora separa os dois casos. Quando `route_to`
+está ausente e outra chave da mesma rota carrega um cargo existente, a
+constatação nomeia essa chave, nomeia o cargo e afirma que a rota está morta dos
+dois lados: `route_to is absent: the key employee holds ib-chief-detective, a
+seat of this business.` Quando duas chaves carregam nome de cargo, ela lista as
+duas e não escolhe nenhuma. Quando `route_to` está mesmo vazio, ela diz
+`route_to is empty` e para de imprimir `(empty)` na posição onde vai o nome do
+cargo.
+
+Nenhum alias foi criado e nenhum fixer foi escrito. `employee:` não é uma segunda
+grafia de `route_to`: este módulo lê `r.route_to`, o `router.js` pula qualquer
+entrada cujo `route_to` não seja string, e uma segunda chave aceita seria mais
+uma coisa que todo leitor futuro teria de tratar. A reescrita mecânica perdeu nos
+números da própria biblioteca. Em 63 empresas e 691 rotas, em 28/08/2026, nenhuma
+rota carrega cargo sob outra chave, enquanto 66 rotas carregam nome de cargo sob
+`requires_escalation_to`, que a §13.2 define como alvo de escalonamento e nunca
+como destino. Essas 66 também declaram um `route_to` válido, então um fixer não
+tocaria nelas hoje; elas são a prova de que uma chave carregando nome de cargo
+não significa `route_to`, e reescrever com base nessa heurística é fixer
+inventando intenção (v6 §28.3). A mensagem é o conserto.
+
 ## 0.10.4 — 2026-08-28
 
 ### Um workflow escrito como roteador de eventos deixou de ser reportado como quebrado

--- a/skills/_shared/lib/verify/kinds/business.ts
+++ b/skills/_shared/lib/verify/kinds/business.ts
@@ -76,6 +76,13 @@ const RETIRED_EMPLOYEE_FIELDS: Record<string, string | null> = {
 const RETIRED_MANIFEST_FIELDS = ["capabilities_required", "default_tools", "project_tool_overrides", "tickets", "ticket_intake", "disclosure_template"];
 const RETIRED_ROUTING_FIELDS = ["mention_routing", "ticket_intake"];
 const RETIRED_ROUTE_FIELDS = ["confidence_threshold", "requires_escalation_to"];
+/**
+ * The keys §13.2 gives a route. A seat name under one of these is that field
+ * doing its own job — `requires_escalation_to` holds a seat in 66 routes of the
+ * installed library and means escalation, never destination — so none of them
+ * is ever read as a misspelled `route_to`.
+ */
+const KNOWN_ROUTE_FIELDS = new Set(["pattern", "patterns", "route_to", ...RETIRED_ROUTE_FIELDS]);
 /** §5.3 / §22: reported, never deleted. */
 const RETIRED_FILES = ["culture.md", "budgets.yaml", "secrets-manifest.yaml", "escalation-triggers.yaml", "approval-chains.yaml", "tickets", "processes"];
 
@@ -469,6 +476,39 @@ function chartFindings(b: BusinessRead): Finding[] {
   return out;
 }
 
+/**
+ * Why a route names no seat, in the reader's terms. Two cases the old message
+ * collapsed into one, at the cost of an audit: `investigation-bureau` carried a
+ * whole route table whose seats sat under the key `employee:`, and the gate
+ * answered `route_to (empty) names no seat` on every one of them, printing a
+ * placeholder where a seat name belongs and blaming a name nobody had written.
+ *
+ * The engine has no alias normalizer, by decision: this module reads
+ * `r.route_to`, and `router.js` skips any entry whose `route_to` is not a
+ * string. A route under another key is dropped on both sides, silently, and the
+ * message is the only place that fact can reach the person fixing it. No second
+ * spelling of the field is accepted anywhere; naming the key is the whole fix.
+ */
+function unusableRouteTo(raw: Record<string, unknown>, coerced: string, names: Set<string>): string {
+  const declared = raw.route_to;
+  if (typeof declared === "string" && declared.trim() !== "") return `route_to ${coerced} names no seat of this business`;
+  if (declared !== undefined && typeof declared !== "string") {
+    return `route_to is a ${Array.isArray(declared) ? "list" : typeof declared}, not a string — the router skips every route whose route_to is not a string`;
+  }
+  const state = "route_to" in raw ? "route_to is empty" : "route_to is absent";
+  const misplaced = Object.entries(raw).filter(([k, v]) => !KNOWN_ROUTE_FIELDS.has(k) && typeof v === "string" && names.has(v)) as Array<[string, string]>;
+  const dead = "Both the gate and the router read route_to only, so this route is dead in both";
+  if (misplaced.length === 1) {
+    const [key, seat] = misplaced[0];
+    return `${state}: the key ${key} holds ${seat}, a seat of this business. ${dead} — rename the key to route_to.`;
+  }
+  if (misplaced.length > 1) {
+    const pairs = misplaced.map(([k, v]) => `${k}: ${v}`).join(", ");
+    return `${state}: ${misplaced.length} keys hold a seat name (${pairs}). ${dead} — which key was meant is the author's call.`;
+  }
+  return `${state} — both the gate and the router drop a route that does not name a seat.`;
+}
+
 /** §13.2: routes name a seat, fire against a real brief, and never match all. */
 function routeFindings(b: BusinessRead, names: Set<string>): Finding[] {
   const out: Finding[] = [];
@@ -478,7 +518,7 @@ function routeFindings(b: BusinessRead, names: Set<string>): Finding[] {
   for (const r of routes) {
     const label = r.pattern.slice(0, 48) || "(empty)";
     if (!names.has(r.route_to)) {
-      out.push(mk("auto_route_unknown_employee", `route_to ${r.route_to || "(empty)"} names no seat of this business`, `${r.source}: ${label}`, r.route_to || label));
+      out.push(mk("auto_route_unknown_employee", unusableRouteTo(r.raw, r.route_to, names), `${r.source}: ${label}`, r.route_to || label));
       continue;
     }
     if (CATCH_ALL.has(r.pattern.trim())) {

--- a/skills/_shared/tests/capability-doctor.test.ts
+++ b/skills/_shared/tests/capability-doctor.test.ts
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const DOCTOR = path.resolve(import.meta.dir, "..", "scripts", "capability-doctor.ts");
 
@@ -122,7 +123,7 @@ test("capability-doctor --json reports the three catalog checks + collisions + s
 
   // 1 violation + 2 unknown-ns + 2 unknown-domain + 1 score_boost = 6.
   expect(cr.summary.strict_findings).toBe(6);
-});
+}, spawnBudgetMs(2));
 
 test("exit-code contract: 0 by default, 1 with --strict when findings exist", () => {
   const dirs = writeFixtures();
@@ -147,4 +148,4 @@ test("--strict passes on a clean tree", () => {
   fs.mkdirSync(businessesDir, { recursive: true });
   const r = runDoctor(["--strict", "--quiet"], { squadsDir, businessesDir });
   expect(r.status).toBe(0);
-});
+}, spawnBudgetMs(2));

--- a/skills/_shared/tests/check-seat-sufficiency.test.ts
+++ b/skills/_shared/tests/check-seat-sufficiency.test.ts
@@ -11,6 +11,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const GATE = join(import.meta.dir, "..", "scripts", "check-seat-sufficiency.ts");
 const ROOTS: string[] = [];
@@ -53,39 +54,39 @@ describe("the ratchet refuses new thinness and tolerates recorded debt", () => {
     expect(r.code).toBe(1);
     expect(r.out).toContain("NEW thinness");
     expect(r.out).toContain("alpha-co/weak.md");
-  });
+  }, spawnBudgetMs(2));
 
   test("the same thin seat, baselined, passes — recorded debt", () => {
     const root = library([["alpha-co", "weak.md", THIN_BODY]]);
     const r = run(root, { baseline: ["alpha-co/weak.md"], args: ["--strict"] });
     expect(r.code).toBe(0);
     expect(r.out).toContain("No seat is new thinness");
-  });
+  }, spawnBudgetMs(2));
 
   test("an enriched seat shows the debt shrinking", () => {
     const root = library([["alpha-co", "fixed.md", SUFFICIENT_BODY]]);
     const r = run(root, { baseline: ["alpha-co/fixed.md"], args: ["--strict"] });
     expect(r.code).toBe(0);
     expect(r.out).toContain("1 enriched");
-  });
+  }, spawnBudgetMs(2));
 
   test("--record refuses to add debt without --allow-regression", () => {
     const root = library([["alpha-co", "weak.md", THIN_BODY]]);
     const r = run(root, { baseline: [], args: ["--record"] });
     expect(r.code).toBe(1);
     expect(r.out).toContain("NEW debt");
-  });
+  }, spawnBudgetMs(2));
 
   test("no baseline at all refuses under --strict rather than approving", () => {
     const root = library([["alpha-co", "good.md", SUFFICIENT_BODY]]);
     const r = run(root, { args: ["--strict"] });
     expect(r.code).toBe(1);
     expect(r.out).toContain("No debt baseline recorded");
-  });
+  }, spawnBudgetMs(2));
 
   test("a fully sufficient library with a baseline passes clean", () => {
     const root = library([["alpha-co", "good.md", SUFFICIENT_BODY]]);
     const r = run(root, { baseline: [], args: ["--strict"] });
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/generated-schema-parity.test.ts
+++ b/skills/_shared/tests/generated-schema-parity.test.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { z } from "zod";
 import { CapabilitySchema, SquadManifestSchema, WorkflowSchema } from "../validators/validators.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
 const SCHEMAS = path.join(REPO, "skills", "_shared", "schemas");
@@ -24,7 +25,7 @@ describe("the generator is the source of the files", () => {
     const r = spawnSync(process.execPath, [path.join(REPO, "scripts", "gen-json-schemas.ts"), "--check"], { encoding: "utf8" });
     expect(r.stdout + r.stderr).toContain("JSON schema parity OK");
     expect(r.status).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   for (const [file, schema] of [
     ["capability.schema.json", CapabilitySchema],

--- a/skills/_shared/tests/self-retrieval-gate.test.ts
+++ b/skills/_shared/tests/self-retrieval-gate.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { runGate, resolveEntity } from "../scripts/self-retrieval-gate.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 // ── fixture registries ──────────────────────────────────────────────────────
 
@@ -149,20 +150,20 @@ describe("runGate hits", () => {
       expect(b.hit).toBe(true);
     }
     expect(r.passed).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("capability id passes with exact squad+capability matching", async () => {
     const r = await runGate("media.promo.render", base);
     expect(r.kind).toBe("capability");
     expect(r.passed).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("business briefs route back to the business", async () => {
     const r = await runGate("aurum-books", base);
     expect(r.kind).toBe("business");
     expect(r.passed).toBe(true);
     for (const b of r.briefs) expect(b.rank).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("clone one_liner self-retrieves top-1", async () => {
     const r = await runGate("ada-editrix", base);
@@ -170,7 +171,7 @@ describe("runGate hits", () => {
     expect(r.briefs.length).toBe(1);
     expect(r.briefs[0].signal).toBe("CLONE_BM25");
     expect(r.passed).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── miss paths ──────────────────────────────────────────────────────────────
@@ -185,7 +186,7 @@ describe("runGate misses", () => {
     expect(miss!.rank === null || miss!.rank > 1).toBe(true);
     // The report carries the actual top-3 for diagnosis.
     expect(miss!.top3.length).toBeGreaterThan(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("--lenient accepts a top-3 rank the strict gate rejects", async () => {
     const strict = await runGate("misdeclared-squad", base);
@@ -194,7 +195,7 @@ describe("runGate misses", () => {
     // The misdeclared brief still lands in top-3 of this tiny corpus.
     expect(lenient.briefs.every((b) => b.rank !== null && b.rank <= 3)).toBe(true);
     expect(lenient.passed).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("entity without example_briefs fails with an explicit reason", async () => {
     const bare = {
@@ -214,17 +215,17 @@ describe("runGate misses", () => {
     expect(r.passed).toBe(false);
     expect(r.reason).toContain("example_briefs");
     expect(r.briefs.length).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("clone without one_liner fails with an explicit reason", async () => {
     const r = await runGate("no-block-clone", base);
     expect(r.passed).toBe(false);
     expect(r.reason).toContain("one_liner");
-  });
+  }, spawnBudgetMs(2));
 
   test("unknown entity fails with a not-found reason", async () => {
     const r = await runGate("ghost-entity", base);
     expect(r.passed).toBe(false);
     expect(r.reason).toContain("not found");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/validate-cli-alias.test.ts
+++ b/skills/_shared/tests/validate-cli-alias.test.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { COMMANDS } from "../../harness/lib/commands.ts";
 import { REPO, VERIFY_CLI, cliEnv, cloneFixture, crlf, lf, posixPath, rmrf, tempRoot } from "./helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const ROOTS: string[] = [];
 afterAll(() => { for (const r of ROOTS) rmrf(r); });
@@ -32,7 +33,7 @@ describe("bare `nrv validate` → doctor, deprecated", () => {
     const plain = run(VERIFY_CLI, [], r, { NIRVANA_VERIFY_DOCTOR_SCRIPT: fake });
     expect(plain.code).toBe(3);
     expect(plain.stdout).toContain("FAKE DOCTOR argv=[]");
-  });
+  }, spawnBudgetMs(2));
 
   test("the default doctor path exists", () => {
     expect(fs.existsSync(path.join(REPO, "skills", "harness", "scripts", "doctor-system.ts"))).toBe(true);
@@ -73,7 +74,7 @@ describe("command table and dispatchers", () => {
     expect(out.code).toBe(0);
     expect(out.stdout).toContain("64");
     expect(out.stdout).toContain("nrv doctor");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("`nrv validate-mind-clones` delegates and keeps its JSON keys", () => {
@@ -100,7 +101,7 @@ describe("`nrv validate-mind-clones` delegates and keeps its JSON keys", () => {
     expect(beta.findings.find((f: any) => f.id === "artifact_missing").severity).toBe("error");
     const quiet = JSON.parse(run(LEGACY_CLI, [path.join(r, "dna"), "--json", "--quiet", "--no-retrieval"], r).stdout);
     expect(quiet.results[0].warnings).toBeUndefined();
-  });
+  }, spawnBudgetMs(2));
 
   test("text mode keeps the ✓/✗ lines and the Summary; default target is the DNA library", () => {
     const r = root();
@@ -110,7 +111,7 @@ describe("`nrv validate-mind-clones` delegates and keeps its JSON keys", () => {
     expect(out.stdout).toContain("✓ ");
     expect(out.stdout).toContain("Summary: 1 mind-clones · 1 ok · 0 failed");
     expect(run(LEGACY_CLI, [path.join(r, "nowhere")], r).code).toBe(2);
-  });
+  }, spawnBudgetMs(2));
 
   test("a single clone directory and a legacy .md persona file are still accepted", () => {
     const r = root();
@@ -121,5 +122,5 @@ describe("`nrv validate-mind-clones` delegates and keeps its JSON keys", () => {
     const j = JSON.parse(md.stdout);
     expect(j.total).toBe(1);
     expect(posixPath(j.results[0].file)).toEndWith("agent/AGENT.md");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/_shared/tests/verify-backup.test.ts
+++ b/skills/_shared/tests/verify-backup.test.ts
@@ -53,7 +53,7 @@ describe("rollback", () => {
     const module = sabotaged("delegates_to_strip", ({ dir: d }) => {
       fs.writeFileSync(path.join(d, "agent", "SOUL.md"), "", "utf8");
       throw new Error("boom");
-    }, spawnBudgetMs(2));
+    });
     const report = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module });
     expect(report.fix_outcome?.rolled_back).toBe(true);
     expect(report.fix_outcome?.rollback_reason).toContain("boom");
@@ -68,7 +68,7 @@ describe("rollback", () => {
     const module = sabotaged("delegates_to_strip", ({ dir: d, finding }) => {
       fs.writeFileSync(path.join(d, "MANIFEST.yaml"), "manifest: [unclosed\n", "utf8");
       return { fixer: "delegates_to_strip", finding: finding.id, applied: true, changed_files: ["MANIFEST.yaml"] };
-    }, spawnBudgetMs(2));
+    });
     const report = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module });
     expect(report.fix_outcome?.rolled_back).toBe(true);
     expect(report.fix_outcome?.rollback_reason).toContain("manifest");
@@ -83,7 +83,7 @@ describe("rollback", () => {
     const deletesSoul = sabotaged("delegates_to_strip", ({ dir: d, finding }) => {
       fs.rmSync(path.join(d, "agent", "SOUL.md"));
       return { fixer: "delegates_to_strip", finding: finding.id, applied: true, changed_files: ["agent/SOUL.md"] };
-    }, spawnBudgetMs(2));
+    });
     const rolled = await verifyEntity("mind-clone", dir, { ...quiet(r), fix: "mechanical", module: deletesSoul });
     expect(rolled.fix_outcome?.rolled_back).toBe(true);
     expect(rolled.fix_outcome?.rollback_reason).toContain("artifact_missing:agent/SOUL.md");

--- a/skills/_shared/tests/verify-baseline.test.ts
+++ b/skills/_shared/tests/verify-baseline.test.ts
@@ -72,7 +72,7 @@ describe("legacy import", () => {
       "business:acme": ["seat_thin:employees/ceo.md", "seat_thin:employees/cto.md"],
       "business:beta": ["seat_thin:employees/ops.md"],
       "mind-clone:jane": ["source_material_missing", "validation_verdict_missing"],
-    }, spawnBudgetMs(2));
+    });
     expect(b?.imported_from?.length).toBe(2);
     expect(fs.existsSync(bl(r))).toBe(true);
     // second load reads the written file: the legacy files are not consulted again

--- a/skills/_shared/tests/verify-business.test.ts
+++ b/skills/_shared/tests/verify-business.test.ts
@@ -154,6 +154,63 @@ describe("errors", () => {
     expect(f.find((x) => x.id === "auto_route_unknown_employee")!.where).toBe("ghost");
   }, spawnBudgetMs(2));
 
+  // The `investigation-bureau` shape (28/08/2026): nine routes named a real
+  // seat under the key `employee:`, and the gate answered `route_to (empty)
+  // names no seat` — blaming a seat name nobody had written. There is no alias
+  // normalizer: the gate reads `r.route_to` and `router.js` skips any entry
+  // whose `route_to` is not a string, so the route is dead on both sides. The
+  // finding has to say that, because a message that hides it costs the reader
+  // the whole search.
+  test("auto_route_unknown_employee: the seat sits under another key", () => {
+    const f = check("misplaced-key", { routing: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    employee: ceo\n' }).findings;
+    const hit = f.find((x) => x.id === "auto_route_unknown_employee");
+    expect(hit).toBeDefined();
+    expect(hit!.message).toContain("employee");
+    expect(hit!.message).toContain("ceo");
+    expect(hit!.message).toMatch(/route_to is absent/);
+    expect(hit!.message).toMatch(/router/);
+    expect(hit!.message).not.toContain("(empty)");
+  }, spawnBudgetMs(2));
+
+  test("auto_route_unknown_employee: two keys hold a seat, and the gate picks neither", () => {
+    const employees = { "ceo.md": INTAKE_SEAT, "second.md": SEAT("second") };
+    const routing = 'auto_routes:\n  - pattern: "(?i)fixture report"\n    employee: ceo\n    owner: second\n';
+    const hit = check("two-keys", { employees, routing }).findings.find((x) => x.id === "auto_route_unknown_employee");
+    expect(hit).toBeDefined();
+    expect(hit!.message).toContain("employee: ceo");
+    expect(hit!.message).toContain("owner: second");
+    expect(hit!.message).not.toContain("(empty)");
+  }, spawnBudgetMs(2));
+
+  // §13.2 defines `requires_escalation_to`, and it is not a routing target.
+  // A seat name under it is a fact, never a rename candidate.
+  test("auto_route_unknown_employee: a retired route field is never read as a misspelled route_to", () => {
+    const routing = 'auto_routes:\n  - pattern: "(?i)fixture report"\n    requires_escalation_to: ceo\n';
+    const hit = check("retired-key", { routing }).findings.find((x) => x.id === "auto_route_unknown_employee");
+    expect(hit).toBeDefined();
+    expect(hit!.message).toMatch(/route_to is absent/);
+    expect(hit!.message).not.toMatch(/requires_escalation_to/);
+    expect(hit!.message).not.toContain("(empty)");
+  }, spawnBudgetMs(2));
+
+  // `router.js` skips any entry whose route_to is not a string, so a YAML scalar
+  // that parses as a number is dropped there while `String()` hid it here.
+  test("auto_route_unknown_employee: route_to that is not a string says which type it is", () => {
+    const f = check("typed-route", { routing: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: 42\n' }).findings;
+    const hit = f.find((x) => x.id === "auto_route_unknown_employee");
+    expect(hit).toBeDefined();
+    expect(hit!.message).toMatch(/route_to is a number, not a string/);
+    expect(hit!.message).not.toContain("(empty)");
+  }, spawnBudgetMs(2));
+
+  test("auto_route_unknown_employee: route_to genuinely empty is not a seat named (empty)", () => {
+    const f = check("empty-route", { routing: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ""\n' }).findings;
+    const hit = f.find((x) => x.id === "auto_route_unknown_employee");
+    expect(hit).toBeDefined();
+    expect(hit!.message).toMatch(/route_to is empty/);
+    expect(hit!.message).not.toContain("(empty)");
+  }, spawnBudgetMs(2));
+
   test("auto_route_in_manifest: the routes are in the wrong file", () => {
     const f = check("manifest-routes", { manifestExtra: 'auto_routes:\n  - pattern: "(?i)fixture report"\n    route_to: ceo\n' }).findings;
     expect(idsOf(f)).toContain("auto_route_in_manifest");

--- a/skills/_shared/tests/verify-business.test.ts
+++ b/skills/_shared/tests/verify-business.test.ts
@@ -458,7 +458,7 @@ describe("the self-retrieval axis", () => {
         '  - "create the brand identity, logo and visual system"',
         'not_for: ["logo design"]', "runtime_requirements:", "  policy: active", "",
       ].join("\n"),
-    }, spawnBudgetMs(2));
+    });
     const registries = {
       squads: { squads: {}, domains: {}, _v4_inferred_capabilities: {}, capabilities: {} },
       businesses: {

--- a/skills/_shared/tests/verify-squad.test.ts
+++ b/skills/_shared/tests/verify-squad.test.ts
@@ -108,12 +108,12 @@ describe("the dialect corpus, judged by protocol", () => {
         "        description: the artifact exists after the build step",
         "        blocking: true",
       ],
-    }, spawnBudgetMs(2));
+    });
     const f = findings(r, "clean-v6");
     expect(idsOf(f).filter((id) => id.startsWith("workflow_"))).toEqual([]);
     expect(idsOf(f)).not.toContain("protocol_below_6");
     expect(runCli(r, ["squad", "clean-v6", "--no-retrieval"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   // A router is a correct file. Reporting it as a defect cost two squads a
   // permanent warning and, under --strict, a REJECTED verdict they had done
@@ -144,14 +144,14 @@ describe("the dialect corpus, judged by protocol", () => {
         "main.md": `---\nname: main\n---\n\n## plan\n\n${"word ".repeat(3000)}\n`,
         "spare.yaml": CANONICAL_WORKFLOW.replace("name: main", "name: spare"),
       },
-    }, spawnBudgetMs(2));
+    });
     const f = findings(r, "twins");
     expect(idsOf(f)).toContain("workflow_twin");
     expect(f.find((x) => x.id === "workflow_twin")!.where).toBe("main.md");
     expect(idsOf(f)).toContain("workflow_orphan");
     expect(f.find((x) => x.id === "workflow_orphan")!.where).toBe("spare.yaml");
     expect(severityOf(f, "workflow_body_too_long")).toBe("warning");
-  });
+  }, spawnBudgetMs(2));
 
   test("a capitalised stem is named, and only under 6.0 does it reject", () => {
     const r = root();
@@ -293,7 +293,7 @@ describe("--fix", () => {
       protocol: "6.0",
       workflows: { "main.md": `---\n${INLINE_PROSE}---\n\n## intro\n\nExisting prose.\n` },
       workflowComponent: "main.md", invokeRef: "workflows/main.md",
-    }, spawnBudgetMs(2));
+    });
     fs.writeFileSync(path.join(dir, "agents", "planner.md"), "---\nname: planner\ndescription: planner\n---\n\n# planner\n", "utf8");
     fs.writeFileSync(path.join(dir, "tasks", "plan.md"), "# plan\n\nJust prose.\n", "utf8");
     fs.rmSync(path.join(dir, "README.md"));
@@ -308,7 +308,7 @@ describe("--fix", () => {
     expect(second.json.fix_outcome.rolled_back).toBe(false);
     expect(treeDigest(dir)).toEqual(after);
     expect(second.json.fixes.filter((x: any) => x.applied)).toEqual([]);
-  });
+  }, spawnBudgetMs(2));
 
   test("workflow_inline_prose_to_body moves the prose to `## <step.id>` verbatim and keeps what was there", () => {
     const r = root();
@@ -316,7 +316,7 @@ describe("--fix", () => {
       protocol: "6.0",
       workflows: { "main.md": `---\n${INLINE_PROSE}---\n\n## intro\n\nExisting prose.\n` },
       workflowComponent: "main.md", invokeRef: "workflows/main.md",
-    }, spawnBudgetMs(2));
+    });
     runCli(r, ["squad", "prose", "--no-retrieval", "--fix"]);
     const text = fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8");
     expect(text).toContain("## intro");
@@ -327,7 +327,7 @@ describe("--fix", () => {
     const graph = parseYaml(text.split("---")[1]);
     expect(graph.steps[0].task).toBeUndefined();
     expect(idsOf(findings(r, "prose"))).not.toContain("workflow_inline_prose");
-  });
+  }, spawnBudgetMs(2));
 
   test("invoke_ref_extension strips the encoding from a v6 ref and from components", () => {
     const r = root();
@@ -344,7 +344,7 @@ describe("--fix", () => {
     const r = root();
     const dir = squadFixture(r, "outputs", {
       capabilityExtra: ["    output:", "      name: report", "      type: markdown", "      humanize: true"],
-    }, spawnBudgetMs(2));
+    });
     writeSurfaceFor(dir, "squad");
     expect(idsOf(findings(r, "outputs"))).toContain("capability_outputs_shape");
     runCli(r, ["squad", "outputs", "--no-retrieval", "--fix"]);
@@ -352,13 +352,13 @@ describe("--fix", () => {
     expect(cap.output).toBeUndefined();
     expect(cap.outputs).toEqual([{ name: "report", type: "markdown" }]);
     expect(idsOf(findings(r, "outputs"))).not.toContain("capability_outputs_shape");
-  });
+  }, spawnBudgetMs(3));
 
   test("twin_merge keeps the YAML graph and the Markdown body, and only when it is a merge", () => {
     const r = root();
     const dir = squadFixture(r, "merge", {
       workflows: { "main.yaml": CANONICAL_WORKFLOW, "main.md": "---\nname: main\n---\n\n## plan\n\nThe body that survives.\n" },
-    }, spawnBudgetMs(2));
+    });
     runCli(r, ["squad", "merge", "--no-retrieval", "--fix"]);
     expect(fs.existsSync(path.join(dir, "workflows", "main.yaml"))).toBe(false);
     const merged = fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8");
@@ -372,13 +372,13 @@ describe("--fix", () => {
     const out = runCli(r, ["squad", "two-graphs", "--no-retrieval", "--fix", "--json"]);
     expect(fs.existsSync(path.join(other, "workflows", "main.yaml"))).toBe(true);
     expect(out.json.fixes.find((x: any) => x.fixer === "twin_merge").note).toContain("not mechanical");
-  });
+  }, spawnBudgetMs(2));
 
   test("workflow_refs_repair renames by case and separator, and never stubs a missing file", () => {
     const r = root();
     const dir = squadFixture(r, "renames", {
       workflows: { "main.yaml": "name: main\nsteps:\n  - id: plan\n    agent: planner\n    task: PLAN\n  - id: build\n    agent: Builder\n    task: nowhere\n" },
-    }, spawnBudgetMs(2));
+    });
     runCli(r, ["squad", "renames", "--no-retrieval", "--fix"]);
     const text = fs.readFileSync(path.join(dir, "workflows", "main.yaml"), "utf8");
     expect(text).toContain("task: plan");
@@ -387,7 +387,7 @@ describe("--fix", () => {
     expect(text).toContain("task: nowhere");
     expect(fs.existsSync(path.join(dir, "tasks", "nowhere.md"))).toBe(false);
     expect(idsOf(findings(r, "renames"))).toContain("workflow_ref_unresolved");
-  });
+  }, spawnBudgetMs(2));
 
   test("a step reference written `tasks/<stem>.md` resolves: the file is on disk", () => {
     const r = root();
@@ -422,13 +422,13 @@ describe("--fix", () => {
     const dir = squadFixture(r, "byoutput", {
       protocol: "6.0", workflows: { "main.md": `---\n${graph}---\n` },
       workflowComponent: "main", invokeRef: "workflows/main",
-    }, spawnBudgetMs(2));
+    });
     expect(idsOf(findings(r, "byoutput"))).toContain("workflow_requires_by_output");
     runCli(r, ["squad", "byoutput", "--no-retrieval", "--fix"]);
     const graphAfter = parseYaml(fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8").split("---")[1]);
     expect(graphAfter.steps[1].requires).toEqual(["plan"]);
     expect(idsOf(findings(r, "byoutput"))).not.toContain("workflow_requires_by_output");
-  });
+  }, spawnBudgetMs(3));
 
   test("a YAML workflow keeps its encoding: the fixer declines and names the migration", () => {
     const r = root();
@@ -455,7 +455,7 @@ describe("the audit scorer after `humanize`", () => {
 
     const declared = squadFixture(r, "c9-acceptance", {
       capabilityExtra: ["    acceptance:", "      - id: built", "        description: the artifact exists"],
-    }, spawnBudgetMs(2));
+    });
     const c9 = criteria.scoreSquad(declared).breakdown.find((b: any) => b.id === 9);
     expect(c9.score).toBe(6);
     expect(c9.evidence).toContain("1/1");
@@ -470,7 +470,7 @@ describe("the audit scorer after `humanize`", () => {
     const r = root();
     const dir = squadFixture(r, "retired-fixer", {
       capabilityExtra: ["    output:", "      name: report", "      type: markdown", "      humanize: true"],
-    }, spawnBudgetMs(2));
+    });
     const results = fixers.applyMechanicalFixes(dir, { patches: [{ kind: "humanize_default_true" }, { kind: "outputs_shape_repair" }] });
     expect(results[0].result.ok).toBe(false);
     expect(results[0].result.reason).toBe("unknown patch kind");

--- a/skills/_shared/tests/workflow-readers-v6.test.ts
+++ b/skills/_shared/tests/workflow-readers-v6.test.ts
@@ -18,6 +18,7 @@ import { contractBreaks } from "../lib/contract-breaks.ts";
 import { extractSurface, writeSurface } from "../lib/surface.ts";
 import { diffSurfaces } from "../lib/surface-diff.ts";
 import { checkPortability } from "../../squads/lib/squad-doctor.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 import {
   collisionSquad, markdownWorkflow, ALPHA_GRAPH, migratedToMarkdown, schema2Surface, tmpRoot,
   v4Squad, v5AgentSequenceSquad, v5StepsSquad, v6MarkdownSquad,
@@ -140,14 +141,14 @@ describe("capability-validator: components and refs resolve to .md", () => {
     expect(out.referenced_files.workflows[0].exists).toBe(true);
     expect(out.referenced_files.workflows[0].path.endsWith("alpha.md")).toBe(true);
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("the v5 squad validates as before, resolving to alpha.yaml", () => {
     const r = runBun(validator, ["squad", v5StepsSquad(root())]);
     const out = JSON.parse(r.stdout);
     expect(out.valid).toBe(true);
     expect(out.referenced_files.workflows[0].path.endsWith("alpha.yaml")).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("a bare component with twins on disk resolves to the .md", () => {
     const dir = collisionSquad(root());
@@ -156,7 +157,7 @@ describe("capability-validator: components and refs resolve to .md", () => {
     const out = JSON.parse(runBun(validator, ["squad", dir]).stdout);
     expect(out.referenced_files.workflows[0].exists).toBe(true);
     expect(out.referenced_files.workflows[0].path.endsWith("x.md")).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("squad-doctor: portability scans workflows in YAML and in Markdown", () => {
@@ -252,11 +253,11 @@ describe("validate-squad: protocol 6.0 takes the capabilities branch", () => {
     expect(r.stdout).toContain("Protocol: 6.0");
     expect(r.stdout).toContain("[PASS] v6 manifest valid");
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("a v5 squad prints exactly what it printed before", () => {
     const r = runBun(script, [v5StepsSquad(root())], { NIRVANA_PROJECT_ROOT: root() });
     expect(r.stdout).toContain("[PASS] v5 manifest valid");
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/businesses/tests/business-fixers.test.ts
+++ b/skills/businesses/tests/business-fixers.test.ts
@@ -29,6 +29,7 @@ import {
   editFrontmatter, joinFrontmatter, prependFrontmatter, readFrontmatter, splitFrontmatter,
 } from "../../_shared/lib/frontmatter-edit.ts";
 import { businessModule, verifyEntity, type KindModule } from "../../_shared/lib/verify/index.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const require_ = createRequire(import.meta.url);
 const REPO = path.resolve(import.meta.dir, "..", "..", "..");
@@ -457,7 +458,7 @@ describe("nrv validate business --fix", () => {
     const again = runCli(r, ["business", "broken-biz", "--no-retrieval", "--fix", "--json"]);
     expect(again.json.summary.errors).toBe(0);
     expect(treeDigest(dir)).toEqual(digest);
-  });
+  }, spawnBudgetMs(3));
 
   test("the backup holds the business as it was before the fixers ran", () => {
     const r = root();
@@ -467,7 +468,7 @@ describe("nrv validate business --fix", () => {
     const backup = out.json.fix_outcome.backup as string;
     expect(fs.existsSync(backup)).toBe(true);
     expect(treeDigest(backup)).toEqual(before);
-  });
+  }, spawnBudgetMs(2));
 
   test("protocol rises only once nothing is an error any more", () => {
     const r = root();
@@ -486,7 +487,7 @@ describe("nrv validate business --fix", () => {
     businessFixture(clean, "clean-v1", { protocol: "1.0" });
     runCli(clean, ["business", "clean-v1", "--no-retrieval", "--fix"]);
     expect(manifestOf(path.join(clean, "businesses", "clean-v1")).protocol).toBe("2.0");
-  });
+  }, spawnBudgetMs(2));
 
   test("--fix never deletes an authored file and never drops a route", () => {
     const r = root();
@@ -501,7 +502,7 @@ describe("nrv validate business --fix", () => {
     expect(fs.readFileSync(path.join(dir, "culture.md"), "utf8")).toContain("Written by a human.");
     expect(fs.existsSync(path.join(dir, "escalation-triggers.yaml"))).toBe(true);
     expect(routingOf(dir).auto_routes).toHaveLength(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("a seat's body survives the whole loop byte for byte", () => {
     const r = root();
@@ -509,7 +510,7 @@ describe("nrv validate business --fix", () => {
     const before = bodyOf(seatFile(dir));
     runCli(r, ["business", "body-biz", "--no-retrieval", "--fix"]);
     expect(bodyOf(seatFile(dir))).toBe(before);
-  });
+  }, spawnBudgetMs(2));
 
   test("a fixer that breaks the manifest rolls the whole business back", async () => {
     const r = root();
@@ -544,7 +545,7 @@ describe("nrv validate business --fix", () => {
     expect(out.json.entities).toBe(2);
     expect(out.json.summary.errors).toBe(0);
     expect(out.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── the environment contract ────────────────────────────────────────────────
@@ -558,5 +559,5 @@ describe("the fixers stay inside the directory they were given", () => {
     runCli(r, ["business", "scoped-biz", "--no-retrieval", "--fix"]);
     expect(fs.existsSync(path.join(dir, "README.md"))).toBe(true);
     expect(path.resolve(dir).startsWith(path.resolve(r))).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/businesses/tests/smoke.test.ts
+++ b/skills/businesses/tests/smoke.test.ts
@@ -18,6 +18,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const SKILLS = join(import.meta.dir, "..", "..");
 const SCRIPTS = join(SKILLS, "businesses", "scripts");
@@ -56,7 +57,7 @@ describe("business lifecycle — init → validate → index → list", () => {
     expect(`${r.stdout}${r.stderr}`).not.toContain("validation failed");
     expect(r.status).toBe(0);
     expect(existsSync(join(home, "businesses", "smoke-solo", "business.yaml"))).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   // A template cannot carry `.nirvana-surface.json` — it is a hash of files
   // that exist only once the wizard has overlaid the manifest — so the
@@ -75,7 +76,7 @@ describe("business lifecycle — init → validate → index → list", () => {
     const fixed = nrv("validate-business.ts", "smoke-solo", "--fix", "--no-retrieval");
     expect(`${fixed.stdout}${fixed.stderr}`).not.toContain("ROLLED BACK");
     expect(fixed.status).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("--report writes the JSON under the project's own .audit-state", () => {
     // Pinned project root: a report belongs to the project that asked for it,
@@ -87,7 +88,7 @@ describe("business lifecycle — init → validate → index → list", () => {
     const file = join(home, ".nirvana", ".audit-state", "smoke-solo", "verify.json");
     expect(r.stdout).toContain(file);
     expect(JSON.parse(readFileSync(file, "utf8")).schema).toBe("nirvana.verify-report/v1");
-  });
+  }, spawnBudgetMs(2));
 
   test("index writes the registry with the new business", () => {
     const r = nrv("index-businesses.ts", "--quiet");
@@ -96,13 +97,13 @@ describe("business lifecycle — init → validate → index → list", () => {
     expect(Object.keys(registry.businesses)).toContain("smoke-solo");
     // employee_count is derived from disk (§6.12), never from the manifest.
     expect(registry.businesses["smoke-solo"].employee_count).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("list prints the business it just indexed", () => {
     const r = nrv("list-businesses.ts");
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("smoke-solo");
-  });
+  }, spawnBudgetMs(2));
 });
 
 /** Employee frontmatter retired by §22. A scaffold must not seed them. */

--- a/skills/harness/lib/router.js
+++ b/skills/harness/lib/router.js
@@ -130,6 +130,245 @@ function stage1IntentClassify(brief, ctx) {
   return { intent, domains, verbs, confidence };
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Business auto_route patterns -> indexable literals
+// ─────────────────────────────────────────────────────────────────────
+// A business `auto_route.pattern` is written as an activation REGEX. The
+// document that has to retrieve it is a bag of words. Handing the regex
+// source to the tokenizer looks like it works — the tokenizer already drops
+// punctuation — and it does not, in three ways measured over the 686 routes
+// of the live library:
+//
+//   `seguran[çc]a`  -> ["seguran","cc"]   a brief says "seguranca"; neither is it
+//   `\bLCP\b`       -> ["blcp"]           the guard glues onto the acronym
+//   `.{0,24}?`      -> ["0","24"]         a gap width becomes vocabulary
+//
+// The first is the one that matters: PT-BR routes spell every accented word
+// as a character class, so the class sits INSIDE the word and splits it. 101
+// of the 400 regex-shaped routes carry at least one such wound.
+//
+// So we read the pattern as a regex and emit the literal phrases it can match.
+// The tokenizer then folds `segurança` and `seguranca` onto the same token,
+// which is why expanding `[çc]` into both spellings costs one token, not two:
+// the class exists because the author wanted both, and folding makes them one.
+//
+// Scope of the parser: alternation, groups (`(...)`, `(?:...)`), character
+// classes, escapes, and quantifiers. Measured on the live library: zero
+// lookarounds, zero backreferences, zero named groups, one negated class, two
+// ranges — all four of those degrade to a separator rather than a guess.
+const ROUTE_LITERAL_VARIANT_CAP = 24;
+
+// `\s` is a separator; `\b` `\w` `\d` and friends carry no literal at all.
+// Both become a space: the tokenizer splits there, and a phrase that loses a
+// boundary loses nothing a bag of words was going to use.
+const REGEX_CLASS_ESCAPES = new Set(['s', 'S', 'w', 'W', 'd', 'D', 'b', 'B', 'A', 'Z', 'z', 'n', 't', 'r', 'f', 'v']);
+// Members that a character class uses as glue rather than as a letter.
+const CLASS_SEPARATOR_MEMBERS = new Set([' ', '-', '_', '/', '\\s', '\\/', '\\-', '\\.']);
+
+/**
+ * Literal phrases a business auto_route pattern can match.
+ *
+ * @param {string} pattern raw `auto_routes[].pattern`
+ * @param {{multiply?: boolean}} [opts] `multiply` crosses a group's branches
+ *   with the prefix that precedes them (`security (review|audit)` ->
+ *   "security review", "security audit") instead of listing them side by side.
+ *   Default ON — see the measurement in routePatternIndexText.
+ * @returns {string[]} deduped, non-empty literal phrases
+ */
+function extractRoutePatternLiterals(pattern, opts) {
+  // `type:` is a routing-kind prefix, not vocabulary, and 139 live patterns
+  // carry it in FRONT of an alternation (`type:conciliacao_bancaria|...`) —
+  // half regex, half the old shape. Strip it once, here, for both halves.
+  const src = String(pattern == null ? '' : pattern).replace(/^\(\?i\)/, '').replace(/^type:/, '');
+  const multiply = !opts || opts.multiply !== false;
+  let i = 0;
+
+  const cross = (a, b) => {
+    const out = [];
+    for (const x of a) for (const y of b) out.push(x + y);
+    return out;
+  };
+
+  const isWordChar = (ch) => !!ch && /[\p{L}\p{N}]/u.test(ch);
+
+  /** The next literal character after any quantifier attached to the atom. */
+  function peekAfterQuantifier() {
+    let j = i;
+    if (src[j] === '{') {
+      const close = src.indexOf('}', j);
+      if (close !== -1 && /^\{\d*,?\d*\}$/.test(src.slice(j, close + 1))) j = close + 1;
+    }
+    while (src[j] === '?' || src[j] === '*' || src[j] === '+') j++;
+    return src[j];
+  }
+
+  function parseClass() {
+    i++; // consume '['
+    const start = i;
+    let negated = false;
+    if (src[i] === '^') { negated = true; i++; }
+    const members = [];
+    while (i < src.length && src[i] !== ']') {
+      if (src[i] === '\\' && i + 1 < src.length) { members.push(src.slice(i, i + 2)); i += 2; continue; }
+      members.push(src[i]); i++;
+    }
+    if (src[i] === ']') i++;
+    const body = src.slice(start, i - 1);
+    // A range (`[a-d]`, `[1-4]`) enumerates without naming; a negation names
+    // what it excludes. Neither is a keyword, so both become a boundary.
+    if (negated || /[^\\]-[^\]]/.test(body)) return [' '];
+    const letters = members.filter((m) => !CLASS_SEPARATOR_MEMBERS.has(m));
+    // `[- ]`, `[\s-]`, `[\/ ]` — glue holding two words apart.
+    if (letters.length === 0) return [' '];
+    // A class inside a word is an accent variant: emit each spelling, let the
+    // tokenizer fold them. Always multiplies with its prefix, `multiply` or
+    // not: `seguran` and `a` are not two keywords, they are one word cut open.
+    return letters.map((m) => (m.length === 2 ? m[1] : m));
+  }
+
+  // `inline: true` means the atom lives INSIDE a word and always crosses with
+  // the prefix — a single character, or a class standing in for one letter.
+  // Only a group's branches are ever laid side by side, and only when
+  // `multiply` is off.
+  function parseAtom(depth) {
+    const c = src[i];
+    if (c === '(') {
+      i++;
+      if (src[i] === '?') {
+        // `(?:` groups for real; any other `(?…` (flags, lookaround) has no
+        // literal of its own. The live library has neither, and a wrong guess
+        // about one would be indexed forever.
+        if (src[i + 1] === ':') i += 2;
+        else { skipGroup(); return { variants: [' '], inline: true }; }
+      }
+      const inner = depth < 8 ? parseAlt(depth + 1) : [' '];
+      if (src[i] === ')') i++;
+      return { variants: inner, inline: inner.length <= 1 };
+    }
+    if (c === '[') return { variants: parseClass(), inline: true };
+    if (c === '\\') {
+      const e = src[i + 1];
+      i += 2;
+      if (e === undefined) return { variants: [' '], inline: true };
+      return { variants: [REGEX_CLASS_ESCAPES.has(e) ? ' ' : e], inline: true };
+    }
+    if (c === '.') {
+      // `.` between two word characters is a JOINER, not a gap: the author
+      // writes `stress.?test` to accept "stress test", "stress-test" and
+      // "stresstest" in one atom. A space only buys the first. A hyphen buys
+      // all three, because the tokenizer already emits the joined form and the
+      // parts for a hyphenated word ("stress-test" -> stresstest, stress,
+      // test). Found by measurement: on "Stress-test our 2027 product
+      // roadmap", the route that literally spells `stress-test` was ranking
+      // ABOVE the one that spells `stress.?test` and means the same thing.
+      // Everywhere else — `.{0,24}` gaps, `display . video 360` — it stays a
+      // separator.
+      i++;
+      return { variants: [isWordChar(src[i - 2]) && isWordChar(peekAfterQuantifier()) ? '-' : ' '], inline: true };
+    }
+    if (c === '^' || c === '$') { i++; return { variants: [' '], inline: true }; }
+    i++;
+    // `_` and `:` join words the tokenizer will not split: `efd_icms_ipi` is
+    // ONE token, and no brief writes it. The old `[-_:]` scrub is why 159
+    // patterns had matchable vocabulary at all — keep that, drop the `-`,
+    // which the tokenizer already repairs into both the joined and the split
+    // forms (`e-?book` -> "ebook" AND "book").
+    return { variants: [c === '_' || c === ':' ? ' ' : c], inline: true };
+  }
+
+  function skipGroup() {
+    let open = 1;
+    while (i < src.length && open > 0) {
+      if (src[i] === '\\') { i += 2; continue; }
+      if (src[i] === '(') open++;
+      else if (src[i] === ')') open--;
+      i++;
+    }
+  }
+
+  // A quantifier repeats the atom we just read. Bag of words does not count,
+  // so every quantifier is consumed and the atom is kept exactly once —
+  // including `?`, whose optional letter is kept (`rights?` -> "rights",
+  // `e-?book` -> "e-book", which the tokenizer already repairs to "ebook").
+  function skipQuantifier() {
+    if (src[i] === '{') {
+      const close = src.indexOf('}', i);
+      if (close !== -1 && /^\{\d*,?\d*\}$/.test(src.slice(i, close + 1))) i = close + 1;
+    }
+    while (src[i] === '?' || src[i] === '*' || src[i] === '+') i++;
+  }
+
+  function parseSeq(depth) {
+    const done = [];
+    let variants = [''];
+    while (i < src.length && src[i] !== '|' && src[i] !== ')') {
+      const atom = parseAtom(depth);
+      skipQuantifier();
+      // The cap is not cosmetic: a route with five two-branch groups is 32
+      // phrases, and the library has patterns with nine groups.
+      if (atom.inline || (multiply && variants.length * atom.variants.length <= ROUTE_LITERAL_VARIANT_CAP)) {
+        variants = cross(variants, atom.variants);
+      } else {
+        done.push(...variants);
+        variants = atom.variants.slice();
+      }
+    }
+    return done.concat(variants);
+  }
+
+  function parseAlt(depth) {
+    const branches = parseSeq(depth).slice();
+    while (i < src.length && src[i] === '|') {
+      i++;
+      branches.push(...parseSeq(depth));
+    }
+    return branches;
+  }
+
+  const out = [];
+  const seen = new Set();
+  for (const v of parseAlt(0)) {
+    const s = v.replace(/\s+/g, ' ').trim();
+    if (!s || seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * The text a business auto_route is indexed under.
+ *
+ * A pattern with no regex metacharacter keeps the `type:X-Y_Z` treatment it
+ * has always had (286 of the 686 live routes are that shape) — the extractor
+ * would give the same tokens plus a glued `metaadscampaign`, which is doc
+ * length nobody queries.
+ *
+ * MEASURED, on the criterion brief plus the first `example_brief` of each of
+ * the twelve Genesis businesses, reading the best rank of any route of the
+ * expected business (lower is better; the whole live corpus in the index):
+ *
+ *   alternation flat, prefix not multiplied ... 4 cases in the top 4, 10 in the top 10
+ *   alternation MULTIPLIED with its prefix ... 5 cases in the top 4, 10 in the top 10
+ *
+ * Multiplied wins two cases and loses none. voicecraft's TTS route goes rank
+ * 7 -> 2 and tracking-360's rank 12 -> 10: both patterns are built from
+ * `ger(ar|e|ando) (o |um |este )?(áudio|voz)`-shaped groups, where the prefix
+ * is the word that carries the meaning and the branches are inflections. Flat
+ * indexes `ger` once and the inflections once each; multiplied repeats the
+ * prefix per branch, which is the term frequency the brief actually queries.
+ * The cost is +9.8% tokens over the 686 route documents, and only 7 of them
+ * have a DISTINCT token set that differs at all — the rest differ only in
+ * term frequency, which is exactly the axis being bought.
+ */
+function routePatternIndexText(pattern) {
+  const raw = String(pattern == null ? '' : pattern);
+  if (!/[(\[\\|?*+{^$.]/.test(raw)) {
+    return raw.replace(/^type:/, '').replace(/[-_:]/g, ' ').trim();
+  }
+  return extractRoutePatternLiterals(raw).join(' ');
+}
+
 /**
  * Build matchable documents from the squads + businesses registries.
  *
@@ -395,11 +634,25 @@ function buildMatchDocs(squadsRegistry, businessesRegistry) {
       const businessDomains = Array.isArray(businessEntry.domains) ? businessEntry.domains.join(' ') : '';
       for (const route of routes) {
         if (!route || typeof route.pattern !== 'string' || typeof route.route_to !== 'string') continue;
-        // Extract keywords from pattern. Patterns are typically `type:X-Y_Z`.
-        // Strip `type:` prefix and split on `[-_:]` to get matchable tokens.
-        const patternClean = route.pattern.replace(/^type:/, '').replace(/[-_:]/g, ' ').trim();
+        // The literals the activation regex can match — see
+        // routePatternIndexText. Before it, this line read the regex source
+        // itself, and the route was unreachable by any brief written in words.
+        const patternClean = routePatternIndexText(route.pattern);
         // Boost matchability: include slug, employee, and pattern keywords twice
         // so BM25 favors brief→pattern matches over generic descriptions.
+        //
+        // ×2 is measured, and ×3 and beyond were REJECTED. Sweeping the weight
+        // on the live corpus against the PT-BR criterion brief (the quoted
+        // brief is data, not prose: i18n-user-facing)
+        // "preciso de uma revisão de segurança no meu monorepo":
+        // ×1 puts sf-security-engineer at rank 32, ×2 at 25,
+        // ×3 at 24, and ×4, ×6 and ×8 all at 24-23. The term frequency
+        // saturates — BM25's k1 caps what repetition buys — while the document
+        // length keeps growing, so past ×2 the weight only lifts routes that
+        // ALREADY matched, and on that brief the one it lifted was sf-cto
+        // (rank 9 -> 2 at ×6), which matches "monorepo" and is the wrong
+        // employee for a security review. Raising the weight to promote the
+        // wrong route is tuning to the test.
         const text = [
           patternClean, patternClean,
           route.route_to.replace(/-/g, ' '),
@@ -2103,6 +2356,8 @@ module.exports = {
   stage4BudgetCheck,
   stage5Invoke,
   buildMatchDocs,
+  extractRoutePatternLiterals,
+  routePatternIndexText,
   prepareMatchIndex,
   buildAliasMap,
   loadKeywordAliases,

--- a/skills/harness/tests/agentic-run-tracking.test.ts
+++ b/skills/harness/tests/agentic-run-tracking.test.ts
@@ -218,7 +218,7 @@ describe("supervisor — agentic runs", () => {
     // clock exists only to age the row) — so the check is simply that the lease
     // is no longer expired.
     expect(Date.parse(after.lease_expires_at!)).toBeGreaterThan(Date.now());
-  });
+  }, spawnBudgetMs(2));
 
   test("expired lease and nothing moving → escalates on the FIRST sweep, human notified", () => {
     const h = freshLedger();
@@ -249,7 +249,7 @@ describe("supervisor — agentic runs", () => {
     expect(after.state).toBe("stalled");
     // Escalation is immediate: retries are for recoveries that could work.
     expect(after.retries).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("a scripted run is untouched by the agentic door", () => {
     const h = freshLedger();
@@ -270,7 +270,7 @@ describe("supervisor — agentic runs", () => {
 
     expect(resumed.length).toBe(1);
     expect(getRun(h, row.run_id)!.state).toBe("delivered");
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── 3. periodic status ────────────────────────────────────────────────────
@@ -299,7 +299,7 @@ describe("supervisor — progress ping", () => {
 
     // The run is not disturbed by being reported on.
     expect(getRun(h, row.run_id)!.state).toBe("running");
-  });
+  }, spawnBudgetMs(2));
 
   test("a run younger than the interval stays quiet", () => {
     const h = freshLedger();
@@ -310,7 +310,7 @@ describe("supervisor — progress ping", () => {
     const pings: number[] = [];
     sweep({ handle: h, pingImpl: (_r, m) => pings.push(m), notifyImpl: noNotify, salvageImpl: noSalvage });
     expect(pings.length).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── 4. the close door ─────────────────────────────────────────────────────

--- a/skills/harness/tests/buyer-path.test.ts
+++ b/skills/harness/tests/buyer-path.test.ts
@@ -25,6 +25,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { fakeHomeEnv } from "./helpers/fake-home.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SLUG = "buyer-path-fixture";
@@ -164,7 +165,7 @@ describe("what the buyer has after running setup.ts", () => {
     expect(reg.length).toBeGreaterThan(0);
     expect(fs.existsSync(reg)).toBe(true);
     expect(fs.readFileSync(reg, "utf8")).toContain("fixture-squad");
-  });
+  }, spawnBudgetMs(2));
 
   test("the pack manifest records the version", () => {
     const p = path.join(home, ".nirvana", "packs", `${SLUG}.json`);

--- a/skills/harness/tests/capability-clones.test.ts
+++ b/skills/harness/tests/capability-clones.test.ts
@@ -21,6 +21,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-capability-clones.ts");
@@ -43,7 +44,7 @@ describe("what counts as a clone", () => {
     const r = run({ "x.y.z": [cap("alpha"), cap("beta")] }, ["--strict"]);
     expect(r.code).toBe(1);
     expect(r.out).toContain("alpha, beta");
-  });
+  }, spawnBudgetMs(2));
 
   test("different keywords make them distinguishable", () => {
     // The actual fix applied to the library: same work, each squad's own words.
@@ -52,7 +53,7 @@ describe("what counts as a clone", () => {
     }, ["--strict"]);
     expect(r.code).toBe(0);
     expect(r.out).toContain("describes itself differently");
-  });
+  }, spawnBudgetMs(2));
 
   test("different example_briefs alone are enough", () => {
     const a = { ...cap("alpha"), example_briefs: ["build me a dashboard"] };
@@ -72,7 +73,7 @@ describe("what counts as a clone", () => {
     });
     expect(r.out).toContain("1 capability ids have more than one provider (3 instances)");
     expect(r.out).toContain("describes itself differently");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("partial cloning is reported precisely", () => {
@@ -87,7 +88,7 @@ describe("partial cloning is reported precisely", () => {
     expect(r.out).toContain("alpha, beta, gamma");
     expect(r.out).toContain("delta");
     expect(r.out).toMatch(/3 of 4 providers/);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the gate is usable from a build step", () => {
@@ -97,7 +98,7 @@ describe("the gate is usable from a build step", () => {
     expect(d.provider_instances).toBe(2);
     expect(d.cloned_instances).toBe(2);
     expect(d.affected[0].camps[0]).toEqual(["alpha", "beta"]);
-  });
+  }, spawnBudgetMs(2));
 
   test("without --strict it reports rather than fails", () => {
     expect(run({ "x.y.z": [cap("alpha"), cap("beta")] }).code).toBe(0);
@@ -107,7 +108,7 @@ describe("the gate is usable from a build step", () => {
     const r = run({ "x.y.z": [cap("alpha"), cap("beta")], "p.q.r": [cap("c"), cap("d")] }, ["x.y.z"]);
     expect(r.out).toContain("alpha, beta");
     expect(r.out).not.toContain("p.q.r");
-  });
+  }, spawnBudgetMs(2));
 });
 
 process.on("exit", () => { try { rmSync(tmp, { recursive: true, force: true }); } catch {} });

--- a/skills/harness/tests/check-brief.test.ts
+++ b/skills/harness/tests/check-brief.test.ts
@@ -17,6 +17,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const CHECK = join(REPO, "scripts", "check-brief.ts");
@@ -54,19 +55,19 @@ describe("it catches what a stale brief gets wrong", () => {
     const r = run("Edit ~/nirvana-packs/genesis-content/squads/no-such-squad-here/squad.yaml");
     expect(r.out).toContain("does not exist");
     expect(r.out).toContain("no-such-squad-here");
-  });
+  }, spawnBudgetMs(2));
 
   test("a script on a branch this checkout does not have", () => {
     const r = run("Run `bun scripts/coverage-ratchet-that-moved.ts --check` first.");
     expect(r.out).toMatch(/no such script/);
-  });
+  }, spawnBudgetMs(2));
 
   test("a slug that is not in the registry", () => {
     // The real shape of this error: a plausible name for a squad that exists
     // under a different one.
     const r = run("Neighbour: `design-system-nirvana-pro`.");
     expect(r.out).toContain("not in the registry");
-  });
+  }, spawnBudgetMs(2));
 
   test("--strict is what a dispatch step would gate on", () => {
     const body = "Edit ~/definitely/not/a/real/path/squad.yaml";
@@ -84,7 +85,7 @@ describe("it stays quiet when the brief is right", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("resolves");
     expect(r.out).toMatch(/checked 1 paths · 1 scripts · 1 slugs/);
-  });
+  }, spawnBudgetMs(2));
 
   test("a Windows path is seen, on any platform", () => {
     // The suite creates its fixtures under tmpdir, which on Windows is a
@@ -94,7 +95,7 @@ describe("it stays quiet when the brief is right", () => {
     expect(r.code).toBe(1);
     expect(r.out).toContain("does not exist");
     expect(r.out).toMatch(/checked 1 paths/);
-  });
+  }, spawnBudgetMs(2));
 
   test("a single-word name is not judged as a slug", () => {
     // 13 of the 255 entities are one word, and three of those words are
@@ -103,26 +104,26 @@ describe("it stays quiet when the brief is right", () => {
     const r = run("Read `testing` notes and the `monitoring` section.", ["--strict"]);
     expect(r.code).toBe(0);
     expect(r.out).toMatch(/· 0 slugs/);
-  });
+  }, spawnBudgetMs(2));
 
   test("a path the agent is told to CREATE is not an error", () => {
     // Briefs name their own outputs. Flagging those would make the checker
     // useless for exactly the briefs that produce something.
     const r = run("Write the report to ~/nirvana-os/.nirvana/outputs/run-01/report.md (new)", ["--strict"]);
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("filenames in backticks are not judged as slugs", () => {
     const r = run("Read `router.js` and `squad.yaml`, then `build-all-packs.sh`.", ["--strict"]);
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("a relative path is left alone rather than guessed at", () => {
     // Without a stated cwd, `skills/harness/lib` could resolve against the repo,
     // the pack, or the installed library. Guessing produces false alarms.
     const r = run("Look under skills/harness/lib and packaging/pack.", ["--strict"]);
     expect(r.code).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the checker reports what it inspected", () => {
@@ -130,7 +131,7 @@ describe("the checker reports what it inspected", () => {
     // A preflight that silently checks nothing reads exactly like a passing one.
     const r = run(`Target: the \`design-system-nirvana\` squad at ${REAL_FILE}`);
     expect(r.out).toMatch(/checked 1 paths · 0 scripts · 1 slugs/);
-  });
+  }, spawnBudgetMs(2));
 });
 
 process.on("exit", () => { try { rmSync(tmp, { recursive: true, force: true }); } catch {} });

--- a/skills/harness/tests/clone-bindings.test.ts
+++ b/skills/harness/tests/clone-bindings.test.ts
@@ -23,6 +23,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-clone-bindings.ts");
@@ -60,7 +61,7 @@ describe("a named clone that is not shipped is caught", () => {
     expect(r.code).toBe(1);
     expect(r.out).toContain("david-vallejo-tracking");
     expect(r.out).not.toContain("simo-ahava-tracking\x1b");  // the present one is not flagged
-  });
+  }, spawnBudgetMs(2));
 
   test("a complete pack passes", () => {
     const dir = pack("complete", {
@@ -70,7 +71,7 @@ describe("a named clone that is not shipped is caught", () => {
     const r = run(dir, ["--strict"]);
     expect(r.code).toBe(0);
     expect(r.out).toContain("Every clone an employee names is present");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the two reference forms", () => {
@@ -92,7 +93,7 @@ describe("the two reference forms", () => {
     const r = run(dir, ["--strict"]);
     expect(r.code).toBe(0);
     expect(r.out).not.toContain("AGENT");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the business dna/ directory", () => {
@@ -107,7 +108,7 @@ describe("the business dna/ directory", () => {
     expect(r.code).toBe(0);
     expect(r.out).not.toContain("README");
     expect(r.out).toContain("0 bindings");
-  });
+  }, spawnBudgetMs(2));
 
   test("a dangling symlink is a binding that already broke", () => {
     const dir = pack("dangling", { clones: ["present-one"], employees: {} });
@@ -117,7 +118,7 @@ describe("the business dna/ directory", () => {
     const r = run(dir, ["--strict"]);
     expect(r.code).toBe(1);
     expect(r.out).toContain("gone-clone");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("it reports what it inspected", () => {
@@ -135,5 +136,5 @@ describe("it reports what it inspected", () => {
     expect(d.bindings).toBe(1);
     expect(d.missing[0].clone).toBe("absent");
     expect(d.missing[0].employee).toBe("one");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/context-guard.test.ts
+++ b/skills/harness/tests/context-guard.test.ts
@@ -16,6 +16,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-ctx-guard-"));
 const SKILLS = path.resolve(import.meta.dir, "..", "..");
@@ -69,7 +70,7 @@ describe("nrv guard context — the verdict", () => {
     const r = guard(["context", "--project", dir, "--used", "50000", "--window", "200000"]);
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("25%");
-  });
+  }, spawnBudgetMs(2));
 
   test("at the threshold it orders a rollover — exit 8, not a warning to ignore", () => {
     const dir = freshProject();
@@ -80,7 +81,7 @@ describe("nrv guard context — the verdict", () => {
     expect(r.stderr).toContain("CONTEXT GUARD");
     expect(r.stderr).toContain("HANDOFF");
     expect(r.stderr).toContain(dir);          // tells you how to resume THIS run
-  });
+  }, spawnBudgetMs(2));
 
   test("exit 8 is distinct from the loop guard's exit 7", () => {
     // Both guards stop the prose, for different reasons and with different
@@ -90,7 +91,7 @@ describe("nrv guard context — the verdict", () => {
     const roll = guard(["context", "--project", dir, "--used", "999999", "--window", "200000"]);
     expect(roll.status).toBe(8);
     expect(roll.status).not.toBe(7);
-  });
+  }, spawnBudgetMs(2));
 
   test("the threshold is configurable, and the default window is documented", () => {
     const dir = freshProject();
@@ -101,7 +102,7 @@ describe("nrv guard context — the verdict", () => {
     const dflt = guard(["context", "--project", freshProject(), "--used", "150000"]);
     expect(dflt.status).toBe(8);
     expect(dflt.stderr).toContain("200,000");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("nrv guard context — the record", () => {
@@ -116,7 +117,7 @@ describe("nrv guard context — the record", () => {
     expect(st.ratio).toBeCloseTo(0.75, 2);
     expect(st.rollovers).toBe(1);
     expect(typeof st.checked_at).toBe("string");
-  });
+  }, spawnBudgetMs(2));
 
   test("rollovers accumulate; a check under budget does not inflate the count", () => {
     const dir = freshProject();
@@ -124,7 +125,7 @@ describe("nrv guard context — the record", () => {
     guard(["context", "--project", dir, "--used", "50000", "--window", "200000"]);   // fresh session, under budget
     guard(["context", "--project", dir, "--used", "180000", "--window", "200000"]);  // filled again
     expect(handoffState(dir).rollovers).toBe(2);
-  });
+  }, spawnBudgetMs(3));
 
   test("a rollover emits context_budget_warning — the event the cockpit already renders", () => {
     const dir = freshProject();
@@ -134,12 +135,12 @@ describe("nrv guard context — the record", () => {
     expect(ev[0].used_tokens).toBe(150000);
     expect(ev[0].budget_tokens).toBe(140000);
     expect(ev[0].action).toBe("rollover_required");
-  });
+  }, spawnBudgetMs(2));
 
   test("staying under budget emits nothing — silence is the normal state", () => {
     guard(["context", "--project", freshProject(), "--used", "10000", "--window", "200000"]);
     expect(auditEvents().filter((e) => e.event === "context_budget_warning").length).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("nrv guard context — refusing to guess", () => {
@@ -151,19 +152,19 @@ describe("nrv guard context — refusing to guess", () => {
       expect(r.status).toBe(2);
       expect(r.stderr).toContain("usage:");
     }
-  });
+  }, spawnBudgetMs(2));
 
   test("a window of zero is rejected rather than dividing by it", () => {
     const r = guard(["context", "--project", TMP, "--used", "100", "--window", "0"]);
     expect(r.status).toBe(2);
-  });
+  }, spawnBudgetMs(2));
 
   test("an unknown subcommand still prints both usages", () => {
     const r = guard(["nonsense"]);
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("guard tick");
     expect(r.stderr).toContain("guard context");
-  });
+  }, spawnBudgetMs(2));
 
   test("an unwritable project dir degrades to a warning, never loses the verdict", () => {
     // Losing the record is bad; losing the ROLLOVER because the record failed
@@ -171,5 +172,5 @@ describe("nrv guard context — refusing to guess", () => {
     const r = guard(["context", "--project", "/proc/nonexistent-nirvana", "--used", "150000", "--window", "200000"]);
     expect(r.status).toBe(8);
     expect(r.stderr).toContain("CONTEXT GUARD");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/delivery-pipeline.test.ts
+++ b/skills/harness/tests/delivery-pipeline.test.ts
@@ -28,6 +28,7 @@ import {
 import { loadHarnessConfig } from "../lib/harness-config.ts";
 import * as runLedger from "../lib/run-ledger.ts";
 import { SCOPE_GUARD_PT_BR } from "../../_shared/lib/scope-guard.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const GATE = path.join(import.meta.dir, "..", "scripts", "quality-gate.ts");
 
@@ -188,7 +189,7 @@ describe("runDelivery — outcomes", () => {
     expect(calls.map(x => x.event)).toContain("gate_passed");
     const delivered = calls.find(x => x.event === "delivered");
     expect(delivered?.payload.gate).toBe("pass");
-  });
+  }, spawnBudgetMs(2));
 
   test("zero gateable artifacts → exit 3, NO gate_passed, NO delivered", () => {
     const oroot = path.join(tmp, "out-zip");
@@ -203,7 +204,7 @@ describe("runDelivery — outcomes", () => {
     expect(events).toContain("x_gate_skipped_no_files");
     expect(events).not.toContain("gate_passed");
     expect(events).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("gate fail with revisions exhausted → exit 2, x_delivery_withheld, NO delivered", () => {
     const oroot = path.join(tmp, "out-fail");
@@ -218,7 +219,7 @@ describe("runDelivery — outcomes", () => {
     expect(events).toContain("gate_failed");
     expect(events).toContain("x_delivery_withheld");
     expect(events).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("--force-deliver escape → delivered with gate:'fail-forced', exit 0", () => {
     const oroot = path.join(tmp, "out-force");
@@ -233,7 +234,7 @@ describe("runDelivery — outcomes", () => {
     expect(events).toContain("gate_failed"); // the failure stays on the record
     const delivered = calls.find(x => x.event === "delivered");
     expect(delivered?.payload.gate).toBe("fail-forced");
-  });
+  }, spawnBudgetMs(2));
 
   test("no deliverables at all → exit 1, verify_failed, gate never runs", () => {
     const oroot = path.join(tmp, "out-empty");
@@ -245,7 +246,7 @@ describe("runDelivery — outcomes", () => {
     expect(events).toContain("verify_failed");
     expect(events).not.toContain("gate_passed");
     expect(events).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("revision seam: a failing artifact fixed by the revision run passes on re-gate", () => {
     const oroot = path.join(tmp, "out-revise");
@@ -272,7 +273,7 @@ describe("runDelivery — outcomes", () => {
     expect(events).toContain("revision_auto");
     const gp = calls.find(x => x.event === "gate_passed");
     expect(gp?.payload.revisions).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("afterGate hook runs ONLY on deliverable outcomes and its zip lands in delivered", () => {
     const orootPass = path.join(tmp, "out-hook-pass");
@@ -292,7 +293,7 @@ describe("runDelivery — outcomes", () => {
     const resFail = runDelivery(failCase.args);
     expect(resFail.exitCode).toBe(2);
     expect(hookRuns).toBe(1); // hook did NOT run for the withheld delivery
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("runDelivery — manifest verify (stub verify-deliverable seam)", () => {
@@ -311,7 +312,7 @@ describe("runDelivery — manifest verify (stub verify-deliverable seam)", () =>
     expect(res.exitCode).toBe(1);
     expect(res.verifySource).toBe("manifest");
     expect(calls.map(x => x.event)).not.toContain("gate_passed");
-  });
+  }, spawnBudgetMs(2));
 
   test("verify script exit 0 (PASS) proceeds to the gate with verifySource manifest", () => {
     const oroot = path.join(tmp, "out-mv-pass");
@@ -321,7 +322,7 @@ describe("runDelivery — manifest verify (stub verify-deliverable seam)", () =>
     const res = runDelivery(args);
     expect(res.exitCode).toBe(0);
     expect(res.verifySource).toBe("manifest");
-  });
+  }, spawnBudgetMs(2));
 
   test("verify script exit 2 (indeterminate) falls back to the output scan", () => {
     const oroot = path.join(tmp, "out-mv-ind");
@@ -332,7 +333,7 @@ describe("runDelivery — manifest verify (stub verify-deliverable seam)", () =>
     expect(res.exitCode).toBe(0);
     expect(res.verifySource).toBe("scan");
     expect(calls.map(x => x.event)).toContain("verify_passed"); // scan emitted it
-  });
+  }, spawnBudgetMs(2));
 
   test("no manifest → homegrown scan (verify-deliverable never spawned)", () => {
     const oroot = path.join(tmp, "out-mv-none");
@@ -344,7 +345,7 @@ describe("runDelivery — manifest verify (stub verify-deliverable seam)", () =>
     const res = runDelivery(args);
     expect(res.exitCode).toBe(0);
     expect(res.verifySource).toBe("scan");
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── completeness ceiling ─────────────────────────────────────────────────
@@ -386,7 +387,7 @@ describe("runDelivery — completenessCeiling", () => {
     expect(row.state).toBe("withheld");
     expect(row.meta.ceiling).toBe("completeness");
     expect(row.meta.ceiling_reason).toBe(CEILING_REASON);
-  });
+  }, spawnBudgetMs(2));
 
   test("ceiling + gate PASS + manifest verify PASS → delivered (the ONE door to `delivered`)", () => {
     const oroot = path.join(tmp, "out-ceil-manifest");
@@ -405,7 +406,7 @@ describe("runDelivery — completenessCeiling", () => {
     expect(res.ceilingApplied).toBeNull();
     expect(calls.map(x => x.event)).toContain("delivered");
     expect(runLedger.getRun(led.handle, led.runId)!.state).toBe("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("ceiling + manifest INDETERMINATE (rc=2 → scan fallback) still caps at withheld", () => {
     const oroot = path.join(tmp, "out-ceil-ind-manifest");
@@ -419,7 +420,7 @@ describe("runDelivery — completenessCeiling", () => {
     expect(res.verifySource).toBe("scan");   // the manifest proved nothing
     expect(res.exitCode).toBe(2);
     expect(res.ceilingApplied).toBe(CEILING_REASON);
-  });
+  }, spawnBudgetMs(2));
 
   test("ceiling + gate FAIL → withheld for QUALITY; ceiling is not the binding reason", () => {
     const oroot = path.join(tmp, "out-ceil-gatefail");
@@ -433,7 +434,7 @@ describe("runDelivery — completenessCeiling", () => {
     const withheld = calls.find(x => x.event === "x_delivery_withheld")!;
     expect(withheld.payload.gate).toBe("fail");
     expect(withheld.payload.ceiling).toBeNull();
-  });
+  }, spawnBudgetMs(2));
 
   test("ceiling outranks --force-deliver (that flag overrides a QUALITY verdict, not completeness)", () => {
     const oroot = path.join(tmp, "out-ceil-force");
@@ -445,7 +446,7 @@ describe("runDelivery — completenessCeiling", () => {
     expect(res.delivered).toBe(false);
     expect(res.ceilingApplied).toBe(CEILING_REASON);
     expect(calls.map(x => x.event)).not.toContain("delivered");
-  });
+  }, spawnBudgetMs(2));
 
   test("no ceiling → behavior identical to before (gate pass delivers)", () => {
     const oroot = path.join(tmp, "out-ceil-absent");
@@ -456,7 +457,7 @@ describe("runDelivery — completenessCeiling", () => {
     expect(res.exitCode).toBe(0);
     expect(res.delivered).toBe(true);
     expect(res.ceilingApplied).toBeNull();
-  });
+  }, spawnBudgetMs(2));
 });
 
 function openTestRun(): { handle: runLedger.LedgerHandle; runId: string } {
@@ -613,7 +614,7 @@ describe("runDelivery — ledger terminal states (never-stall guarantee)", () =>
     const row = runLedger.getRun(led.handle, led.runId)!;
     expect(row.state).toBe("delivered");
     expect(row.meta.gate).toBe("pass");
-  });
+  }, spawnBudgetMs(2));
 
   test("gate fail → ledger withheld (terminal), NOT delivered", () => {
     const oroot = path.join(tmp, "out-led-fail");
@@ -626,7 +627,7 @@ describe("runDelivery — ledger terminal states (never-stall guarantee)", () =>
     const row = runLedger.getRun(led.handle, led.runId)!;
     expect(row.state).toBe("withheld");
     expect(row.meta.gate).toBe("fail");
-  });
+  }, spawnBudgetMs(2));
 
   test("zero gateable → ledger withheld with gate:'indeterminate' (terminal, supervisor never re-dispatches)", () => {
     const oroot = path.join(tmp, "out-led-ind");
@@ -639,7 +640,7 @@ describe("runDelivery — ledger terminal states (never-stall guarantee)", () =>
     const row = runLedger.getRun(led.handle, led.runId)!;
     expect(row.state).toBe("withheld");
     expect(row.meta.gate).toBe("indeterminate");
-  });
+  }, spawnBudgetMs(2));
 });
 
 // ── gate retry ceiling → accepted with reservations (owner policy 2026-08-21) ─
@@ -662,7 +663,7 @@ describe("runDelivery — gate exhausted: accepted with reservations", () => {
     expect(events).toContain("delivered");
     expect(events).not.toContain("x_delivery_withheld");
     expect(calls.find(x => x.event === "delivered")!.payload.gate).toBe("fail-accepted");
-  });
+  }, spawnBudgetMs(2));
 
   test("the completeness ceiling outranks the acceptance (reservations never cover a missing deliverable)", () => {
     const oroot = path.join(tmp, "out-reservations-ceiling");
@@ -673,7 +674,7 @@ describe("runDelivery — gate exhausted: accepted with reservations", () => {
     expect(res.delivered).toBe(false);
     expect(res.exitCode).toBe(2);
     expect(res.ceilingApplied).toBe(CEILING_REASON);
-  });
+  }, spawnBudgetMs(2));
 
   test("explicit withhold policy keeps the strict exit 2", () => {
     const oroot = path.join(tmp, "out-reservations-strict");
@@ -684,7 +685,7 @@ describe("runDelivery — gate exhausted: accepted with reservations", () => {
     expect(res.exitCode).toBe(2);
     expect(res.delivered).toBe(false);
     expect(calls.map(x => x.event)).toContain("x_delivery_withheld");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("producesForRubric — delivery.produces_to_rubric", () => {

--- a/skills/harness/tests/dispatch-contract.test.ts
+++ b/skills/harness/tests/dispatch-contract.test.ts
@@ -16,6 +16,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
 const GATE = path.join(ROOT, "scripts", "check-dispatch-contract.ts");
@@ -136,7 +137,7 @@ describe("check-dispatch-contract — the gate itself", () => {
     const r = spawnSync(process.execPath, [GATE], { encoding: "utf8", cwd: ROOT });
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("clean");
-  });
+  }, spawnBudgetMs(2));
 
   test("fails when an example goes back to blocking", () => {
     expect(sandbox((dir) => {
@@ -163,5 +164,5 @@ describe("check-dispatch-contract — the gate itself", () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -25,6 +25,7 @@ import {
   type Runtime,
 } from "../../_shared/lib/host-agent-driver.ts";
 import { writeFakeCli, readCapturedArgs, CAPTURE_PRELUDE } from "./helpers/fake-cli.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-driver-adapters-test-"));
 const BIN = path.join(TMP, "bin");
@@ -190,7 +191,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBe(0.42);
     expect(r.costUnavailable).toBeUndefined();
     assertArgvSafe("claude");
-  });
+  }, spawnBudgetMs(2));
 
   test("codex: STDIN; costUnavailable (tokens only, no USD)", () => {
     const r = run("codex");
@@ -200,7 +201,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBeNull();
     expect(r.costUnavailable).toBe(true);
     assertArgvSafe("codex");
-  });
+  }, spawnBudgetMs(2));
 
   test("gemini-cli: STDIN via -p ''; costUnavailable", () => {
     const r = run("gemini-cli");
@@ -214,7 +215,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(p).toBeGreaterThanOrEqual(0);
     expect(args[p + 1]).toBe(""); // prompt rides stdin, not argv
     assertArgvSafe("gemini");
-  });
+  }, spawnBudgetMs(2));
 
   test("antigravity-cli: bootstrap prompt-file above threshold; costUnavailable", () => {
     const r = run("antigravity-cli");
@@ -223,7 +224,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBeNull();
     expect(r.costUnavailable).toBe(true);
     assertArgvSafe("agy");
-  });
+  }, spawnBudgetMs(2));
 
   test("kimi-cli: bootstrap prompt-file; native cost from result event", () => {
     const r = run("kimi-cli");
@@ -233,7 +234,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBe(0.07);
     expect(r.costUnavailable).toBeUndefined();
     assertArgvSafe("kimi");
-  });
+  }, spawnBudgetMs(2));
 
   test("grok-cli: native --prompt-file; native cost", () => {
     const r = run("grok-cli");
@@ -243,7 +244,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBe(0.11);
     expect(r.costUnavailable).toBeUndefined();
     assertArgvSafe("grok");
-  });
+  }, spawnBudgetMs(2));
 
   test("pi: native @file attachment; native summed cost", () => {
     const r = run("pi");
@@ -253,7 +254,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBe(0.05);
     expect(r.costUnavailable).toBeUndefined();
     assertArgvSafe("pi");
-  });
+  }, spawnBudgetMs(2));
 
   test("qwen-code: STDIN; costUnavailable", () => {
     const r = run("qwen-code");
@@ -262,7 +263,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBeNull();
     expect(r.costUnavailable).toBe(true);
     assertArgvSafe("qwen");
-  });
+  }, spawnBudgetMs(2));
 
   test("opencode: bootstrap prompt-file; costUnavailable", () => {
     const r = run("opencode");
@@ -271,7 +272,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBeNull();
     expect(r.costUnavailable).toBe(true);
     assertArgvSafe("opencode");
-  });
+  }, spawnBudgetMs(2));
 
   test("temp prompt files are cleaned up after the run", () => {
     run("antigravity-cli");
@@ -279,7 +280,7 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     run("pi");
     const leftovers = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith("nrv-prompt-"));
     expect(leftovers).toEqual([]);
-  });
+  }, spawnBudgetMs(3));
 });
 
 describe("driver adapters — failure contract (error envelope on exit 0 → ok:false)", () => {
@@ -288,63 +289,63 @@ describe("driver adapters — failure contract (error envelope on exit 0 → ok:
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toBeTruthy();
-  });
+  }, spawnBudgetMs(2));
 
   test("codex: terminal error event", () => {
     const r = run("codex", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("upstream 500");
-  });
+  }, spawnBudgetMs(2));
 
   test("gemini-cli: error field in envelope", () => {
     const r = run("gemini-cli", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("quota exhausted");
-  });
+  }, spawnBudgetMs(2));
 
   test("antigravity-cli: is_error + error object", () => {
     const r = run("antigravity-cli", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("agy backend down");
-  });
+  }, spawnBudgetMs(2));
 
   test("kimi-cli: error event + result is_error", () => {
     const r = run("kimi-cli", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("provider exploded");
-  });
+  }, spawnBudgetMs(2));
 
   test("grok-cli: is_error + error string", () => {
     const r = run("grok-cli", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("xai upstream error");
-  });
+  }, spawnBudgetMs(2));
 
   test("pi: stopReason=error in stream (the original quirk)", () => {
     const r = run("pi", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("403");
-  });
+  }, spawnBudgetMs(2));
 
   test("qwen-code: error field in envelope", () => {
     const r = run("qwen-code", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     expect(r.error).toContain("qwen quota");
-  });
+  }, spawnBudgetMs(2));
 
   test("opencode: non-zero exit (only signal it has)", () => {
     const r = run("opencode", "error");
     expect(r.ok).toBe(false);
     expect(r.exitCode).toBe(1);
     expect(r.error).toContain("boom");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("light layer — callHostAgent / callHostAgentAsync", () => {
@@ -353,7 +354,7 @@ describe("light layer — callHostAgent / callHostAgentAsync", () => {
     expect("text" in r && r.text).toBe("len:300000");
     if ("host" in r) expect(r.host).toBe("claude-code");
     assertArgvSafe("claude");
-  });
+  }, spawnBudgetMs(2));
 
   test("callHostAgentAsync honors legacy __testRuntime shape (buildArgs only)", async () => {
     // Spawn the interpreter directly (see fake-cli.ts): the legacy shape carries
@@ -369,7 +370,7 @@ describe("light layer — callHostAgent / callHostAgentAsync", () => {
     };
     const r = await callHostAgentAsync("", "hi", { __testRuntime: legacy, timeoutMs: 10_000, heartbeatMs: 0 });
     expect("text" in r && r.text).toBe("legacy-ok");
-  });
+  }, spawnBudgetMs(2));
 
   test("persona truncation warns on stderr with sizes", () => {
     const seen: string[] = [];

--- a/skills/harness/tests/driver-autonomy-flags.test.ts
+++ b/skills/harness/tests/driver-autonomy-flags.test.ts
@@ -19,6 +19,7 @@ import {
   runHeadless, type Runtime,
 } from "../../_shared/lib/host-agent-driver.ts";
 import { CAPTURE_PRELUDE, readCapturedArgs, writeFakeCli } from "./helpers/fake-cli.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-driver-autonomy-"));
 const BIN = path.join(TMP, "bin");
@@ -187,7 +188,7 @@ describe("headless layer — runHeadless argv per runtime", () => {
     // link the shim reader could not check on the machine that wrote it.
     if (flag === "--append-system-prompt") expect(args[at + 1]).toBe("line one\nline two");
     else expect(fs.readFileSync(args[at + 1], "utf8")).toBe("line one\nline two");
-  });
+  }, spawnBudgetMs(2));
 
   test("codex: --dangerously-bypass-approvals-and-sandbox by default; the workspace-write sandbox under =0", () => {
     expect(argv("codex", "codex", undefined)).toContain("--dangerously-bypass-approvals-and-sandbox");

--- a/skills/harness/tests/engine-purity-run-artifacts.test.ts
+++ b/skills/harness/tests/engine-purity-run-artifacts.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { outputsDir } from "../../_shared/lib/scope.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
 const GATE = path.join(ROOT, "scripts", "check-engine-purity.ts");
@@ -54,13 +55,13 @@ describe("run artifacts cannot be committed", () => {
   test("nothing under a write path is tracked right now", () => {
     const tracked = spawnSync("git", ["ls-files", "outputs", ".nirvana", ".harness-logs"], { cwd: ROOT, encoding: "utf8" });
     expect((tracked.stdout || "").trim()).toBe("");
-  });
+  }, spawnBudgetMs(2));
 
   test("the gate passes on the shipped tree", () => {
     const r = runGate();
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("OK");
-  });
+  }, spawnBudgetMs(2));
 
   test("every path the engine writes to is gitignored", () => {
     // Derived, not listed: if outputsDir() moves, this test follows it there and
@@ -88,7 +89,7 @@ describe("run artifacts cannot be committed", () => {
     } finally {
       fs.rmSync(p, { force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the guarded set follows the engine, not a memory of it", () => {

--- a/skills/harness/tests/entity-admission.test.ts
+++ b/skills/harness/tests/entity-admission.test.ts
@@ -19,6 +19,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-entity-admission.ts");
@@ -69,7 +70,7 @@ describe("hard problems always fail", () => {
     const r = run(root, { baseline: {} });
     expect(r.code).toBe(1);
     expect(r.out).toContain("no routing.one_liner");
-  });
+  }, spawnBudgetMs(2));
 
   test("a numbered legacy category does not enter", () => {
     const root = pack((r) => {
@@ -84,14 +85,14 @@ describe("hard problems always fail", () => {
     const r = run(root, { baseline: {} });
     expect(r.code).toBe(1);
     expect(r.out).toContain("numbered legacy category");
-  });
+  }, spawnBudgetMs(2));
 
   test("a missing surface file does not enter", () => {
     const root = pack((r) => rmSync(join(r, "squads", "one-squad", ".nirvana-surface.json")));
     const r = run(root, { baseline: {} });
     expect(r.code).toBe(1);
     expect(r.out).toContain("no .nirvana-surface.json");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("metadata debt is baselined — shrink only, and new content enters complete", () => {
@@ -108,14 +109,14 @@ describe("metadata debt is baselined — shrink only, and new content enters com
     const r = run(root, { baseline: {} });
     expect(r.code).toBe(1);
     expect(r.out).toContain("new content enters complete");
-  });
+  }, spawnBudgetMs(2));
 
   test("the same gap on a BASELINED clone passes — recorded debt", () => {
     const root = pack(noVerdict);
     const r = run(root, { baseline: { "jane-doe": ["no_verdict"] } });
     expect(r.code).toBe(0);
     expect(r.out).toContain("recorded metadata debt");
-  });
+  }, spawnBudgetMs(2));
 
   test("a NEW gap on a baselined clone still fails", () => {
     const root = pack((r) =>
@@ -127,19 +128,19 @@ describe("metadata debt is baselined — shrink only, and new content enters com
     const r = run(root, { baseline: { "jane-doe": ["no_verdict"] } });
     expect(r.code).toBe(1);
     expect(r.out).toContain("NEW gap on a known entity");
-  });
+  }, spawnBudgetMs(2));
 
   test("--record refuses to add debt without --allow-regression", () => {
     const root = pack(noVerdict);
     const r = run(root, { baseline: {}, record: true });
     expect(r.code).toBe(1);
     expect(r.out).toContain("would gain NEW debt");
-  });
+  }, spawnBudgetMs(2));
 
   test("a clean pack passes, and no baseline at all refuses rather than approves", () => {
     expect(run(pack(), { baseline: {} }).code).toBe(0);
     const r = run(pack());
     expect(r.code).toBe(1);
     expect(r.out).toContain("No debt baseline recorded");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/gauntlet-revision-loop.e2e.test.ts
+++ b/skills/harness/tests/gauntlet-revision-loop.e2e.test.ts
@@ -298,7 +298,7 @@ describe("Gauntlet causal revision loop", () => {
     expect(loop.calls.revisions).toHaveLength(1);
     expect(fs.readFileSync(path.join(loop.outputsRoot, "report.html"), "utf8")).toContain("Revision 2 of can_1");
     expect(fs.existsSync(path.join(loop.outputsRoot, "relatorio-final.pdf"))).toBeTrue();
-  });
+  }, spawnBudgetMs(2));
 
   test("the dispatch evaluator drives the causal revision from the scorecard's revisionRequests and reaches the final gate", () => {
     const loop = scenario({ grade: () => PASS });

--- a/skills/harness/tests/glance-execution-runner.test.ts
+++ b/skills/harness/tests/glance-execution-runner.test.ts
@@ -12,6 +12,7 @@ import { canonicalRunIdFor } from "../scripts/dispatch.ts";
 import { writeFakeDispatch } from "./helpers/fake-dispatch.ts";
 import { shimRuntimeOnPath } from "./helpers/fake-glance-child.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const DISPATCH = path.join(import.meta.dir, "..", "scripts", "dispatch.ts");
 const roots: string[] = [];
@@ -187,12 +188,12 @@ describe("--run-id in dispatch.ts", () => {
       expect(r.status).toBe(4);
       expect(r.stderr).toContain("pass an inline brief or --brief-file");
     }
-  });
+  }, spawnBudgetMs(2));
 
   test("the usage text documents the flag", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-run-id-help-")); roots.push(cwd);
     const r = spawnSync(process.execPath, [DISPATCH], { cwd, encoding: "utf8", env: { ...process.env, NIRVANA_NO_UPDATE_CHECK: "1", NIRVANA_SCOPE_QUIET: "1" } });
     expect(r.status).toBe(4);
     expect(r.stderr).toContain("--run-id=<runId>");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/graph-command.test.ts
+++ b/skills/harness/tests/graph-command.test.ts
@@ -12,6 +12,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const SCRIPT = join(REPO, "skills", "harness", "scripts", "graph.ts");
@@ -58,7 +59,7 @@ describe("nrv graph closure", () => {
     } finally {
       rmSync(pack, { recursive: true, force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("nrv graph order and check", () => {

--- a/skills/harness/tests/organizational-non-regression.test.ts
+++ b/skills/harness/tests/organizational-non-regression.test.ts
@@ -11,6 +11,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-organizational-non-regression.ts");
@@ -56,7 +57,7 @@ test("reads an installed business", () => {
     expect(out).toContain("1 pass");
     expect(out).toContain("difference ...... 0 path(s)");
     expect(out).toContain("ORGANIZATIONAL NON-REGRESSION: OK");
-  });
+  }, spawnBudgetMs(2));
 
   test("a suite that writes into a root fails and lists the added, changed and removed paths", () => {
     const f = fixture("writes", ({ businesses, squads }) => `
@@ -76,7 +77,7 @@ test("migrates the installed entities in place", () => {
     expect(out).toContain(`removed ${short(join(f.businesses, "acme", "employees", "intake.md"))}`);
     expect(out).toContain("3 path(s) differ under the installed roots");
     expect(out).not.toContain("ORGANIZATIONAL NON-REGRESSION: OK");
-  });
+  }, spawnBudgetMs(2));
 
   test("a failing suite fails the gate even when the roots are untouched", () => {
     const f = fixture("fails", () => `
@@ -87,11 +88,11 @@ test("breaks", () => { expect(1).toBe(2); });
     expect(status).toBe(1);
     expect(out).toContain("difference ...... 0 path(s)");
     expect(out).toContain("suites exited 1");
-  });
+  }, spawnBudgetMs(2));
 
   test("no installed roots means nothing to protect", () => {
     const { status, out } = gate([join(ROOT, "absent", "businesses")], [join(ROOT, "absent", "suite")]);
     expect(status).toBe(0);
     expect(out).toContain("nothing to protect");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/pdf-valid.test.ts
+++ b/skills/harness/tests/pdf-valid.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { evaluate } from "../rubrics/pdf-valid.ts";
 import { GATEABLE_EXTS, rubricsForExt } from "../scripts/quality-gate.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const tmp = mkdtempSync(join(tmpdir(), "pdf-valid-"));
 const PAD = "%".repeat(6000); // clears the stub floor without changing structure
@@ -39,7 +40,7 @@ describe("pdf-valid rubric", () => {
     writeFileSync(p, minimalPdf(), "latin1");
     const r = await evaluate({ artifact: p, content: "" });
     expect(r.passed).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("a truncated PDF (no %%EOF) fails with a named fix", async () => {
     const p = join(tmp, "trunc.pdf");
@@ -47,7 +48,7 @@ describe("pdf-valid rubric", () => {
     const r = await evaluate({ artifact: p, content: "" });
     expect(r.passed).toBe(false);
     expect(r.fix_list.some((f) => f.includes("%%EOF"))).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("a non-PDF byte blob fails on the header", async () => {
     const p = join(tmp, "fake.pdf");
@@ -55,7 +56,7 @@ describe("pdf-valid rubric", () => {
     const r = await evaluate({ artifact: p, content: "" });
     expect(r.passed).toBe(false);
     expect(r.fix_list.some((f) => f.includes("%PDF-"))).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("object-stream PDFs with zero regex-visible pages still pass structurally", async () => {
     // /ObjStm present, no /Type /Page in clear text — the compressed-PDF trap.
@@ -70,7 +71,7 @@ describe("pdf-valid rubric", () => {
     } finally {
       process.env.PATH = prevPath;
     }
-  });
+  }, spawnBudgetMs(2));
 
   test("an empty-body PDF (no pages, no object streams) fails", async () => {
     const p = join(tmp, "empty.pdf");
@@ -83,7 +84,7 @@ describe("pdf-valid rubric", () => {
     } finally {
       process.env.PATH = prevPath;
     }
-  });
+  }, spawnBudgetMs(2));
 });
 
 // cleanup

--- a/skills/harness/tests/router-route-pattern-keywords.test.ts
+++ b/skills/harness/tests/router-route-pattern-keywords.test.ts
@@ -1,0 +1,141 @@
+// router-route-pattern-keywords.test.ts — the BM25 document of a business
+// auto_route must carry the pattern's LITERALS, not its regex source.
+//
+// The defect this locks: `router.js` built the route document from
+// `pattern.replace(/^type:/,'').replace(/[-_:]/g,' ')`, written when patterns
+// were `type:X-Y_Z`. Every business route in the library is a regex instead,
+// and the canonical tokenizer shreds one: `seguran[çc]a` becomes
+// ["seguran","cc"] — neither is the brief's "seguranca" — while `\bLCP\b`
+// becomes "blcp" and `.{0,24}` contributes "0" and "24". The route could not
+// win a natural-language brief, so `routeFires` at stage3Decide (correct, and
+// deliberately untouched here) never had a route leader to filter for.
+import { describe, expect, test, afterAll } from "bun:test";
+import { createRequire } from "node:module";
+
+const EMBEDDER_BEFORE = process.env.NIRVANA_EMBEDDER;
+process.env.NIRVANA_EMBEDDER = "off";
+afterAll(() => {
+  if (EMBEDDER_BEFORE === undefined) delete process.env.NIRVANA_EMBEDDER;
+  else process.env.NIRVANA_EMBEDDER = EMBEDDER_BEFORE;
+});
+
+const require = createRequire(import.meta.url);
+const router = require("../lib/router.js");
+const bm25 = require("../lib/bm25.js");
+
+const EMPTY_SQUADS = { schema_version: "1.0.0", capabilities: {}, squads: {} };
+
+/** Tokens of the single business_route doc built for `pattern`. */
+function routeTokens(pattern: string): Set<string> {
+  const docs = router.buildMatchDocs(EMPTY_SQUADS, {
+    schema_version: "1.0.0",
+    businesses: { "software-forge": { domains: ["software"], manifest_path: "/x/business.yaml" } },
+    _business_routing: { "software-forge": [{ pattern, route_to: "sf-security-engineer" }] },
+  });
+  const doc = docs.find((d: any) => d.meta?.type === "business_route");
+  expect(doc).toBeTruthy();
+  return new Set<string>(bm25.tokenize(doc.text));
+}
+
+describe("business_route documents index pattern literals", () => {
+  test("a character class yields the folded word, not a prefix plus a garbage pair", () => {
+    const t = routeTokens("(?i)(seguran[çc]a|security\\s+(review|audit)|threat\\s*model)");
+    // What a brief actually says.
+    expect(t.has("seguranca")).toBe(true);
+    // What the class used to leave behind.
+    expect(t.has("cc")).toBe(false);
+    expect(t.has("seguran")).toBe(false);
+  });
+
+  test("alternation literals survive, escapes and quantifiers do not", () => {
+    const t = routeTokens("(?i)(seguran[çc]a|security\\s+(review|audit)|threat\\s*model)");
+    for (const w of ["security", "review", "audit", "threat", "model"]) {
+      expect(t.has(w)).toBe(true);
+    }
+    for (const junk of ["s", "w", "b", "i"]) expect(t.has(junk)).toBe(false);
+  });
+
+  test("word-boundary escapes do not glue onto the acronym they guard", () => {
+    const t = routeTokens("(?i)(core\\s+web\\s+vitals|\\bLCP\\b|\\bINP\\b|lighthouse)");
+    expect(t.has("lcp")).toBe(true);
+    expect(t.has("inp")).toBe(true);
+    expect(t.has("blcp")).toBe(false);
+    expect(t.has("binp")).toBe(false);
+  });
+
+  test("a bounded gap contributes no tokens of its own", () => {
+    const t = routeTokens("(?i)(audite|revise)\\w*\\s+.{0,24}?(rascunho|cap[ií]tulo)");
+    expect(t.has("audite")).toBe(true);
+    expect(t.has("capitulo")).toBe(true);
+    expect(t.has("0")).toBe(false);
+    expect(t.has("24")).toBe(false);
+    expect(t.has("ii")).toBe(false);
+  });
+
+  test("a `type:X-Y_Z` pattern keeps the behaviour it already had", () => {
+    const t = routeTokens("type:meta-ads-campaign");
+    for (const w of ["meta", "ads", "campaign"]) expect(t.has(w)).toBe(true);
+    expect(t.has("type")).toBe(false);
+  });
+
+  test("a dot between two word characters is a joiner, not a gap", () => {
+    // `stress.?test` and `stress-test` mean the same thing to the author. Only
+    // the hyphen earns the joined token the tokenizer emits, and a brief that
+    // writes "Stress-test" queries exactly that.
+    const t = routeTokens("stress.?test\\w*|robustness|red.?team");
+    expect(t.has("stresstest")).toBe(true);
+    expect(t.has("stress")).toBe(true);
+    expect(t.has("test")).toBe(true);
+    expect(t.has("redteam")).toBe(true);
+  });
+
+  test("a bounded gap next to a dot is still a gap", () => {
+    const t = routeTokens("(?i)(cruz\\w*|cross.?check\\w*)\\s+.{0,25}(depoiment\\w*|log)");
+    expect(t.has("crosscheck")).toBe(true);
+    // `.{0,25}` sits between `+` and `(` — not between two word characters.
+    expect(t.has("25")).toBe(false);
+    expect([...t].some((x) => x.includes("depoimentlog"))).toBe(false);
+  });
+
+  test("`type:` in front of an alternation is stripped and `_` separates", () => {
+    // 139 live routes are this hybrid: the old shape's prefix, a regex body.
+    // The tokenizer does not split `efd_icms_ipi`, so the underscore has to.
+    const t = routeTokens("type:conciliacao_bancaria|bank_reconciliation|ofx");
+    for (const w of ["conciliacao", "bancaria", "bank", "reconciliation", "ofx"]) {
+      expect(t.has(w)).toBe(true);
+    }
+    expect(t.has("type")).toBe(false);
+    expect(t.has("conciliacao_bancaria")).toBe(false);
+  });
+
+  test("a range, a negation and a lookaround contribute nothing rather than a guess", () => {
+    const t = routeTokens("(?i)(series\\s+[a-d]|nr[\\s-]?15|deck)");
+    expect(t.has("series")).toBe(true);
+    expect(t.has("deck")).toBe(true);
+    expect(t.has("nr")).toBe(true);
+    expect(t.has("15")).toBe(true);
+    for (const junk of ["a", "b", "c", "d", "ad"]) expect(t.has(junk)).toBe(false);
+  });
+
+  test("the route beats a squad doc that only shares the generic words", () => {
+    const docs = router.buildMatchDocs(
+      {
+        schema_version: "1.0.0",
+        squads: { "generic-writer": { description: "Escreve textos e revisões para o meu time", domains: ["writing"] } },
+        capabilities: {},
+      },
+      {
+        schema_version: "1.0.0",
+        businesses: { "software-forge": { domains: ["software engineering"], manifest_path: "/x/business.yaml" } },
+        _business_routing: {
+          "software-forge": [{ pattern: "(?i)(seguran[çc]a|security\\s+(review|audit))", route_to: "sf-security-engineer" }],
+        },
+      },
+    );
+    const index = bm25.buildIndex(docs);
+    const ranked = bm25.query(index, "preciso de uma revisão de segurança no meu monorepo", { topK: 5 });
+    expect(ranked.length).toBeGreaterThan(0);
+    expect(ranked[0].doc?.meta?.type).toBe("business_route");
+    expect(ranked[0].doc?.meta?.route_to).toBe("sf-security-engineer");
+  });
+});

--- a/skills/harness/tests/routing-digest.test.ts
+++ b/skills/harness/tests/routing-digest.test.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 import {
   buildDigest, buildKeywordAliases, splitKeywordGroups, foldKey, detectLang,
   estimateTokens, trunc, TOKEN_BUDGET, loadDigestInput,
@@ -403,7 +404,7 @@ describe("routing digest — CLI against fixture registry files", () => {
       BUILDER, "--businesses", biz, "--squads", sq, "--clones", cl, "--out", out, "--check-budget", "--quiet",
     ], { encoding: "utf8" });
     expect(check.status).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("fails loudly when no registry is readable", () => {
     const r = spawnSync(process.execPath, [
@@ -414,7 +415,7 @@ describe("routing digest — CLI against fixture registry files", () => {
       "--out", path.join(tmp, "digest.md"),
     ], { encoding: "utf8" });
     expect(r.status).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("trunc", () => {
@@ -454,7 +455,7 @@ describe("empty library vs unreadable registry", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("library is empty");
     expect(fs.existsSync(out)).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 
   test("registries that cannot be read still fail, exit 1", () => {
     const r = run([
@@ -465,7 +466,7 @@ describe("empty library vs unreadable registry", () => {
     ]);
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("no registry could be read");
-  });
+  }, spawnBudgetMs(2));
 
   test("loadDigestInput reports WHICH registries parsed", () => {
     const input = loadDigestInput({

--- a/skills/harness/tests/runtime-failover.test.ts
+++ b/skills/harness/tests/runtime-failover.test.ts
@@ -25,6 +25,7 @@ import { classify } from "../lib/quota-detector.ts";
 import { runWithCascade } from "../lib/cascade-runner.ts";
 import { isInCooldown } from "../lib/cooldown-registry.ts";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 // Verbatim stderr from the failed gemini-cli run of the 2026-08-05 matrix.
 const REAL_GEMINI_STDERR = [
@@ -136,7 +137,7 @@ describe("cascade — a dead runtime hands off instead of ending the run", () =>
     } finally {
       process.env.PATH = process.env.PATH!.replace(`${probeDir}${path.delimiter}`, "");
     }
-  });
+  }, spawnBudgetMs(4));
 
   test("auth failure rotates to the next runtime and the work completes", () => {
     const res = runWithCascade({

--- a/skills/harness/tests/scope-guard-travels.test.ts
+++ b/skills/harness/tests/scope-guard-travels.test.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 import { buildStepBrief } from "../lib/team-orchestrator.ts";
 import { AUTONOMOUS_DIRECTIVE } from "../lib/host-agent-driver.ts";
 import { SCOPE_GUARD_EN, SCOPE_GUARD_PT_BR } from "../../_shared/lib/scope-guard.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
 
@@ -55,5 +56,5 @@ describe("the gate", () => {
       "autonomous directive", "nrv revise", "fix prompt", "squad brief file", "Glance child", "agent-x persona", "judge-x persona",
       "DISPATCH-INSTRUCTION template", "SKILL.md", "04-multi-target.md",
     ]) expect(r.stdout).toContain(surface);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/search-kinds.test.ts
+++ b/skills/harness/tests/search-kinds.test.ts
@@ -16,6 +16,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const SCRIPT = path.resolve(import.meta.dir, "../scripts/search.ts");
 
@@ -125,5 +126,5 @@ describe("nrv search — keyed-object registries", () => {
     });
     expect(r.status).toBe(0); // non-fatal
     expect(r.stderr).toMatch(/warn: squads registry/);
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/supervisor-sweep.test.ts
+++ b/skills/harness/tests/supervisor-sweep.test.ts
@@ -21,6 +21,7 @@ import {
   type RecoveryResult, type RedispatchOverrides, type SalvageVerdict,
 } from "../scripts/supervisor.ts";
 import { openLedger, openRun, getRun, markState, pidAlive, type LedgerHandle, type RunRow } from "../lib/run-ledger.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 let dbSeq = 0;
 function freshLedger(): LedgerHandle {
@@ -54,7 +55,7 @@ describe("supervisor sweep — recovery paths", () => {
     expect(after.retries).toBe(1);
     expect(s.resumed).toBe(1);
     expect(s.recovered).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("failed resume keeps the run recoverable for the next sweep", () => {
     const h = freshLedger();
@@ -65,7 +66,7 @@ describe("supervisor sweep — recovery paths", () => {
     expect(after.retries).toBe(1);
     expect(s.resumed).toBe(1);
     expect(s.recovered).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("expired lease + live-but-stalled pid → SIGTERM (default kill) + redispatch seam", async () => {
     const h = freshLedger();
@@ -110,7 +111,7 @@ describe("supervisor sweep — recovery paths", () => {
     expect(after.state).toBe("running");
     expect(Date.parse(after.lease_expires_at!)).toBeGreaterThan(Date.now());
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 
   test("retries exhausted → stalled + notify seam; resume NOT attempted; later sweeps skip it", () => {
     const h = freshLedger();
@@ -129,7 +130,7 @@ describe("supervisor sweep — recovery paths", () => {
     expect(notified).toBe(1);
     expect(s2.skipped).toBe(1);
     expect(s2.escalated).toBe(0);
-  });
+  }, spawnBudgetMs(3));
 
   test("valid lease → untouched", () => {
     const h = freshLedger();
@@ -137,7 +138,7 @@ describe("supervisor sweep — recovery paths", () => {
     const s = sweep({ handle: h, resumeImpl: okResume([]), redispatchImpl: () => ({ ok: true }), notifyImpl: noNotify });
     expect(s.skipped).toBe(1);
     expect(getRun(h, row.run_id)!.state).toBe("dispatched");
-  });
+  }, spawnBudgetMs(2));
 
   test("self-guard: a run claiming the supervisor's own pid is never signaled nor recovered", () => {
     const h = freshLedger();
@@ -153,7 +154,7 @@ describe("supervisor sweep — recovery paths", () => {
     expect(touched.length).toBe(0);
     expect(s.skipped).toBe(1);
     expect(getRun(h, row.run_id)!.state).toBe("running");
-  });
+  }, spawnBudgetMs(2));
 
   test("kill seam only ever receives the LEDGERED pid", () => {
     const h = freshLedger();
@@ -168,7 +169,7 @@ describe("supervisor sweep — recovery paths", () => {
     });
     expect(killed).toEqual([child.pid!]);
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 
   test("sweep never throws — a poisoned row is counted as an error, the rest still sweep", () => {
     const h = freshLedger();
@@ -183,7 +184,7 @@ describe("supervisor sweep — recovery paths", () => {
     });
     expect(s.errors).toBe(1);
     expect(getRun(h, good.run_id)!.state).toBe("delivered");
-  });
+  }, spawnBudgetMs(3));
 });
 
 // ── artifact salvage at exhaustion ────────────────────────────────────────
@@ -274,7 +275,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     // Escalation still fired — salvage enriches it, never silences it.
     expect(auditFor(row.run_id, "human_notification_required").length).toBe(1);
     expect(auditFor(row.run_id, "x_ledger_notify_human").length).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("THE CEILING: exhaustion + artifacts that PASS + NO manifest → WITHHELD, reason in the audit", () => {
     const h = freshLedger();
@@ -307,7 +308,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(auditFor(row.run_id, "x_ledger_salvage_result").at(-1)?.ceiling).toContain("interrupted");
     expect(auditFor(row.run_id, "human_notification_required").at(-1)?.delivered).toBe(false);
     expect(auditFor(row.run_id, "x_ledger_notify_human").at(-1)?.artifacts).toBe(1);
-  });
+  }, spawnBudgetMs(2));
 
   test("exhaustion + artifacts that FAIL the gate → WITHHELD for quality, ceiling not the reason", () => {
     const h = freshLedger();
@@ -327,7 +328,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(notices[0].gate).toBe("fail");
     expect(notices[0].ceiling).toBeNull();
     expect(notices[0].delivered).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 
   test("exhaustion + NO artifacts → current behavior unchanged: stalled, notified once, nothing judged", () => {
     const h = freshLedger();
@@ -348,7 +349,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(getRun(h, row.run_id)!.state).toBe("stalled");
     expect(notices[0].judged).toBe(false);
     expect(notices[0].skipReason).toBe("no_artifacts");
-  });
+  }, spawnBudgetMs(2));
 
   test("the salvage is READ-ONLY: no runtime spawn, outputs dir byte-identical afterwards", () => {
     const h = freshLedger();
@@ -368,7 +369,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     // runHeadless seam, so nothing on disk moved.
     expect(snapshot(oroot)).toEqual(before);
     expect(getRun(h, row.run_id)!.state).toBe("withheld");
-  });
+  }, spawnBudgetMs(2));
 
   test("MID-RECOVERY: a run with retries left never reaches the salvage (resume path)", () => {
     const h = freshLedger();
@@ -389,7 +390,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(salvages.length).toBe(0);   // structurally unreachable: escalate() never ran
     expect(s.escalated).toBe(0);
     expect(s.salvaged).toBe(0);
-  });
+  }, spawnBudgetMs(2));
 
   test("MID-RECOVERY: a live-but-stalled run with retries left never reaches the salvage (redispatch path)", () => {
     const h = freshLedger();
@@ -410,7 +411,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(s.redispatched).toBe(1);
     expect(salvages.length).toBe(0);
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 
   test("a live ledgered child aborts the salvage even if the call site is reached", () => {
     const h = freshLedger();
@@ -432,7 +433,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     expect(notices[0].skipReason).toBe("live_writer");
     expect(getRun(h, row.run_id)!.state).toBe("stalled");
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 
   test("already-salvaged row is not re-judged; a NEW stalled run still notifies", () => {
     const h = freshLedger();
@@ -488,7 +489,7 @@ describe("supervisor salvage — artifacts of an escalated run are judged, never
     sweep(deps());
     expect(notified).toBe(3);
     expect(getRun(h, c.run_id)!.state).toBe("stalled");
-  });
+  }, spawnBudgetMs(7));
 
   test("the escalation notice carries the verdict, not just the reason", () => {
     const h = freshLedger();
@@ -729,7 +730,7 @@ describe("supervisor redispatch — the outcome goes through the delivery pipeli
     const noMeta = redispatchRun(h, bare, quietDelivery());
     expect(noMeta.finalState).toBe("failed");
     expect(noMeta.detail).toContain("cannot re-dispatch");
-  });
+  }, spawnBudgetMs(2));
 
   test("through the sweep: the summary counts what the pipeline actually decided", () => {
     const h = freshLedger();
@@ -751,7 +752,7 @@ describe("supervisor redispatch — the outcome goes through the delivery pipeli
     expect(after.retries).toBe(1);
     expect(auditFor(row.run_id, "x_ledger_recovery_result").at(-1)?.final_state).toBe("delivered");
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 
   test("the resume branch reads revise.ts's EXIT CODE, never its prose", () => {
     // defaultResume used to map exit 0 → delivered and grep stdout for
@@ -784,7 +785,7 @@ describe("supervisor redispatch — the outcome goes through the delivery pipeli
     expect(getRun(h, row.run_id)!.state).toBe("withheld");
     expect(auditFor(row.run_id, "x_ledger_recovery_result").at(-1)?.final_state).toBe("withheld");
     child.kill("SIGKILL");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("supervisor — lazy sweep guards and speed", () => {
@@ -811,7 +812,7 @@ describe("supervisor — lazy sweep guards and speed", () => {
     const h = openLedger();
     openRun(h, { initialLeaseSec: -60 });
     expect(maybeSweep()).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("supervisor — launchd plist", () => {
@@ -830,7 +831,7 @@ describe("supervisor — launchd plist", () => {
     expect(plist).toContain(supervisorScript);
     // In-process render matches the CLI output.
     expect(renderLaunchdPlist()).toBe(plist);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("sweep — cross-process lock", () => {

--- a/skills/harness/tests/update-check.test.ts
+++ b/skills/harness/tests/update-check.test.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 import {
   compareVersions, readNotice, ageMs, isStale, renderMessage, fetchLatestVersion, CHECK_TTL_MS,
@@ -176,20 +177,20 @@ describe("the CLI, as a subprocess against a stub API", () => {
     expect(lines[1]).toBe("0.3.0");
     expect(lines[2]).toContain("0.3.0");
     expect(lines[2]).toContain("nrv update");
-  });
+  }, spawnBudgetMs(2));
 
   test("--print emits the pending notice on STDERR, leaving stdout clean", () => {
     const r = run("--print", "0.2.0");
     expect(r.stderr).toContain("0.3.0");
     expect(r.stdout.trim()).toBe("");
-  });
+  }, spawnBudgetMs(2));
 
   test("being current empties the cache — checked, nothing to say", () => {
     const r = run("--refresh", "0.3.0");
     expect(r.status).toBe(0);
     expect(readNotice(NOTICE)).toBeNull();          // stamped, nothing pending
     expect(run("--print", "0.3.0").stderr.trim()).toBe("");
-  });
+  }, spawnBudgetMs(2));
 
   test("a stale notice is not printed to someone who already updated", () => {
     // The cache still says 0.3.0 is out; the user is now ON 0.3.0. Silence,
@@ -211,7 +212,7 @@ describe("the CLI, as a subprocess against a stub API", () => {
       env: { ...process.env, NIRVANA_HOME: TMP, NIRVANA_SKILLS_DIR: SKILLS, NIRVANA_NO_UPDATE_CHECK: "1" },
     });
     expect(printed.stderr.trim()).toBe("");
-  });
+  }, spawnBudgetMs(2));
 
   test("a failing API keeps the pending notice instead of dropping it", () => {
     fs.writeFileSync(NOTICE, `${Math.floor(Date.now() / 1000)}\n0.3.0\nNirvana-OS 0.3.0 is available\n`);
@@ -223,7 +224,7 @@ describe("the CLI, as a subprocess against a stub API", () => {
     });
     expect(r.status).toBe(0);                                  // offline is not a failure
     expect(readNotice(NOTICE)?.latest).toBe("0.3.0");           // and not a reason to forget
-  });
+  }, spawnBudgetMs(2));
 
   test("an unknown installed version says nothing at all", () => {
     fs.rmSync(path.join(SKILLS, "VERSION"), { force: true });
@@ -233,7 +234,7 @@ describe("the CLI, as a subprocess against a stub API", () => {
     });
     expect(r.status).toBe(0);
     expect(r.stderr.trim()).toBe("");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the bash wrapper", () => {
@@ -263,7 +264,7 @@ describe("the bash wrapper", () => {
     const r = nrv(["definitely-not-a-command"]);
     expect(r.stderr).toContain("Nirvana-OS 0.3.0 is available");
     expect(r.status).toBe(2);            // the unknown-subcommand path still works
-  });
+  }, spawnBudgetMs(2));
 
   test("says nothing once the installed version matches the cached one", () => {
     fs.writeFileSync(path.join(SKILLS, "VERSION"), "0.3.0\n");
@@ -281,12 +282,12 @@ describe("the bash wrapper", () => {
     // first line of stderr, which is where the wrapper would have put it.
     const r = nrv(["update", "--check"]);
     expect((r.stderr || "").split("\n")[0]).not.toContain("is available");
-  });
+  }, spawnBudgetMs(2));
 
   test("a missing cache never breaks the command", () => {
     fs.rmSync(NOTICE, { force: true });
     const r = nrv(["definitely-not-a-command"]);
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("unknown subcommand");
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/version-parity.test.ts
+++ b/skills/harness/tests/version-parity.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const GATE = join(REPO, "scripts", "check-version-parity.ts");
@@ -56,7 +57,7 @@ describe("one version, told the same way everywhere", () => {
     const r = spawnSync(process.execPath, [GATE, "--strict"], { cwd: REPO, encoding: "utf8" });
     expect(r.status).toBe(0);
     expect(`${r.stdout ?? ""}`).toMatch(/All \d+ agree on/);
-  });
+  }, spawnBudgetMs(2));
 
   test("`nrv --version` reads skills/VERSION first", () => {
     // The gate's whole premise. If the CLI ever stops preferring that file, the

--- a/skills/harness/tests/wiki-lint-script.test.ts
+++ b/skills/harness/tests/wiki-lint-script.test.ts
@@ -10,6 +10,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { evaluate } from "../rubrics/wiki-lint.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const GATE = path.join(import.meta.dir, "..", "scripts", "quality-gate.ts");
 const SKILLS_DIR = path.join(import.meta.dir, "..", "..");
@@ -69,5 +70,5 @@ describe("quality-gate — an abstaining rubric never becomes a silent PASS", ()
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/harness/tests/windows-spawn.test.ts
+++ b/skills/harness/tests/windows-spawn.test.ts
@@ -27,6 +27,7 @@ import * as path from "node:path";
 
 import { firstExecutablePath, parseCmdShim, resolveExecutable, resolveShimTarget, quoteForCmd, whichProbe } from "../../_shared/lib/host-agent-driver.ts";
 import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const REAL_PLATFORM = process.platform;
 const REAL_PATH = process.env.PATH;
@@ -239,7 +240,7 @@ describe("quoteForCmd", () => {
     const quoted = quoteForCmd("line one\nline two");
     expect(quoted.startsWith('"')).toBe(true);
     expect(quoted).toContain("\n");
-  });
+  }, spawnBudgetMs(2));
 
   test("escapes embedded quotes instead of ending the argument early", () => {
     expect(quoteForCmd('say "hi"')).toBe('"say \\"hi\\""');

--- a/skills/squads/tests/activator-sudo-and-passthrough.test.ts
+++ b/skills/squads/tests/activator-sudo-and-passthrough.test.ts
@@ -14,6 +14,7 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const REPO = join(import.meta.dir, "..", "..", "..");
 const ACTIVATOR = join(REPO, "skills", "squads", "lib", "activator.js");
@@ -53,7 +54,7 @@ describe("activator honors the sudo half of the exit-code contract", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("activate-squad.ts surfaces the activator JSON", () => {
@@ -73,5 +74,5 @@ describe("activate-squad.ts surfaces the activator JSON", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, spawnBudgetMs(2));
 });

--- a/skills/squads/tests/migrate-squad.test.ts
+++ b/skills/squads/tests/migrate-squad.test.ts
@@ -23,6 +23,7 @@ import { spawnSync } from "node:child_process";
 import { parse as parseYaml } from "yaml";
 import { cliEnv, rmrf, squadFixture, tempRoot, treeDigest, REPO } from "../../_shared/tests/helpers/verify-fixture.ts";
 import { runCli } from "../../_shared/tests/helpers/verify-fixture.ts";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
 
 const MIGRATE_CLI = path.join(REPO, "skills", "squads", "scripts", "migrate-squad.ts");
 
@@ -210,7 +211,7 @@ describe("one squad per dialect: dry run writes nothing, --apply admits, a secon
       // 4. the surface change a buyer sees is patch or minor, never breaking.
       expect(["patch", "minor", "none"]).toContain(applied.json.surface_diff.bump);
       expect(applied.json.surface_diff.breaking).toBe(0);
-    });
+    }, spawnBudgetMs(3));
   }
 });
 
@@ -246,7 +247,7 @@ describe("nothing is invented", () => {
     expect(md).not.toContain("## plan\n");
     const graph: any = parseYaml(md.split("---")[1]);
     expect(graph.steps.find((s: any) => s.id === "plan").task).toBe("main-plan");
-  });
+  }, spawnBudgetMs(2));
 
   test("--no-extract-tasks keeps the prompt in the body", () => {
     const r = root();
@@ -272,7 +273,7 @@ describe("the twin", () => {
     expect(md).toContain("The planner reads the brief and writes the outline.");  // the .md's body survived
     const graph: any = parseYaml(md.split("---")[1]);
     expect(graph.steps.map((s: any) => s.id)).toEqual(["plan", "build"]);         // the .yaml's graph won
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("event_routes", () => {
@@ -285,7 +286,7 @@ describe("event_routes", () => {
     expect(out.json.refusals.join(" ")).toContain("event_routes");
     expect(treeDigest(dir)).toEqual(before);
     expect(out.json.backup).toBeNull();
-  });
+  }, spawnBudgetMs(2));
 
   test("--force leaves that document alone and migrates the rest of the squad", () => {
     const r = root();
@@ -297,7 +298,7 @@ describe("event_routes", () => {
     expect(fs.existsSync(path.join(dir, "workflows", "main.yaml"))).toBe(true);
     expect(fs.existsSync(path.join(dir, "workflows", "second.md"))).toBe(true);
     expect(parseYaml(fs.readFileSync(path.join(dir, "squad.yaml"), "utf8")).protocol).toBe("6.0");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("--map-refs", () => {
@@ -316,7 +317,7 @@ describe("--map-refs", () => {
     const graph: any = parseYaml(fs.readFileSync(path.join(dir, "workflows", "main.md"), "utf8").split("---")[1]);
     expect(graph.steps[0].agent).toBe("planner");
     expect(graph.steps[0].task).toBe("plan");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("acceptance", () => {
@@ -355,7 +356,7 @@ describe("backup and rollback", () => {
     const back = runMigrate(r, ["rollback", "--rollback", applied.json.at]);
     expect(back.code).toBe(0);
     expect(treeDigest(dir)).toEqual(before);
-  });
+  }, spawnBudgetMs(2));
 
   test("--rollback refuses when the squad changed after the migration", () => {
     const r = root();
@@ -371,7 +372,7 @@ describe("backup and rollback", () => {
     expect(treeDigest(dir)).toEqual(migrated);
 
     expect(runMigrate(r, ["rollback-dirty", "--rollback", applied.json.at, "--force"]).code).toBe(0);
-  });
+  }, spawnBudgetMs(3));
 
   test("the report lands in the state dir, never inside the squad", () => {
     const r = root();
@@ -385,7 +386,7 @@ describe("backup and rollback", () => {
       expect(saved.files[0]).toHaveProperty(key);
     }
     expect(fs.readdirSync(dir).some((n) => n.startsWith("migrate-"))).toBe(false);
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("the gate agrees", () => {
@@ -400,7 +401,7 @@ describe("the gate agrees", () => {
     expect(after.json.summary.errors).toBe(0);
     expect(after.json.findings.map((f: any) => f.id)).not.toContain("protocol_below_6");
     expect(after.json.verdict).toBe("ADMITTED");
-  });
+  }, spawnBudgetMs(2));
 });
 
 describe("usage", () => {
@@ -421,5 +422,5 @@ describe("usage", () => {
     expect(out.code).toBe(0);
     expect(out.json.map((x: any) => x.slug).sort()).toEqual(["all-one", "all-two"]);
     expect(out.json.every((x: any) => x.mode === "dry-run")).toBe(true);
-  });
+  }, spawnBudgetMs(2));
 });


### PR DESCRIPTION
Two defects the twelve Genesis business audits surfaced today, each measured before and after.

## Router — a route was indexed by its regex source

`buildMatchDocs` fed the regex *source* to BM25. The canonical tokenizer shreds one: `seguran[çc]a` becomes `["seguran","cc"]`, and a brief's `segurança` matches neither. Two new functions read the pattern as a regex and index the literal phrases it can match.

| | before | after |
|---|---|---|
| debris tokens, 686 live routes | 381 | **43** |
| debris tokens, 110 Genesis routes | 175 | **7** |
| briefs placing any business route | 8/25 | **10/25** |
| briefs placing the expected business's route | 6/25 | **8/25** |

No brief lost a route. The 286 patterns with no metacharacter keep their old text byte-for-byte. `routeFires` is untouched — the filter was always correct, it just sat behind a ranking the pattern could not win.

Floors hold: top-1 98.6% (≥96.5%), business 90.5% (≥84%), false-dispatch 0.

### Reported, not forced

`preciso de uma revisão de segurança no meu monorepo` still does not place `sf-security-engineer`. Rank 32 → 25, and it stops there. The brief carries four content tokens and the route's vocabulary holds one, while three competitors hold three. Adding `revis[ãa]o\s+de\s+seguran[çc]a` to that pattern puts the route at rank 2 — proven in memory, disk untouched. The remaining gap is the pattern's vocabulary, not its encoding, and closing it is a content edit rather than a mechanism change.

## Gate — the message blamed a name nobody wrote

`auto_route_unknown_employee` answered `route_to (empty) names no seat of this business` for eight `investigation-bureau` routes whose seat was written under `employee:`. It printed a marker where a name belongs. The message now names the key, names the seat, and states that the gate and `router.js` both drop the route — because they do: neither has an alias normalizer, so such a route is dead on both sides, silently.

No alias was added to the schema, and no fixer was written. A fixer could only anchor on "another key carries a seat name", and across 691 installed routes that is true 66 times — all 66 meaning escalation, never destination. The evidence says 66 to 0.

Library scan: **0** routes carry a seat under a non-`route_to` key today. The four business templates all teach `route_to`. This was one business's mistake, not an inherited pattern.

## Verification

- `bun test skills` — 2218 pass, 3 skip, **0 fail**
- `bun run check:all` — **exit 0**, 31 surfaces

One `coverage-ratchet` decrease was accepted with a reason: `strategic-council` keywords 43 → 38, where today's audit swapped 14 advisor surnames for 9 phrases a brief actually contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)