### PR TITLE
fix(audit,glance): the run card can say what the run is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The run card can say what the run is
+
+The cockpit read `(no brief captured)` on 56 of 57 cards while the briefs sat in
+the log, because `brief_received` came out of three emitters in three shapes and
+no shape was complete. The router CLI sent the whole brief and no `trace_id`;
+`brief-squad.ts` and `brief-business.ts` sent a `trace_id`-less `brief_chars`;
+`dispatch.ts` sent a `trace_id` and `brief_chars`. `buildRuns` groups by
+`ev.trace_id || "no-trace"` and reads the text from `ev.brief`, so the only event
+carrying text was the only one that could never reach a run: on the live cockpit
+the single card with a brief was `no-trace`, holding 53 events from unrelated
+runs at once.
+
+Every emitter now carries both halves. `brief_excerpt` is a bounded, single-line
+form of the brief (`_shared/lib/brief-excerpt.ts`), capped at 300 characters —
+measured, not guessed: across both audit roots over 2026-08-22..28, 163
+`brief_received` events ran p50 83 chars, p90 176, p99 221, max 357. `brief_chars`
+stays beside it carrying the true length, so a reader can always tell an excerpt
+from a whole brief. The router CLI stops writing the unbounded field into a file
+appended thousands of times a day, and carries `NIRVANA_TRACE_ID` when it runs
+inside a dispatch; typed by hand it is a lookup, not a run, and still carries no
+trace rather than inventing a phantom card.
+
+`dispatch_squad` and `dispatch_agent_x` carry the excerpt too, so a run whose
+`brief_received` landed in another log still shows what it was asked to do.
+
+### The card counts orchestration apart from hook noise
+
+"2039 EVENTS" measured how long an agent ran, not how much the run did: the hook
+fires one `tool_invoked` and one `bash_completed` per tool call, and on
+2026-08-28 those two names alone were 4702 of 5250 events. The card now reads
+`N signal / M events`, where signal excludes `tool_invoked`, `bash_completed`,
+`x_ledger_lease_renewed` and `x_ledger_progress_ping`. It is a deny list on
+purpose: a new event name counts as signal until someone measures otherwise.
+Nothing is removed from the log — the swimlane, the fabrication detector and the
+cost aggregator still read every event.
+
+### The card names what the run was dispatched to
+
+`target` and `outputs_dir` come off the dispatch events themselves, never
+inferred from context, and render `—` when no dispatch event carries them
+(`views/absence.js`). Measured on the same 7-day log: 0 of 182 runs could name a
+target before, 81 can now, and cards showing a brief went from 20 to 59.
+
 ## 0.11.0 — 2026-08-28
 
 ### The clock stops deciding whether a run is alive

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,51 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O card do run consegue dizer o que o run é
+
+O cockpit lia `(no brief captured)` em 56 de 57 cards enquanto os briefs estavam
+no log, porque `brief_received` saía de três emissores em três formatos e nenhum
+formato era completo. O CLI do router mandava o brief inteiro e nenhum
+`trace_id`; `brief-squad.ts` e `brief-business.ts` mandavam um `brief_chars` sem
+`trace_id`; `dispatch.ts` mandava `trace_id` e `brief_chars`. O `buildRuns`
+agrupa por `ev.trace_id || "no-trace"` e lê o texto de `ev.brief`, então o único
+evento que carregava texto era o único que jamais chegaria a um run: no cockpit
+vivo, o único card com brief era o `no-trace`, segurando 53 eventos de runs sem
+relação entre si.
+
+Agora todo emissor carrega as duas metades. `brief_excerpt` é a forma limitada e
+de uma linha do brief (`_shared/lib/brief-excerpt.ts`), com teto de 300
+caracteres — medido, não chutado: nas duas raízes de auditoria entre 22 e
+28/08/2026, 163 eventos `brief_received` deram p50 de 83 caracteres, p90 de 176,
+p99 de 221 e máximo de 357. O `brief_chars` fica ao lado carregando o tamanho
+verdadeiro, então quem lê sempre distingue um trecho de um brief inteiro. O CLI
+do router para de escrever o campo sem teto num arquivo que recebe milhares de
+linhas por dia, e passa a carregar `NIRVANA_TRACE_ID` quando roda dentro de um
+despacho; digitado à mão ele é uma consulta, não um run, e continua sem trace em
+vez de inventar um card fantasma.
+
+`dispatch_squad` e `dispatch_agent_x` também carregam o trecho, então um run cujo
+`brief_received` caiu em outro log ainda mostra o que foi pedido a ele.
+
+### O card conta orquestração separada do ruído de hook
+
+"2039 EVENTS" media quanto tempo um agente ficou rodando, não quanto o run fez: o
+hook dispara um `tool_invoked` e um `bash_completed` por chamada de ferramenta, e
+em 28/08/2026 só esses dois nomes foram 4702 de 5250 eventos. O card agora lê
+`N signal / M events`, onde o sinal exclui `tool_invoked`, `bash_completed`,
+`x_ledger_lease_renewed` e `x_ledger_progress_ping`. É uma lista de exclusão de
+propósito: um nome de evento novo conta como sinal até alguém medir o contrário.
+Nada sai do log — a swimlane, o detector de fabricação e o agregador de custo
+continuam lendo todos os eventos.
+
+### O card nomeia para onde o run foi despachado
+
+`target` e `outputs_dir` vêm dos próprios eventos de despacho, nunca inferidos do
+contexto, e renderizam `—` quando nenhum evento de despacho os carrega
+(`views/absence.js`). Medido no mesmo log de 7 dias: 0 de 182 runs conseguiam
+nomear um alvo antes, 81 conseguem agora, e os cards que mostram um brief foram
+de 20 para 59.
+
 ## 0.11.0 — 2026-08-28
 
 ### O relógio para de decidir se um run está vivo

