### PR TITLE
fix(driver): the timeout becomes a budget of silence, not a lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The clock stops deciding whether a run is alive
+
+A dispatched runtime was killed by a timer that could not see it working.
+`callHostAgentAsync` armed one `setTimeout(kill, timeoutMs)` at spawn, so it
+fired on elapsed time alone, and the default was 120 seconds. `judge.ts` passed
+60. The runtime those calls spawn is `claude -p --output-format json`, which
+prints one JSON object at the END of the call: a model that thought for longer
+than the budget was SIGTERMed with its answer still in flight, and the caller
+read `"claude exited null"` — the same message a crash produces.
+
+`timeoutMs` is now a budget of SILENCE. The timer measures from the last byte
+and rearms for whatever is left of the budget whenever the child has spoken, so
+a child that keeps writing outlives any elapsed time and only silence is fatal.
+A child killed for silence resolves as `inactivity_timeout` carrying how long it
+had been quiet and how many bytes it had produced, and the driver emits
+`x_driver_child_killed` naming the rule, the budget and the last activity.
+
+The numbers came from measurement, not from taste. Across 557 Claude Code
+transcripts on the owner's machine, 123,318 gaps between two consecutive
+non-human entries (scoped to one sessionId, cut at compaction boundaries): p50
+1.1s, p95 28s, p99 192s. 1.8% of the pauses a model takes between two tool calls
+run longer than two minutes, 0.45% longer than ten, 0.089% longer than
+forty-five. Past an hour the count stops falling, which is resumed sessions
+rather than any real pause. The default budget is 45 minutes, where the credible
+tail ends.
+
+Three windows moved with it. The stall watchdog now defaults to DISARMED
+(`heartbeatMs: 0`) instead of 60 seconds: for a non-streaming adapter "no bytes
+yet" is the normal shape of a call in progress, not a stall, and a caller whose
+child streams asks for the tighter window explicitly. The ledgered wall clock
+went from 24h to 7 days — this machine's ledger holds 371 runs whose longest is
+25.5h and whose longest delivered one is 4.9h, so 24h sat below the observed
+maximum and was a second hang detector rather than a backstop. And a ledgered
+run's lease, the window that actually decides a run is dead, went from 600s to
+the same 45 minutes; ten minutes of silence is inside the normal behaviour of a
+working agent, which the supervisor already knew for the agentic path
+(`AGENTIC_LEASE_SEC = 1800`) and not for the scripted one.
+
+`quality-judge.js` and `judge.ts` dropped their own floors (120s/60s wall clock,
+60s stall) and let the driver decide; `squad-audit-consensus.js` dropped the 90s
+heartbeat it kept in front of its own 240s budget, which on a runtime that
+prints nothing until the end was a 90-second wall clock producing the freeze it
+was added to prevent; `host-agent-retry.js` retries `inactivity_timeout` on the
+same terms as `stall`. `callHostAgent` keeps a wall
+clock because `spawnSync` blocks the event loop and no timer can observe the
+child at all — it now says so, and its default is the same 45 minutes instead of
+two.
+
 ### A route under the wrong key says so, instead of blaming a seat
 
 `investigation-bureau` was audited on 28/08/2026 and the gate answered nine times

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,58 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O relógio para de decidir se um run está vivo
+
+Um runtime despachado era morto por um cronômetro que não conseguia vê-lo
+trabalhando. O `callHostAgentAsync` armava um único `setTimeout(kill, timeoutMs)`
+no spawn, então ele disparava só por tempo decorrido, e o padrão era 120
+segundos. O `judge.ts` passava 60. O runtime que essas chamadas sobem é o
+`claude -p --output-format json`, que imprime um único objeto JSON no FIM da
+chamada: um modelo que pensasse mais que o orçamento levava SIGTERM com a
+resposta ainda em voo, e o chamador lia `"claude exited null"` — a mesma mensagem
+que um crash produz.
+
+O `timeoutMs` agora é um orçamento de SILÊNCIO. O cronômetro mede a partir do
+último byte e se rearma pelo que sobrou do orçamento sempre que o filho falou,
+então um filho que continua escrevendo sobrevive a qualquer tempo decorrido e só
+o silêncio é fatal. Um filho morto por silêncio resolve como `inactivity_timeout`
+carregando há quanto tempo estava calado e quantos bytes tinha produzido, e o
+driver emite `x_driver_child_killed` nomeando a regra, o orçamento e a última
+atividade.
+
+Os números vieram de medição, não de gosto. Em 557 transcrições do Claude Code
+na máquina do dono, 123.318 intervalos entre duas entradas não humanas
+consecutivas (no escopo de um mesmo sessionId, cortados nas fronteiras de
+compactação): p50 1,1s, p95 28s, p99 192s. 1,8% das pausas que um modelo tira
+entre duas chamadas de ferramenta passam de dois minutos, 0,45% passam de dez,
+0,089% passam de quarenta e cinco. Depois de uma hora a contagem para de cair, o
+que é sessão retomada e não pausa real. O orçamento padrão é 45 minutos, onde a
+cauda crível termina.
+
+Três janelas se moveram junto. O vigia de stall agora nasce DESARMADO
+(`heartbeatMs: 0`) em vez de 60 segundos: para um adaptador que não faz streaming,
+"nenhum byte ainda" é a forma normal de uma chamada em andamento, não um stall, e
+quem sabe que o filho dele faz streaming pede a janela mais apertada
+explicitamente. O relógio de parede dos runs com ledger foi de 24h para 7 dias —
+o ledger desta máquina tem 371 runs cujo mais longo é 25,5h e cujo mais longo
+entregue é 4,9h, então 24h ficava abaixo do máximo observado e era um segundo
+detector de travamento em vez de um limite de segurança. E o lease de um run com
+ledger, a janela que de fato decide que um run morreu, foi de 600s para os
+mesmos 45 minutos; dez minutos de silêncio estão dentro do comportamento normal
+de um agente trabalhando, coisa que o supervisor já sabia para o caminho agêntico
+(`AGENTIC_LEASE_SEC = 1800`) e não para o roteirizado.
+
+O `quality-judge.js` e o `judge.ts` largaram os pisos próprios (120s/60s de
+relógio de parede, 60s de stall) e deixam o driver decidir; o
+`squad-audit-consensus.js` largou o heartbeat de 90s que mantinha na frente do
+próprio orçamento de 240s, que num runtime que não imprime nada até o fim era um
+relógio de parede de 90 segundos produzindo o congelamento que ele existia para
+evitar; o `host-agent-retry.js` repete `inactivity_timeout` nos mesmos termos de
+`stall`. O
+`callHostAgent` mantém relógio de parede porque o `spawnSync` bloqueia o event
+loop e nenhum cronômetro consegue observar o filho — agora ele diz isso, e o
+padrão dele é os mesmos 45 minutos em vez de dois.
+
 ### Uma rota sob a chave errada diz isso, em vez de culpar um cargo
 
 O `investigation-bureau` foi auditado em 28/08/2026 e o portão respondeu nove

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -685,6 +685,14 @@ export function detectHost(opts: { preferred?: string } = {}): RuntimeAdapter | 
  * callHostAgent — dispatches a single LLM call through the host runtime.
  * Persona is the role's persona text (loaded from the agent .md). User
  * message is the actual task prompt.
