### PR TITLE
feat(glance): authentication, tenancy and retention for the served cockpit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,56 @@ outside the rule, reproduces exactly against both the 96-entry and the
 real log. `bun test skills` — 2307 pass, 3 skip, 0 fail. `bun run check:all` —
 exit 0.
 
+### The served cockpit gets a lock, and the engine learns whose data it is holding
+
+Cut 6 of `.nirvana/plans/event-contract.md`. The Glance cockpit's `server.ts`
+had zero occurrences of `authorization`, `bearer`, `api_key` or `authenticate`
+across 2,253 lines; the entire security model was the loopback bind. Right for
+a laptop, wrong for what the plan describes next: `nrv glance --host` on a
+VPS, holding a law-practice app's case for hours.
+
+**Boundary.** The bind host decides both authentication and tenancy, so there
+is one flag to remember, not two. Loopback (`127.0.0.1` / `localhost` / `::1`,
+still the default) is unchanged — no token, byte for byte the cockpit that
+shipped before this cut. Any other host refuses every request, API and static
+assets alike, before routing runs, until it carries a Bearer credential.
+
+**Credential.** Reused, not reinvented: `nrv serve keygen`'s existing key
+store (`lib/serve/auth.ts`, sha256-at-rest, timing-safe compare) now also
+gates a served Glance, through one additive field, `ApiKeyRecord.glance`. A
+key minted for the job API does not silently unlock the interactive cockpit —
+`nrv serve keygen --glance` opts in. Read versus write inside Glance stays the
+existing per-process `--read-only` flag, not a second per-key axis: Glance is
+one operator's own cockpit, not cut 7's multi-caller job API.
+
+**Tenant.** A served process is bound to exactly one project root, already
+true structurally for its control-plane and run-kernel databases. The one
+place that was not already true: `HARNESS_LOGS_DIR` / `MAESTRO_LOGS_DIR`,
+which `paths.js` resolves once at require time and never re-resolves from a
+later `process.env` write — the trap `tests/helpers/engine-log-dirs.ts`
+already named and worked around for tests. `overridePath()` (`bun-helpers.ts`)
+mutates that frozen object in place, the same technique, now exposed for a
+production caller: a served instance pins both the variable and the object to
+its own project on boot and restores both on close.
+
+**Retention.** `audit.project_retention_days` (default 365, the number
+`HarnessConfigSchema` already declared and never wired to anything) rotates a
+served instance's own project log at boot, through `audit.js`'s `rotate()` —
+also already declared, also never called by anything until now. The local
+case is not auto-rotated by this cut: a filing deadline is the served
+scenario's problem, and deleting a laptop's own history as a side effect of
+an unrelated change is the opposite of "the local default must not become
+hostile." The owner sets the real number for their LGPD obligation with
+`nrv config set audit.project_retention_days <n> --scope project`.
+
+**Verified.** A new test, `glance-auth-tenancy.test.ts`, pins an
+unauthenticated served request refused (401) and the same request served
+(200) with a `--glance` key — watched failing before the boundary existed.
+Local startup measured before and after (`--no-open --port 0`, three runs
+each): ~60ms baseline, ~64-71ms after, inside run-to-run noise — no new code
+runs on the loopback path. `bun test skills/harness` — 1518 pass, 2 skip, 0
+fail. `bun test skills/_shared/tests` — 615 pass, 1 skip, 0 fail.
+
 ## 0.12.0 — 2026-08-28
 
 ### A generated schema stops depending on the machine that generated it

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -86,6 +86,60 @@ exatamente tanto contra o enum de 96 entradas quanto contra o de 91, porque
 nenhum dos cinco nomes removidos jamais apareceu no log real. `bun test skills`
 — 2307 passam, 3 pulados, 0 falhas. `bun run check:all` — saída 0.
 
+### O cockpit servido ganha uma trava, e o engine aprende de quem são os dados que está guardando
+
+Corte 6 de `.nirvana/plans/event-contract.md`. O `server.ts` do cockpit Glance
+tinha zero ocorrências de `authorization`, `bearer`, `api_key` ou `authenticate`
+em 2.253 linhas; todo o modelo de segurança era o bind em loopback. Certo para
+um laptop, errado para o que o plano descreve a seguir: `nrv glance --host`
+numa VPS, segurando o caso de um app de escritório de advocacia por horas.
+
+**Fronteira.** O host do bind decide autenticação e tenancy ao mesmo tempo,
+então existe uma flag para lembrar, não duas. Loopback (`127.0.0.1` /
+`localhost` / `::1`, ainda o padrão) fica inalterado — sem token, byte a byte
+o mesmo cockpit que existia antes deste corte. Qualquer outro host recusa toda
+requisição, API e arquivos estáticos igualmente, antes de qualquer
+roteamento, até carregar uma credencial Bearer.
+
+**Credencial.** Reaproveitada, não reinventada: o armazém de chaves que
+`nrv serve keygen` já tinha (`lib/serve/auth.ts`, sha256 em repouso,
+comparação em tempo constante) agora também trava um Glance servido, por um
+campo aditivo, `ApiKeyRecord.glance`. Uma chave gerada para a API de jobs não
+libera silenciosamente o cockpit interativo — `nrv serve keygen --glance` é
+opt-in explícito. Leitura versus escrita dentro do Glance continua a flag
+`--read-only` por processo já existente, não um segundo eixo por chave: o
+Glance é o cockpit de um único operador, não a API multi-chamador do corte 7.
+
+**Tenant.** Um processo servido fica preso a exatamente um projeto, já
+verdade estruturalmente para seu control-plane e seu run-kernel. O único
+lugar onde isso ainda não era verdade: `HARNESS_LOGS_DIR` / `MAESTRO_LOGS_DIR`,
+que `paths.js` resolve uma vez, no require, e nunca mais reavalia a partir de
+uma escrita posterior em `process.env` — a armadilha que
+`tests/helpers/engine-log-dirs.ts` já nomeava e contornava para os testes.
+`overridePath()` (`bun-helpers.ts`) muta esse objeto congelado no lugar, a
+mesma técnica, agora exposta para um chamador de produção: uma instância
+servida prende a variável e o objeto ao seu próprio projeto na subida e
+restaura os dois ao fechar.
+
+**Retenção.** `audit.project_retention_days` (padrão 365, o número que o
+`HarnessConfigSchema` já declarava e nunca ligou a nada) gira o log do
+próprio projeto de uma instância servida na subida, através do `rotate()` de
+`audit.js` — também já declarado, também nunca chamado por nada até agora. O
+caso local não é auto-rotacionado por este corte: um prazo de protocolo é
+problema do cenário servido, e apagar o histórico do próprio laptop como
+efeito colateral de uma mudança sem relação é o oposto de "o padrão local não
+pode virar hostil". O dono define o número real para a sua obrigação de LGPD
+com `nrv config set audit.project_retention_days <n> --scope project`.
+
+**Verificado.** Um teste novo, `glance-auth-tenancy.test.ts`, prende uma
+requisição servida sem autenticação recusada (401) e a mesma requisição
+servida (200) com uma chave `--glance` — observado falhando antes de a
+fronteira existir. Startup local medido antes e depois (`--no-open --port 0`,
+três rodadas cada): ~60ms de base, ~64-71ms depois, dentro do ruído normal de
+execução — nenhum código novo roda no caminho de loopback. `bun test
+skills/harness` — 1518 passam, 2 pulados, 0 falhas. `bun test
+skills/_shared/tests` — 615 passam, 1 pulado, 0 falhas.
+
 ## 0.12.0 — 2026-08-28
 
 ### Um schema gerado para de depender da máquina que o gerou