--- a/skills/_shared/lib/brief-excerpt.ts
+++ b/skills/_shared/lib/brief-excerpt.ts
@@ -1,0 +1,39 @@
+// brief-excerpt.ts — the one bounded form of a brief that is allowed onto an
+// audit event.
+//
+// Two defects meet here. The audit log is appended thousands of times a day
+// (measured 2026-08-28: 5250 events / 2.05 MB in ~/.harness-logs alone, 390
+// bytes per event on average), so a field carrying a whole brief — sometimes
+// thousands of characters — grows the file without a ceiling. The answer used
+// on most emitters was to send `brief_chars` instead, a number, and the run
+// card that reads it has nothing to show. Neither is right: the card needs
+// text, the log needs a bound.
+//
+// The cap is measured, not guessed. Across both audit roots over 2026-08-22..28,
+// 163 `brief_received` events: p50 83 chars, p90 176, p99 221, max 357. At 300
+// the excerpt carries better than 99% of real briefs whole, bounds the worst
+// case at roughly 0.8× the average event, and still overflows one card line —
+// which truncates in CSS anyway.
+//
+// `brief_chars` stays beside it and keeps carrying the TRUE length, so a reader
+// can always tell an excerpt from a whole brief.
+
+/** Hard ceiling, in characters, for any brief text on an audit event. */
+export const BRIEF_EXCERPT_MAX = 300;
+
+/**
+ * The bounded, single-line form of a brief.
+ *
+ * Returns `null` when there is nothing to show — absence, which a reader renders
+ * as `—`, is not the same as an empty string it would render as blank.
+ */
+export function briefExcerpt(brief: unknown, max: number = BRIEF_EXCERPT_MAX): string | null {
+  if (typeof brief !== "string") return null;
+  // A brief is markdown: newlines, indentation, run-on spacing. The card shows
+  // one line, so collapse here rather than in every reader.
+  const flat = brief.replace(/\s+/g, " ").trim();
+  if (!flat) return null;
+  if (flat.length <= max) return flat;
+  // The ellipsis counts against the cap: the field is never longer than `max`.
+  return flat.slice(0, max - 1) + "…";
+}

