### PR TITLE
feat(squads): the event contract reaches the agent that invents the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,48 @@ snapshots per RFC 8785, which is the standard answer to the byte-determinism
 problem that broke this repository's schema parity the same week. Neither PR had
 a gate telling him to.
 
+### The event vocabulary reaches the agent that names the event
+
+Cut 1 measured the gap this closes: scanning 523 entities found emission sites
+in 3 of them, against 285 rogue types and 961 occurrences in the log. Almost
+nothing that reaches the log has a literal on disk, because an agent invents
+an event name mid-run, not while a squad is being authored — documentation
+read once at creation time never reaches that moment.
+
+`buildSquadPrompt` (`squad-exec.ts`) now injects a "COMO REPORTAR EVENTOS"
+block whenever a dispatch resolves a declared capability: emit through
+`nrv audit emit <name> --squad=<slug> --trace=<trace>`, prefix an unlisted
+name with `x_` so the log matches what was typed, and keep the payload to a
+short summary, never a full brief, output or secret. The block rides the same
+gate as the rest of the capability section: a squad without a resolved
+capability, the legacy `squad.execute` fallback, keeps the historical prompt
+byte for byte, which `squad-exec.test.ts` pinned before this cut and still
+does after it. `capabilities[]` has been mandatory for a squad to be
+discoverable since v5, so every squad on that path already carries the
+contract; only the pre-v5 legacy fallback does not, and migrating it is cut
+4's job, not this one's.
+
+Measured on a real squad (`adaptive-tutor-k12`, capability
+`education.tutoring.adaptive_cycle`): the prompt grew from 36,652 to 37,225
+bytes, 573 for the whole block including its worked example. Running the
+exact command the block tells the agent to run,
+`nrv audit emit x_pagina_altura_acima_orcamento --squad=demo-squad --trace=... --json='{...}'`,
+produces `source: "/squad/demo-squad"` and
+`type: "sh.squads.nirvana.ext.x_pagina_altura_acima_orcamento"` — one sample,
+not a rate, but the first correctly-prefixed, correctly-attributed site where
+there were zero before.
+
+Businesses got no new prompt bytes. `employee-prompt.ts` already carries the
+identical pattern at the point an employee records its mind-clone choice
+(`nrv audit emit x_clone_choice --business=<slug> ...`), and cut 1 measured
+zero rogue event names across 61 businesses — the block squads needed already
+existed there, so adding a second one would have been cost without benefit.
+The squad template was left untouched for the matching reason from the other
+side: every squad created from it declares `capabilities[]` by Creation Rule
+5, so it inherits the runtime-injected contract for free, and a literal
+example event stamped into the template risks becoming exactly the kind of
+unedited, never-emitted copy cut 1 found on disk elsewhere.
+
 ### A dispatched agent's hook events land next to the run that produced them
 
 The run-card cut reported this without fixing it: one run wrote to two audit

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -210,6 +210,48 @@ seus snapshots conforme a RFC 8785, que é a resposta padrão para o problema de
 determinismo de bytes que quebrou a paridade de schema deste repositório na mesma
 semana. Nenhuma das duas tinha um portão exigindo isso dele.
 