--- a/skills/_shared/lib/bun-helpers.ts
+++ b/skills/_shared/lib/bun-helpers.ts
@@ -60,6 +60,19 @@ let _paths: Record<string, string> | null = null;
 /** Invalidate the cached paths object so the next access re-reads process.env.
  *  Used by Glance Settings panel after live-reloading .env vars. */
 export function invalidatePathsCache(): void { _paths = null; }
+/**
+ * Overrides one resolved path for the life of the process, or until restored with another call.
+ * paths.js exports a plain object resolved ONCE at require time (its own comment says so); a
+ * process.env write plus invalidatePathsCache() alone does NOT pick it up, because require()
+ * hands back that same frozen object out of the module cache on the next load — the trap
+ * skills/harness/tests/helpers/engine-log-dirs.ts documents and works around by mutating the
+ * cached object's properties directly, in place, rather than trying to force a re-resolution.
+ * This is that same technique, exposed for a production caller (a served Glance instance
+ * pinning its own tenant's log directory) instead of only a test fixture.
+ */
+export function overridePath(key: string, value: string): void {
+  loadPaths()[key] = value;
+}
 function loadPaths(): Record<string, string> {
   if (_paths) return _paths;
   for (const p of PATHS_JS_CANDIDATES) {

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -141,6 +141,53 @@ function removeTmpFiles(files: string[] | undefined): void {
   }
 }
 
+/** Every prefix writePromptFile is ever called with (default "nrv-prompt",
+ * plus claudeDirectiveArgs' "nrv-directive"). One place, so the reaper below
+ * can never drift from what this module actually creates. */
+const TMP_FILE_PREFIXES = ["nrv-prompt-", "nrv-directive-"];
+
+/**
+ * Process-wide safety net for the one gap a `finally`/`settle()` cannot close:
+ * a process killed by an external signal while blocked inside spawnSync never
+ * runs its own cleanup. Verified on this machine (Bun 2026-08-29): a
+ * `process.on('SIGTERM', ...)` handler does not help either — the callback is
+ * deferred until the blocking spawnSync call itself returns, so it cannot fire
+ * while the process is stuck waiting on a hung child, which is exactly the
+ * case the supervisor's kill exists for. SIGKILL cannot be caught at all, by
+ * either mechanism.
+ *
+ * This is why every adapter's own try/finally stays as-is (correct for normal
+ * exit, error, and spawnSync's own timeout-to-CHILD) and the file it cannot
+ * reach is instead swept by a SEPARATE, later-running process that never
+ * shares the killed process's fate. Call this from that other process (the
+ * supervisor sweep), never from the same run that might leak — a self-reap
+ * would need the very JS execution the leak scenario denies it.
+ *
+ * `maxAgeMs` defaults to 24h: comfortably longer than any lease-driven kill
+ * or retry cycle (minutes), so it can never race a legitimately slow but
+ * still-live run's file, while reliably reclaiming anything orphaned by a
+ * kill.
+ */
+export function reapOrphanedPromptFiles(opts: { dir?: string; maxAgeMs?: number } = {}): string[] {
+  const dir = opts.dir ?? os.tmpdir();
+  const maxAgeMs = opts.maxAgeMs ?? 24 * 60 * 60_000;
+  const now = Date.now();
+  const removed: string[] = [];
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return removed; }
+  for (const name of entries) {
+    if (!TMP_FILE_PREFIXES.some((p) => name.startsWith(p))) continue;
+    const full = path.join(dir, name);
+    try {
+      const st = fs.statSync(full);
+      if (!st.isFile() || now - st.mtimeMs < maxAgeMs) continue;
+      fs.rmSync(full, { force: true });
+      removed.push(full);
+    } catch { /* raced with its own creator/consumer — not our problem */ }
+  }
+  return removed;
+}
+
 /** The "where does this CLI live" probe, per platform. Windows `where` takes its options with a
  * slash (`WHERE [/R dir] [/Q] ... pattern...`), so the `-v` this used to pass was read as a SECOND
  * PATTERN, not a flag: the probe asked for a file named `-v` as well and answered about both. On
@@ -2137,6 +2184,7 @@ export const __testables = {
   argvOrPromptFile,
   promptFileBootstrap,
   envelopeErrorMessage,
+  TMP_FILE_PREFIXES,
 };
 
 if (import.meta.main) {

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -217,6 +217,16 @@ export const SETTINGS = {
     "Teto de gasto em USD de um turno do maestro no chat do Glance (claude --max-budget-usd); 0 = sem teto.",
     { default: 5, type: nonNegative, expects: "número >= 0 (USD); 0 = sem teto" }),
 
+  // Enforced today only by a served Glance instance (`glance --host` beyond loopback), against
+  // the log already pinned to the project (the tenant). The default (365) is the same number
+  // already declared, and never wired to anything, in
+  // HarnessConfigSchema.audit.project_retention_days — not a new policy. A legal document has a
+  // filing deadline and an LGPD obligation: the real value is the project owner's call, made
+  // via `nrv config set audit.project_retention_days <n> --scope project`.
+  "audit.project_retention_days": numberSetting("audit.project_retention_days",
+    "Dias de retenção do log de auditoria de um projeto servido antes da rotação apagar o diretório do dia; o valor certo para uma obrigação legal (ex.: LGPD) é decisão do dono, não um padrão do engine.",
+    { default: 365, type: z.number().int().positive(), expects: "inteiro > 0 (dias)" }),
+
   "runtime.provider_catalog_dir": stringSetting("runtime.provider_catalog_dir",
     "Diretórios de catálogo de providers (separados por : ou ; no Windows); vazio = ~/.nirvana/providers e <projeto>/.nirvana/providers.",
     { env: "NIRVANA_PROVIDER_CATALOG_DIR", expects: "lista de caminhos separados pelo delimitador do sistema, ou vazio" }),

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -38,7 +38,7 @@ import {
 import { startJob, getJob, listJobs, streamJob, cancelJob, isMutatingActive } from "./action-runner.ts";
 import { deriveAgentStates, summarizeStates } from "./agent-state.ts";
 import { readSubsystems } from "./subsystems.ts";
-import { paths, invalidatePathsCache } from "../../../_shared/lib/bun-helpers.ts";
+import { paths, invalidatePathsCache, overridePath } from "../../../_shared/lib/bun-helpers.ts";
 import { readEnvFile, writeEnvFile, setVar, deleteVar, getVar, toMap } from "../../../_shared/lib/env-file.ts";
 import { CONFIG_SCHEMA, getField, isEditableKey, maskSecret } from "./config-schema.ts";
 import {
@@ -52,6 +52,10 @@ import { handleObservabilityRoute } from "./views/observability-handler.ts";
 import { AgentXCanaryQueue, ConversationService, MaestroTurnQueue, ProjectService, resumeCommand, type Conversation, type GlanceAgentXCanaryAdapter, type GlanceExecutionRunner, type MessageRouter, type TurnView } from "../control-plane/index.ts";
 import { createRun as createKernelRun, getRun as getKernelRun, listEvents as listKernelEvents, openKernel } from "../run-kernel/index.ts";
 import { getGauntlet, listCandidateRevisions, listScorecards, projectMultiTargetRun } from "../gauntlet/index.ts";
+// The same Bearer-token store `nrv serve` already ships (sha256-at-rest, timing-safe compare,
+// `nrv serve keygen`/`keys`) — one credential system for both HTTP surfaces of the engine,
+// never a second one invented here for the cockpit.
+import { authenticate as authenticateApiKey } from "../serve/auth.ts";
 
 /**
  * A gate report in the shape the mind-clone validation routes have always
@@ -93,6 +97,11 @@ export interface ServerOptions {
   // The agentic router a Message without an explicit target goes through before its Run is
   // prepared (business, then squad, then agent-x); absent, such a Message stays on agent-x.
   messageRouter?: MessageRouter;
+  // Bind address. Default (or any loopback spelling) keeps today's local, unauthenticated
+  // cockpit. Anything else is a served instance: every request needs a Bearer credential
+  // (`nrv serve keygen --glance`) and the process becomes bound to one tenant — see
+  // `isLoopback` below.
+  host?: string;
 }
 
 // ─── Setup copy helper (used by /api/setup/copy-batch and /api/setup/copy-stream) ───
@@ -261,9 +270,18 @@ function findFreePort(start = 3737, attempts = 50): number {
   return Math.floor(Math.random() * (65535 - 49152)) + 49152;
 }
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
 export async function startServer(opts: ServerOptions) {
   const port = opts.port === "auto" || opts.port === 0 ? findFreePort() : opts.port;
-  const url = `http://localhost:${port}`;
+  const host = opts.host || "127.0.0.1";
+  // Loopback (the default) is the local, unauthenticated cockpit — unchanged from before this
+  // flag existed. Any other bind address is a *served* instance: the machine's local case must
+  // never become hostile, so the boundary that turns on authentication and tenant-scoped logs
+  // is exactly the boundary that already turns on network exposure, never a second flag to
+  // remember to set.
+  const isLoopback = LOOPBACK_HOSTS.has(host);
+  const url = `http://${isLoopback ? "localhost" : host}:${port}`;
   const projectRoot = path.resolve(process.env.NIRVANA_PROJECT_ROOT || process.cwd());
   const controlPlaneDb = path.join(projectRoot, ".nirvana", "control-plane.sqlite");
   const kernelDb = path.join(projectRoot, ".nirvana", "run-kernel.sqlite");
@@ -414,6 +432,49 @@ export async function startServer(opts: ServerOptions) {
   };
   const settingScope = (value: unknown): SettingScope | null => (value === "project" || value === "global" ? value : null);
 
+  // ─── Tenancy + retention (served instances only) ───────────────────────
+  // Tenant = the projectRoot this process is bound to (resolved once, above — already true
+  // structurally for controlPlaneDb/kernelDb). paths.js already project-scopes
+  // HARNESS_LOGS_DIR/MAESTRO_LOGS_DIR on its own WHEN a project root is present at the moment
+  // it first resolves (module load, before startServer runs) — but that resolution is a plain
+  // object computed ONCE at require time (paths.js's own comment says so) and never
+  // re-evaluated; a later process.env write plus invalidatePathsCache() does not reach it,
+  // because require() hands back the same frozen object out of the module cache (the trap
+  // skills/harness/tests/helpers/engine-log-dirs.ts documents and works around for tests).
+  // `overridePath()` is that same in-place-mutation technique, for a production caller: it pins
+  // this tenant's own project directory as the log root regardless of what was resolved before
+  // (covers the case where startServer's own projectRoot — process.env.NIRVANA_PROJECT_ROOT
+  // verbatim, no marker walk — disagrees with paths.js's cwd-walked one, e.g. launched from a
+  // project subdirectory). The env var is pinned too, for log-paths.ts/audit.js's readers,
+  // which DO re-check process.env on every call. Both restored on `close()` so a host starting
+  // several servers in one process never leaks one tenant's pin into the next.
+  const previousHarnessLogsDir = process.env.HARNESS_LOGS_DIR;
+  const previousMaestroLogsDir = process.env.MAESTRO_LOGS_DIR;
+  const previousPathsHarnessLogsDir = paths.HARNESS_LOGS_DIR;
+  const previousPathsMaestroLogsDir = paths.MAESTRO_LOGS_DIR;
+  if (!isLoopback) {
+    const tenantHarnessLogsDir = path.join(projectRoot, ".nirvana", "logs", "harness");
+    const tenantMaestroLogsDir = path.join(projectRoot, ".nirvana", "logs", "maestro");
+    process.env.HARNESS_LOGS_DIR = tenantHarnessLogsDir;
+    process.env.MAESTRO_LOGS_DIR = tenantMaestroLogsDir;
+    overridePath("HARNESS_LOGS_DIR", tenantHarnessLogsDir);
+    overridePath("MAESTRO_LOGS_DIR", tenantMaestroLogsDir);
+    // Retention: configurable (`audit.project_retention_days`, settings-schema.ts), default 365
+    // carried over from the declared-but-never-wired HarnessConfigSchema.audit default — not a
+    // new policy. Only the served case is auto-rotated here: deleting a laptop owner's own
+    // history as a side effect of an unrelated cut is exactly what "do not break the local
+    // case" warns against, and the brief's LGPD/filing-deadline scenario is about the served
+    // deployment. The owner sets the real value for their obligation via
+    // `nrv config set audit.project_retention_days <n> --scope project`; this default is a
+    // personal-use number, not a compliance recommendation.
+    try {
+      const days = resolveSetting("audit.project_retention_days", settingsResolveOptions()).value as number;
+      const { rotate } = createRequire(import.meta.url)("../audit.js");
+      const { deleted } = rotate(days);
+      if (deleted.length) settingsAudit("x_retention_rotated", { retention_days: days, deleted_count: deleted.length });
+    } catch (error) { console.error(`[glance] retention rotation skipped (${(error as Error).message})`); }
+  }
+
   // Write PID file (auto-cleanup on exit)
   try {
     fs.mkdirSync(path.dirname(PID_FILE), { recursive: true });
@@ -422,11 +483,27 @@ export async function startServer(opts: ServerOptions) {
 
   const server = Bun.serve({
     port,
-    // Bind to loopback only: the cockpit (with actions) stays restricted to this
-    // machine, never exposed to the LAN by default.
-    hostname: "127.0.0.1",
+    // Loopback by default: the cockpit (with actions) stays restricted to this machine, never
+    // exposed to the LAN unless `--host` says so explicitly (see `isLoopback` above).
+    hostname: host,
     async fetch(req) {
       bumpActivity();
+      // Authentication boundary = the bind host, not a separate flag: a served instance (any
+      // non-loopback host) refuses every request — API, static assets, SSE, everything — until
+      // it carries a valid credential. `authenticate()` is the exact function `nrv serve`'s job
+      // API already gates on; a key only clears this check when minted with `--glance`
+      // (`ApiKeyRecord.glance`, additive field in serve/auth.ts) — a job-API key does not
+      // silently become a cockpit key. Read vs. write inside Glance stays governed by the
+      // existing per-process `allowActions` (`--read-only`) flag, not per-key: Glance is one
+      // operator's own cockpit, not a multi-caller API, so a single access bit plus the
+      // existing process-level flag is enough; per-key read/write scoping is cut 7's problem,
+      // where many distinct external callers actually need different grants.
+      if (!isLoopback) {
+        const key = authenticateApiKey(req);
+        if (!key || !key.glance) {
+          return problem(401, "Unauthorized", "this Glance instance is bound beyond localhost; Authorization: Bearer <token from `nrv serve keygen --glance`> is required");
+        }
+      }
       const u = new URL(req.url);
       const p = u.pathname;
 
@@ -1955,7 +2032,11 @@ export async function startServer(opts: ServerOptions) {
 
   console.error(`[glance] up on ${url}  (scope=${getScope().mode}, allow_actions=${opts.allowActions}, theme=${opts.theme})`);
   console.error(`[glance] auto-shutdown after ${opts.idleMin}min idle  ·  Ctrl+C to exit`);
-  if (opts.open) openBrowser(url);
+  if (!isLoopback) console.error(`[glance] served on ${host} — authentication required (Authorization: Bearer <token from \`nrv serve keygen --glance\`>); tenant = ${projectRoot}`);
+  // A served instance is a VPS process with no display attached to it, most of the time; even
+  // when one exists, opening a browser aimed at a bare non-TLS network address is not this
+  // cut's call to make. Loopback keeps today's behavior unchanged.
+  if (opts.open && isLoopback) openBrowser(url);
 
   // Detaches the queue from its children (tests stop servers without exiting the process;
   // shutdown() runs it before the server stops, so a child still running is left to the next
@@ -1990,6 +2071,12 @@ export async function startServer(opts: ServerOptions) {
     try { kernel?.close(); } catch {}
     try { conversations?.close(); } catch {}
     kernel = null; conversations = null;
+    if (!isLoopback) {
+      if (previousHarnessLogsDir === undefined) delete process.env.HARNESS_LOGS_DIR; else process.env.HARNESS_LOGS_DIR = previousHarnessLogsDir;
+      if (previousMaestroLogsDir === undefined) delete process.env.MAESTRO_LOGS_DIR; else process.env.MAESTRO_LOGS_DIR = previousMaestroLogsDir;
+      overridePath("HARNESS_LOGS_DIR", previousPathsHarnessLogsDir);
+      overridePath("MAESTRO_LOGS_DIR", previousPathsMaestroLogsDir);
+    }
   };
 
   return { server, url, port, recovery, detach, close };

--- a/skills/harness/lib/glance/views/settings-panel.js
+++ b/skills/harness/lib/glance/views/settings-panel.js
@@ -19,6 +19,7 @@ export const GROUP_LABELS = Object.freeze({
   multi_target: 'Multi-target', gauntlet: 'Gauntlet', execution: 'Execução', glance: 'Glance', runtime: 'Runtime',
   routing: 'Roteamento', supervisor: 'Supervisor', updates: 'Atualizações', budget: 'Orçamento',
   baselines: 'Baselines de custo', quality_gate: 'Quality gate', delivery: 'Entrega', verify: 'Portão de admissão',
+  audit: 'Auditoria',
 });
 
 export const SOURCE_LABELS = Object.freeze({

--- a/skills/harness/lib/host-agent-driver.ts
+++ b/skills/harness/lib/host-agent-driver.ts
@@ -20,6 +20,7 @@ export {
   LEDGER_DEFAULT_TIMEOUT_MS,
   DEFAULT_ALLOWED_TOOLS,
   MAX_ARGV_PROMPT_BYTES,
+  reapOrphanedPromptFiles,
 } from "../../_shared/lib/host-agent-driver.ts";
 export type {
   Runtime,

--- a/skills/harness/lib/serve/auth.ts
+++ b/skills/harness/lib/serve/auth.ts
@@ -24,6 +24,10 @@ export interface ApiKeyRecord {
   daily_runs?: number;
   /** Webhook registered for this key (terminal-state callback). */
   webhook?: { url: string; secret: string };