+ *
+ * `timeoutMs` here is WALL CLOCK, and it is the one place in this file where
+ * that is not a defect but a limit: spawnSync blocks the event loop, so no
+ * timer can run and nothing can observe the child working. Say it plainly
+ * rather than let a caller assume the async contract. Work that may legitimately
+ * take a long time belongs in callHostAgentAsync (silence budget) or runHeadless
+ * (heartbeat sidecar); the default here is only large enough that the blocking
+ * path stops being the thing that kills a thinking model.
  */
 export function callHostAgent(persona: string, userMessage: string, opts: CallOpts = {}): HostCall | HostError {
   const host = opts.__testRuntime ?? detectHost({ preferred: opts.preferredHost });
@@ -697,7 +705,7 @@ export function callHostAgent(persona: string, userMessage: string, opts: CallOp
     const exec = resolveExecutable(host.cli);
     r = spawnSync(exec.command, exec.args(call.args), {
       encoding: "utf8",
-      timeout: opts.timeoutMs ?? 120_000,
+      timeout: opts.timeoutMs ?? DEFAULT_INACTIVITY_BUDGET_MS,
       maxBuffer: 8 * 1024 * 1024,
       env: { ...process.env },
       ...(exec.shell ? { shell: true } : {}),
@@ -726,23 +734,58 @@ export function callHostAgent(persona: string, userMessage: string, opts: CallOp
  * run in parallel from the same process. Returns the same shape as
  * callHostAgent but as a Promise.
  *
- * Stall watchdog (opt-in): when `heartbeatMs > 0`, the driver tracks the
- * timestamp of the most recent stdout/stderr chunk. If no bytes arrive within
- * `heartbeatMs` (default 60_000), the driver classifies the call as stalled.
- * Behavior depends on `heartbeatMode`:
- *   - 'kill' (default): SIGTERM the child immediately, escalate to SIGKILL
- *     after 5s, resolve with `{ error: 'stall', stalled_after_ms, ... }`.
- *   - 'warn': resolve with stall signal but let the child keep running until
- *     timeout. Useful in tests or when caller wants to log without aborting.
+ * Two windows, one activity signal (`lastDataAt`, advanced by every
+ * stdout/stderr chunk):
+ *
+ *  - `timeoutMs` — the budget of SILENCE every call gets, default
+ *    DEFAULT_INACTIVITY_BUDGET_MS. Rearms on activity; resolves with
+ *    `{ error: 'inactivity_timeout', stalled_after_ms, ... }`.
+ *  - `heartbeatMs` — a TIGHTER opt-in window for callers whose adapter
+ *    streams. `heartbeatMode: 'kill'` (default) SIGTERMs and resolves with
+ *    `{ error: 'stall', ... }`; `'warn'` resolves early and lets the child run
+ *    on until the inactivity budget.
+ *
+ * `heartbeatMs` defaults to 0 — DISARMED — because most adapters here are not
+ * streaming: `claude -p --output-format json`, gemini, grok, kimi and
+ * antigravity all print one JSON object at the END of the call. For those,
+ * "no bytes yet" is not a stall signal, it is the normal shape of a call in
+ * progress, and the old 60 s default was a 60-second wall clock on an LLM
+ * wearing the name of an activity check. A caller that knows its child streams
+ * asks for the tighter window explicitly.
  *
  * The driver does not retry — that is the caller's job (see
- * `_shared/lib/host-agent-retry.js`). Audit events are emitted by callers,
- * not here, to keep the driver host-agnostic and free of cross-skill imports.
+ * `_shared/lib/host-agent-retry.js`). Cost telemetry is emitted by callers;
+ * the one event the driver emits itself is the kill (emitDriverAudit), because
+ * only the driver knows which rule fired.
  */
 export type HeartbeatMode = "kill" | "warn";
+
+/**
+ * Default budget of SILENCE for a light-layer call — 45 minutes.
+ *
+ * It replaced a 120 s WALL-CLOCK default, and both halves of that sentence
+ * were wrong. Measured on this machine's 557 Claude Code transcripts
+ * (123,318 gaps between two consecutive non-human entries, scoped to one
+ * sessionId and cut at compaction boundaries): p50 1.1 s, p95 28 s, p99 192 s.
+ * 1.8% of the pauses a model takes between two tool calls are longer than two
+ * minutes, 0.45% longer than ten, 0.089% longer than forty-five — and past an
+ * hour the count stops falling (90 → 77 → 71), which is the resumed-session
+ * floor rather than any real pause. 45 min is where the credible tail ends.
+ *
+ * It is a budget of silence, not of life: any byte on stdout/stderr rearms it,
+ * so a child that keeps working is never killed for working long. What it
+ * bounds is a child that has stopped saying anything at all.
+ */
+export const DEFAULT_INACTIVITY_BUDGET_MS = 45 * 60_000;
+
 export interface CallOpts {
+  /** Max ms of SILENCE before the child is killed (default
+   *  DEFAULT_INACTIVITY_BUDGET_MS). Rearmed by every stdout/stderr byte — this
+   *  is not a wall-clock lifetime. */
   timeoutMs?: number;
-  heartbeatMs?: number;            // 0 disables; default 60_000
+  /** Tighter opt-in stall window for callers whose adapter streams. Default 0
+   *  (disarmed) — see callHostAgentAsync's contract. */
+  heartbeatMs?: number;
   minBytesPerHeartbeat?: number;   // bytes counted toward "alive"; default 1
   heartbeatMode?: HeartbeatMode;   // default 'kill'
   /** Preferred runtime slug (e.g. from runtime-rules decideRuntime). Must
@@ -766,6 +809,32 @@ export interface CallOpts {
   __testRuntime?: any;
 }
 
+/** The audit module, or null when it cannot be loaded. Lazy for the same
+ *  reason emitCostAudit is: the driver must not depend on a sibling skill at
+ *  module init. */
+function loadAudit(): { emit?: (e: string, p: unknown, c?: unknown) => void } | null {
+  try { return require(path.join(SKILLS_ROOT, "harness", "lib", "audit.js")); }
+  catch { return null; }
+}
+
+/**
+ * A child the driver kills says WHY, in the audit, before it dies.
+ *
+ * Until this existed, a run killed by the global timeout reached its caller as
+ * `"<cli> exited null"` — the same message a crash produces, with nothing about
+ * the rule that fired or how long the child had been silent. Telemetry is
+ * fire-and-forget; the kill never waits on it.
+ */
+function emitDriverAudit(event: string, payload: Record<string, unknown>, opts: CallOpts): void {
+  const audit = loadAudit();
+  if (!audit?.emit) return;
+  try {
+    audit.emit(event, { caller_id: opts.caller_id || null, ...payload }, {
+      project_id: opts.project_id || process.env.NIRVANA_PROJECT_ID || null,
+    });
+  } catch { /* non-fatal */ }
+}
+
 /**
  * Fire-and-forget audit emission. Loaded lazily so the driver stays free of
  * cross-skill dependencies at module init.
@@ -775,10 +844,7 @@ function emitCostAudit(host: any, stdoutRaw: string, opts: CallOpts) {
   if (!host?.parseUsage) return;
   const usage = host.parseUsage(stdoutRaw);
   if (!usage) return;
-  let audit: any = null;
-  try {
-    audit = require(path.join(SKILLS_ROOT, "harness", "lib", "audit.js"));
-  } catch { return; }
+  const audit = loadAudit();
   if (!audit?.emit) return;
   try {
     audit.emit("cost_emission", {
@@ -802,7 +868,7 @@ export function callHostAgentAsync(persona: string, userMessage: string, opts: C
       resolve({ error: "no host agent CLI found on PATH (tried: " + RUNTIMES.map(r => r.cli).join(", ") + ")" });
       return;
     }
-    const heartbeatMs = opts.heartbeatMs ?? 60_000;
+    const heartbeatMs = opts.heartbeatMs ?? 0;
     const minBytes = opts.minBytesPerHeartbeat ?? 1;
     const mode: HeartbeatMode = opts.heartbeatMode ?? "kill";
 
@@ -839,10 +905,8 @@ export function callHostAgentAsync(persona: string, userMessage: string, opts: C
     //   - keep.escalation: the SIGKILL escalation must outlive a stall-kill
     //     settle so a SIGTERM-ignoring child still dies; close clears it.
     //   - keep.timeout: in 'warn' mode the child keeps running after the
-    //     early resolve, so the global timeout stays armed; close clears it.
-    let globalTimeout: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-      try { child.kill("SIGTERM"); } catch {}
-    }, opts.timeoutMs ?? 120_000);
+    //     early resolve, so the inactivity timer stays armed; close clears it.
+    let globalTimeout: ReturnType<typeof setTimeout> | null = null;
     let watchdog: ReturnType<typeof setInterval> | null = null;
     let killEscalation: ReturnType<typeof setTimeout> | null = null;
     let settled = false;
@@ -860,6 +924,47 @@ export function callHostAgentAsync(persona: string, userMessage: string, opts: C
       settled = true;
       resolve(payload);
     };
+
+    // ── inactivity budget ──────────────────────────────────────────────────
+    // `timeoutMs` used to arm ONE setTimeout at spawn, so it fired on elapsed
+    // time and could not tell a model thinking from a dead socket. It now
+    // measures from the last byte: the timer rearms for whatever is left of the
+    // budget whenever the child has spoken since it was set, so a child that
+    // keeps writing outlives any elapsed time and only silence is fatal.
+    //
+    // It reads the same `lastDataAt` the stall watchdog reads — one activity
+    // signal, two windows, never two notions of "alive".
+    const inactivityBudgetMs = opts.timeoutMs ?? DEFAULT_INACTIVITY_BUDGET_MS;
+    const armInactivity = (ms: number) => {
+      globalTimeout = setTimeout(() => {
+        const silentMs = Date.now() - lastDataAt;
+        if (silentMs < inactivityBudgetMs) { armInactivity(inactivityBudgetMs - silentMs); return; }
+        globalTimeout = null;
+        stallSignaled = true;   // the watchdog must not fire a second verdict
+        emitDriverAudit("x_driver_child_killed", {
+          rule: "inactivity",
+          host: host.name,
+          budget_ms: inactivityBudgetMs,
+          silent_ms: silentMs,
+          bytes_received: bytesReceived,
+        }, opts);
+        try { child.kill("SIGTERM"); } catch {}
+        // Same escalation the stall path uses: a SIGTERM-ignoring child still
+        // dies, and `keep.escalation` lets that timer outlive this settle.
+        killEscalation = setTimeout(() => {
+          killEscalation = null;
+          try { child.kill("SIGKILL"); } catch {}
+        }, 5000);
+        settle({
+          error: "inactivity_timeout",
+          host: host.name,
+          exit_code: -1,
+          stalled_after_ms: silentMs,
+          bytes_received_before_stall: bytesReceived,
+        }, { escalation: true });
+      }, ms);
+    };
+    armInactivity(inactivityBudgetMs);
 
     if (heartbeatMs > 0) {
       const tickMs = Math.max(500, Math.floor(heartbeatMs / 2));
@@ -966,14 +1071,15 @@ export interface RunHeadlessOpts {
    * CLIs that don't have this concept. */
   providerHint?: string;
   /** Dispatch-ledger heartbeat (routing-360 Phase 4). When present the run is
-   * SUPERVISED: a detached sidecar renews the run's lease while the child
-   * shows activity, and the global timeout DEFAULTS to 45 min (the old NONE
-   * default let a hung child run forever unobserved — pass timeoutMs
-   * explicitly for long book/PDF workloads). */
+   * SUPERVISED: a detached sidecar renews the run's lease while the child shows
+   * activity, and the wall clock falls back to LEDGER_DEFAULT_TIMEOUT_MS — a
+   * backstop above any real run, not a hang detector. What ends a hung run is
+   * the lease expiring DEFAULT_LEASE_SEC after the last sign of life. */
   ledger?: LedgerHeartbeatOpts;
-  /** Max ms without observed activity before the heartbeat STOPS renewing the
-   * lease (default: the supervisor.stall_threshold_ms setting, 5 min). Only
-   * meaningful together with opts.ledger. */
+  /** Max ms without observed activity before the sidecar RECORDS the gap
+   * (`x_ledger_stall_observed`, the supervisor.stall_threshold_ms setting,
+   * 5 min). This is an early warning and kills nothing: the lease is what
+   * decides. Only meaningful together with opts.ledger. */
   stallBudgetMs?: number;
 }
 
@@ -992,27 +1098,54 @@ export interface LedgerHeartbeatOpts {
   dbPath?: string;
   /** Heartbeat check interval in ms (default 15s; tests shrink it). */
   intervalMs?: number;
-  /** Seconds each renewal extends the lease from now (default 600). */
+  /** Seconds each renewal extends the lease from now (default
+   * DEFAULT_LEASE_SEC). This is the window that decides a run is dead. */
   leaseSec?: number;
 }
 
 /**
- * Default wall-clock timeout for LEDGERED runs: 24h — a BACKSTOP, not the
- * hang detector. Real work legitimately runs for hours (a book, a season of
- * video, a large migration), and killing it on the clock destroys finished
- * work for no reason.
+ * Wall-clock backstop for LEDGERED runs: 7 days.
  *
- * What actually catches a hang is the activity-based heartbeat: the sidecar
- * renews the lease only while stdout/stderr bytes or output-dir mtimes
- * advance, and stops after `stallBudgetMs` (default 5 min) of silence. The
- * lease then expires and the supervisor sweeps the run — minutes after the
- * process really stalled, regardless of how long it was allowed to live. The
- * wall-clock ceiling exists only for the pathological case where a child
- * keeps emitting output forever without converging.
+ * The ceiling survives, and it moved. It survives because the activity signal
+ * cannot catch one failure by construction — a child that keeps emitting
+ * output forever without converging is indistinguishable from a child that is
+ * working, so something has to bound it. It moved because 24h was not above
+ * the work: this machine's ledger holds 371 runs, whose longest is 25.5h and
+ * whose longest DELIVERED one is 4.9h (p50 21min, p90 62min, p99 5.7h). A
+ * ceiling below the observed maximum is not a backstop, it is a second hang
+ * detector — a worse one, that kills finished work at the clock.
+ *
+ * 7 days sits ~7x above anything this system has produced, which is the whole
+ * point: it can never be the rule that ends real work, and a runaway is still
+ * noticed within a week instead of never.
+ *
+ * What actually catches a hang is the heartbeat sidecar: it renews the lease
+ * only while stdout/stderr bytes or output-dir mtimes advance, and stops when
+ * they do not. The lease then expires and the supervisor sweeps the run,
+ * DEFAULT_LEASE_SEC after the last sign of life, regardless of how long the
+ * run was allowed to live.
  *
  * Unledgered calls keep the historical no-timeout behavior (see timeoutMs).
  */
-export const LEDGER_DEFAULT_TIMEOUT_MS = 24 * 60 * 60_000;
+export const LEDGER_DEFAULT_TIMEOUT_MS = 7 * 24 * 60 * 60_000;
+
+/**
+ * How long a ledgered run stays leased after its last observed activity — the
+ * window that actually decides whether a run is alive, and therefore the one
+ * the measurement has to size.
+ *
+ * It was 600s. Ten minutes of silence is inside the normal behaviour of a
+ * working agent: of the 123,318 intra-turn gaps measured across this machine's
+ * transcripts, 0.45% exceed ten minutes, and the code that supervises the
+ * AGENTIC path already says so in its own comment ("a squad legitimately
+ * thinks for ten minutes between writes", AGENTIC_LEASE_SEC = 1800). The
+ * scripted path was left on the tighter window, so a long-thinking child had
+ * its lease expire while it worked and the supervisor read it as orphaned.
+ *
+ * Now the same 45 minutes the light layer tolerates: one number for "how long
+ * silence is allowed to mean nothing", whichever layer is asking.
+ */
+export const DEFAULT_LEASE_SEC = DEFAULT_INACTIVITY_BUDGET_MS / 1000;
 
 /** Effective timeout for a run: explicit timeoutMs always wins; a ledgered
  * run without one gets LEDGER_DEFAULT_TIMEOUT_MS; otherwise none. Exported
@@ -1118,7 +1251,7 @@ function runWithLedgerHeartbeat(opts: RunHeadlessOpts, runner: (o: RunHeadlessOp
     "--out", outFile, "--err", errFile, "--done", doneFile,
     "--interval", String(led.intervalMs ?? 15_000),
     "--stall", String(opts.stallBudgetMs ?? resolveSetting("supervisor.stall_threshold_ms").value),
-    "--lease", String(led.leaseSec ?? 600),
+    "--lease", String(led.leaseSec ?? DEFAULT_LEASE_SEC),
     "--parent", String(process.pid),
   ];
   if (led.watchDir) {
@@ -1902,7 +2035,7 @@ export function runHeadless(opts: RunHeadlessOpts): RunHeadlessResult {
       );
     }
   }
-  // Ledgered runs get the heartbeat sidecar + the 45-min default timeout;
+  // Ledgered runs get the heartbeat sidecar + the 7-day wall-clock backstop;
   // unledgered calls are byte-for-byte the historical behavior.
   if (opts.ledger?.runId) return runWithLedgerHeartbeat(opts, dispatchToRunner);
   return dispatchToRunner(opts);

--- a/skills/_shared/lib/host-agent-retry.js
+++ b/skills/_shared/lib/host-agent-retry.js
@@ -77,7 +77,11 @@ async function callWithRetryOnStall(persona, userMessage, opts = {}) {
   let currentMsg = userMessage;
   while (true) {
     const r = await driver.callHostAgentAsync(persona, currentMsg, driverOpts);
-    const stalled = r && (r.error === 'stall' || r.error === 'stall_warning');
+    // `inactivity_timeout` is the same verdict at the wider window: the driver
+    // killed a child that had stopped producing bytes. A wrapper that retries
+    // one and not the other would silently stop retrying the moment a caller
+    // let the driver pick the budget.
+    const stalled = r && (r.error === 'stall' || r.error === 'stall_warning' || r.error === 'inactivity_timeout');
     if (!stalled) return r;
     emitSafe('stall_detected', {
       attempt,

--- a/skills/_shared/lib/quality-judge.js
+++ b/skills/_shared/lib/quality-judge.js
@@ -189,9 +189,12 @@ async function runQualityJudge({ phase, artifact, rubric_path, context, timeoutM
   // Use retry wrapper so stalled judge calls get one automatic retry.
   let retry = null;
   try { retry = require(path.join(__dirname, 'host-agent-retry.js')); } catch {}
+  // No floors here. The driver's budget is a budget of SILENCE and the runtime
+  // this judge calls prints one JSON object at the END of the call, so the old
+  // pair (120s wall clock, 60s "stall") could only ever measure how long the
+  // model was allowed to think. A caller with a real deadline still passes one.
   const callOpts = {
-    timeoutMs: timeoutMs || 120_000,
-    heartbeatMs: 60_000,
+    ...(Number.isFinite(timeoutMs) && timeoutMs > 0 ? { timeoutMs } : {}),
     maxRetries: 1,
   };
   const r = retry && retry.callWithRetryOnStall

--- a/skills/harness/lib/judge.ts
+++ b/skills/harness/lib/judge.ts
@@ -282,7 +282,12 @@ export async function judge(input: JudgeInput, opts: JudgeOpts = {}): Promise<Ju
   const preferredHost = await resolveJudgePreferredRuntime(input, opts, available);
 
   const call = await driver.callHostAgentAsync(persona, userMsg, {
-    timeoutMs: opts.timeoutMs ?? 60_000,
+    // No floor of our own: the driver's budget is a budget of SILENCE, and a
+    // judge grading a long artifact against a seven-criterion rubric routinely
+    // thinks for more than the 60s this used to allow. `claude -p
+    // --output-format json` prints nothing until it is done, so those 60s were
+    // a wall clock, and the verdict they produced was a runtime error.
+    ...(typeof opts.timeoutMs === "number" ? { timeoutMs: opts.timeoutMs } : {}),
     ...(preferredHost ? { preferredHost } : {}),
   });
 

--- a/skills/harness/tests/driver-activity-timeout.test.ts
+++ b/skills/harness/tests/driver-activity-timeout.test.ts
@@ -1,0 +1,150 @@
+// driver-activity-timeout.test.ts — the driver's kill decision is ACTIVITY-based.
+//
+// The defect: `callHostAgentAsync` armed one `setTimeout(kill, timeoutMs)` at
+// spawn. It fired on elapsed time alone, so a child writing steadily for longer
+// than the budget was SIGTERMed with all its work in flight, and the caller got
+// `"<cli> exited null"` — a message that names neither the rule that fired nor
+// what the child had been doing.
+//
+// The contract asserted here: `timeoutMs` is a budget of SILENCE. A child that
+// keeps producing bytes survives any elapsed time; a child that stops producing
+// them for the budget dies, and says so in a payload a human can read.
+//
+// Hermetic: no runtime, no network. The "agent" is a Bun script and the driver
+// is pointed straight at `bun` (the driver-watchdog.test.ts convention — nothing
+// stands between the driver and the process it signals).
+import { describe, expect, test, afterAll } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { makeTempRoot } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import {
+  DEFAULT_INACTIVITY_BUDGET_MS,
+  LEDGER_DEFAULT_TIMEOUT_MS,
+  resolveLedgerTimeoutMs,
+} from "../../_shared/lib/host-agent-driver.ts";
+
+const TMP = makeTempRoot("nrv-driver-activity-");
+const DRIVER = path.resolve(import.meta.dir, "..", "..", "_shared", "lib", "host-agent-driver.ts");
+const SKILLS = path.resolve(import.meta.dir, "..", "..");
+
+afterAll(() => {
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+function fakeAgent(name: string, body: string): string {
+  const f = path.join(TMP, `${name}-agent.ts`);
+  fs.writeFileSync(f, body);
+  return f;
+}
+
+interface Scenario { wallMs: number; payload: Record<string, unknown>; logsDir: string }
+
+function runScenario(name: string, cli: string, callOpts: string): Scenario {
+  const script = path.join(TMP, `${name}.ts`);
+  const logsDir = path.join(TMP, `${name}-logs`);
+  fs.writeFileSync(script, [
+    `import { callHostAgentAsync } from ${JSON.stringify(DRIVER)};`,
+    `const res = await callHostAgentAsync("", "hi", {`,
+    `  __testRuntime: { name: "fake", cli: ${JSON.stringify(process.execPath)}, buildArgs: () => [${JSON.stringify(cli)}], parseStdout: (s: string) => s.trim() },`,
+    `  ${callOpts}`,
+    `});`,
+    `console.log("RESOLVED:" + JSON.stringify(res));`,
+  ].join("\n"));
+  const t0 = Date.now();
+  const r = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    timeout: spawnBudgetMs(4),
+    env: { ...process.env, HARNESS_LOGS_DIR: logsDir, NIRVANA_SKILLS_DIR: SKILLS },
+  });
+  const wallMs = Date.now() - t0;
+  const line = (r.stdout || "").split("\n").find((l) => l.startsWith("RESOLVED:"));
+  expect(line).toBeTruthy();
+  return { wallMs, payload: JSON.parse((line as string).slice("RESOLVED:".length)), logsDir };
+}
+
+function auditEvents(logsDir: string): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  if (!fs.existsSync(logsDir)) return out;
+  for (const day of fs.readdirSync(logsDir)) {
+    const f = path.join(logsDir, day, "audit.jsonl");
+    if (!fs.existsSync(f)) continue;
+    for (const line of fs.readFileSync(f, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip */ }
+    }
+  }
+  return out;
+}
+
+describe("driver — a working child is not killed by the clock", () => {
+  test("a child producing output steadily outlives its budget many times over", () => {
+    // Writes every 250ms for 3s against a 1s budget: twelve renewals, three
+    // times the old wall-clock ceiling. Pre-fix this resolved as a SIGTERM at 1s.
+    const cli = fakeAgent("steady", `
+      for (let i = 0; i < 12; i++) { console.log("chunk " + i); await Bun.sleep(250); }
+      console.log("done");
+    `);
+    const { payload } = runScenario("survives", cli, `timeoutMs: 1_000, heartbeatMs: 0`);
+    expect(payload.error).toBeUndefined();
+    expect(payload.exit_code).toBe(0);
+    expect(String(payload.text)).toContain("done");
+  }, spawnBudgetMs(4));
+
+  test("a child that goes silent dies at the budget and names the rule that killed it", () => {
+    const cli = fakeAgent("goes-silent", `console.log("start");\nawait Bun.sleep(30_000);`);
+    const { wallMs, payload, logsDir } = runScenario("dies", cli, `timeoutMs: 1_000, heartbeatMs: 0`);
+    expect(payload.error).toBe("inactivity_timeout");
+    expect(payload.exit_code).toBe(-1);
+    // What the child had been doing, in the payload — not just "exited null".
+    expect(Number(payload.stalled_after_ms)).toBeGreaterThanOrEqual(1_000);
+    expect(Number(payload.bytes_received_before_stall)).toBeGreaterThan(0);
+    // The SIGKILL escalation must not outlive the settle: the process exits at
+    // the kill, not five seconds later.
+    expect(wallMs).toBeLessThan(spawnBudgetMs(2));
+
+    // A run that dies leaves a reason a human can read.
+    const killed = auditEvents(logsDir).filter(e => e.event === "x_driver_child_killed");
+    expect(killed.length).toBe(1);
+    expect(killed[0].rule).toBe("inactivity");
+    expect(killed[0].budget_ms).toBe(1_000);
+    expect(Number(killed[0].silent_ms)).toBeGreaterThanOrEqual(1_000);
+    expect(Number(killed[0].bytes_received)).toBeGreaterThan(0);
+  }, spawnBudgetMs(4));
+
+  test("silence is measured from the LAST byte, not from spawn", () => {
+    // Two seconds of work, then silence, against a 1s budget. A wall clock kills
+    // at 1s; a silence budget kills at ~3s. The wall time separates the two.
+    const cli = fakeAgent("late-silence", `
+      for (let i = 0; i < 8; i++) { console.log("tick " + i); await Bun.sleep(250); }
+      await Bun.sleep(30_000);
+    `);
+    const { wallMs, payload } = runScenario("late", cli, `timeoutMs: 1_000, heartbeatMs: 0`);
+    expect(payload.error).toBe("inactivity_timeout");
+    expect(wallMs).toBeGreaterThan(2_500);
+  }, spawnBudgetMs(4));
+});
+
+describe("driver — the budgets themselves", () => {
+  test("no caller inherits a two-minute ceiling on an LLM call", () => {
+    // Measured on this machine's 557 Claude Code transcripts (123,318 intra-turn
+    // gaps, session-scoped, compaction-aware): 1.8% of the pauses between two
+    // consecutive tool calls exceed two minutes. A 120s default killed roughly
+    // one thinking pause in fifty-five.
+    expect(DEFAULT_INACTIVITY_BUDGET_MS).toBeGreaterThan(120_000);
+    // 45 min sits above the last credible single pause in that sample (0.089%
+    // of gaps exceed it, and most of those are resumed sessions).
+    expect(DEFAULT_INACTIVITY_BUDGET_MS).toBe(45 * 60_000);
+  });
+
+  test("the ledgered wall clock is a backstop no real run can reach", () => {
+    expect(resolveLedgerTimeoutMs({ timeoutMs: 1234, ledger: { runId: "x" } })).toBe(1234);
+    expect(resolveLedgerTimeoutMs({ ledger: { runId: "x" } })).toBe(LEDGER_DEFAULT_TIMEOUT_MS);
+    expect(resolveLedgerTimeoutMs({})).toBeUndefined();
+    // The longest run in this machine's ledger (371 rows) is 25.5h, and the
+    // longest DELIVERED one 4.9h. 24h cut below both; the backstop must sit far
+    // above the work, because the hang detector is the activity signal.
+    expect(LEDGER_DEFAULT_TIMEOUT_MS).toBeGreaterThan(25.5 * 60 * 60_000);
+  });
+});