--- a/skills/businesses/scripts/brief-business.ts
+++ b/skills/businesses/scripts/brief-business.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { exec, paths, EXIT, BUN_BIN } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope, enumerate, outputsDir } from "../../_shared/lib/scope.ts";
+import { briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
 
 const skillDir = path.join(paths.CLAUDE_SKILLS_DIR, "businesses");
 // Single scope, reused for the business lookup AND outputsDir (don't resolve twice).
@@ -91,12 +92,18 @@ fs.writeFileSync(briefFile, `# Brief
 ${brief}
 `);
 
+// The event carries the trace AND a bounded excerpt of the brief. Without the
+// trace it landed in buildRuns' "no-trace" bucket and the business's own run card
+// read "(no brief captured)"; with only `brief_chars` there was nothing to show
+// even once it arrived. `brief_chars` stays as the TRUE length beside the excerpt.
 const auditFile = path.join(projectDir, "audit.jsonl");
 const auditEntry = JSON.stringify({
   ts: submitted,
   event: "brief_received",
+  trace_id: projectId,
   project_id: projectId,
   business_slug: slug,
+  brief_excerpt: briefExcerpt(brief),
   brief_chars: brief.length,
 });
 fs.appendFileSync(auditFile, auditEntry + "\n");

--- a/skills/harness/lib/dispatch-cascade.ts
+++ b/skills/harness/lib/dispatch-cascade.ts
@@ -30,6 +30,7 @@ import type { Runtime } from "./host-agent-driver.ts";
 import { runWithCascade } from "./cascade-runner.ts";
 import type { RouterFailurePolicy } from "./harness-config.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
+import { briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
 
 export type DispatchStepKind = "business" | "squad" | "agent-x";
 
@@ -384,6 +385,9 @@ export function runAgentX(args: RunAgentXArgs): AgentXResult {
     trace_id: args.projectId, project_id: args.projectId,
     runtime: args.runtime, persona_file: promptPath,
     reason: args.reason, outputs_root: args.outputsRoot,
+    // Parity with dispatch_squad: the proof-of-dispatch event carries what the
+    // generalist was asked to do, bounded — see brief-excerpt.ts for the cap.
+    brief_excerpt: briefExcerpt(args.brief), brief_chars: args.brief.length,
   });
 
   const cascadeImpl = args.runWithCascadeImpl ?? runWithCascade;

--- a/skills/harness/lib/glance/agent-state.ts
+++ b/skills/harness/lib/glance/agent-state.ts
@@ -239,7 +239,9 @@ export function deriveAgentStates(events: Array<any>): AgentState[] {
       if (ev.caller_id) callerIds.add(ev.caller_id);
 
       if (ev.event === "brief_received" && !brief) {
-        brief = (ev.brief || ev.user_input || ev.payload?.brief || "").toString().slice(0, 80) || null;
+        // brief_excerpt is the bounded field the emitters write today; `brief`
+        // is the router CLI's old unbounded one, still present in logs on disk.
+        brief = (ev.brief_excerpt || ev.brief || ev.user_input || ev.payload?.brief || "").toString().slice(0, 80) || null;
       }
 
       if (ev.event === "cost_emission") {

--- a/skills/harness/lib/glance/data-loader.ts
+++ b/skills/harness/lib/glance/data-loader.ts
@@ -214,17 +214,39 @@ export function getBusinessDetail(slug: string) {
 // Gemini-CLI, Codex, the auto-emit hook, anything. This is what powers
 // the Projects/Runs tab in Glance with paperclip-style command-center UX.
 
+/** Event names that say only "an agent was running" — which the run's status
+ *  already says. The hook fires one `tool_invoked` and one `bash_completed` per
+ *  tool call, and the ledger renews a lease on a timer; measured on 2026-08-28,
+ *  those four names were 4702 of 5250 events in ~/.harness-logs and 323 of 1940
+ *  in the project's log. Counting them made a run that did one thing and a run
+ *  that did fifty look equally busy.
+ *
+ *  Deliberately a DENY list, not an allow list: a new event name is signal until
+ *  someone measures that it is not, so a future emitter is never silently
+ *  dropped from the count. The events stay in the log — they have other readers
+ *  (the swimlane, the fabrication detector, cost). Only the count changes. */
+const NOISE_EVENTS = new Set([
+  "tool_invoked",
+  "bash_completed",
+  "x_ledger_lease_renewed",
+  "x_ledger_progress_ping",
+]);
+
 interface Run {
   trace_id: string;
   project_id: string | null;
   cwd: string | null;
-  brief: string | null;             // first brief_received text
+  brief: string | null;             // first brief_received excerpt
   business_slug: string | null;
   squad_name: string | null;
+  target: string | null;            // "<kind>:<slug>" of what the run was dispatched to
+  outputs_dir: string | null;       // where the dispatched target was told to write
   status: "running" | "delivered" | "gate_failed" | "no_match" | "unknown";
   started_at: string;               // ISO of first event
   last_event_at: string;             // ISO of last event
-  event_count: number;
+  event_count: number;              // every event on the trace
+  noise_event_count: number;        // the NOISE_EVENTS share of event_count
+  signal_event_count: number;       // event_count - noise_event_count
   artifact_paths: string[];          // unique artifacts touched
   events: any[];                    // full timeline (truncated to last 200)
   suspicious: boolean;              // fabrication detector verdict
@@ -305,10 +327,14 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
           brief: null,
           business_slug: null,
           squad_name: null,
+          target: null,
+          outputs_dir: null,
           status: "unknown",
           started_at: ev.ts,
           last_event_at: ev.ts,
           event_count: 0,
+          noise_event_count: 0,
+          signal_event_count: 0,
           artifact_paths: [],
           events: [],
           suspicious: false,
@@ -327,6 +353,8 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
       // Track distinct hosts (for fabrication detector + UI hint)
       if (ev.host && !r.hosts.includes(ev.host)) r.hosts.push(ev.host);
       r.event_count++;
+      if (NOISE_EVENTS.has(ev.event)) r.noise_event_count++;
+      else r.signal_event_count++;
       if (ev.ts < r.started_at) r.started_at = ev.ts;
       if (ev.ts > r.last_event_at) r.last_event_at = ev.ts;
       if (!r.project_id && ev.project_id) r.project_id = ev.project_id;
@@ -335,9 +363,26 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
       const evSquad = ev.squad_name ?? (ev as any).squad;
       if (!r.business_slug && evBiz) r.business_slug = evBiz;
       if (!r.squad_name && evSquad) r.squad_name = evSquad;
-      // Capture brief from first brief_received
-      if (ev.event === "brief_received" && !r.brief) {
-        r.brief = ev.brief || ev.user_input || ev.payload?.brief || null;
+      // Capture brief from the first event that carries one. `brief_excerpt` is
+      // the bounded field every emitter writes today (see brief-excerpt.ts);
+      // `brief` is the router CLI's old unbounded one, still in logs on disk.
+      // dispatch_squad / dispatch_agent_x carry it too, so a run whose
+      // brief_received landed elsewhere still shows what it was asked to do.
+      if (!r.brief) {
+        r.brief = ev.brief_excerpt || ev.brief || ev.user_input || ev.payload?.brief || null;
+      }
+      // What the run was dispatched TO. Only ever read from the dispatch events
+      // — the ones whose whole purpose is to record the decision. Nothing is
+      // inferred: a run with no dispatch event keeps `target: null`, which the
+      // view renders as `—` (views/absence.js).
+      if (!r.target) {
+        if (ev.event === "dispatch_squad") r.target = `squad:${ev.squad_name ?? ev.squad_slug ?? "?"}`;
+        else if (ev.event === "dispatch_business") r.target = `business:${ev.business_slug ?? "?"}`;
+        else if (ev.event === "dispatch_agent_x") r.target = "agent-x";
+        else if (ev.event === "brief_received" && ev.target) r.target = String(ev.target);
+      }
+      if (!r.outputs_dir && (ev.outputs_dir || ev.outputs_root)) {
+        r.outputs_dir = ev.outputs_dir || ev.outputs_root;
       }
       // Status precedence: gate_failed > delivered > no_match > running
       if (ev.event === "delivered") r.status = "delivered";

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -883,8 +883,17 @@
                 <span class="badge badge-neutral badge-sm" x-show="run.squad_name" x-text="`squad: ${run.squad_name}`"></span>
                 <span class="badge badge-neutral badge-sm" x-show="run.project_id" x-text="`proj: ${run.project_id}`"></span>
                 <span class="badge badge-neutral badge-mono badge-sm" x-text="`#${run.trace_id.slice(0, 8)}`"></span>
-                <span class="badge badge-neutral badge-sm" x-text="`${run.event_count} events`"></span>
-                <span class="badge badge-neutral badge-sm" x-show="run.artifact_paths.length" x-text="`${run.artifact_paths.length} artifact${run.artifact_paths.length === 1 ? '' : 's'}`"></span>
+                <!-- What the run was dispatched to, read from the dispatch event itself.
+                     `—` when no dispatch event carries it: an inferred target would be a
+                     guess on the one card whose job is to say what actually happened. -->
+                <span class="badge badge-neutral badge-sm" x-text="`→ ${countText(run.target)}`"></span>
+                <!-- Signal first. The total is still there, labelled for what it is: the
+                     hook fires two events per tool call, so it measures how long an agent
+                     ran, not how much the run did. -->
+                <span class="badge badge-neutral badge-sm"
+                      :title="`${run.event_count} events on this trace · ${run.noise_event_count} of them tool calls and heartbeats`"
+                      x-text="`${countText(run.signal_event_count)} signal / ${countText(run.event_count)} events`"></span>
+                <span class="badge badge-neutral badge-sm" x-text="`${countText(run.artifact_paths.length)} artifact${run.artifact_paths.length === 1 ? '' : 's'}`"></span>
                 <span class="badge badge-neutral badge-sm" x-show="run.hosts && run.hosts.length" x-text="run.hosts.join(' · ')"></span>
               </div>
             </button>
@@ -921,6 +930,12 @@
                   <template x-if="selectedRun.project_id"><dd class="text-mono-sm" x-text="selectedRun.project_id"></dd></template>
                   <template x-if="selectedRun.cwd"><dt>cwd</dt></template>
                   <template x-if="selectedRun.cwd"><dd class="text-mono-sm" x-text="selectedRun.cwd"></dd></template>
+                  <dt>dispatched to</dt>
+                  <dd x-text="countText(selectedRun.target)"></dd>
+                  <dt>outputs</dt>
+                  <dd class="text-mono-sm" x-text="countText(selectedRun.outputs_dir)"></dd>
+                  <dt>events</dt>
+                  <dd x-text="`${countText(selectedRun.signal_event_count)} signal · ${countText(selectedRun.noise_event_count)} tool calls and heartbeats`"></dd>
                   <dt>started</dt>
                   <dd x-text="new Date(selectedRun.started_at).toLocaleString()"></dd>
                   <dt>last</dt>
@@ -956,7 +971,7 @@
                             <span class="timeline-event-name" x-text="ev.event"></span>
                             <span class="timeline-event-time" x-text="ev.ts ? ev.ts.slice(11, 19) : ''"></span>
                           </div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'brief_received' && ev.brief" x-text="ev.brief"></div>
+                          <div class="timeline-event-detail" x-show="(ev.event === 'brief_received' || ev.event === 'dispatch_squad' || ev.event === 'dispatch_agent_x') && (ev.brief_excerpt || ev.brief)" x-text="ev.brief_excerpt || ev.brief"></div>
                           <div class="timeline-event-detail" x-show="ev.event === 'tool_invoked'" x-text="`${ev.action || ''} ${ev.file_path || ev.command || ''}`"></div>
                           <div class="timeline-event-detail" x-show="ev.event === 'artifact_touched' || ev.event === 'delivered'" x-text="ev.artifact_path || ev.file_path"></div>
                           <div class="timeline-event-detail" x-show="ev.event === 'cost_emission' && ev.usage" x-text="`tokens in=${ev.usage?.input_tokens || 0} out=${ev.usage?.output_tokens || 0} usd=${(ev.total_cost_usd || 0).toFixed(4)}`"></div>

--- a/skills/harness/lib/router.js
+++ b/skills/harness/lib/router.js
@@ -2421,8 +2421,24 @@ if (require.main === module) {
       process.exit(4);
     }
     try {
-      // Audit: brief received (always written when CLI is invoked)
-      try { audit.emit('brief_received', { brief, command: cmd }); } catch {}
+      // Audit: brief received (always written when CLI is invoked).
+      //
+      // This was the ONLY brief_received carrying the brief text, and the only
+      // one with no trace — so buildRuns filed it under "no-trace" and no run
+      // card ever saw it. It also sent the WHOLE brief, unbounded, into a file
+      // appended thousands of times a day. Both halves fixed: a bounded excerpt
+      // (brief-excerpt.ts) with the true length beside it, and the trace when
+      // the CLI runs inside a dispatch. `nrv find` typed by hand is a lookup and
+      // not a run, so it still carries no trace — an invented one would put a
+      // phantom card in the cockpit.
+      try {
+        const { briefExcerpt } = require(path.join(__dirname, '..', '..', '_shared', 'lib', 'brief-excerpt.ts'));
+        const traceId = process.env.NIRVANA_TRACE_ID || null;
+        audit.emit('brief_received', {
+          ...(traceId ? { trace_id: traceId } : {}),
+          brief_excerpt: briefExcerpt(brief), brief_chars: brief.length, command: cmd,
+        });
+      } catch {}
       const result = await route(brief, {
         prefer,
         amplify: !noAmplify,

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -26,6 +26,7 @@ import { LIMITS } from "../../_shared/validators/limits.ts";
 import { runWithCascade } from "./cascade-runner.ts";
 import { sessionKey, getSession, putSession, dropSession } from "./session-store.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
 import { resolveClonePersona, loadCloneRegistry } from "../../_shared/lib/clone-resolver.ts";
 import { layersForPhase } from "../../_shared/lib/dna-layer-policy.ts";
 import { findCloneForTask } from "../../_shared/lib/clone-search.ts";
@@ -442,6 +443,10 @@ export function runSquadHeadless(args: SquadExecArgs): SquadExecResult {
     ...(args.capabilityId ? { capability_id: args.capabilityId } : {}),
     mode: args.mode,
     outputs_dir: outDir,
+    // The proof-of-dispatch event says which squad, and now also what it was
+    // asked to do. Bounded — see brief-excerpt.ts for the measured cap.
+    brief_excerpt: briefExcerpt(args.brief),
+    brief_chars: args.brief.length,
   }, args.projectRoot);
 
   const cascadeImpl = args.runWithCascadeImpl ?? runWithCascade;

--- a/skills/harness/references/03-audit.md
+++ b/skills/harness/references/03-audit.md
@@ -24,7 +24,7 @@ authoritative for legacy readers, SQLite is the race-safe substrate.
 Append-only, one JSON object per line, UTF-8.
 
 ```jsonl
-{"ts":"2026-08-05T17:30:11.241Z","event":"brief_received","trace_id":"01HZ...","brief":"...","command":"route"}
+{"ts":"2026-08-05T17:30:11.241Z","event":"brief_received","trace_id":"01HZ...","brief_excerpt":"...","brief_chars":142,"command":"route"}
 {"ts":"2026-08-05T17:30:11.342Z","event":"routing_decision","signal":"HIGH","target_id":"squad_capability:audio-suite:audio_video.transcribe","route_tier":"stage2_squad"}
 {"ts":"2026-08-05T17:30:12.001Z","event":"dispatch_business","trace_id":"01HZ...","business_slug":"ars-libri"}
 {"ts":"2026-08-05T17:31:14.901Z","event":"cost_emission","agent":"transcriber","model":"sonnet","tokens_input":1200,"tokens_output":340,"cost_usd":0.0228}
@@ -266,9 +266,12 @@ cutoff; call it periodically (cron / runtime hook).
 
 ## Privacy
 
-- Prefer `brief_length` / `brief_excerpt` over the full brief in events; some
-  writers do log the full brief (`brief_received` from the router CLI) — keep
-  that in mind when sharing logs.
+- Never put a full brief on an event. `brief_excerpt`
+  (`_shared/lib/brief-excerpt.ts`) is the only sanctioned form: bounded at 300
+  characters, single line, with `brief_chars` beside it carrying the true length.
+  The router CLI used to send the whole brief; it no longer does. A field that
+  grows without a ceiling on a file appended thousands of times a day is a
+  defect, not a feature.
 - Hash custom fields containing PII before `emit`.
 - The isolation guard keeps other projects' audit logs out of the current
   session.

--- a/skills/harness/scripts/dispatch.ts
+++ b/skills/harness/scripts/dispatch.ts
@@ -40,6 +40,7 @@ import { proxyEnrichBrief } from "../lib/brief-proxy.ts";
 import { resolveRoutingMode } from "../../_shared/lib/routing-mode.ts";
 import { runTeam } from "../lib/team-orchestrator.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
 import { agenticRoute, type AgenticRouteDecision } from "../lib/agentic-router.ts";
 import { runWithCascade } from "../lib/cascade-runner.ts";
 import { resolveCascadeRoot, loadCascade, nextAfter } from "../lib/cascade.ts";
@@ -1072,9 +1073,12 @@ function printDeliverySummary(res: DeliveryResult, pid: string, oroot: string, z
 
 // ── SQUAD-ONLY ROUTE — dispatch the squad(s) for real (Phase 4.1) ─────────
 // Pre-Phase-4 this printed shell instructions and exited 0 WITHOUT
-// dispatching. Now: scaffold via brief-squad.ts (validates the manifest,
-// emits brief_received + dispatch_squad), then — in exec mode — run each
-// squad through squad-exec and the shared delivery pipeline.
+// dispatching. Now: scaffold via brief-squad.ts (validates the manifest, and
+// emits brief_received + dispatch_squad ITSELF — grep this file for
+// `dispatch_squad` and you find only this comment, which is why it says whose
+// event it is), then — in exec mode — run each squad through squad-exec, which
+// emits the richer dispatch_squad (capability_id, mode, outputs_dir), and the
+// shared delivery pipeline.
 if (pendingCascade?.kind === "squad-only") {
   const squads = pendingCascade.squads;
   const rt = runtimeDecision.runtime;
@@ -1272,7 +1276,7 @@ if (pendingCascade?.kind === "judge-x") {
   const projDir = path.join(scaffoldRoot, "judge-x");
   fs.mkdirSync(projDir, { recursive: true });
   dispatchAudit.bindProjectRoot(PROJECT_ROOT);
-  emit("brief_received", { trace_id: pid, project_id: pid, target: "judge-x", brief_chars: brief.length });
+  emit("brief_received", { trace_id: pid, project_id: pid, target: "judge-x", brief_excerpt: briefExcerpt(brief), brief_chars: brief.length });
 
   if (!wantExec) {
     console.log(c("cyan", "  judge-x runs only with --exec: nothing was judged."));
@@ -1338,7 +1342,7 @@ if (pendingCascade?.kind === "agent-x") {
   const briefPath = path.join(scaffoldRoot, "brief-enriched.md");
   fs.writeFileSync(briefPath, brief, "utf8");
   dispatchAudit.bindProjectRoot(PROJECT_ROOT);
-  emit("brief_received", { trace_id: pid, project_id: pid, target: "agent-x", brief_chars: brief.length });
+  emit("brief_received", { trace_id: pid, project_id: pid, target: "agent-x", brief_excerpt: briefExcerpt(brief), brief_chars: brief.length });
 
   if (!wantExec) {
     console.log("");

--- a/skills/harness/scripts/watch.ts
+++ b/skills/harness/scripts/watch.ts
@@ -122,7 +122,7 @@ function fmtEvent(ev: any): string {
 
   let body = "";
   if (ev.event === "brief_received") {
-    body = ev.brief || ev.user_input || ev.payload?.brief || "";
+    body = ev.brief_excerpt || ev.brief || ev.user_input || ev.payload?.brief || "";
     body = body.slice(0, 120);
   } else if (ev.event === "routing_decision") {
     body = `signal=${ev.signal || "?"} target=${ev.target || ev.target_id || "?"}`;

--- a/skills/harness/tests/glance-run-card-brief.test.ts
+++ b/skills/harness/tests/glance-run-card-brief.test.ts
@@ -1,0 +1,188 @@
+// glance-run-card-brief.test.ts — the run card has to be able to say what the run is.
+//
+// The owner, looking at his own cockpit on 2026-08-28: "não temos nem brief sendo
+// coletado pelo glance". Measured the same day, over the two audit roots this machine
+// writes to (`~/.harness-logs/2026-08-28`, 5250 events; `<project>/.nirvana/logs/harness/
+// 2026-08-28`, 1940 events), `brief_received` came out of three emitters in three shapes:
+//
+//   ['brief','command','event','ts']                              49×  router.js CLI
+//   ['brief_chars','event','project_id','squad_name','ts']         18×  brief-squad.ts
+//   ['brief_chars','event','project_id','target','trace_id','ts']   8×  dispatch.ts
+//
+// Exactly one of the three carries the brief text, and it is the only one with no
+// `trace_id`. buildRuns groups by `ev.trace_id || "no-trace"` and reads the brief from
+// `ev.brief`, so the text always landed in the bucket no run reads, and every card that
+// belonged to a real trace rendered "(no brief captured)" while the brief sat in the log.
+//
+// What these cases pin:
+//   1. the excerpt is bounded — the log is appended thousands of times a day;
+//   2. every emitter carries BOTH the trace and the excerpt, so the two halves meet;
+//   3. a run built from a real-shaped log shows its brief, its target, and counts
+//      orchestration apart from hook noise (2450 tool_invoked + 2252 bash_completed
+//      out of 5250 events made a one-step run and a fifty-step run look equally busy).
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { BRIEF_EXCERPT_MAX, briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
+
+const SKILLS = path.resolve(import.meta.dir, "..", "..");
+const TMP = makeTempRoot("nrv-run-card-brief-");
+const previousLogsDir = process.env.HARNESS_LOGS_DIR;
+
+afterAll(() => {
+  if (previousLogsDir === undefined) delete process.env.HARNESS_LOGS_DIR;
+  else process.env.HARNESS_LOGS_DIR = previousLogsDir;
+  removeDir(TMP);
+});
+
+describe("briefExcerpt bounds what travels on an event", () => {
+  test("a brief shorter than the cap travels whole, on one line", () => {
+    expect(briefExcerpt("Uma landing page\npara uma clínica veterinária"))
+      .toBe("Uma landing page para uma clínica veterinária");
+  });
+
+  test("a long brief is cut to the cap, ellipsis included — the field never grows past it", () => {
+    const long = "a".repeat(BRIEF_EXCERPT_MAX * 4);
+    const excerpt = briefExcerpt(long)!;
+    expect(excerpt.length).toBe(BRIEF_EXCERPT_MAX);
+    expect(excerpt.endsWith("…")).toBe(true);
+  });
+
+  test("nothing to excerpt answers null, so a reader can tell absence from an empty string", () => {
+    expect(briefExcerpt("")).toBeNull();
+    expect(briefExcerpt("   \n  ")).toBeNull();
+    expect(briefExcerpt(undefined)).toBeNull();
+  });
+});
+
+describe("a squad dispatch carries its trace AND its brief", () => {
+  const home = path.join(TMP, "squad-home");
+  const projectRoot = path.join(TMP, "squad-project");
+  const logs = path.join(TMP, "squad-logs");
+  const BRIEF = "Auditar a visibilidade em busca de uma clínica veterinária, com plano de 90 dias";
+  let events: any[] = [];
+
+  beforeAll(() => {
+    const squad = path.join(home, "squads", "fixture-squad");
+    fs.mkdirSync(path.join(squad, "agents"), { recursive: true });
+    fs.writeFileSync(path.join(squad, "agents", "fixture.md"), "# fixture\n");
+    fs.writeFileSync(path.join(squad, "squad.yaml"), [
+      "name: fixture-squad",
+      "version: 1.0.0",
+      'protocol: "5.0"',
+      "description: A fixture squad used by the run-card brief tests.",
+      "experimental_domains: true",
+      "components:",
+      "  agents: [fixture.md]",
+      "  tasks: []",
+      "  workflows: []",
+      "capabilities:",
+      "  - id: general.fixture.run",
+      "    description: Do the fixture thing.",
+      "    domains: [fixture]",
+      "    produces: [nothing]",
+      '    examples: ["rode o fixture"]',
+      "    invoke:",
+      "      type: agent",
+      "      ref: fixture",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(projectRoot, { recursive: true });
+
+    const r = spawnSync(process.execPath, [
+      path.join(SKILLS, "squads", "scripts", "brief-squad.ts"),
+      "fixture-squad", BRIEF, "--project", "projeto-do-card",
+    ], {
+      encoding: "utf8", cwd: projectRoot,
+      env: {
+        ...process.env,
+        SQUADS_DIR: path.join(home, "squads"),
+        NIRVANA_HOME: home,
+        NIRVANA_PROJECT_ROOT: projectRoot,
+        NIRVANA_RUN_LEDGER_DB: path.join(TMP, "squad-ledger.sqlite"),
+        NIRVANA_SKILLS_DIR: SKILLS,
+        HARNESS_LOGS_DIR: logs,
+        NIRVANA_DISPATCH_TRACKS_RUN: "1",
+      },
+    });
+    if (r.status !== 0) throw new Error(`brief-squad failed (${r.status}): ${r.stdout}\n${r.stderr}`);
+    const today = new Date().toISOString().slice(0, 10);
+    events = fs.readFileSync(path.join(logs, today, "audit.jsonl"), "utf8")
+      .split("\n").filter(Boolean).map(l => JSON.parse(l));
+  }, spawnBudgetMs(1));
+
+  test("dispatch_squad names the squad and carries the trace", () => {
+    const dispatched = events.filter(e => e.event === "dispatch_squad");
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0].trace_id).toBe("projeto-do-card");
+    expect(dispatched[0].squad_name).toBe("fixture-squad");
+  });
+
+  test("brief_received carries the trace, so it reaches the run that asked for it", () => {
+    const received = events.filter(e => e.event === "brief_received");
+    expect(received.length).toBe(1);
+    expect(received[0].trace_id).toBe("projeto-do-card");
+  });
+
+  test("both events carry the excerpt AND the true length — the card shows one, the reader can tell it was cut", () => {
+    for (const name of ["brief_received", "dispatch_squad"]) {
+      const ev = events.find(e => e.event === name);
+      expect(ev.brief_excerpt).toBe(BRIEF);
+      expect(ev.brief_chars).toBe(BRIEF.length);
+    }
+  });
+});
+
+describe("a run built from a real-shaped log says what it is", () => {
+  const logs = path.join(TMP, "reader-logs");
+  const TRACE = "e26355f1-74e7-4394-a2e2-9bca5f83984e";
+  const BRIEF = "Auditar a visibilidade em busca de uma clínica veterinária";
+  let run: any;
+
+  beforeAll(async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const dir = path.join(logs, today);
+    fs.mkdirSync(dir, { recursive: true });
+    const at = (n: number) => `${today}T10:${String(n).padStart(2, "0")}:00.000Z`;
+    // The shapes the emitters write, plus the hook noise that shares the trace.
+    const lines = [
+      { ts: at(0), event: "brief_received", trace_id: TRACE, project_id: TRACE, squad_name: "seo-geo-aeo", brief_excerpt: BRIEF, brief_chars: BRIEF.length },
+      { ts: at(1), event: "dispatch_squad", trace_id: TRACE, project_id: TRACE, squad_name: "seo-geo-aeo", squad_slug: "seo-geo-aeo", brief_excerpt: BRIEF, brief_chars: BRIEF.length, outputs_dir: "/tmp/out" },
+      ...Array.from({ length: 40 }, (_, i) => ({ ts: at(2), event: "tool_invoked", trace_id: TRACE, tool_name: "Bash", action: "run", command: `echo ${i}` })),
+      ...Array.from({ length: 40 }, (_, i) => ({ ts: at(3), event: "bash_completed", trace_id: TRACE, command: `echo ${i}`, success: true })),
+      ...Array.from({ length: 5 }, () => ({ ts: at(4), event: "x_ledger_lease_renewed", trace_id: TRACE })),
+      { ts: at(5), event: "artifact_touched", trace_id: TRACE, file_path: "/tmp/out/relatorio.md" },
+      { ts: at(6), event: "gate_passed", trace_id: TRACE, rubric: "wiki-lint", score: 0.94 },
+      { ts: at(7), event: "delivered", trace_id: TRACE, artifact_path: "/tmp/out/relatorio.md" },
+    ];
+    fs.writeFileSync(path.join(dir, "audit.jsonl"), lines.map(l => JSON.stringify(l)).join("\n") + "\n");
+    process.env.HARNESS_LOGS_DIR = logs;
+    const { buildRuns } = await import("../lib/glance/data-loader.ts");
+    run = buildRuns({ days: 7 }).runs!.find((r: any) => r.trace_id === TRACE);
+    expect(run).toBeTruthy();
+  });
+
+  test("the card shows the brief instead of '(no brief captured)'", () => {
+    expect(run.brief).toBe(BRIEF);
+  });
+
+  test("the card can name what the run was dispatched to", () => {
+    expect(run.squad_name).toBe("seo-geo-aeo");
+    expect(run.target).toBe("squad:seo-geo-aeo");
+    expect(run.outputs_dir).toBe("/tmp/out");
+  });
+
+  test("orchestration is counted apart from hook noise", () => {
+    // 90 events: 85 of them are two hook names and a lease heartbeat.
+    expect(run.event_count).toBe(90);
+    expect(run.noise_event_count).toBe(85);
+    expect(run.signal_event_count).toBe(5);
+  });
+
+  test("what the log does not carry stays undetermined — no invented field", () => {
+    expect(run.business_slug).toBeNull();
+  });
+});

--- a/skills/squads/scripts/brief-squad.ts
+++ b/skills/squads/scripts/brief-squad.ts
@@ -25,6 +25,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { exec, paths, EXIT, BUN_BIN } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope, enumerate, outputsDir } from "../../_shared/lib/scope.ts";
+import { briefExcerpt } from "../../_shared/lib/brief-excerpt.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
 
 const skillDir = path.join(paths.CLAUDE_SKILLS_DIR, "squads");
@@ -97,9 +98,20 @@ ${scopeGuard("pt-BR")}
 // normalized `squad_name` field (the improver/learning loop reads squad_name).
 // Dual-write: project-local audit.jsonl + the harness daily log (so nrv glance,
 // nrv doctor and validate-chain see it). This runs regardless of runtime.
+//
+// Both events carry `trace_id` and both carry the brief excerpt. Neither used to:
+// brief_received had no trace, so buildRuns filed it under "no-trace" and the run
+// that asked for the work never got its own brief; and the only emitter that did
+// carry the text was the router CLI, which has no trace at all. Half the record in
+// each of two events reached nobody. `brief_chars` stays: it is the TRUE length,
+// which the bounded excerpt can no longer tell you.
 const auditFile = path.join(projectDir, "audit.jsonl");
+const excerpt = briefExcerpt(brief);
 function emit(event: string, extra: Record<string, unknown> = {}): void {
-  const line = JSON.stringify({ ts: submitted, event, project_id: projectId, squad_name: slug, ...extra });
+  const line = JSON.stringify({
+    ts: submitted, event, trace_id: projectId, project_id: projectId, squad_name: slug,
+    brief_excerpt: excerpt, brief_chars: brief.length, ...extra,
+  });
   fs.appendFileSync(auditFile, line + "\n");
   try {
     const { harnessLogsDir } = require(path.join(skillDir, "..", "_shared", "lib", "log-paths.ts"));
@@ -108,8 +120,8 @@ function emit(event: string, extra: Record<string, unknown> = {}): void {
     fs.appendFileSync(path.join(auditDir, "audit.jsonl"), line + "\n");
   } catch { /* non-fatal */ }
 }
-emit("brief_received", { brief_chars: brief.length });
-emit("dispatch_squad", { trace_id: projectId });
+emit("brief_received");
+emit("dispatch_squad");
 
 // Open the dispatch run-ledger row for this agentic dispatch. Same reasoning as
 // the audit events above, one layer up: the supervisor's never-forgotten


### PR DESCRIPTION
The owner, looking at his own cockpit: *"Não temos nem brief sendo coletado pelo glance. A run está muito pobre de informação."*

## The defect

`(no brief captured)` on **56 of 57 cards**, while the briefs sat in the log.

Three `brief_received` emitters wrote three shapes and none was complete. `dispatch.ts:1275` carried `trace_id` and `brief_chars` — the *length*, not the text. `brief-business.ts:97` carried the text and no `trace_id`, so it landed in the `no-trace` bucket that `data-loader.ts:296` never reads. One emitter reached the right run with a number; the other carried the words into a bucket nothing looks at.

## The fix

Every emitter carries both halves: `brief_excerpt` bounded at **300 chars** (measured — p99 of real briefs is 221) with `brief_chars` beside it for the true length. `dispatch_squad` and `dispatch_agent_x` carry it too.

The card also names **what the run was dispatched to** (`target`, `outputs_dir`, read from the dispatch events and nowhere else, `—` when absent), and **counts orchestration apart from hook noise** (`N signal / M events`). The hook fires two events per tool call and was 4,702 of 5,250 events in one day, so a run that did one thing and a run that did fifty looked equally busy.

## Measured, not asserted

The same real log through the old and new readers, 182 runs:

| | before | after |
|---|---|---|
| cards showing a brief | 20 | **59** |
| cards naming a target | 0 | **81** |

## A correction to the brief that ordered this cut

The brief claimed `dispatch_squad` was promised in a comment and never emitted, citing zero events. **It is emitted** — 36 times that day, by `brief-squad.ts:112` and `squad-exec.ts:436`. The zero came from reading `~/.harness-logs`, which is not where the squad path writes. No third emitter was added; the misleading comment at `dispatch.ts:1076` now names whose event it is. `agent-x` had no hole either — `dispatch_agent_x` fires at `dispatch-cascade.ts:383` and was only missing the brief.

## Reported, not fixed

**Two live audit roots, and no reader joining them.** A dispatched agent works in an outputs root that is not a project, so its hook events fall through to `~/.harness-logs` while the orchestrator's go to `<project>/.nirvana/logs/harness`. One run, two files, 5,250 events against 1,940 — and that split is exactly what made the zero above look real. Smallest correct fix is pinning `HARNESS_LOGS_DIR` into the child's env, a pattern `evaluator-adapter.ts:217` already proves. Its own cut.

## Verification

`bun test skills` — 2248 pass, 3 skip, **0 fail**. `bun run check:all` — **exit 0**, 31 surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)