+  /** Grants access to the Glance cockpit (`nrv glance --host`), separate from the job API this
+   *  file otherwise governs — off by default, so a key minted for job submission does not
+   *  silently also unlock the interactive cockpit (chat, settings, setup actions). */
+  glance?: boolean;
 }
 
 interface KeysFile { keys: ApiKeyRecord[]; usage: Record<string, { day: string; runs: number }> }
@@ -46,7 +50,7 @@ function save(f: KeysFile): void {
 const sha256 = (s: string) => createHash("sha256").update(s).digest("hex");
 
 /** Generates a key, stores its hash, RETURNS THE TOKEN ONCE. */
-export function keygen(opts: { label?: string; budgetUsd?: number; dailyRuns?: number } = {}): { token: string; record: ApiKeyRecord } {
+export function keygen(opts: { label?: string; budgetUsd?: number; dailyRuns?: number; glance?: boolean } = {}): { token: string; record: ApiKeyRecord } {
   const token = "nrv_" + randomBytes(24).toString("base64url");
   const record: ApiKeyRecord = {
     id: "key_" + randomBytes(6).toString("hex"),
@@ -55,6 +59,7 @@ export function keygen(opts: { label?: string; budgetUsd?: number; dailyRuns?: n
     created_at: new Date().toISOString(),
     ...(opts.budgetUsd ? { budget_usd: opts.budgetUsd } : {}),
     ...(opts.dailyRuns ? { daily_runs: opts.dailyRuns } : {}),
+    ...(opts.glance ? { glance: true } : {}),
   };
   const f = load();
   f.keys.push(record);

--- a/skills/harness/scripts/glance.ts
+++ b/skills/harness/scripts/glance.ts
@@ -9,6 +9,9 @@
  *   bun glance.ts --idle-min 60            # 60min idle timeout (default 30)
  *   bun glance.ts --theme awwwards         # awwwards-style hero
  *   bun glance.ts --allow-actions          # enables write endpoints (Phase 5)
+ *   bun glance.ts --host 0.0.0.0           # served instance: requires a Bearer credential
+ *                                          # (nrv serve keygen --glance) and pins this
+ *                                          # process's logs to its own project (tenancy)
  */
 
 import { parseArgs } from "../../_shared/lib/bun-helpers.ts";
@@ -16,6 +19,7 @@ import { describeSettingSource, resolveSetting } from "../../_shared/lib/setting
 import { createDispatchExecutionRunner, detectExecutionRuntime } from "../lib/control-plane/execution-runner.ts";
 import { createAgenticMessageRouter } from "../lib/control-plane/message-router.ts";
 import { startServer } from "../lib/glance/server.ts";
+import { listKeys } from "../lib/serve/auth.ts";
 
 const { flags } = parseArgs();
 
@@ -29,6 +33,7 @@ USAGE
   glance --no-open                    don't auto-open the browser
   glance --idle-min 60                idle timeout in minutes (default 30)
   glance --theme apple|apple-dark|awwwards    visual theme (default apple)
+  glance --host 0.0.0.0               served instance — see SERVED below
   glance -h | --help                  this message
 
 WRITE ACTIONS (ON by default)
@@ -37,6 +42,16 @@ WRITE ACTIONS (ON by default)
   the actions menu (index, audit-batch, run-smoke, …). The server binds to
   127.0.0.1 only, so it stays private to this machine.
   Use --read-only for a safe, look-but-don't-touch session.
+
+SERVED (--host beyond loopback)
+  Every request needs Authorization: Bearer <token>, minted with
+  \`nrv serve keygen --glance\` (a key without --glance does not unlock the
+  cockpit, even if it is valid for the job API). This process's audit/run
+  logs are pinned to its own project for the life of the process — one
+  served process is one tenant. Retention of that project's log is
+  \`nrv config set audit.project_retention_days <n> --scope project\`
+  (default 365; the value that fits a legal/LGPD obligation is your call).
+  The engine ships no TLS: put a reverse proxy in front for a public host.
 
 EXECUTION
   A Message in an adopted project runs in a child dispatch process (the server
@@ -57,6 +72,13 @@ The cockpit auto-detects the project root from \$cwd (walks up looking for
 const port = flags.port ? Number(flags.port) : "auto";
 const open = !flags["no-open"];
 const idleMin = flags["idle-min"] ? Number(flags["idle-min"]) : 30;
+const host = (flags.host as string) || "127.0.0.1";
+if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") {
+  const glanceKeys = listKeys().filter((k) => k.glance && !k.revoked).length;
+  if (glanceKeys === 0) {
+    console.error(`[glance] WARNING: bound to ${host} with zero --glance keys — every request will be refused until you run \`nrv serve keygen --glance\`.`);
+  }
+}
 // Glance is the Nirvana-OS control cockpit: write actions (setup, saving .env,
 // chat, running actions) come ENABLED by default. The server binds only to
 // 127.0.0.1, so it stays restricted to this machine. --read-only returns to
@@ -83,4 +105,4 @@ if (executionEnabled) {
   console.error(`[glance] execution OFF (${allowActions ? `glance.execution=false via ${describeSettingSource(execution)}` : "--read-only"})`);
 }
 
-await startServer({ port, open, idleMin, allowActions, theme, executionRunner, messageRouter });
+await startServer({ port, open, idleMin, allowActions, theme, executionRunner, messageRouter, host });

--- a/skills/harness/scripts/serve.ts
+++ b/skills/harness/scripts/serve.ts
@@ -9,8 +9,11 @@
  * Usage:
  *   nrv serve [start] [--port 7777] [--host 127.0.0.1] [--max-concurrent 2]
  *             [--cors https://app.example.com]
- *   nrv serve keygen [--label name] [--budget-usd 5] [--daily-runs 50]
+ *   nrv serve keygen [--label name] [--budget-usd 5] [--daily-runs 50] [--glance]
  *   nrv serve keys [list|revoke <key_id>]
+ *
+ * `--glance` also authenticates a served `nrv glance --host` cockpit with this key — off by
+ * default, so a key minted for job submission does not silently unlock the interactive cockpit.
  */
 import { startServer } from "../lib/serve/server.ts";
 import { keygen, listKeys, revokeKey, serveDir } from "../lib/serve/auth.ts";
@@ -27,11 +30,13 @@ if (sub === "keygen") {
     label: flag("label", "default"),
     budgetUsd: flag("budget-usd") ? parseFloat(flag("budget-usd")!) : undefined,
     dailyRuns: flag("daily-runs") ? parseInt(flag("daily-runs")!, 10) : undefined,
+    glance: argv.includes("--glance"),
   });
   console.log(`\n  key id:  ${record.id}`);
   console.log(`  label:   ${record.label}`);
   if (record.budget_usd) console.log(`  budget:  US$ ${record.budget_usd} per run`);
   if (record.daily_runs) console.log(`  quota:   ${record.daily_runs} runs/day`);
+  if (record.glance) console.log(`  glance:  yes — this key also authenticates a served \`nrv glance --host\` cockpit`);
   console.log(`\n  TOKEN (shown once — store it now):\n\n    ${token}\n`);
   console.log(`  Use it as: Authorization: Bearer ${token.slice(0, 12)}…\n`);
   process.exit(0);
@@ -48,7 +53,7 @@ if (sub === "keys") {
   const keys = listKeys();
   if (!keys.length) console.log("no keys yet — create one with: nrv serve keygen");
   for (const k of keys) {
-    console.log(`  ${k.id}  ${k.label}${k.revoked ? "  (revoked)" : ""}${k.budget_usd ? `  budget $${k.budget_usd}` : ""}${k.daily_runs ? `  ${k.daily_runs}/day` : ""}`);
+    console.log(`  ${k.id}  ${k.label}${k.revoked ? "  (revoked)" : ""}${k.budget_usd ? `  budget $${k.budget_usd}` : ""}${k.daily_runs ? `  ${k.daily_runs}/day` : ""}${k.glance ? "  glance" : ""}`);
   }
   process.exit(0);
 }

--- a/skills/harness/scripts/supervisor.ts
+++ b/skills/harness/scripts/supervisor.ts
@@ -122,7 +122,7 @@ const SALVAGE_CEILING_REASON =
 function lazyCascade(): { runWithCascade: (args: any) => any } {
   return requireCjs("../lib/cascade-runner.ts");
 }
-function lazyDriver(): { AUTONOMOUS_DIRECTIVE: string } {
+function lazyDriver(): { AUTONOMOUS_DIRECTIVE: string; reapOrphanedPromptFiles: (opts?: { dir?: string; maxAgeMs?: number }) => string[] } {
   return requireCjs("../lib/host-agent-driver.ts");
 }
 function lazyDelivery(): typeof import("../lib/delivery-pipeline.ts") {
@@ -716,6 +716,18 @@ function sweepLocked(deps: SweepDeps, summary: SweepSummary): SweepSummary {
       summary.errors++;
       console.error(`[supervisor] sweep of ${row.run_id} failed: ${(e as Error)?.message ?? e}`);
     }
+  }
+  // Process-wide cleanup for prompt/directive temp files a killed dispatch
+  // process never got to remove itself (see reapOrphanedPromptFiles): a
+  // process.on('SIGTERM') handler cannot preempt a blocking spawnSync, so the
+  // creator's own finally is structurally unable to run when the supervisor's
+  // kill above lands mid-call. This sweeper is a different, later-running
+  // process, so it reaps what that one could not.
+  try {
+    const reaped = lazyDriver().reapOrphanedPromptFiles();
+    if (reaped.length) emitAudit("x_ledger_tmp_reaped", { count: reaped.length, files: reaped });
+  } catch (e) {
+    console.error(`[supervisor] tmp-file reap failed: ${(e as Error)?.message ?? e}`);
   }
   try { setSupervisorMeta(h, "last_sweep_at", String(Date.now())); } catch { /* bookkeeping only */ }
   return summary;

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -21,11 +21,13 @@ import {
   callHostAgent,
   callHostAgentAsync,
   MAX_ARGV_PROMPT_BYTES,
+  reapOrphanedPromptFiles,
   __testables,
   type Runtime,
 } from "../../_shared/lib/host-agent-driver.ts";
 import { writeFakeCli, readCapturedArgs, CAPTURE_PRELUDE } from "./helpers/fake-cli.ts";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-driver-adapters-test-"));
 const BIN = path.join(TMP, "bin");
@@ -275,12 +277,44 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
   }, spawnBudgetMs(2));
 
   test("temp prompt files are cleaned up after the run", () => {
+    // Scoped to what THIS test creates: os.tmpdir() is shared with every other
+    // process on the machine, so asserting on its full listing turns any
+    // foreign nrv-prompt-* leftover (a dead session, another dispatch) into a
+    // failure of this run. Snapshot before, diff after.
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith("nrv-prompt-")));
     run("antigravity-cli");
     run("grok-cli");
     run("pi");
-    const leftovers = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith("nrv-prompt-"));
-    expect(leftovers).toEqual([]);
+    const after = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith("nrv-prompt-"));
+    const leftoversFromThisRun = after.filter((f) => !before.has(f));
+    expect(leftoversFromThisRun).toEqual([]);
   }, spawnBudgetMs(3));