--- a/skills/harness/tests/driver-ledger-heartbeat.test.ts
+++ b/skills/harness/tests/driver-ledger-heartbeat.test.ts
@@ -64,12 +64,14 @@ function readAuditEvents(): Array<Record<string, unknown>> {
 }
 
 describe("driver — ledger default timeout", () => {
-  test("explicit timeoutMs always wins; ledgered runs default to a 24h backstop; unledgered stay uncapped", () => {
+  test("explicit timeoutMs always wins; ledgered runs default to a 7-day backstop; unledgered stay uncapped", () => {
     expect(resolveLedgerTimeoutMs({ timeoutMs: 1234, ledger: { runId: "x" } })).toBe(1234);
     expect(resolveLedgerTimeoutMs({ ledger: { runId: "x" } })).toBe(LEDGER_DEFAULT_TIMEOUT_MS);
-    // 24h is a BACKSTOP: hangs are caught by the activity heartbeat (~5 min
-    // stall budget), not by the clock, so real long-form work is never killed.
-    expect(LEDGER_DEFAULT_TIMEOUT_MS).toBe(24 * 60 * 60_000);
+    // A BACKSTOP, above the work rather than inside it: hangs are caught by the
+    // lease expiring after the last sign of life, not by the clock. 24h used to
+    // sit BELOW this machine's longest ledgered run (25.5h) — a ceiling under
+    // the observed maximum kills finished work instead of catching a runaway.
+    expect(LEDGER_DEFAULT_TIMEOUT_MS).toBe(7 * 24 * 60 * 60_000);
     expect(resolveLedgerTimeoutMs({})).toBeUndefined();
   });
 });

--- a/skills/squads/lib/squad-audit-consensus.js
+++ b/skills/squads/lib/squad-audit-consensus.js
@@ -172,13 +172,16 @@ async function callAgent(_client, role, userMessage) {
   const driver = loadHostDriver();
   if (!driver) return { role, text: '', error: 'host-agent-driver not loadable' };
   const persona = readPersona(role) || `You are the ${role} agent in a squad audit consensus loop.`;
-  // Async path with stall watchdog: 90s heartbeat + 1 retry on stall. Avoids
-  // 600s freezes when the agent reads heavy + writes heavy in one call.
+  // Async path with a 240s budget of SILENCE + 1 retry on it. Still guards the
+  // 600s freeze when the agent reads heavy and writes heavy in one call, but
+  // without the 90s heartbeat that used to fire first: the runtimes this calls
+  // print one JSON object at the END, so "no bytes for 90s" was a model
+  // thinking, and killing it produced the freeze it was meant to prevent.
   let retry = null;
   try {
     retry = require(path.join(SKILLS_ROOT, '_shared', 'lib', 'host-agent-retry.js'));
   } catch {}
-  const callOpts = { heartbeatMs: 90_000, timeoutMs: 240_000, maxRetries: 1 };
+  const callOpts = { timeoutMs: 240_000, maxRetries: 1 };
   const r = retry && retry.callWithRetryOnStall
     ? await retry.callWithRetryOnStall(persona, userMessage, callOpts)
     : await driver.callHostAgentAsync(persona, userMessage, callOpts);


### PR DESCRIPTION
The owner's report, which is the specification: *"Colocar timeout curto em LLM é burrice, porque ela pode passar muito tempo pensando e nosso sistema é realmente demorado. Temos dispatch que o runtime demora horas para retornar e finalizar, até dias."*

## The defect

`callHostAgentAsync` armed one `setTimeout(kill, timeoutMs)` at spawn. It fired on elapsed time alone and never asked whether the child was producing anything. Default 120 s; `judge.ts` passed **60 s** — a one-minute wall clock over an LLM call that grades a deliverable.

## The fix

`timeoutMs` is now a budget of **silence**, not a lifetime. The timer measures from the last stdout/stderr byte and rearms for whatever is left of the budget whenever the child speaks. A child that keeps producing output survives any elapsed time; a child that goes quiet still dies, resolving as `inactivity_timeout` with how long it had been silent and how many bytes it had produced, and emitting `x_driver_child_killed` naming the rule, the budget and the last activity. **Nothing is ever extended in silence** — a run that dies leaves a reason a human can read.

This is the pattern the wider community converged on for the same failure ([NousResearch/hermes-agent#4815](https://github.com/NousResearch/hermes-agent/issues/4815), *"gateway agent timeout kills legitimate long-running tasks"*): wall clock cannot separate a hard problem from a dead socket; inactivity can.

## Four windows, resized from measurement

| window | was | is | why |
|---|---|---|---|
| light-layer budget | 120 s wall clock | **45 min of silence** | 1.8% of real intra-turn pauses exceed 2 min; 0.089% exceed 45 min |
| stall watchdog | 60 s, armed | **disarmed** | five of nine adapters print one JSON object at the END of the call |
| ledgered wall clock | 24 h | **7 days** | the longest ledgered run on this machine is 25.5 h |
| ledgered lease | 600 s | **2,700 s** | 0.45% of pauses exceed ten minutes |

**Evidence:** 123,318 gaps between consecutive non-human entries across 557 Claude Code transcripts on this machine — p50 1.1 s, p95 28 s, p99 192 s, p99.9 23.8 min. Past an hour the count stops falling (90 → 77 → 71), which is the resumed-session floor rather than a pause. Ledger corroboration over 371 runs: p50 21 min, p90 62 min, p99 5.7 h, longest 25.5 h, longest delivered 4.9 h.

The 24 h ceiling **sat below the observed maximum**. It was already killing work that was still running.

`supervisor.stall_threshold_ms` (5 min) was deliberately left alone: it kills nothing and stays the cheap early warning.

## Verification

`bun test skills/_shared skills/harness` — 2029 pass, 3 skip, 0 fail. A failing test was written and watched failing first: a child producing output steadily past the ceiling survives; a child that goes silent dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)