### PR TITLE
test(heartbeat): the orphan check waits for the process to go, not for 400ms

### DIFF
--- a/skills/harness/tests/driver-ledger-heartbeat.test.ts
+++ b/skills/harness/tests/driver-ledger-heartbeat.test.ts
@@ -129,10 +129,19 @@ describe("driver — heartbeat sidecar", () => {
     expect(typeof stallEvents[0].heartbeat_at).toBe("string");
 
     // No dangling sidecar (the managed equivalent of "all timers cleared"):
-    // give the SIGTERM/sentinel a moment, then look for the run id in ps.
-    Bun.sleepSync(400);
-    const pg = spawnSync("pgrep", ["-f", row.run_id], { encoding: "utf8" });
-    expect((pg.stdout || "").trim()).toBe("");
+    // the parent sends SIGTERM/writes the sentinel with no grace period, so a
+    // fixed delay before checking races the sidecar's own teardown exactly
+    // like the artifact-touch fakes used to (see awaitAuditLine above). Poll
+    // for the process to be gone instead — fast when the machine is fast,
+    // and it still fails if the process never actually goes away.
+    let pgOut = "";
+    const pgDeadline = Date.now() + 5_000;
+    for (;;) {
+      pgOut = (spawnSync("pgrep", ["-f", row.run_id], { encoding: "utf8" }).stdout || "").trim();
+      if (pgOut === "" || Date.now() >= pgDeadline) break;
+      Bun.sleepSync(50);
+    }
+    expect(pgOut).toBe("");
   }, 20_000);
 
   test("unledgered calls keep byte-for-byte legacy behavior (pipes, no sidecar)", () => {


### PR DESCRIPTION
## Summary
- The commit landed on this branch after PR #164 was already merged, so `pull_request` never fired and CI never ran it (it passed 6/6 local runs only).
- Replaces the last fixed-clock bet in `driver-ledger-heartbeat.test.ts`: instead of sleeping a guessed 400ms after SIGTERM and checking `pgrep` once, it polls until the process is actually gone, bounded at 5s.

## Test plan
- [ ] CI green on ubuntu, macos, windows (`smoke.yml`)
- [x] 6 consecutive local runs pass, 19.68-19.78s

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>