+### O vocabulário de eventos chega ao agente que nomeia o evento
+
+O corte 1 mediu a lacuna que este corte fecha: escanear 523 entidades achou
+sítios de emissão em 3 delas, contra 285 tipos vadios e 961 ocorrências no log.
+Quase nada do que chega ao log tem um literal em disco, porque um agente
+inventa o nome do evento no meio do run, não enquanto o squad está sendo
+autorado — documentação lida uma vez, na criação, nunca alcança esse momento.
+
+`buildSquadPrompt` (`squad-exec.ts`) agora injeta um bloco "COMO REPORTAR
+EVENTOS" sempre que um despacho resolve uma capability declarada: emita por
+`nrv audit emit <nome> --squad=<slug> --trace=<trace>`, prefixe um nome fora
+da lista com `x_` para que o log combine com o que foi digitado, e mantenha o
+payload num resumo curto, nunca um brief inteiro, um output completo ou um
+segredo. O bloco anda no mesmo portão do resto da seção de capability: um
+squad sem capability resolvida, o fallback legado `squad.execute`, mantém o
+prompt histórico byte a byte, o que `squad-exec.test.ts` já fixava antes deste
+corte e continua fixando depois dele. `capabilities[]` é obrigatório para um
+squad ser descoberto desde a v5, então todo squad nesse caminho já carrega o
+contrato; só o fallback legado pré-v5 não carrega, e migrá-lo é trabalho do
+corte 4, não deste.
+
+Medido num squad real (`adaptive-tutor-k12`, capability
+`education.tutoring.adaptive_cycle`): o prompt cresceu de 36.652 para 37.225
+bytes, 573 para o bloco inteiro incluindo seu exemplo trabalhado. Rodar o
+comando exato que o bloco manda o agente rodar,
+`nrv audit emit x_pagina_altura_acima_orcamento --squad=demo-squad --trace=... --json='{...}'`,
+produz `source: "/squad/demo-squad"` e
+`type: "sh.squads.nirvana.ext.x_pagina_altura_acima_orcamento"` — uma amostra,
+não uma taxa, mas o primeiro sítio corretamente prefixado e atribuído onde
+antes havia zero.
+
+Empresas não ganharam nenhum byte novo de prompt. `employee-prompt.ts` já
+carrega o mesmo padrão no ponto em que um funcionário registra sua escolha de
+mind-clone (`nrv audit emit x_clone_choice --business=<slug> ...`), e o corte
+1 mediu zero nomes de evento vadios em 61 empresas — o bloco que os squads
+precisavam já existia ali, então adicionar um segundo seria custo sem
+benefício. O template de squad ficou intocado pela razão simétrica: todo
+squad criado a partir dele declara `capabilities[]` pela Regra de Criação 5,
+então herda o contrato injetado em runtime de graça, e um evento de exemplo
+estampado literalmente no template arrisca virar exatamente o tipo de cópia
+nunca editada e nunca emitida que o corte 1 achou espalhada em disco.
+
 ### Os eventos de hook de um agente despachado passam a cair ao lado do run que os produziu
 
 O corte do run-card relatou isso sem consertar: um run escrevia em duas raízes