+
+  test("reapOrphanedPromptFiles: process-wide cleanup for what a killed process's own finally could never reach", () => {
+    // Its own scoped directory, not os.tmpdir() — the reaper is a machine-wide
+    // sweep by design (see host-agent-driver.ts), so it must be pointed at a
+    // private root here or it would also judge every real leftover on this box.
+    const scratch = makeTempRoot("nrv-reap-test-");
+    try {
+      const stale = path.join(scratch, "nrv-prompt-old-123.md");
+      const fresh = path.join(scratch, "nrv-prompt-fresh-456.md");
+      const unrelated = path.join(scratch, "not-ours-789.md");
+      fs.writeFileSync(stale, "stale");
+      fs.writeFileSync(fresh, "fresh");
+      fs.writeFileSync(unrelated, "unrelated");
+      const old = new Date(Date.now() - 25 * 60 * 60_000); // 25h ago > the 24h default
+      fs.utimesSync(stale, old, old);
+
+      const removed = reapOrphanedPromptFiles({ dir: scratch });
+
+      expect(removed).toEqual([stale]);
+      expect(fs.existsSync(stale)).toBe(false);
+      expect(fs.existsSync(fresh)).toBe(true);      // too young — still a live run's file, by all evidence available
+      expect(fs.existsSync(unrelated)).toBe(true);  // wrong prefix — not this driver's file at all
+    } finally {
+      removeDir(scratch);
+    }
+  }, spawnBudgetMs(1));
 });
 
 describe("driver adapters — failure contract (error envelope on exit 0 → ok:false)", () => {

--- a/skills/harness/tests/glance-auth-tenancy.test.ts
+++ b/skills/harness/tests/glance-auth-tenancy.test.ts
@@ -1,0 +1,159 @@
+// glance-auth-tenancy.test.ts — cut 6 of the event-contract plan
+// (.nirvana/plans/event-contract.md): authentication, tenancy and retention
+// for a served Glance cockpit (`nrv glance --host`).
+//
+// What this defends: the loopback default stays exactly as unauthenticated as
+// before this cut (the local case must never become hostile); a served
+// instance (any non-loopback --host) refuses every request without a Bearer
+// credential minted with `nrv serve keygen --glance`, and a plain job-API key
+// (minted without --glance) does not silently unlock the cockpit; a served
+// instance reads and writes its own project's logs, not the machine-global
+// default, so two tenants' processes on the same host never see each other's
+// runs; that pin is undone on close so a test process starting several
+// servers never leaks one instance's tenant into the next; and retention
+// (`audit.project_retention_days`, configurable, default 365) is enforced
+// only for the served case — the local case is never auto-rotated by this cut.
+//
+// Hermetic: a temp NIRVANA_HOME, a temp project, a temp serve keys directory.
+// No LLM, no network beyond loopback. Runs with: bun test skills/harness/tests
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { SETTINGS_SCHEMA } from "../../_shared/lib/settings.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+
+const SCHEMA_VARIABLES = SETTINGS_SCHEMA.flatMap((spec) => [spec.env, ...(spec.envAliases ?? [])]).filter((name): name is string => !!name);
+const SCRUBBED = [...SCHEMA_VARIABLES, "NIRVANA_PROJECT_ROOT", "NIRVANA_HOME", "HARNESS_LOGS_DIR", "MAESTRO_LOGS_DIR", "NIRVANA_SERVE_DIR"];
+const saved = new Map<string, string | undefined>();
+beforeAll(() => { for (const name of SCRUBBED) { saved.set(name, process.env[name]); delete process.env[name]; } });
+afterAll(() => { for (const [name, value] of saved) { if (value === undefined) delete process.env[name]; else process.env[name] = value; } });
+
+const roots: string[] = [];
+const servers: Array<{ close: () => void }> = [];
+afterEach(() => {
+  while (servers.length) { try { servers.pop()!.close(); } catch {} }
+  for (const name of SCRUBBED) delete process.env[name];
+  while (roots.length) removeDir(roots.pop()!);
+});
+
+function fixture() {
+  const root = makeTempRoot("nrv-glance-auth-");
+  roots.push(root);
+  const home = path.join(root, "home");
+  const project = path.join(root, "project");
+  fs.mkdirSync(path.join(home, ".nirvana"), { recursive: true });
+  fs.mkdirSync(path.join(project, ".nirvana"), { recursive: true });
+  process.env.NIRVANA_HOME = home;
+  process.env.NIRVANA_PROJECT_ROOT = project;
+  process.env.NIRVANA_SERVE_DIR = path.join(root, "serve");
+  return { root, home, project };
+}
+type Fixture = ReturnType<typeof fixture>;
+
+async function start(host?: string) {
+  const { startServer } = await import("../lib/glance/server.ts");
+  const server = await startServer({ port: 0, open: false, idleMin: 60, allowActions: true, theme: "apple", host });
+  servers.push(server);
+  return server;
+}
+
+async function mintKey(opts: { label: string; glance?: boolean }) {
+  const { keygen } = await import("../lib/serve/auth.ts");
+  return keygen(opts).token;
+}
+
+const get = (server: { port: number }, p: string, token?: string) =>
+  fetch(`http://127.0.0.1:${server.port}${p}`, token ? { headers: { authorization: `Bearer ${token}` } } : {});
+
+describe("Glance authentication boundary", () => {
+  test("loopback (the default) stays unauthenticated — the local case never becomes hostile", async () => {
+    fixture();
+    const server = await start();
+    const res = await get(server, "/api/v1/projects");
+    expect(res.status).toBe(200);
+  });
+
+  test("a served instance refuses a request carrying no credential", async () => {
+    fixture();
+    const server = await start("0.0.0.0");
+    const res = await get(server, "/api/v1/projects");
+    expect(res.status).toBe(401);
+    const body = await res.json() as any;
+    expect(String(body.detail)).toContain("Bearer");
+  });
+
+  test("a served instance refuses a valid key that was not minted with --glance", async () => {
+    fixture();
+    const token = await mintKey({ label: "job-only" });
+    const server = await start("0.0.0.0");
+    const res = await get(server, "/api/v1/projects", token);
+    expect(res.status).toBe(401);
+  });
+
+  test("a served instance serves a request carrying a --glance key", async () => {
+    fixture();
+    const token = await mintKey({ label: "cockpit", glance: true });
+    const server = await start("0.0.0.0");
+    const res = await get(server, "/api/v1/projects", token);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("Glance tenancy", () => {
+  test("a served instance pins its logs to its own project, not the machine-global default", async () => {
+    const setup: Fixture = fixture();
+    const token = await mintKey({ label: "cockpit", glance: true });
+    const server = await start("0.0.0.0");
+    const res = await get(server, "/api/logs?type=harness", token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.source as string).toContain(path.join(setup.project, ".nirvana", "logs", "harness"));
+  });
+
+  test("the local case never touches HARNESS_LOGS_DIR — no pinning side effect outside served mode", async () => {
+    fixture();
+    expect(process.env.HARNESS_LOGS_DIR).toBeUndefined();
+    await start();
+    // paths.js already resolves project-scoped logs on its own when NIRVANA_PROJECT_ROOT is
+    // set (pre-existing behavior, unrelated to this cut); what this cut must NOT do for the
+    // local case is reach for the env var override at all.
+    expect(process.env.HARNESS_LOGS_DIR).toBeUndefined();
+  });
+
+  test("closing a served instance restores HARNESS_LOGS_DIR so the next server in the same process is not pinned", async () => {
+    const setup: Fixture = fixture();
+    const token = await mintKey({ label: "cockpit", glance: true });
+    const served = await start("0.0.0.0");
+    expect(process.env.HARNESS_LOGS_DIR).toBe(path.join(setup.project, ".nirvana", "logs", "harness"));
+    const pinned = await get(served, "/api/logs?type=harness", token);
+    expect((await pinned.json() as any).source as string).toContain(path.join(setup.project, ".nirvana", "logs", "harness"));
+    served.close();
+    expect(process.env.HARNESS_LOGS_DIR).toBeUndefined();
+
+    await start();
+    expect(process.env.HARNESS_LOGS_DIR).toBeUndefined();
+  });
+});
+
+describe("Glance retention", () => {
+  test("a served instance rotates its own project log past the configured retention, on boot", async () => {
+    const setup: Fixture = fixture();
+    const staleDir = path.join(setup.project, ".nirvana", "logs", "harness", "2000-01-01");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDir, "audit.jsonl"), "");
+    fs.writeFileSync(path.join(setup.project, ".nirvana", "config.yaml"), "audit:\n  project_retention_days: 1\n", "utf8");
+
+    // Rotation runs at boot, before the first request — no fetch needed here.
+    await start("0.0.0.0");
+    expect(fs.existsSync(staleDir)).toBe(false);
+  });
+
+  test("the local case is not auto-rotated by this cut", async () => {
+    const setup: Fixture = fixture();
+    const staleDir = path.join(setup.home, ".harness-logs", "2000-01-01");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDir, "audit.jsonl"), "");
+    await start();
+    expect(fs.existsSync(staleDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
Cut 6 of `.nirvana/plans/event-contract.md`, plus the temp-file leak it uncovered.

**Windows CI ran green on this branch before this PR was opened.**

## The defect

`grep -cE "authorization|bearer|api[_-]?key|authenticate"` over `glance/server.ts`: **0**, across 2,253 lines. The entire security model was the bind address, plus the assumption that only this machine can reach it. `glance.ts` defaults `allowActions = true`.

Correct for a laptop. Wrong for a VPS holding a law-practice app's case for hours.

## A premise in the brief was wrong, and the cut says so

The brief was written as if no authentication existed anywhere. It does: **`nrv serve` already ships an authenticated HTTP surface** (`skills/harness/lib/serve/auth.ts`, PRs #74/#75, predating this plan) with its own Bearer key store. This cut **reuses that store** rather than inventing a second one.

## Decisions, each argued in the trace report

**Tenant = the project root a served process is bound to.** Already structurally true for `control-plane.sqlite` and `run-kernel.sqlite`. Cost, stated plainly: no multi-tenant routing inside one process — N tenants means N processes, which is already how `nrv glance` and `nrv serve` are invoked.

**A token grants one bit, not a scope list.** Read-vs-write already exists as a boot flag decided once by whoever starts the process. Per-key grants matter when many external callers need different ones — that is cut 7's job API, not one operator's cockpit.

**The local case is untouched, and was verified by running it**: `nrv glance` with no arguments still binds `127.0.0.1`, actions on, and answers `/api/health` with **HTTP 200 and no credential**. You do not manage a token to see your own runs.

## The leak this branch also closes — and the larger defect behind it

`driver-adapters.test.ts:277` asserted that `os.tmpdir()` holds **no** `nrv-prompt-*` files at all, so any other process's residue failed it. It cost three separate diagnoses today. It now measures its own work.

But the leak it was hiding is real, and the cause is not the cleanup code:

**`dispatch.ts` records `childPid: process.pid` — its own pid**, the process that will later block inside `spawnSync`, not the CLI child that call spawns. `supervisor.ts`'s stalled-run recovery signals exactly that pid. Nothing in this codebase registers `process.on("SIGTERM")`, so the OS default applies: the dispatch process is torn down mid-syscall, before any `finally` — including `removeTmpFiles` — can run. Every adapter's cleanup is correct and sufficient for normal exit, error exit, thrown exception and `spawnSync`'s own timeout. It simply never executes when **the supervisor kills the wrong process**.

The supervisor then marks the run failed, retries, and the retry's own file is cleaned normally — so the run reads as *completed* from outside while the killed attempt's file is abandoned. That is exactly the three files observed today at 20:41, 20:47 and 21:07.

**The supervisor targeting the wrong pid is named here and not fixed** — it is a materially larger change to its kill target, and it deserves its own cut.

## Verification

`bun test skills` — 2,331 tests, **0 fail**. `bun run check:all` — **exit 0**. Windows CI green on this branch. Local cockpit boot verified by running it, not by reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)