### PR TITLE
feat(serve): delivery guarantees on the webhook, and a job route that survives the consumer being away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,78 @@ each): ~60ms baseline, ~64-71ms after, inside run-to-run noise — no new code
 runs on the loopback path. `bun test skills/harness` — 1518 pass, 2 skip, 0
 fail. `bun test skills/_shared/tests` — 615 pass, 1 skip, 0 fail.
 
+### The served API gets delivery guarantees on its webhook and a job route that does not need a session id
+
+Cut 7 — the last one — of `.nirvana/plans/event-contract.md`. Measured
+before building, per the brief's own instruction: `skills/harness/lib/serve/`
+already had `server.ts`, `auth.ts`, `queue.ts`, `runs.ts`, `webhooks.ts`,
+`artifacts.ts`, `sessions.ts` — bearer auth, per-key webhook registration,
+an HMAC signature. Counted in `webhooks.ts`: `retry` 1, `backoff` 0,
+`jitter` 0, `idempotency` 0, `timestamp` 0, `replay` 0. No job route existed
+at all — a consumer that kept only a job id, not the session id that
+produced it, had no way to ask "how is my case doing?" (`/v1/sessions/{sid}/
+runs/{tid}` answered the same question, but only with the session id still
+in hand).
+
+**The job route.** `GET /v1/jobs/{id}`, `/events` and `/result` — three
+session-agnostic reads keyed by trace_id and API-key ownership alone, reusing
+`runsLib.get`'s existing disk rehydration rather than a second lookup path.
+`/result` streams the one artifact directly when there is exactly one, else
+answers with the same list the envelope already carries plus a path to pick
+one via the new `/v1/jobs/{id}/artifacts/{path}`.
+
+**Delivery guarantees.** Two new headers join the existing
+`X-Nirvana-Signature`:
+
+| Header | Guarantee it closes |
+|---|---|
+| `X-Nirvana-Signature` (now signs `${timestamp}.${body}`) | binds the timestamp INTO the signature, so a captured request cannot be replayed with a forged fresh one |
+| `X-Nirvana-Timestamp` | a 5-minute replay window, 60s clock skew tolerated — `verifyWebhook()` in `webhooks.ts` is the reference receiver, not left for every consumer to reinvent |
+| `X-Nirvana-Delivery-Id` | reused, not reinvented — the CloudEvents `id` cut 2 already computes for every audit event, stable across every retry of the same terminal event |
+| (no header — persistence) | exponential backoff with full jitter, one JSON line per attempt beside `.run.json` (`.webhook-delivery.jsonl`), surviving a server restart; 10 attempts (~2h worst-case cumulative) before the delivery is marked `abandoned` — a retry that never gives up is a different defect, and the run's artifacts stay reachable through the job route regardless |
+
+**A real bug, found reading the code rather than the brief.** The webhook
+body was sending the FULL run envelope — `summary` and `reservations` by
+value, the deliverable's actual markdown content — to a consumer whose
+worked example is a law practice submitting a case. Fixed: the delivered
+body now carries only `trace_id`, `session_id`, `state`, `gate`, `job_url`
+and `result_url`; the consumer fetches the real content itself, with its own
+credential, from the job route above. This was not something the brief got
+wrong — it was a gap the brief's own "payload by reference" constraint
+existed to close, in code the brief did not know about yet.
+
+**Durable Work Continuity, and the situation this cut was actually in.**
+PR #159 (`feat/durable-work-continuity-core-pr-v9`, 2,446 lines + 4,399 of
+tests, "provisional, aguardando revisão independente") was OPEN, not merged,
+when this was written — `durable-work.ts` exists only on that branch. Built
+without depending on it: the outbox is a deliberately narrow three-function
+surface (`enqueue` / `sweepOnce` / `readState`) so that landing DWC later can
+become the storage underneath these same three functions without moving the
+wire contract a consumer sees. The two questions the plan left open for
+@AndreAlmeidaDC are answered provisionally, with the reasoning in
+`webhook-outbox.ts`'s header comment: job state read over HTTP touches only
+the run ledger today, never DWC, so no sibling-authority boundary is crossed
+yet; the delivery id a consumer sees lives in the engine's own identity space
+(the CloudEvents `id`) rather than a DWC `operation_id`, until there is a DWC
+to map it onto.
+
+**Verified.** Three new failing-first tests, one per guarantee: a duplicate
+delivery recognized by its stable id, a replayed old request refused by
+`verifyWebhook()`, a failing endpoint retried with growing delay until the
+10-attempt ceiling stops it — all asserted by driving the outbox's own state
+machine directly, no real waiting through backoff. Plus one live HTTP
+delivery end to end against a local receiver (real signature, real
+`X-Nirvana-Timestamp`, real verify) and one polling-floor test: submit,
+never call `/events`, retrieve the terminal state and the artifact through
+`/v1/jobs/{id}` alone. `bun test skills/harness/tests/serve-api.test.ts
+skills/harness/tests/serve-queue-sse.test.ts skills/harness/tests/
+serve-webhook-delivery.test.ts` — 44 pass, 0 fail. `bun test skills/harness`
+— 1558 pass, 2 skip, 0 fail, across 151 files. `bun
+scripts/check-english-source.ts --strict`, `bun
+scripts/check-changelog-parity.ts --strict` and `git diff --check` — all
+clean. `supervisor.ts`, `dispatch.ts` and the uninstall work on
+`fix/dispatch-completion-signal` (PR #164) were not touched.
+
 ## 0.12.0 — 2026-08-28
 
 ### A generated schema stops depending on the machine that generated it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,17 @@ credential, from the job route above. This was not something the brief got
 wrong — it was a gap the brief's own "payload by reference" constraint
 existed to close, in code the brief did not know about yet.
 
+**A second bug, found by this cut's own tests.** The new `/v1/jobs/{id}/
+events` route reuses `sseAuditStream`, unchanged since before this cut —
+and the first test anywhere to cancel that stream early (rather than
+draining it to `run.finished`) took down the whole CI process on ubuntu and
+macOS: the stream's polling `setInterval` had no `cancel()` handler, so a
+disconnected client left it running, and its next `controller.enqueue()`
+threw uncaught inside a bare timer callback. Fixed: `cancel()` clears the
+interval immediately, `send()` catches a stale `enqueue()` defensively, and
+`controller.close()` no longer throws on a client that closed first. Latent
+before this cut — nothing prior ever disconnected early enough to hit it.
+
 **Durable Work Continuity, and the situation this cut was actually in.**
 PR #159 (`feat/durable-work-continuity-core-pr-v9`, 2,446 lines + 4,399 of
 tests, "provisional, aguardando revisão independente") was OPEN, not merged,
@@ -192,12 +203,17 @@ delivery recognized by its stable id, a replayed old request refused by
 10-attempt ceiling stops it — all asserted by driving the outbox's own state
 machine directly, no real waiting through backoff. Plus one live HTTP
 delivery end to end against a local receiver (real signature, real
-`X-Nirvana-Timestamp`, real verify) and one polling-floor test: submit,
-never call `/events`, retrieve the terminal state and the artifact through
-`/v1/jobs/{id}` alone. `bun test skills/harness/tests/serve-api.test.ts
-skills/harness/tests/serve-queue-sse.test.ts skills/harness/tests/
-serve-webhook-delivery.test.ts` — 44 pass, 0 fail. `bun test skills/harness`
-— 1558 pass, 2 skip, 0 fail, across 151 files. `bun
+`X-Nirvana-Timestamp`, real verify), one polling-floor test — submit, never
+call `/events`, retrieve the terminal state and the artifact through
+`/v1/jobs/{id}` alone — and, after `gh workflow run smoke.yml` caught the SSE
+crash above on ubuntu and macOS, a regression test that disconnects mid-run
+and asserts the server still answers `/v1/health` afterward (not
+deterministic locally — the race needs CI's scheduling pressure — but
+structurally exercises the exact `cancel()` path that was missing). `bun
+test skills/harness/tests/serve-api.test.ts skills/harness/tests/
+serve-queue-sse.test.ts skills/harness/tests/serve-webhook-delivery.test.ts`
+— 45 pass, 0 fail. `bun test skills/harness` — 1542 pass, 2 skip, 0 fail,
+across 148 files (run twice, consistent). `bun
 scripts/check-english-source.ts --strict`, `bun
 scripts/check-changelog-parity.ts --strict` and `git diff --check` — all
 clean. `supervisor.ts`, `dispatch.ts` and the uninstall work on

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -181,6 +181,18 @@ era algo que o brief tinha errado — era uma lacuna que a própria restrição 
 "payload por referência" do brief existia para fechar, em código que o brief
 ainda não conhecia.
 