--- a/skills/businesses/SKILL.md
+++ b/skills/businesses/SKILL.md
@@ -64,6 +64,8 @@ When an employee is spawned via subagent (using `buildEmployeePrompt()` from `li
 
 These rules turn employees from "general-purpose subagents with persona text" into real Nirvana-OS citizens with auditable, resumable state.
 
+**Event vocabulary.** `buildEmployeePrompt()` already shows the working example (`nrv audit emit x_clone_choice --business=<slug> --trace=<trace> --json='{...}'`) at the point an employee records its mind-clone choice — measured at zero rogue event names across 61 businesses (event-contract cut, 2026-08-28), so no separate block was added here the way squads got one. Same rule as squads: an event outside the closed enum (`references/03-audit.md` in the harness skill) gets the explicit `x_` prefix at the call site, never a bare invented name.
+
 ---
 
 ## First invocation (auto-bootstrap)

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -294,6 +294,25 @@ export function capabilityContext(squadDir: string, capabilityId: string): Squad
 
 const EM_DASH_CELL = "—";
 
+/**
+ * The event vocabulary a dispatched squad needs at the moment it writes an
+ * event: the CLI, the attribution flag, and the `x_` escape hatch. Inlined
+ * instead of a pointer to `references/03-audit.md` — that path is inside the
+ * engine skill tree, and a squad's `addDirs` never guarantees it is readable;
+ * the whole premise of this cut (Cut 1, #157) is that a doc read once at
+ * authoring time does not reach the agent naming an event mid-run.
+ *
+ * Mirrors the pattern `employee-prompt.ts` already ships for businesses
+ * (`nrv audit emit x_clone_choice --business=<slug> --trace=<trace> --json=...`),
+ * which Cut 1 measured at zero rogue events — the working precedent, not a
+ * new invention.
+ */
+function renderEventContractBlock(squadSlug: string, traceId?: string): string {
+  const trace = traceId || "<trace_id>";
+  return `## COMO REPORTAR EVENTOS
+Emita marcos do seu trabalho com \`nrv audit emit <nome> --squad=${squadSlug} --trace=${trace}\`. Sempre passe \`--squad=${squadSlug}\`: é o que atribui o evento a você no cockpit. O nome não precisa estar na lista fechada do motor — se não estiver, escreva-o já com o prefixo \`x_\` (ex.: \`x_pagina_altura_acima_orcamento\`), assim o nome que chega ao log é o mesmo que você digitou. Payload vai em \`--json='{...}'\`, curto: nunca o brief inteiro, um output completo ou um segredo, só o resumo que o evento precisa carregar.`;
+}
+
 /** The capability block, plus the workflow block when the graph resolved. */
 function renderCapabilityBlock(ctx: SquadCapabilityPromptContext): string {
   const lines = ["## SUA CAPABILITY", `- **id**: \`${ctx.capabilityId}\``];
@@ -340,6 +359,9 @@ export function buildSquadPrompt(args: {
   /** The capability this dispatch runs (capability-resolver.ts). Absent, or the
    *  legacy `squad.execute`, keeps the historical prompt. */
   capabilityId?: string | null;
+  /** The run's trace_id, shown in the event-contract block's example command.
+   *  Absent falls back to a `<trace_id>` placeholder — never omits the block. */
+  traceId?: string;
 }): string {
   const { squadSlug, squadDir, brief, outDir, mode, cloneInjection: cloneInj } = args;
   const readIfExists = (p: string) => fs.existsSync(p) ? fs.readFileSync(p, "utf8") : "";
@@ -354,8 +376,14 @@ export function buildSquadPrompt(args: {
   const tasksBlock = collect(tasksDir, 3) || "(no tasks/ dir)";
 
   // The capability sections, or "" — the whole compatibility surface of this cut.
+  // The event-contract block rides the same gate: a squad without a resolved
+  // capability (legacy, undeclared) keeps the historical prompt byte for byte —
+  // squad-exec.test.ts pins that path. Every squad with `capabilities[]`
+  // declared (mandatory since Creation Rule 5) gets the contract for free.
   const capability = args.capabilityId ? capabilityContext(squadDir, args.capabilityId) : null;
-  const capabilitySection = capability ? `${renderCapabilityBlock(capability)}\n\n` : "";
+  const capabilitySection = capability
+    ? `${renderCapabilityBlock(capability)}\n\n${renderEventContractBlock(squadSlug, args.traceId)}\n\n`
+    : "";
   const componentsHeading = capability?.components ? "" : " (top 3)";
   const agentsSection = capability?.components?.agents ?? agentsBlock;
   const tasksSection = capability?.components?.tasks ?? tasksBlock;
@@ -431,6 +459,7 @@ export function runSquadHeadless(args: SquadExecArgs): SquadExecResult {
   const prompt = buildSquadPrompt({
     squadSlug: args.squadSlug, squadDir, brief: args.brief, outDir,
     mode: args.mode, cloneInjection: cloneInj, capabilityId: args.capabilityId,
+    traceId: args.projectId,
   });
 
   appendAudit({

--- a/skills/harness/tests/squad-exec.test.ts
+++ b/skills/harness/tests/squad-exec.test.ts
@@ -228,6 +228,50 @@ describe("promptPath — the workflow reference reads the same on every platform
   });
 });
 
+describe("buildSquadPrompt — the event-contract block (event-contract cut)", () => {
+  // Cut 1 (#157) measured the gap this closes: 286 rogue event types across
+  // 964 occurrences, and zero correctly `x_`-prefixed sites in the library —
+  // because nothing the dispatched agent reads told it the vocabulary exists.
+  test("a prompt built for a squad with a resolved capability contains the contract", () => {
+    const squadDir = scaffoldCapabilitySquad(path.join(tmp, "squads"));
+    const p = buildSquadPrompt({
+      squadSlug: "guided", squadDir, brief: "analise a conta", outDir: "/out/dir",
+      mode: "squad-only", cloneInjection: { block: "", decision: "PADRÃO" },
+      capabilityId: "analysis.report.produce", traceId: "01HZ-trace-x",
+    });
+    expect(p).toContain("## COMO REPORTAR EVENTOS");
+    expect(p).toContain("nrv audit emit");
+    expect(p).toContain("--squad=guided");
+    expect(p).toContain("--trace=01HZ-trace-x");
+    expect(p).toContain("prefixo `x_`");
+    // No payload/secret guidance, stated explicitly rather than implied.
+    expect(p).toContain("nunca o brief inteiro, um output completo ou um segredo");
+    // Rides right after the capability block, before the agents/tasks sections.
+    expect(p.indexOf("## SUA CAPABILITY")).toBeLessThan(p.indexOf("## COMO REPORTAR EVENTOS"));
+    expect(p.indexOf("## COMO REPORTAR EVENTOS")).toBeLessThan(p.indexOf("## SEUS AGENTES"));
+  });
+
+  test("without a trace id, the example command falls back to a placeholder instead of dropping the block", () => {
+    const squadDir = scaffoldCapabilitySquad(path.join(tmp, "squads"));
+    const p = buildSquadPrompt({
+      squadSlug: "guided", squadDir, brief: "b", outDir: "/o",
+      mode: "squad-only", cloneInjection: { block: "", decision: "PADRÃO" },
+      capabilityId: "analysis.report.produce",
+    });
+    expect(p).toContain("## COMO REPORTAR EVENTOS");
+    expect(p).toContain("--trace=<trace_id>");
+  });
+
+  test("a squad with no resolved capability gets no contract block — the historical prompt is untouched", () => {
+    const squadDir = scaffoldSquad(path.join(tmp, "squads"), "brandcraft");
+    const p = buildSquadPrompt({
+      squadSlug: "brandcraft", squadDir, brief: "the brief", outDir: "/out/dir",
+      mode: "squad-only", cloneInjection: { block: "", decision: "PADRÃO" },
+    });
+    expect(p).not.toContain("## COMO REPORTAR EVENTOS");
+  });
+});
+
 describe("buildSquadPrompt — with a resolved capability", () => {
   test("the capability, its workflow and only the referenced components reach the prompt", () => {
     const squadDir = scaffoldCapabilitySquad(path.join(tmp, "squads"));

--- a/skills/squads/SKILL.md
+++ b/skills/squads/SKILL.md
@@ -290,6 +290,7 @@ When creating a NEW squad, ALWAYS:
     bun ~/.nirvana/skills/_shared/scripts/self-retrieval-gate.ts <squad-slug>
     ```
     Every declared `example_brief` must route back to this squad top-1 (exit 0). On a miss, the defect is in the capability metadata — never "the router"; iterate keywords / example_briefs / not_for per the contract and rerun. Also confirm neighboring squads' home briefs still route to their owners. **Do not report the squad as created while this gate is red.**
+16. **Event vocabulary — nothing to add by hand.** Declaring `capabilities[]` (rule 5) is what makes a dispatch carry the event contract: `squad-exec.ts` injects a "COMO REPORTAR EVENTOS" block into the prompt of any squad whose capability resolves, telling the agent to emit via `nrv audit emit <nome> --squad=<slug> --trace=<trace>`, to prefix an unlisted name with `x_` so the log matches what it wrote, and to keep payloads short (no brief, no full output, no secret). The closed enum and the CloudEvents envelope are `references/03-audit.md`; the `x_` namespace stays open by design — the gate is on shape, never on what an event reports.
 
 ## Agent Template (v5)
 


### PR DESCRIPTION
Cut 3 of `.nirvana/plans/event-contract.md` — rewritten from what the plan said, after cut 1 measured why the plan was wrong.

## The plan said documentation. The measurement says otherwise

The plan wrote this cut as "a section in the squads and businesses `SKILL.md`". Cut 1 (#157) then measured:

| | |
|---|---|
| rogue event types reaching the log | **286** across 964 occurrences |
| entities with an emission site on disk | **3** |
| correctly `x_`-prefixed sites, anywhere | **0** |

**The gap between 286 and 3 is the finding.** Almost nothing that reaches the log is written in a file. Agents invent event names mid-run, and documentation read once while authoring a squad never reaches the agent naming an event inside a run.

So the rule goes where the agent reads it: `buildSquadPrompt` in `squad-exec.ts` renders an event-contract block — emit through `nrv audit emit` with the squad slug and trace, prefix an unlisted name with `x_`, keep the payload to a short summary, never a brief, output or secret.

## Placement was forced, not chosen

`squad-exec.test.ts` pins the prompt **byte-for-byte** when no capability resolves, and all four variants — `undefined`, `null`, `"squad.execute"`, an unknown id — collapse to `capability === null`. Any unconditional addition breaks that pin.

Gating on capability resolution is the only placement that both adds the contract and leaves the pin green. Not a narrow carve-out: `capabilities[]` has been mandatory since protocol v5, so every squad built since then resolves one.

## Businesses deliberately get no block

Cut 1 measured **zero** findings across 61 businesses — they already emit canonical events. `employee-prompt.ts` is unchanged, and `skills/businesses/SKILL.md` records *why*, so the next author does not read the omission as an oversight.

## Verification

`bun test skills` — 2300 tests, **0 fail**, including the untouched byte-identical pin. `bun run check:all` — **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)