### PR TITLE
fix(init): point audit hook warning to setup

### DIFF
--- a/skills/_shared/scripts/init-project.ts
+++ b/skills/_shared/scripts/init-project.ts
@@ -571,7 +571,7 @@ async function main() {
   try {
     const result = require("node:child_process").spawnSync("bun", [path.join(SKILLS_ROOT, "_shared", "scripts", "install.ts"), "--check"], { encoding: "utf8" });
     if (result.status !== 0) {
-      log.warn(`Audit hooks are NOT yet wired into your agents. Run: nrv install`);
+      log.warn(`Audit hooks are NOT yet wired into your agents. Run: nrv setup`);
       log.info(`(this configures Claude Code + Gemini-CLI to emit audit events automatically)`);
     } else {
       log.ok(`Audit hooks active across installed agents — runs auto-track in 'nrv glance'.`);

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -17,12 +17,12 @@
  * future agents (Cursor, …) plug in by adding entries to AGENTS_TO_INSTALL.
  *
  * Usage:
- *   nrv install            # install / repair hooks + verify toolchain
- *   nrv install --dry      # show what would change, don't write
- *   nrv install --uninstall  # remove our hooks (keeps user's other settings)
- *   nrv install --check    # report installation status, exit 0/1
- *   nrv install --repair-path [--apply]  # Windows: drop temporary nrv-* entries from the user PATH
- *   nrv install -h         # this message
+ *   nrv setup              # install / repair hooks + verify toolchain
+ *   nrv setup --dry        # show what would change, don't write
+ *   nrv setup --uninstall  # remove our hooks (keeps user's other settings)
+ *   nrv setup --check      # report installation status, exit 0/1
+ *   nrv setup --repair-path [--apply]  # Windows: drop temporary nrv-* entries from the user PATH
+ *   nrv setup -h           # this message
  */
 
 import * as fs from "node:fs";
@@ -512,17 +512,21 @@ function repairUserPath(apply: boolean): number {
 function main() {
   const { flags } = parseArgs();
   if (flags.h || flags.help) {
-    console.log(`nrv install — one-shot Nirvana setup
+    console.log(`nrv setup — one-shot Nirvana setup
 
 USAGE
-  nrv install              install / repair hooks across all agents
-  nrv install --dry        show what would change, don't write anything
-  nrv install --check      report status (exit 0 = ready, 1 = needs setup)
-  nrv install --uninstall  remove our hooks and PATH block (keeps user's other settings)
-  nrv install --repair-path          Windows: list temporary nrv-* entries left on the
+  nrv setup                        install / repair hooks across all agents
+  nrv setup --dry                  show what would change, don't write anything
+  nrv setup --check                report status (exit 0 = ready, 1 = needs setup)
+  nrv setup --uninstall            remove our hooks and PATH block (keeps user's other settings)
+  nrv setup --repair-path          Windows: list temporary nrv-* entries left on the
                                      user PATH by earlier test runs (nothing written)
-  nrv install --repair-path --apply  remove exactly those entries, keep the rest as is
-  nrv install -h           this help
+  nrv setup --repair-path --apply  remove exactly those entries, keep the rest as is
+  nrv setup -h                     this help
+
+COMPATIBILITY
+  nrv install --bootstrap runs the same setup. Existing install flags such as
+  --check and --repair-path remain supported.
 
 WHAT IT DOES
   1. Verifies toolchain (bun installed, PATH includes ~/.local/bin)

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -50,6 +50,7 @@ export const COMMANDS: Command[] = [
 
   // install & lifecycle
   { name: "install", custom: true, category: "install", args: "<source> | --bootstrap | --check | --repair-path", summary: "Install an asset (squad/business/clone/pack); --bootstrap wires audit hooks; --repair-path cleans the Windows user PATH", visibility: "user" },
+  { name: "setup", target: "_shared/scripts/install.ts", category: "install", summary: "Install or repair audit hooks across supported agents", visibility: "user" },
   { name: "uninstall", custom: true, category: "install", args: "<name> | --engine | --hooks", summary: "Remove an asset, the engine (keeps content), or just the hooks", visibility: "user" },
   { name: "installed", aliases: ["list-installed"], target: "_shared/scripts/list-installed.ts", category: "install", summary: "List active installations", visibility: "user" },
   { name: "update", aliases: ["self-update", "upgrade"], target: "harness/scripts/update.ts", category: "install", args: "[--check]", summary: "Update the engine: git pull (dev) or re-fetch the latest release (npx)", visibility: "user" },
@@ -100,7 +101,6 @@ export const COMMANDS: Command[] = [
   { name: "license", aliases: ["verify-license", "whoami"], target: "_shared/scripts/license.ts", category: "license", args: "[status|check|install [<path>]|activate]", summary: "Show your copy's provenance, install a PROVENANCE.json, activate (offline-safe)", visibility: "user" },
 
   // advanced / dev
-  { name: "setup", target: "_shared/scripts/install.ts", category: "dev", summary: "Re-wire audit hooks (= install --bootstrap)", visibility: "dev" },
   { name: "install-content", target: "_shared/scripts/install-content.ts", category: "dev", args: "<dir> --slug <slug>", summary: "Overlay a content pack onto the engine (used by a pack's setup.ts)", visibility: "dev" },
   { name: "use-businesses", aliases: ["business", "businesses"], target: "harness/scripts/route.ts", category: "dev", summary: "Route forcing business-first preference", visibility: "dev" },
   { name: "use-squads", aliases: ["squad", "squads"], target: "harness/scripts/route.ts", category: "dev", summary: "Route forcing squad-first preference", visibility: "dev" },

--- a/skills/harness/tests/init-audit-hooks-guidance.test.ts
+++ b/skills/harness/tests/init-audit-hooks-guidance.test.ts
@@ -1,0 +1,45 @@
+// init-audit-hooks-guidance.test.ts — `nrv init` must point users at the
+// command that actually installs or repairs audit hooks.
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+const NRV = path.join(ROOT, "skills/harness/scripts/nrv.ts");
+const INIT = fs.readFileSync(path.join(ROOT, "skills/_shared/scripts/init-project.ts"), "utf8");
+
+function runNrv(...args: string[]) {
+  return spawnSync(process.execPath, [NRV, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, NIRVANA_SKILLS_DIR: path.join(ROOT, "skills") },
+  });
+}
+
+describe("audit hook setup guidance", () => {
+  test("the post-init warning recommends nrv setup", () => {
+    const warning = INIT.split("\n").find((line) => line.includes("Audit hooks are NOT yet wired")) ?? "";
+    expect(warning).toContain("Run: nrv setup");
+    expect(warning).not.toContain("Run: nrv install");
+  });
+
+  test("nrv setup routes to the hook installer and describes that command", () => {
+    const result = runNrv("setup", "--help");
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}`).toContain("nrv setup");
+    expect(`${result.stdout}`).toMatch(/install \/ repair hooks across all agents/);
+  });
+
+  test("the main help lists setup as the audit-hook command", () => {
+    const result = runNrv("help");
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}`).toMatch(/setup\s+Install or repair audit hooks across supported agents/);
+  });
+
+  test("bare nrv install remains the asset installer", () => {
+    const result = runNrv("install", "--help");
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}`).toMatch(/install a business, squad, mind-clone, or pack/);
+    expect(`${result.stdout}`).not.toMatch(/install \/ repair hooks across all agents/);
+  });
+});


### PR DESCRIPTION
## What this changes

`nrv init` now tells users to run `nrv setup` when audit hooks are missing. The setup command's own help and the main command list now use the same guidance, while bare `nrv install` remains the asset installer.

The root cause was a command-routing split: bare `nrv install` routes to `install-asset.ts`, but the post-init warning and hook-installer help still described it as the hook setup command. A focused regression test now verifies the warning, setup routing/help, main help, and preservation of bare install behavior.

## How it was tested

- `bun test skills/harness/tests/init-audit-hooks-guidance.test.ts skills/harness/tests/init-existing-project.test.ts skills/_shared/tests/validate-cli-alias.test.ts` (24 pass, 0 fail on Windows)
- `bun run check:quick` (pass)
- `git diff --check` (pass)

The full harness suite was also sampled but is not claimed as passing on this Windows host because unrelated baseline/environment tests fail on symlink privileges, locale formatting, and existing body-indexing assertions.

## Checklist

- [ ] `bun test skills/harness/tests` passes
- [x] No hardcoded model names
- [x] No paid pack content, secrets, or `.env` values added
- [x] **I have read and agree to the Nirvana-OS CLA v1.0** (signed-off commit)