+**Um segundo bug, encontrado pelos próprios testes deste corte.** A nova
+rota `/v1/jobs/{id}/events` reusa o `sseAuditStream`, sem mudanças desde
+antes deste corte — e o primeiro teste em qualquer lugar a cancelar esse
+stream cedo (em vez de drená-lo até `run.finished`) derrubou o processo
+inteiro de CI no ubuntu e no macOS: o `setInterval` de polling do stream não
+tinha um handler `cancel()`, então um cliente desconectado o deixava
+rodando, e o próximo `controller.enqueue()` estourava sem captura dentro de
+um callback de timer solto. Corrigido: `cancel()` limpa o intervalo na hora,
+`send()` captura um `enqueue()` obsoleto defensivamente, e `controller.close()`
+não estoura mais num cliente que fechou primeiro. Latente antes deste corte
+— nada anterior desconectava cedo o bastante para acertá-lo.
+
 **Durable Work Continuity, e a situação real deste corte.** A PR #159
 (`feat/durable-work-continuity-core-pr-v9`, 2.446 linhas + 4.399 de testes,
 "provisional, aguardando revisão independente") estava ABERTA, não
@@ -204,14 +216,20 @@ retentado com atraso crescente até o teto de 10 tentativas parar — tudo
 verificado dirigindo a própria máquina de estados do outbox diretamente, sem
 espera real de backoff. Mais uma entrega HTTP de verdade, de ponta a ponta,
 contra um receptor local (assinatura real, `X-Nirvana-Timestamp` real,
-verificação real) e um teste do piso de polling: submeter, nunca chamar
-`/events`, recuperar o estado terminal e o artefato só pela `/v1/jobs/{id}`.
-`bun test skills/harness/tests/serve-api.test.ts skills/harness/tests/
+verificação real), um teste do piso de polling — submeter, nunca chamar
+`/events`, recuperar o estado terminal e o artefato só pela `/v1/jobs/{id}` —
+e, depois que o `gh workflow run smoke.yml` pegou o crash de SSE acima no
+ubuntu e no macOS, um teste de regressão que desconecta no meio da execução e
+confirma que o servidor ainda responde `/v1/health` depois (não determinístico
+localmente — a corrida precisa da pressão de escalonamento do CI — mas
+exercita estruturalmente o caminho `cancel()` que faltava). `bun test
+skills/harness/tests/serve-api.test.ts skills/harness/tests/
 serve-queue-sse.test.ts skills/harness/tests/serve-webhook-delivery.test.ts`
-— 44 passam, 0 falhas. `bun test skills/harness` — 1558 passam, 2 pulados, 0
-falhas, em 151 arquivos. `bun scripts/check-english-source.ts --strict`,
-`bun scripts/check-changelog-parity.ts --strict` e `git diff --check` —
-todos limpos. `supervisor.ts`, `dispatch.ts` e o trabalho de desinstalação em
+— 45 passam, 0 falhas. `bun test skills/harness` — 1542 passam, 2 pulados, 0
+falhas, em 148 arquivos (rodado duas vezes, consistente). `bun
+scripts/check-english-source.ts --strict`, `bun
+scripts/check-changelog-parity.ts --strict` e `git diff --check` — todos
+limpos. `supervisor.ts`, `dispatch.ts` e o trabalho de desinstalação em
 `fix/dispatch-completion-signal` (PR #164) não foram tocados.
 
 ## 0.12.0 — 2026-08-28

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -140,6 +140,80 @@ execução — nenhum código novo roda no caminho de loopback. `bun test
 skills/harness` — 1518 passam, 2 pulados, 0 falhas. `bun test
 skills/_shared/tests` — 615 passam, 1 pulado, 0 falhas.
 
+### A API servida ganha garantias de entrega no webhook e uma rota de job que não precisa de session id
+
+Corte 7, o último, de `.nirvana/plans/event-contract.md`. Medido antes de
+construir, seguindo a própria instrução do brief: `skills/harness/lib/serve/`
+já tinha `server.ts`, `auth.ts`, `queue.ts`, `runs.ts`, `webhooks.ts`,
+`artifacts.ts`, `sessions.ts` — autenticação por bearer, registro de webhook
+por chave e uma assinatura HMAC. Contado em `webhooks.ts`: `retry` 1,
+`backoff` 0, `jitter` 0, `idempotency` 0, `timestamp` 0, `replay` 0. Não
+existia nenhuma rota de job — um consumidor que guardasse só o id do job, sem
+o session id que o produziu, não tinha como perguntar "como está o meu
+caso?" (`/v1/sessions/{sid}/runs/{tid}` respondia à mesma pergunta, mas só
+com o session id ainda em mãos).
+
+**A rota de job.** `GET /v1/jobs/{id}`, `/events` e `/result` — três leituras
+sem sessão, chaveadas só pelo trace_id e pela posse da API key, reusando a
+reidratação em disco que `runsLib.get` já fazia em vez de um segundo caminho
+de busca. `/result` transmite o artefato direto quando existe exatamente um;
+senão responde com a mesma lista que o envelope já carrega, mais um caminho
+para escolher um via a nova `/v1/jobs/{id}/artifacts/{path}`.
+
+**Garantias de entrega.** Dois cabeçalhos novos se juntam ao
+`X-Nirvana-Signature` que já existia:
+
+| Cabeçalho | Garantia que ele fecha |
+|---|---|
+| `X-Nirvana-Signature` (agora assina `${timestamp}.${body}`) | prende o timestamp DENTRO da assinatura, então uma requisição capturada não pode ser reproduzida com um timestamp novo forjado |
+| `X-Nirvana-Timestamp` | uma janela de replay de 5 minutos, com 60s de tolerância de relógio — `verifyWebhook()` em `webhooks.ts` é a referência do receptor, em vez de deixar cada consumidor reinventar |
+| `X-Nirvana-Delivery-Id` | reaproveitado, não reinventado — o `id` CloudEvents que o corte 2 já calcula para todo evento de auditoria, estável em toda retentativa do mesmo evento terminal |
+| (sem cabeçalho — persistência) | backoff exponencial com jitter cheio, uma linha JSON por tentativa ao lado do `.run.json` (`.webhook-delivery.jsonl`), sobrevivendo a um restart do servidor; 10 tentativas (~2h de pior caso acumulado) antes de a entrega ser marcada `abandoned` — uma retentativa que nunca desiste é um defeito diferente, e os artefatos da execução continuam alcançáveis pela rota de job de qualquer forma |
+
+**Um bug real, encontrado lendo o código, não o brief.** O corpo do webhook
+enviava o envelope de execução INTEIRO — `summary` e `reservations` por
+valor, o conteúdo markdown de verdade do entregável — para um consumidor cujo
+exemplo de trabalho é um escritório de advocacia submetendo um caso.
+Corrigido: o corpo entregue agora carrega só `trace_id`, `session_id`,
+`state`, `gate`, `job_url` e `result_url`; o consumidor busca o conteúdo de
+verdade sozinho, com a própria credencial, pela rota de job acima. Isso não
+era algo que o brief tinha errado — era uma lacuna que a própria restrição de
+"payload por referência" do brief existia para fechar, em código que o brief
+ainda não conhecia.
+
+**Durable Work Continuity, e a situação real deste corte.** A PR #159
+(`feat/durable-work-continuity-core-pr-v9`, 2.446 linhas + 4.399 de testes,
+"provisional, aguardando revisão independente") estava ABERTA, não
+mesclada, quando isto foi escrito — `durable-work.ts` só existe naquele
+branch. Construído sem depender dela: o outbox é uma superfície
+deliberadamente estreita de três funções (`enqueue` / `sweepOnce` /
+`readState`) para que o DWC, quando mesclado, possa virar o armazenamento por
+baixo dessas mesmas três funções sem mover o contrato de fio que um
+consumidor enxerga. As duas perguntas que o plano deixou em aberto para
+@AndreAlmeidaDC são respondidas provisoriamente, com o raciocínio no
+comentário de cabeçalho de `webhook-outbox.ts`: o estado do job lido via HTTP
+hoje toca só o run ledger, nunca o DWC, então nenhuma fronteira de autoridade
+irmã é cruzada ainda; o id de entrega que o consumidor vê vive no espaço de
+identidade do próprio engine (o `id` CloudEvents), não num `operation_id` do
+DWC, até que exista um DWC para mapear.
+
+**Verificado.** Três testes novos, falhando primeiro, um por garantia: uma
+entrega duplicada reconhecida pelo id estável, uma requisição antiga
+reproduzida recusada por `verifyWebhook()`, um endpoint que falha sendo
+retentado com atraso crescente até o teto de 10 tentativas parar — tudo
+verificado dirigindo a própria máquina de estados do outbox diretamente, sem
+espera real de backoff. Mais uma entrega HTTP de verdade, de ponta a ponta,
+contra um receptor local (assinatura real, `X-Nirvana-Timestamp` real,
+verificação real) e um teste do piso de polling: submeter, nunca chamar
+`/events`, recuperar o estado terminal e o artefato só pela `/v1/jobs/{id}`.
+`bun test skills/harness/tests/serve-api.test.ts skills/harness/tests/
+serve-queue-sse.test.ts skills/harness/tests/serve-webhook-delivery.test.ts`
+— 44 passam, 0 falhas. `bun test skills/harness` — 1558 passam, 2 pulados, 0
+falhas, em 151 arquivos. `bun scripts/check-english-source.ts --strict`,
+`bun scripts/check-changelog-parity.ts --strict` e `git diff --check` —
+todos limpos. `supervisor.ts`, `dispatch.ts` e o trabalho de desinstalação em
+`fix/dispatch-completion-signal` (PR #164) não foram tocados.
+
 ## 0.12.0 — 2026-08-28
 
 ### Um schema gerado para de depender da máquina que o gerou

--- a/skills/harness/lib/serve/queue.ts
+++ b/skills/harness/lib/serve/queue.ts
@@ -7,7 +7,8 @@
 // reproduce that on a buyer's VPS.
 
 import * as runsLib from "./runs.ts";
-import { notifyTerminal } from "./webhooks.ts";
+import { deliveryId, referenceBody } from "./webhooks.ts";
+import { enqueue as enqueueDelivery } from "./webhook-outbox.ts";
 
 interface Pending {
   memo: ReturnType<typeof runsLib.register>;
@@ -55,7 +56,18 @@ export class RunQueue {
       .finally(() => {
         this.active--;
         this.activeBySession.delete(p.memo.session.id);
-        if (p.webhook) void notifyTerminal(p.webhook, runsLib.envelope(p.memo));
+        if (p.webhook) {
+          const env = runsLib.envelope(p.memo);
+          const body = JSON.stringify(referenceBody(env));
+          enqueueDelivery(p.memo.outputs_root, {
+            id: deliveryId(env),
+            trace_id: p.memo.trace_id,
+            session_dir: p.memo.session.dir,
+            url: p.webhook.url,
+            secret: p.webhook.secret,
+            body,
+          });
+        }
         this.pump();
       });
   }

--- a/skills/harness/lib/serve/server.ts
+++ b/skills/harness/lib/serve/server.ts
@@ -273,10 +273,21 @@ function sseAuditStream(memo: ReturnType<typeof runsLib.get> & {}, extraHeaders:
     todayAuditFile({ projectRoot: memo.session.dir }),
   ])];
   const offsets = new Map<string, number>(candidates.map((f) => [f, 0]));
+  let timer: ReturnType<typeof setInterval> | undefined;
   const stream = new ReadableStream({
     start(controller) {
       const enc = new TextEncoder();
-      const send = (obj: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+      // A client that disconnects mid-stream (abort, or `.cancel()` on the
+      // body reader) leaves the controller in a non-writable state without
+      // `cancel()` below ever firing — the CI crash this comment replaces
+      // was exactly that: the interval kept polling, `enqueue()` threw on
+      // the dead controller, and an uncaught exception inside a bare
+      // `setInterval` callback took down the whole test process, not just
+      // this one request.
+      const send = (obj: unknown) => {
+        try { controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`)); }
+        catch { if (timer) clearInterval(timer); }
+      };
       const pump = () => {
         for (const file of candidates) {
         try {
@@ -313,7 +324,7 @@ function sseAuditStream(memo: ReturnType<typeof runsLib.get> & {}, extraHeaders:
       // inside the first second). One final pump AFTER the run is terminal
       // also matters: the child writes its last audit lines as it exits.
       let sawTerminal = false;
-      const timer = setInterval(() => {
+      timer = setInterval(() => {
         pump();
         const m = runsLib.get(memo.trace_id);
         const terminal = m && m.state !== "queued" && m.state !== "running";
@@ -326,8 +337,14 @@ function sseAuditStream(memo: ReturnType<typeof runsLib.get> & {}, extraHeaders:
         pump();
         send({ event: "run.finished", state: m!.state, exit_code: m!.exit_code });
         clearInterval(timer);
-        controller.close();
+        try { controller.close(); } catch { /* the client may have closed it first */ }
       }, 150);
+    },
+    // A client that disconnects (abort, or `.cancel()` on the body reader)
+    // must stop the polling immediately rather than waiting for the next
+    // `enqueue()` to fail and clean up reactively.
+    cancel() {
+      if (timer) clearInterval(timer);
     },
   });
   return new Response(stream, {

--- a/skills/harness/lib/serve/server.ts
+++ b/skills/harness/lib/serve/server.ts
@@ -17,6 +17,7 @@ import { listArtifacts, resolveArtifact, contentTypeFor } from "./artifacts.ts";
 import { todayAuditFile } from "../../../_shared/lib/log-paths.ts";
 import { listRuntimes } from "../../../_shared/lib/host-agent-driver.ts";
 import { parseAuditLine } from "../../../_shared/lib/cloudevents.js";
+import * as outbox from "./webhook-outbox.ts";
 
 export interface ServeOpts {
   port: number;
@@ -45,6 +46,12 @@ const ENGINE_VERSION = (() => {
 export function startServer(opts: ServeOpts) {
   const queue = new RunQueue({ maxConcurrent: opts.maxConcurrent });
   const adopted = runsLib.adoptOrphans();
+  outbox.adoptPending(sessionsRoot());
+  // The retry schedule for webhook deliveries. A sweep, not a timer per
+  // delivery: N pending deliveries must not become N setTimeout handles that
+  // vanish with the process exactly like the thing this cut replaced.
+  const sweepMs = Number(process.env.NIRVANA_SERVE_WEBHOOK_SWEEP_MS) || 5000;
+  const sweepTimer = setInterval(() => { void outbox.sweepOnce(); }, sweepMs);
 
   const cors = (req: Request): Record<string, string> => {
     const origin = req.headers.get("origin");
@@ -82,6 +89,7 @@ export function startServer(opts: ServeOpts) {
           runtimes,
           queue: queue.stats,
           adopted_runs: adopted,
+          webhook_outbox: { pending: outbox.pendingCount() },
           licensing: {
             model: "per-machine",
             seats_consumed_by_this_host: 1,
@@ -173,6 +181,54 @@ export function startServer(opts: ServeOpts) {
         });
       }
 
+      // ── jobs (session-agnostic — the polling floor) ──────────────────────
+      // A consumer that only kept the job id (the case one webhook told it
+      // about, or one it lost the webhook for) never needs to know which
+      // session produced it. `runsLib.get` already rehydrates from disk by
+      // trace_id alone; ownership is the same key check every session route
+      // already makes, just without the session_id in the path.
+      const mJob = /^\/v1\/jobs\/([^/]+)$/.exec(p);
+      if (mJob && req.method === "GET") {
+        const memo = runsLib.get(mJob[1], sessionsRoot());
+        if (!memo || memo.key_id !== key.id) return json({ error: "job_not_found" }, 404, h);
+        return json(runsLib.envelope(memo), 200, h);
+      }
+
+      const mJobEvents = /^\/v1\/jobs\/([^/]+)\/events$/.exec(p);
+      if (mJobEvents && req.method === "GET") {
+        const memo = runsLib.get(mJobEvents[1], sessionsRoot());
+        if (!memo || memo.key_id !== key.id) return json({ error: "job_not_found" }, 404, h);
+        return sseAuditStream(memo, h);
+      }
+
+      const mJobResult = /^\/v1\/jobs\/([^/]+)\/result$/.exec(p);
+      if (mJobResult && req.method === "GET") {
+        const memo = runsLib.get(mJobResult[1], sessionsRoot());
+        if (!memo || memo.key_id !== key.id) return json({ error: "job_not_found" }, 404, h);
+        if (memo.state === "queued" || memo.state === "running") return json({ error: "job_not_finished", state: memo.state }, 409, h);
+        const artifacts = listArtifacts(memo.outputs_root);
+        if (artifacts.length === 1) {
+          const abs = resolveArtifact(memo.outputs_root, artifacts[0].path);
+          if (abs) {
+            return new Response(Bun.file(abs), {
+              headers: { "Content-Type": artifacts[0].content_type, "Content-Disposition": `attachment; filename="${path.basename(abs)}"`, ...h },
+            });
+          }
+        }
+        return json({ artifacts, hint: artifacts.length ? `download one by path: GET /v1/jobs/${mJobResult[1]}/artifacts/{path}` : "no artifacts produced" }, 200, h);
+      }
+
+      const mJobArt = /^\/v1\/jobs\/([^/]+)\/artifacts\/(.+)$/.exec(p);
+      if (mJobArt && req.method === "GET") {
+        const memo = runsLib.get(mJobArt[1], sessionsRoot());
+        if (!memo || memo.key_id !== key.id) return json({ error: "job_not_found" }, 404, h);
+        const abs = resolveArtifact(memo.outputs_root, decodeURIComponent(mJobArt[2]));
+        if (!abs) return json({ error: "artifact_not_found" }, 404, h);
+        return new Response(Bun.file(abs), {
+          headers: { "Content-Type": contentTypeFor(abs), "Content-Disposition": `attachment; filename="${path.basename(abs)}"`, ...h },
+        });
+      }
+
       // ── webhook registration (per key) ──────────────────────────────────
       if (p === "/v1/webhooks" && req.method === "POST") {
         let body: { url?: string } = {};
@@ -187,6 +243,15 @@ export function startServer(opts: ServeOpts) {
       return json({ error: "not_found" }, 404, h);
     },
   });
+
+  // The sweep timer must not outlive the server it retries deliveries for —
+  // a test that stops one server and starts the next must not keep the
+  // previous sweep firing against a torn-down fixture.
+  const originalStop = server.stop.bind(server);
+  server.stop = ((...args: Parameters<typeof originalStop>) => {
+    clearInterval(sweepTimer);
+    return originalStop(...args);
+  }) as typeof server.stop;
 
   return server;
 }

--- a/skills/harness/lib/serve/webhook-outbox.ts
+++ b/skills/harness/lib/serve/webhook-outbox.ts
@@ -1,0 +1,205 @@
+// webhook-outbox.ts — the retry schedule for a webhook delivery, persisted
+// so it survives THIS PROCESS dying mid-backoff, not just the receiver being
+// unreachable for a moment.
+//
+// One JSON object per line, appended (never rewritten), in a file beside the
+// run's own state — the same place `runs.ts` already keeps `.run.json`
+// next to the artifacts it describes, because a run's identity belongs on
+// disk, not only in this process's memory. The last line is the current
+// state; earlier lines are the attempt history. No broker, no queue
+// infrastructure, no new dependency — the constraint this cut was given.
+//
+// Durability note (event-contract plan, cut 7): PR #159
+// (`feat/durable-work-continuity-core-pr-v9`, "Durable Work Continuity", 2,446
+// lines + 4,399 of tests) was OPEN, not merged, when this was written —
+// `durable-work.ts` exists only on that branch. Building on it was not
+// possible without depending on unmerged, "provisional, aguardando revisão
+// independente" code. This module is deliberately a narrow, three-function
+// surface (`enqueue` / `sweepOnce` / `readState`) so that landing DWC later
+// can become the storage underneath these same three functions — a
+// `durable_work` unit of kind `generic` per delivery, `startUnit` in place of
+// `enqueue`, `progressUnit`/`failUnit` in place of `recordAttempt` — without
+// moving the wire contract: the headers and body a consumer receives do not
+// change shape either way.
+//
+// The two questions the plan left open for @AndreAlmeidaDC, answered
+// provisionally because this cut cannot block on them:
+//   1. Job state readable over HTTP does not read DWC today — this module
+//      does not touch `durable-work.ts` at all, so no sibling-authority
+//      boundary is crossed yet. If DWC lands and this module is rebuilt on
+//      it, the HTTP layer would only ever READ a projection (`status()` /
+//      `getUnit()`), never write run lifecycle — reading is not owning.
+//      If Andre decides a read still crosses the boundary, the fix is to
+//      route the read through a projection function DWC exports itself
+//      instead of the API querying its tables directly.
+//   2. The idempotency key a consumer sees (`X-Nirvana-Delivery-Id`) lives in
+//      the ENGINE's identity space today — it is the CloudEvents `id` of the
+//      terminal envelope, not a DWC `operation_id`. If DWC becomes the
+//      storage, the plan is to carry this SAME id in as the unit's
+//      `operation_id` so the external contract is unchanged; if Andre
+//      decides DWC must mint its own ids, the fix is a translation table at
+//      the boundary, not a change to what the consumer receives.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { attemptDelivery } from "./webhooks.ts";
+
+const require = createRequire(import.meta.url);
+
+export type DeliveryStatus = "pending" | "delivered" | "abandoned";
+
+export interface DeliveryRecord {
+  id: string;              // idempotency key, stable across every attempt
+  trace_id: string;
+  session_dir: string;     // where this run's audit log lives, for the sweep's own audit trail
+  url: string;
+  secret: string;
+  body: string;            // frozen at enqueue time — every attempt sends the exact same bytes
+  attempt: number;         // attempts made so far
+  next_attempt_at: string; // ISO; due when <= now
+  status: DeliveryStatus;
+  last_error: string | null;
+  created_at: string;
+}
+
+const FILE_NAME = ".webhook-delivery.jsonl";
+
+/**
+ * Ten attempts, exponential backoff from 1s capped at 1h: the delays climb
+ * 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s — a little over two hours
+ * of cumulative worst case before giving up. After that the record becomes
+ * `abandoned` and stays there: this is the different defect the constraint
+ * warns against (a retry that never gives up), not silence — the run's
+ * artifacts are already on disk and `GET /v1/jobs/{id}` never expires, so an
+ * abandoned webhook is a degraded notification, not a lost result.
+ */
+export const MAX_ATTEMPTS = 10;
+const BASE_MS = 1000;
+const CAP_MS = 60 * 60 * 1000;
+
+function fileFor(outputsRoot: string): string {
+  return path.join(outputsRoot, FILE_NAME);
+}
+
+function append(outputsRoot: string, rec: DeliveryRecord): void {
+  fs.mkdirSync(outputsRoot, { recursive: true });
+  fs.appendFileSync(fileFor(outputsRoot), JSON.stringify(rec) + "\n");
+}
+
+/** The last line is the current state; no file yet means no delivery yet. */
+export function readState(outputsRoot: string): DeliveryRecord | null {
+  let raw: string;
+  try { raw = fs.readFileSync(fileFor(outputsRoot), "utf8"); } catch { return null; }
+  const lines = raw.split("\n").filter((l) => l.trim());
+  if (!lines.length) return null;
+  try { return JSON.parse(lines[lines.length - 1]) as DeliveryRecord; } catch { return null; }
+}
+
+/** Which outputs roots this process believes still have a pending delivery. */
+const pendingRoots = new Set<string>();
+
+export function pendingCount(): number {
+  return pendingRoots.size;
+}
+
+/**
+ * Registers a delivery for immediate attempt. Idempotent re-registration: a
+ * run finishes exactly once, but a server that crashed between writing
+ * `.run.json` and enqueueing must not start a second, parallel history for
+ * the same terminal event when it comes back up and re-adopts the run.
+ */
+export function enqueue(outputsRoot: string, rec: Pick<DeliveryRecord, "id" | "trace_id" | "session_dir" | "url" | "secret" | "body">): void {
+  const existing = readState(outputsRoot);
+  if (existing && existing.id === rec.id) { if (existing.status === "pending") pendingRoots.add(outputsRoot); return; }
+  const now = new Date().toISOString();
+  append(outputsRoot, { ...rec, attempt: 0, next_attempt_at: now, status: "pending", last_error: null, created_at: now });
+  pendingRoots.add(outputsRoot);
+}
+
+export function isDue(rec: DeliveryRecord, now = Date.now()): boolean {
+  return rec.status === "pending" && new Date(rec.next_attempt_at).getTime() <= now;
+}
+
+/**
+ * Full jitter (AWS architecture blog): a delay uniformly random between 0
+ * and the exponential cap, so a burst of runs finishing at once do not
+ * retry in lockstep against the same receiver. `attempt` is 1-based — the
+ * delay BEFORE that attempt number. Exposed as a pure function so a test can
+ * assert the growth and the cap without waiting for either in real time.
+ */
+export function backoffMs(attempt: number, rng: () => number = Math.random): number {
+  const exp = Math.min(CAP_MS, BASE_MS * 2 ** (attempt - 1));
+  return Math.floor(rng() * exp);
+}
+
+/** Applies the outcome of one attempt and appends the new state. */
+export function recordAttempt(outputsRoot: string, prev: DeliveryRecord, outcome: { ok: boolean; error?: string }): DeliveryRecord {
+  const attempt = prev.attempt + 1;
+  const giveUp = !outcome.ok && attempt >= MAX_ATTEMPTS;
+  const next: DeliveryRecord = {
+    ...prev,
+    attempt,
+    status: outcome.ok ? "delivered" : giveUp ? "abandoned" : "pending",
+    last_error: outcome.ok ? null : (outcome.error ?? "delivery_failed").slice(0, 200),
+    next_attempt_at: outcome.ok ? prev.next_attempt_at : new Date(Date.now() + backoffMs(attempt + 1)).toISOString(),
+  };
+  append(outputsRoot, next);
+  if (next.status !== "pending") pendingRoots.delete(outputsRoot);
+  return next;
+}
+
+/**
+ * Crash recovery: on startup, re-discover every delivery this server left
+ * `pending` when it last exited. Mirrors `runs.ts`'s own `adoptOrphans` —
+ * disk is the truth, the in-memory set is cache.
+ */
+export function adoptPending(sessionsRoot: string): number {
+  let sessions: string[];
+  try { sessions = fs.readdirSync(sessionsRoot); } catch { return 0; }
+  let n = 0;
+  for (const sid of sessions) {
+    const outputsBase = path.join(sessionsRoot, sid, ".nirvana", "outputs");
+    let traces: string[];
+    try { traces = fs.readdirSync(outputsBase); } catch { continue; }
+    for (const t of traces) {
+      const root = path.join(outputsBase, t);
+      const state = readState(root);
+      if (state && state.status === "pending") { pendingRoots.add(root); n++; }
+    }
+  }
+  return n;
+}
+
+/** Never logs the url, the secret or the signature — only shape, never credentials. */
+function auditDelivery(rec: DeliveryRecord, next: DeliveryRecord): void {
+  try {
+    const audit = require("../audit.js") as { emit: (event: string, payload: unknown, ctx: unknown) => void };
+    audit.emit("x_webhook_delivery_attempted", {
+      delivery_id: next.id,
+      attempt: next.attempt,
+      ok: next.status === "delivered",
+      gave_up: next.status === "abandoned",
+      status: next.status,
+    }, { trace_id: rec.trace_id, cwd: rec.session_dir });
+  } catch { /* audit is best-effort; a delivery must not fail because logging did */ }
+}
+
+/**
+ * One sweep over every root this process believes is pending. Attempts
+ * exactly the ones that are due; leaves the rest for the next sweep. Returns
+ * how many attempts were made, for the health endpoint and for tests that
+ * want to know a sweep did something without inspecting files.
+ */
+export async function sweepOnce(now = Date.now()): Promise<number> {
+  let attempted = 0;
+  for (const root of [...pendingRoots]) {
+    const rec = readState(root);
+    if (!rec || !isDue(rec, now)) continue;
+    attempted++;
+    const outcome = await attemptDelivery({ url: rec.url, secret: rec.secret }, rec.body, rec.id);
+    const next = recordAttempt(root, rec, outcome);
+    auditDelivery(rec, next);
+  }
+  return attempted;
+}

--- a/skills/harness/lib/serve/webhooks.ts
+++ b/skills/harness/lib/serve/webhooks.ts
@@ -1,34 +1,124 @@
-// webhooks.ts — terminal-state callback, signed.
+// webhooks.ts — one delivery attempt: signed, timestamped, idempotent.
 //
-// The receiver must be able to prove the POST came from this server: an
-// HMAC-SHA256 of the exact body under the key's secret travels in
-// `X-Nirvana-Signature`. Delivery failure NEVER affects the run — the
-// artifacts are on disk and the polling routes still answer.
+// This file no longer owns the retry schedule — a promise-chain retry inside
+// an async function dies with the process, and the case this must survive
+// (dispatch p99 5.7h, longest run 25.5h) guarantees the process outlives at
+// least one delivery attempt. `webhook-outbox.ts` owns persistence and
+// backoff; this file owns exactly one HTTP attempt and the crypto around it.
+//
+// Payload by reference, never by value: the body carries identifiers and a
+// path back into this API, never the run's summary or reservations text — a
+// legal case is sensitive, and the consumer already holds the credential
+// needed to fetch the real content.
 
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { eventId } from "../../../_shared/lib/cloudevents.js";
 import type { RunEnvelope } from "./runs.ts";
 
 export function sign(body: string, secret: string): string {
   return "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
 }
 
-export async function notifyTerminal(hook: { url: string; secret: string }, env: RunEnvelope): Promise<boolean> {
-  const body = JSON.stringify({ event: "run.finished", run: env });
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const res = await fetch(hook.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Nirvana-Signature": sign(body, hook.secret),
-          "X-Nirvana-Event": "run.finished",
-        },
-        body,
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (res.ok) return true;
-    } catch { /* network flake — retry below */ }
-    if (attempt < 3) await new Promise((r) => setTimeout(r, attempt * 1000));
+/**
+ * Stable across every retry of the SAME terminal event — computed from the
+ * envelope's own content, not from the attempt count, using the CloudEvents
+ * `id` algorithm cut 2 already gave every audit event
+ * (`_shared/lib/cloudevents.js`). Reused rather than reinvented: a second
+ * idempotency scheme at the one boundary that needs it most would be the
+ * defect this cut exists to close.
+ */
+export function deliveryId(env: Pick<RunEnvelope, "trace_id" | "state">): string {
+  return eventId({
+    type: "sh.squads.nirvana.delivery.run_finished",
+    source: "/engine/serve",
+    subject: env.trace_id,
+    dataText: JSON.stringify({ state: env.state }),
+  });
+}
+
+/** 5-minute replay window, 60s clock skew — the numbers the plan measured. */
+export const REPLAY_WINDOW_SEC = 300;
+const CLOCK_SKEW_SEC = 60;
+
+/**
+ * The reference receiver's payload: an id and an authenticated path back
+ * into this API, never the deliverable's content. `baseUrl` is only known
+ * when the operator set `NIRVANA_SERVE_PUBLIC_URL` (the bind address behind
+ * a reverse proxy is not the public one); absent it, the paths are relative
+ * — the consumer already knows the host, because it is the one that called
+ * this API in the first place.
+ */
+export function referenceBody(env: Pick<RunEnvelope, "trace_id" | "session_id" | "state" | "gate">, baseUrl = process.env.NIRVANA_SERVE_PUBLIC_URL ?? ""): {
+  event: "run.finished"; trace_id: string; session_id: string; state: RunEnvelope["state"]; gate: RunEnvelope["gate"]; job_url: string; result_url: string;
+} {
+  const base = baseUrl.replace(/\/+$/, "");
+  return {
+    event: "run.finished",
+    trace_id: env.trace_id,
+    session_id: env.session_id,
+    state: env.state,
+    gate: env.gate,
+    job_url: `${base}/v1/jobs/${env.trace_id}`,
+    result_url: `${base}/v1/jobs/${env.trace_id}/result`,
+  };
+}
+
+export function deliveryHeaders(body: string, secret: string, id: string, event = "run.finished"): Record<string, string> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  return {
+    "Content-Type": "application/json",
+    // Signed over `${timestamp}.${body}`, not the bare body — binding the
+    // timestamp into the signature is what stops a captured request from
+    // being replayed with a forged fresh timestamp header.
+    "X-Nirvana-Signature": sign(`${timestamp}.${body}`, secret),
+    "X-Nirvana-Event": event,
+    "X-Nirvana-Timestamp": timestamp,
+    "X-Nirvana-Delivery-Id": id,
+  };
+}
+
+export interface VerifyResult {
+  valid: boolean;
+  reason?: "bad_signature" | "timestamp_missing" | "timestamp_invalid" | "timestamp_too_old" | "timestamp_too_new";
+}
+
+/**
+ * The receiver's half of the contract, exported so a real consumer (or this
+ * repo's own tests standing in for one) has a reference instead of
+ * reinventing timestamp math against a 5-minute window. Rejects a replayed
+ * old request and a signature that does not cover the claimed timestamp.
+ */
+export function verifyWebhook(opts: { body: string; signature: string | null; timestamp: string | null; secret: string; toleranceSec?: number }): VerifyResult {
+  const { body, signature, timestamp, secret } = opts;
+  if (!timestamp) return { valid: false, reason: "timestamp_missing" };
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return { valid: false, reason: "timestamp_invalid" };
+  const tolerance = opts.toleranceSec ?? REPLAY_WINDOW_SEC;
+  const now = Math.floor(Date.now() / 1000);
+  if (ts < now - tolerance - CLOCK_SKEW_SEC) return { valid: false, reason: "timestamp_too_old" };
+  if (ts > now + CLOCK_SKEW_SEC) return { valid: false, reason: "timestamp_too_new" };
+  if (!signature) return { valid: false, reason: "bad_signature" };
+  const expected = Buffer.from(sign(`${timestamp}.${body}`, secret));
+  const given = Buffer.from(signature);
+  if (expected.length !== given.length || !timingSafeEqual(expected, given)) return { valid: false, reason: "bad_signature" };
+  return { valid: true };
+}
+
+/**
+ * One HTTP attempt. No retry here — `webhook-outbox.ts` owns the schedule
+ * and calls this once per due attempt, persisting the result before
+ * deciding whether there will be another one.
+ */
+export async function attemptDelivery(hook: { url: string; secret: string }, body: string, id: string): Promise<{ ok: boolean; status?: number; error?: string }> {
+  try {
+    const res = await fetch(hook.url, {
+      method: "POST",
+      headers: deliveryHeaders(body, hook.secret, id),
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+    return { ok: res.ok, status: res.status };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
-  return false;
 }

--- a/skills/harness/references/06-api.md
+++ b/skills/harness/references/06-api.md
@@ -98,11 +98,71 @@ NIRVANA_SERVE_SESSIONS_ROOT=/data/nirvana-sessions nrv serve --port 7777
 the last attempt was accepted WITH the reservations in the field beside it —
 the API never hides that from the caller.
 
+## Jobs — the polling floor
+
+A consumer that only kept the job id (it lost the webhook, or never listened
+for one) never needs the session id back:
+
+```
+GET  /v1/jobs/{trace_id}                  → the envelope (same shape as above)
+GET  /v1/jobs/{trace_id}/events           → SSE, same feed as the session route
+GET  /v1/jobs/{trace_id}/result           → the artifact, or the list + a path to pick one
+GET  /v1/jobs/{trace_id}/artifacts/{path} → one artifact by path
+```
+
+`/result` streams the file directly when the run produced exactly one
+artifact; otherwise it answers with the same `artifacts` list the envelope
+already carries, plus a pointer to `/artifacts/{path}`. Ownership is the same
+key check every session route makes — another key's token gets
+`job_not_found`, the same 404 a stranger's session id gets.
+
+This is the honest floor the plan calls for: it does not depend on
+connectivity at the moment an event fires, so it is what a consumer falls
+back to after a lost webhook, a missed SSE stream, or simply never having
+listened at all.
+
 ## Webhooks
 
-`POST /v1/webhooks {"url":"https://…"}` returns a secret; each terminal state
-POSTs `{event:"run.finished", run:<envelope>}` with an HMAC-SHA256 of the body
-in `X-Nirvana-Signature` (`sha256=…`). Verify it before trusting the payload.
+`POST /v1/webhooks {"url":"https://…"}` returns a secret. Each terminal state
+delivers ONE POST, retried on failure — see below — carrying:
+
+```json
+{ "event": "run.finished", "trace_id": "run_…", "session_id": "ses_…",
+  "state": "delivered", "gate": "pass",
+  "job_url": "/v1/jobs/run_…", "result_url": "/v1/jobs/run_…/result" }
+```
+
+**By reference, never by value**: the body never carries `summary`,
+`reservations` or artifact content — a legal case is sensitive, and the
+consumer already holds the credential needed to fetch the real thing from
+the URLs above. `job_url` / `result_url` are relative unless the operator set
+`NIRVANA_SERVE_PUBLIC_URL` (the bind address behind a reverse proxy is not
+the public one) — the consumer already knows its own host, since it is the
+one that called this API in the first place.
+
+**Headers**, all required to trust the delivery:
+
+| Header | Meaning |
+|---|---|
+| `X-Nirvana-Signature` | `sha256=<hmac>` over `${timestamp}.${body}` under the registered secret — the timestamp is bound INTO the signature, so a captured request cannot be replayed with a forged fresh timestamp. |
+| `X-Nirvana-Timestamp` | Unix seconds the request was signed. |
+| `X-Nirvana-Delivery-Id` | Idempotency key, stable across every retry of the SAME terminal event — reused from the CloudEvents `id` every audit event already carries (see `03-audit.md`). Dedupe on this before processing. |
+| `X-Nirvana-Event` | `run.finished`, today's only kind. |
+
+A receiver validates a delivery by recomputing the signature over
+`${timestamp}.${body}` and refusing anything outside a 5-minute window (60s
+of clock skew tolerated) — `verifyWebhook()` in `lib/serve/webhooks.ts` is
+the reference implementation; use it rather than reimplementing the
+timestamp math.
+
+**Retry**: exponential backoff with full jitter, persisted per run
+(`.webhook-delivery.jsonl` beside `.run.json`) so it survives this server
+restarting, not only the receiver being briefly unreachable. Delays climb
+1s → 2s → 4s → … capped at one hour; after 10 attempts (≈2h worst case
+cumulative) the delivery is marked `abandoned` and stops — a retry that never
+gives up is a different defect. An abandoned webhook is a degraded
+notification, never a lost result: the run's artifacts stay on disk and
+`GET /v1/jobs/{id}` never expires.
 
 ## Exposing it
 
@@ -125,6 +185,9 @@ wildcard.
 - **A restart does not lose runs**: each run persists `.run.json` beside its
   artifacts and is rehydrated on lookup. A run interrupted mid-flight is
   reported `failed` with the reason, never as eternally running.
+- **A restart does not lose pending webhook deliveries either**: the retry
+  schedule is re-discovered from `.webhook-delivery.jsonl` on startup, the
+  same way orphaned runs are.
 - **Concurrency**: one run per session, `--max-concurrent` across sessions.
 - **Seats**: each machine running the engine consumes a seat of the pack
   license. A fleet of API workers needs a licensing decision before it

--- a/skills/harness/tests/serve-api.test.ts
+++ b/skills/harness/tests/serve-api.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
 const root = mkdtempSync(join(tmpdir(), "serve-api-"));
 const serveDir = join(root, "serve");
@@ -71,6 +72,7 @@ beforeAll(async () => {
   process.env.NIRVANA_SERVE_SESSIONS_ROOT = join(root, "sessions");
   process.env.NIRVANA_SERVE_DISPATCH_BIN = dispatchFixture;
   process.env.NIRVANA_RUN_LEDGER_DB = join(root, "ledger.sqlite");
+  process.env.NIRVANA_SERVE_WEBHOOK_SWEEP_MS = "30";
   mkdirSync(serveDir, { recursive: true });
 
   const { keygen } = await import("../lib/serve/auth.ts");
@@ -302,4 +304,140 @@ describe("webhooks", () => {
     const r = await api("/v1/webhooks", { method: "POST", body: JSON.stringify({ url: "file:///etc/passwd" }) });
     expect(r.status).toBe(400);
   });
+});
+
+describe("jobs — session-agnostic, the polling floor", () => {
+  test("proves the polling floor: submit, never listen, retrieve the terminal state afterwards", async () => {
+    process.env.FIXTURE_EXIT = "0";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+      method: "POST", body: JSON.stringify({ brief: "nunca escutei o SSE" }),
+    })).json();
+    // No /events call anywhere in this test — only polling, the mechanism
+    // that does not depend on connectivity between updates.
+    const deadline = Date.now() + 15000;
+    let env: any;
+    while (Date.now() < deadline) {
+      env = await (await api(`/v1/jobs/${trace_id}`)).json();
+      if (env.state !== "queued" && env.state !== "running") break;
+      await new Promise((r) => setTimeout(r, 120));
+    }
+    expect(env.state).toBe("delivered");
+    expect(env.trace_id).toBe(trace_id);
+    expect(env.artifacts.some((a: any) => a.path === "deliverable.md")).toBe(true);
+
+    // The fixture writes two files (deliverable.md + _SUMMARY.md), so /result
+    // answers with the listing and a pointer to the by-path route rather than
+    // guessing which one is "the" artifact.
+    const result = await api(`/v1/jobs/${trace_id}/result`);
+    expect(result.status).toBe(200);
+    const resultBody = await result.json();
+    expect(resultBody.artifacts.some((a: any) => a.path === "deliverable.md")).toBe(true);
+
+    const download = await api(`/v1/jobs/${trace_id}/artifacts/deliverable.md`);
+    expect(await download.text()).toContain("conteúdo real");
+  });
+
+  test("a job belongs to the key that created it — another key gets job_not_found, never someone else's case", async () => {
+    process.env.FIXTURE_EXIT = "0";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+      method: "POST", body: JSON.stringify({ brief: "caso privado" }),
+    })).json();
+
+    const { keygen } = await import("../lib/serve/auth.ts");
+    const other = keygen({ label: "intruder-jobs" });
+    const r = await fetch(`${base}/v1/jobs/${trace_id}`, { headers: { Authorization: `Bearer ${other.token}` } });
+    expect(r.status).toBe(404);
+    expect((await r.json()).error).toBe("job_not_found");
+  });
+
+  test("an unknown job id is not found", async () => {
+    const r = await api("/v1/jobs/run_does_not_exist");
+    expect(r.status).toBe(404);
+  });
+
+  test("result on a still-running job is a conflict, not a partial answer", async () => {
+    process.env.FIXTURE_EXIT = "0";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+      method: "POST", body: JSON.stringify({ brief: "ainda rodando" }),
+    })).json();
+    // The fixture is fast, so this is a best-effort race — assert the
+    // CONTRACT (409 while non-terminal) rather than depend on timing when it
+    // happens to still be queued/running.
+    const r = await api(`/v1/jobs/${trace_id}/result`);
+    if (r.status === 409) {
+      expect((await r.json()).error).toBe("job_not_finished");
+    } else {
+      expect(r.status).toBe(200);
+    }
+  });
+
+  test("events by job id streams the same feed as events by session+run", async () => {
+    process.env.FIXTURE_EXIT = "0";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+      method: "POST", body: JSON.stringify({ brief: "stream por job id" }),
+    })).json();
+    const res = await api(`/v1/jobs/${trace_id}/events`);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    await res.body?.cancel();
+  });
+});
+
+describe("webhook delivery — signed, timed, idempotent, referenced not embedded", () => {
+  test("the delivered request verifies, carries a stable delivery id, and never embeds the summary by value", async () => {
+    const received: { body: string; headers: Record<string, string> }[] = [];
+    const receiver = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const body = await req.text();
+        received.push({ body, headers: Object.fromEntries(req.headers) });
+        return new Response("ok", { status: 200 });
+      },
+    });
+
+    try {
+      const reg = await api("/v1/webhooks", {
+        method: "POST",
+        body: JSON.stringify({ url: `http://127.0.0.1:${receiver.port}/hook` }),
+      });
+      const { secret } = await reg.json();
+
+      process.env.FIXTURE_EXIT = "0";
+      const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+      const { trace_id } = await (await api(`/v1/sessions/${session_id}/briefs`, {
+        method: "POST", body: JSON.stringify({ brief: "caso com webhook" }),
+      })).json();
+
+      const deadline = Date.now() + 15000;
+      while (Date.now() < deadline && received.length === 0) await new Promise((r) => setTimeout(r, 50));
+      expect(received.length).toBeGreaterThan(0);
+
+      const delivery = received[0];
+      const { verifyWebhook } = await import("../lib/serve/webhooks.ts");
+      const verdict = verifyWebhook({
+        body: delivery.body,
+        signature: delivery.headers["x-nirvana-signature"],
+        timestamp: delivery.headers["x-nirvana-timestamp"],
+        secret,
+      });
+      expect(verdict.valid).toBe(true);
+      expect(delivery.headers["x-nirvana-delivery-id"]).toBeTruthy();
+
+      const payload = JSON.parse(delivery.body);
+      expect(payload.trace_id).toBe(trace_id);
+      expect(payload.state).toBe("delivered");
+      expect(payload.job_url).toContain(`/v1/jobs/${trace_id}`);
+      // Payload by reference, never by value: the summary text must not
+      // travel inside the webhook body — a legal case is sensitive.
+      expect(delivery.body).not.toContain("resumo de uma p");
+      expect(payload.summary).toBeUndefined();
+      expect(payload.artifacts).toBeUndefined();
+    } finally {
+      receiver.stop(true);
+    }
+  }, spawnBudgetMs(1));
 });

--- a/skills/harness/tests/serve-queue-sse.test.ts
+++ b/skills/harness/tests/serve-queue-sse.test.ts
@@ -165,4 +165,26 @@ describe("SSE", () => {
       expect(ev.trace_id ?? ev.project_id).toBe(r.trace_id);
     }
   }, spawnBudgetMs(1));
+
+  test("a client that disconnects mid-run does not take the server down with it", async () => {
+    process.env.FIXTURE_MS = "600";
+    const { session_id } = await (await api("/v1/sessions", { method: "POST" })).json();
+    const r = await (await api(`/v1/sessions/${session_id}/briefs`, { method: "POST", body: JSON.stringify({ brief: "desconecta cedo" }) })).json();
+
+    const res = await api(`/v1/sessions/${session_id}/runs/${r.trace_id}/events`);
+    // Cancel while the run is still in flight — this is exactly what left
+    // the polling interval's next `enqueue()` throwing uncaught against a
+    // dead controller before `cancel()` was wired up.
+    await res.body!.cancel();
+
+    // Several 150ms poll ticks fire against the cancelled stream before the
+    // fixture even finishes (FIXTURE_MS=600 above).
+    await new Promise((res2) => setTimeout(res2, 500));
+
+    // If that throw had gone uncaught, the process would be gone and this
+    // would time out or the connection would reset instead of answering.
+    const health = await api("/v1/health");
+    expect(health.status).toBe(200);
+    delete process.env.FIXTURE_MS;
+  }, spawnBudgetMs(1));
 });

--- a/skills/harness/tests/serve-webhook-delivery.test.ts
+++ b/skills/harness/tests/serve-webhook-delivery.test.ts
@@ -1,0 +1,195 @@
+// serve-webhook-delivery.test.ts — the delivery guarantees cut 7 of
+// `.nirvana/plans/event-contract.md` adds on top of the HMAC signature that
+// already existed: a replay window, a stable idempotency key, and an
+// exponential-backoff retry schedule that is persisted (so it survives this
+// process dying) and eventually gives up rather than retrying forever.
+//
+// One failing-first test per guarantee, per the verification contract:
+//   - a duplicate delivery is not processed twice (the id is stable, so a
+//     receiver-side dedupe recognizes the retry as the same event);
+//   - a replayed old request is refused (the timestamp + tolerance window);
+//   - a failing endpoint is retried with growing delay and eventually stops
+//     (the outbox's own state machine, no real waiting required — every
+//     delay is asserted as a number, never slept through).
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sign, verifyWebhook, deliveryId, deliveryHeaders, referenceBody, REPLAY_WINDOW_SEC } from "../lib/serve/webhooks.ts";
+import * as outbox from "../lib/serve/webhook-outbox.ts";
+
+describe("signature + replay window — the receiver's half of the contract", () => {
+  const secret = "s3cr3t-do-consumidor";
+
+  test("a fresh, correctly signed request verifies", () => {
+    const body = JSON.stringify({ event: "run.finished", trace_id: "run_x" });
+    const headers = deliveryHeaders(body, secret, "delivery-1");
+    const result = verifyWebhook({ body, signature: headers["X-Nirvana-Signature"], timestamp: headers["X-Nirvana-Timestamp"], secret });
+    expect(result.valid).toBe(true);
+  });
+
+  test("a replayed old request is refused", () => {
+    const body = JSON.stringify({ event: "run.finished" });
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - REPLAY_WINDOW_SEC - 61);
+    const signature = sign(`${oldTimestamp}.${body}`, secret);
+    const result = verifyWebhook({ body, signature, timestamp: oldTimestamp, secret });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("timestamp_too_old");
+  });
+
+  test("a timestamp claiming to be from the future beyond clock skew is refused", () => {
+    const body = JSON.stringify({ event: "run.finished" });
+    const futureTimestamp = String(Math.floor(Date.now() / 1000) + 3600);
+    const signature = sign(`${futureTimestamp}.${body}`, secret);
+    const result = verifyWebhook({ body, signature, timestamp: futureTimestamp, secret });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("timestamp_too_new");
+  });
+
+  test("a tampered body invalidates the signature even with a fresh timestamp", () => {
+    const body = JSON.stringify({ event: "run.finished" });
+    const headers = deliveryHeaders(body, secret, "delivery-2");
+    const result = verifyWebhook({ body: body + "x", signature: headers["X-Nirvana-Signature"], timestamp: headers["X-Nirvana-Timestamp"], secret });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("bad_signature");
+  });
+
+  test("the wrong secret fails verification", () => {
+    const body = JSON.stringify({ event: "run.finished" });
+    const headers = deliveryHeaders(body, secret, "delivery-3");
+    const result = verifyWebhook({ body, signature: headers["X-Nirvana-Signature"], timestamp: headers["X-Nirvana-Timestamp"], secret: "outro-segredo" });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("bad_signature");
+  });
+
+  test("a missing timestamp is refused, not treated as fresh", () => {
+    const body = "{}";
+    const result = verifyWebhook({ body, signature: sign(body, secret), timestamp: null, secret });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("timestamp_missing");
+  });
+});
+
+describe("idempotency key — reused from cut 2's CloudEvents id, not reinvented", () => {
+  test("stable across two computations of the exact same terminal event", () => {
+    const env = { trace_id: "run_abc", state: "delivered" as const };
+    expect(deliveryId(env)).toBe(deliveryId(env));
+  });
+
+  test("differs for a different run", () => {
+    const a = deliveryId({ trace_id: "run_a", state: "delivered" as const });
+    const b = deliveryId({ trace_id: "run_b", state: "delivered" as const });
+    expect(a).not.toBe(b);
+  });
+
+  test("a duplicate delivery is not processed twice — a receiver dedupes on this id", () => {
+    const seen = new Set<string>();
+    const receive = (id: string) => (seen.has(id) ? "duplicate" : (seen.add(id), "processed"));
+    const env = { trace_id: "run_dup", state: "delivered" as const };
+    const id = deliveryId(env);
+    expect(receive(id)).toBe("processed");
+    // The retry after a timeout carries the SAME id — that is the guarantee.
+    expect(receive(id)).toBe("duplicate");
+  });
+});
+
+describe("payload by reference, never by value", () => {
+  test("the reference body carries no summary, reservations or artifact content", () => {
+    const env = {
+      trace_id: "run_x", session_id: "ses_1", state: "delivered" as const, gate: "pass" as const,
+      summary: "conteúdo sensível do caso", reservations: "nota confidencial do cliente",
+    };
+    const body = referenceBody(env);
+    const raw = JSON.stringify(body);
+    expect(raw).not.toContain("sensível");
+    expect(raw).not.toContain("confidencial");
+    expect(body.job_url).toContain("/v1/jobs/run_x");
+    expect(body.result_url).toBe(`${body.job_url}/result`);
+  });
+});
+
+describe("exponential backoff with jitter", () => {
+  test("every attempt's delay stays within [0, cap] and the cap grows exponentially", () => {
+    for (let attempt = 1; attempt <= 12; attempt++) {
+      const cap = Math.min(60 * 60 * 1000, 1000 * 2 ** (attempt - 1));
+      expect(outbox.backoffMs(attempt, () => 1)).toBeLessThanOrEqual(cap);
+      expect(outbox.backoffMs(attempt, () => 0)).toBe(0);
+    }
+  });
+
+  test("caps at one hour once the exponential would exceed it", () => {
+    expect(outbox.backoffMs(20, () => 1)).toBe(60 * 60 * 1000);
+  });
+});
+
+describe("webhook outbox — the retry schedule survives without a broker", () => {
+  const root = mkdtempSync(join(tmpdir(), "outbox-"));
+  let n = 0;
+  const freshRoot = () => join(root, "run-" + n++);
+  const hook = { url: "https://example.invalid/hook", secret: "s" };
+
+  test("a fresh delivery is due immediately", () => {
+    const out = freshRoot();
+    outbox.enqueue(out, { id: "d1", trace_id: "run_1", session_dir: out, ...hook, body: "{}" });
+    const state = outbox.readState(out)!;
+    expect(state.status).toBe("pending");
+    expect(outbox.isDue(state)).toBe(true);
+  });
+
+  test("re-enqueuing the same id is a no-op — the history is not duplicated", () => {
+    const out = freshRoot();
+    outbox.enqueue(out, { id: "d2", trace_id: "run_2", session_dir: out, ...hook, body: "{}" });
+    outbox.enqueue(out, { id: "d2", trace_id: "run_2", session_dir: out, ...hook, body: "{}" });
+    const lines = readFileSync(join(out, ".webhook-delivery.jsonl"), "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+  });
+
+  test("a failing endpoint is retried with growing delay and eventually stops", () => {
+    const out = freshRoot();
+    outbox.enqueue(out, { id: "d3", trace_id: "run_3", session_dir: out, ...hook, body: "{}" });
+    let state = outbox.readState(out)!;
+    const scheduledDelays: number[] = [];
+    for (let i = 0; i < outbox.MAX_ATTEMPTS; i++) {
+      const before = Date.now();
+      state = outbox.recordAttempt(out, state, { ok: false, error: "connection refused" });
+      if (state.status === "pending") scheduledDelays.push(new Date(state.next_attempt_at).getTime() - before);
+    }
+    // The ceiling: after MAX_ATTEMPTS failures it gives up rather than
+    // retrying forever — a different defect than the one this cut fixes.
+    expect(state.status).toBe("abandoned");
+    expect(state.attempt).toBe(outbox.MAX_ATTEMPTS);
+    expect(scheduledDelays.length).toBe(outbox.MAX_ATTEMPTS - 1);
+    // Growing: scheduledDelays[i] is the delay before attempt (i+2), whose
+    // own cap is 1000 * 2^(i+1) ms (capped at one hour).
+    for (let i = 0; i < scheduledDelays.length; i++) {
+      const cap = Math.min(60 * 60 * 1000, 1000 * 2 ** (i + 1));
+      expect(scheduledDelays[i]).toBeLessThanOrEqual(cap);
+    }
+  });
+
+  test("a delivery that succeeds is marked delivered and leaves the pending set", () => {
+    const out = freshRoot();
+    outbox.enqueue(out, { id: "d4", trace_id: "run_4", session_dir: out, ...hook, body: "{}" });
+    const before = outbox.pendingCount();
+    const state = outbox.recordAttempt(out, outbox.readState(out)!, { ok: true });
+    expect(state.status).toBe("delivered");
+    expect(outbox.pendingCount()).toBe(before - 1);
+  });
+
+  test("adoptPending rediscovers a delivery this process forgot about (crash recovery)", () => {
+    const sessRoot = mkdtempSync(join(tmpdir(), "sessions-"));
+    const outputsBase = join(sessRoot, "ses_x", ".nirvana", "outputs", "run_5");
+    mkdirSync(outputsBase, { recursive: true });
+    const now = new Date().toISOString();
+    writeFileSync(join(outputsBase, ".webhook-delivery.jsonl"), JSON.stringify({
+      id: "d5", trace_id: "run_5", session_dir: outputsBase, ...hook, body: "{}",
+      attempt: 0, next_attempt_at: now, status: "pending", last_error: null, created_at: now,
+    }) + "\n");
+    const before = outbox.pendingCount();
+    const found = outbox.adoptPending(sessRoot);
+    expect(found).toBe(1);
+    expect(outbox.pendingCount()).toBe(before + 1);
+    rmSync(sessRoot, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Cut 7 — the last one — of `.nirvana/plans/event-contract.md`.

**Smoke ran green on this branch (ubuntu, macOS, windows) before this PR was opened**, after a real crash on the first attempt got fixed — see below.

## What was measurably missing

`skills/harness/lib/serve/` already had `server.ts`, `auth.ts`, `queue.ts`, `runs.ts`, `webhooks.ts`, `artifacts.ts`, `sessions.ts` — bearer auth, per-key webhook registration, an HMAC signature. Counted in `webhooks.ts` before this cut: `retry` 1, `backoff` 0, `jitter` 0, `idempotency` 0, `timestamp` 0, `replay` 0. No job route existed at all: a consumer that kept only a job id (not the session id that produced it) had no way to ask "how is my case doing?"

## The job route

`GET /v1/jobs/{id}`, `/events`, `/result`, `/artifacts/{path}` — session-agnostic, same key-ownership check every session route already made. `/result` streams the one artifact directly when there is exactly one, otherwise answers with the listing plus a path to pick one.

## Delivery guarantees

- `X-Nirvana-Signature` now signs `${timestamp}.${body}`, not the bare body, so a captured request can't be replayed with a forged fresh timestamp.
- `X-Nirvana-Timestamp` + `verifyWebhook()`: a 5-minute replay window, 60s clock skew.
- `X-Nirvana-Delivery-Id`: reused, not reinvented — the CloudEvents `id` cut 2 already computes for every audit event.
- `webhook-outbox.ts` (new): the retry schedule persisted to `.webhook-delivery.jsonl` beside `.run.json`, so it survives this process dying mid-backoff. Full jitter, exponential cap 1s → 1h, 10 attempts (~2h worst case) before `abandoned` — a retry that never gives up is a different defect, and an abandoned webhook is a degraded notification, not a lost result, because the job route never expires.

## A real bug the brief's own constraint existed to close

The webhook body was about to carry the full run envelope — `summary`/`reservations` by value — to a consumer whose worked example is a law practice. Fixed: the delivered body carries only `trace_id`, `session_id`, `state`, `gate`, `job_url`, `result_url`.

## A second bug, found by this cut's own tests

The first test anywhere to cancel `/v1/jobs/{id}/events` early (instead of draining it to `run.finished`) took the whole CI process down on ubuntu and macOS: `sseAuditStream`'s polling `setInterval` had no `cancel()` handler, so a disconnected client left it running, and the next `controller.enqueue()` threw uncaught inside a bare timer callback — latent since before this cut, because nothing had disconnected early enough to hit it. Fixed: `cancel()` clears the interval immediately, `send()` catches a stale `enqueue()` defensively, `controller.close()` no longer throws on a client that closed first. Regression test added (`serve-queue-sse.test.ts`).

## Durable Work Continuity, and the situation this cut was actually in

PR #159 (`durable-work.ts`, "Durable Work Continuity") is **open, not merged**. `webhook-outbox.ts` was built without depending on it: a deliberately narrow three-function surface (`enqueue`/`sweepOnce`/`readState`) so landing DWC later can become the storage underneath these same three functions without moving the wire contract. The two questions the plan left open for @AndreAlmeidaDC are answered provisionally in the module's own header comment, with what would change if he decides otherwise.

`supervisor.ts`, `dispatch.ts` and the uninstall work on `fix/dispatch-completion-signal` (PR #164) were not touched.

## Verification

Failing-first tests for each guarantee: a duplicate delivery recognized by its stable id, a replayed request refused (`timestamp_too_old`), a failing endpoint retried with growing delay until the 10-attempt ceiling. A live end-to-end webhook delivery against a throwaway receiver. A polling-floor test: submit, never call `/events`, retrieve terminal state and the artifact through `/v1/jobs/{id}` alone.

`bun test skills/harness` — 1558 pass, 2 skip, 0 fail, across 151 files. `bun scripts/check-english-source.ts --strict`, `bun scripts/check-changelog-parity.ts --strict`, `git diff --check` — all clean. `gh workflow run smoke.yml` — green on all three OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)