### PR TITLE
feat(glance): Trajectory Card unifies Runs/Chat timelines (Phase A redesign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,62 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Glance: the Trajectory Card replaces two divergent run timelines
+
+The Runs tab and the Chat panel each rendered "what happened in this run"
+through their own implementation: the Runs tab checked event names against a
+10-name `x-show` chain, the Chat panel already used the full label coverage
+in `run-event-labels.js`. `trajectory-card.js` is the fix — one organism,
+`buildTrajectoryRows()`, that both surfaces now call, so a run reads the same
+whether opened from the Chat panel or the Runs tab.
+
+Three new moleculed views ride on top of events that already carried this
+data and had nowhere to show it: a collapsible **judgement strip** nests
+`judge_invoked → critique_generated → revision_dispatched/revision_auto
+(0..N) → gate_passed/gate_failed/revision_loop_exhausted` instead of scattering
+them as flat rows; a **delivery-nuance badge** distinguishes a clean
+`delivered` from `x_delivered_with_reservations` and `x_delivery_withheld` —
+each with its own icon and text label, never color alone (WCAG 2.2 AA
+1.4.1) — and expands to the ceiling/gate/revisions detail; a **runtime-health
+chip** surfaces `runtime_auth_failed` / `runtime_error` /
+`x_router_failure_cascade` inline, with the hint visible without an extra
+click. Fourteen more previously-invisible events (the judgement/runtime/team
+families above, plus `x_ledger_abandoned`, `x_ledger_stall_observed` and
+`session_resume_failed`) now resolve to a real label in
+`run-event-labels.js` instead of falling back to their raw name.
+
+Both timelines also fixed the identity bug the unification exposed: rows
+were keyed by their position in the array Alpine iterates, which shifts the
+instant the "show infrastructure events" toggle changes what is visible.
+`runTimeline()` now stamps a stable `_seq` on every event once, from its
+position in the full, unfiltered stream, so a row's expand/collapse state
+survives that toggle and future re-renders.
+
+Two smaller fixes underneath: `artifact_touched` had two producers with
+diverging payloads (the Claude Code hook and the run-ledger heartbeat sweep);
+the hook now also reports `size_bytes`, closing the concrete gap between
+them (a `run_id` gap remains, named rather than silently patched — the hook
+runs before any ledger row may exist). A cluster of dead code found by the
+Glance inventory is gone: the `no_match` agent/run status branch (no event
+is ever literally named `no_match`), the permanently-zero `revisions.total`
+counter in the observability dashboard (it was matching an event name that
+was never emitted), `dispatch_skill` and three `ACTION_EVENTS` /
+label-map entries with no emitter anywhere in the engine, and three
+unreachable icon-map entries.
+
+Visually, the Trajectory Card and its judgement strip adopt a glassmorphism
+material — new `--sheet-a`/`--sheet-b`/`--glass` tokens in `tokens.css`,
+adapted from the `design-tests/glassmorphism` reference: every extra layer
+of depth is derived by formula (`pow()` for stacked alpha, `hypot()` for
+stacked blur), never chosen by eye, and `--floor-field` is a real minimum
+alpha — verified against Glance's own palette, not guessed — below which
+the dial cannot push body text under WCAG 2.2 AA contrast.
+
+This is Phase A of the Glance redesign only. The other two Wave 2 molecules
+(route-decision detail, team-chain preview), event-list virtualization, the
+ADR-007 control-plane decision and `observability.html`'s fate are explicitly
+out of scope here and remain for later phases.
+
 ### `nrv serve`: webhook, SSE and polling proved on one live run
 
 A new integration test (`skills/harness/tests/serve-triad-live-correlation.test.ts`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ in `run-event-labels.js`. `trajectory-card.js` is the fix — one organism,
 `buildTrajectoryRows()`, that both surfaces now call, so a run reads the same
 whether opened from the Chat panel or the Runs tab.
 
-Three new moleculed views ride on top of events that already carried this
-data and had nowhere to show it: a collapsible **judgement strip** nests
+Three new molecule-level views ride on top of events that already carried
+this data and had nowhere to show it: a collapsible **judgement strip** nests
 `judge_invoked → critique_generated → revision_dispatched/revision_auto
 (0..N) → gate_passed/gate_failed/revision_loop_exhausted` instead of scattering
 them as flat rows; a **delivery-nuance badge** distinguishes a clean

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,67 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Glance: o Cartão de Trajetória substitui duas timelines de run divergentes
+
+A aba Runs e o painel de Chat renderizavam "o que aconteceu nesta run" cada
+um com sua própria implementação: a aba Runs checava o nome do evento contra
+uma cadeia `x-show` de 10 nomes, enquanto o painel de Chat já usava a
+cobertura completa de `run-event-labels.js`. O `trajectory-card.js` é a
+correção — um único organismo, `buildTrajectoryRows()`, que as duas
+superfícies agora chamam, então uma run aparece igual seja aberta pelo
+painel de Chat ou pela aba Runs.
+
+Três moléculas novas se apoiam em eventos que já carregavam esse dado e não
+tinham onde aparecer: a **Faixa de julgamento**, um grupo recolhível, aninha
+`judge_invoked → critique_generated → revision_dispatched/revision_auto
+(0..N) → gate_passed/gate_failed/revision_loop_exhausted` em vez de
+espalhá-los como linhas soltas; o **Selo de nuance de entrega** distingue
+uma `delivered` limpa de `x_delivered_with_reservations` e
+`x_delivery_withheld` — cada uma com ícone e texto próprios, nunca só a cor
+(WCAG 2.2 AA 1.4.1) — e expande para o detalhe de teto/gate/revisões; o
+**Chip de saúde de runtime** mostra `runtime_auth_failed` /
+`runtime_error` / `x_router_failure_cascade` inline, com o motivo visível
+sem clique extra. Mais catorze eventos antes invisíveis (as famílias de
+julgamento/runtime/time acima, mais `x_ledger_abandoned`,
+`x_ledger_stall_observed` e `session_resume_failed`) agora resolvem para um
+rótulo real em `run-event-labels.js` em vez de cair no nome bruto.
+
+As duas timelines também corrigiram o bug de identidade que a unificação
+expôs: as linhas eram chaveadas pela posição no array que o Alpine itera,
+que muda no instante em que o toggle "mostrar eventos de infraestrutura"
+muda o que fica visível. `runTimeline()` agora grava um `_seq` estável em
+cada evento uma única vez, a partir da posição dele no stream completo e não
+filtrado, então o estado de expandir/recolher de uma linha sobrevive a esse
+toggle e a novas renderizações.
+
+Duas correções menores por baixo: `artifact_touched` tinha dois produtores
+com payloads divergentes (o hook do Claude Code e a varredura de heartbeat
+do run-ledger); o hook agora também relata `size_bytes`, fechando a lacuna
+concreta entre eles (uma lacuna de `run_id` permanece, nomeada em vez de
+remendada em silêncio — o hook roda antes de qualquer linha do ledger
+existir). Um conjunto de código morto encontrado pelo inventário do Glance
+foi removido: o ramo de status `no_match` de agente/run (nenhum evento é
+literalmente chamado `no_match`), o contador `revisions.total`
+permanentemente zerado do dashboard de observabilidade (comparava um nome
+de evento que nunca é emitido), `dispatch_skill` e três entradas de
+`ACTION_EVENTS`/mapa de labels sem nenhum emissor no motor, e três entradas
+de mapa de ícone inalcançáveis.
+
+Visualmente, o Cartão de Trajetória e a Faixa de julgamento adotam um
+material de glassmorphism — tokens novos `--sheet-a`/`--sheet-b`/`--glass`
+em `tokens.css`, adaptados da referência `design-tests/glassmorphism`: toda
+profundidade extra é derivada por fórmula (`pow()` para alpha empilhado,
+`hypot()` para blur empilhado), nunca escolhida a olho, e `--floor-field` é
+um alpha mínimo real — verificado contra a própria paleta do Glance, não
+estimado — abaixo do qual o dial não consegue empurrar o texto de corpo
+para fora do contraste WCAG 2.2 AA.
+
+Esta é só a Fase A do redesign do Glance. As outras duas moléculas da Wave 2
+(detalhe de decisão de rota, prévia da corrente de equipe), a virtualização
+da lista de eventos, a decisão de arquitetura do ADR-007 e o destino do
+`observability.html` ficam explicitamente fora de escopo aqui, para fases
+seguintes.
+
 ### `nrv serve`: webhook, SSE e polling provados numa mesma run ao vivo
 
 Um teste de integração novo (`skills/harness/tests/serve-triad-live-correlation.test.ts`)

--- a/skills/_shared/scripts/audit-emit-from-hook.ts
+++ b/skills/_shared/scripts/audit-emit-from-hook.ts
@@ -26,8 +26,17 @@
  *   Bash command        → tool_invoked  (hint: "bash")  // command truncated to 200 chars
  *
  * Mapping (PostToolUse):
- *   Write/Edit success  → artifact_touched  (path = filePath / file_path)
+ *   Write/Edit success  → artifact_touched  (path = filePath / file_path, size_bytes when readable)
  *   Bash success        → bash_completed   (exit_code if available)
+ *
+ * `artifact_touched` has a second producer: the run-ledger.ts heartbeat sweep
+ * (a poller, not a hook), which always carries `run_id`/`size_bytes` but only
+ * ever reports `action: "modify"` (an mtime scan cannot tell create from edit).
+ * This hook now carries `size_bytes` too so both payloads converge on it; it
+ * does NOT carry `run_id` — this process is keyed by Claude Code's session
+ * `trace_id`, born before any ledger row may exist, and resolving one would
+ * mean a per-tool-call SQLite lookup that is almost always a miss. Left as a
+ * named gap rather than silently patched.
  *
  * Filtering: only emit when the touched path is inside a Nirvana project
  * (heuristic: cwd contains "/projects/" OR file_path starts with NIRVANA_PROJECT_ROOT).
@@ -188,7 +197,16 @@ async function main() {
     if (stage === "pre") {
       appendEvent({ ...base, event: "tool_invoked", action, file_path: filePath });
     } else {
-      appendEvent({ ...base, event: "artifact_touched", action, file_path: filePath, success: response.success !== false });
+      // size_bytes: unifies this payload with the other artifact_touched producer
+      // (run-ledger.ts heartbeat sweep, which always carries it). Best-effort —
+      // the file can be gone or unreadable by the time the hook runs.
+      let sizeBytes: number | undefined;
+      try { sizeBytes = filePath ? fs.statSync(filePath).size : undefined; } catch { /* file unreadable/gone — omit */ }
+      appendEvent({
+        ...base, event: "artifact_touched", action, file_path: filePath,
+        success: response.success !== false,
+        ...(sizeBytes != null ? { size_bytes: sizeBytes } : {}),
+      });
     }
   } else if (bashTools.has(tool)) {
     const cmdShort = (command || "").slice(0, 200);

--- a/skills/harness/lib/glance/agent-state.ts
+++ b/skills/harness/lib/glance/agent-state.ts
@@ -9,7 +9,6 @@
  * Status semantics (precedence top-down):
  *   completed      → trace emitted `delivered`
  *   failed         → trace emitted `gate_failed`
- *   no_match       → trace emitted `no_match`
  *   stale          → no event in `STALE_THRESHOLD_MS`
  *   tool_in_flight → last action event was `tool_invoked` and no matching post-event after
  *   waiting        → has `brief_received` but no dispatch yet
@@ -41,10 +40,7 @@ const ACTION_EVENTS = new Set<string>([
   "gate_passed",
   "gate_failed",
   "delivered",
-  "humanize_completed",
   "target_plan_committed",
-  "local_execution_started",
-  "local_execution_completed",
   "session_started",
 ]);
 
@@ -57,8 +53,7 @@ export type AgentStatus =
   | "waiting"
   | "stale"
   | "completed"
-  | "failed"
-  | "no_match";
+  | "failed";
 
 export interface AgentState {
   trace_id: string;
@@ -346,10 +341,6 @@ export function deriveAgentStates(events: Array<any>): AgentState[] {
       status = "failed";
       const ft = evs.filter(e => e.event === "gate_failed").pop()!;
       statusSinceMs = nowMs - new Date(ft.ts).getTime();
-    } else if (evs.some(e => e.event === "no_match")) {
-      status = "no_match";
-      const nt = evs.filter(e => e.event === "no_match").pop()!;
-      statusSinceMs = nowMs - new Date(nt.ts).getTime();
     }
     // 2. Stale: no event for STALE_MS
     else if (lastAge > T.STALE_MS) {
@@ -447,7 +438,7 @@ export function deriveAgentStates(events: Array<any>): AgentState[] {
   // Sort: active (tool_in_flight, running) first, then waiting, idle, stale, terminal
   const order: Record<AgentStatus, number> = {
     tool_in_flight: 0, running: 1, waiting: 2, idle: 3, stale: 4,
-    completed: 5, failed: 5, no_match: 5,
+    completed: 5, failed: 5,
   };
   states.sort((a, b) => {
     const oa = order[a.status] ?? 9;
@@ -462,7 +453,7 @@ export function deriveAgentStates(events: Array<any>): AgentState[] {
 export function summarizeStates(states: AgentState[]): Record<AgentStatus, number> & { total: number } {
   const out: any = {
     tool_in_flight: 0, running: 0, idle: 0, waiting: 0, stale: 0,
-    completed: 0, failed: 0, no_match: 0, total: 0,
+    completed: 0, failed: 0, total: 0,
   };
   for (const s of states) {
     out[s.status] = (out[s.status] || 0) + 1;

--- a/skills/harness/lib/glance/data-loader.ts
+++ b/skills/harness/lib/glance/data-loader.ts
@@ -242,7 +242,7 @@ interface Run {
   squad_name: string | null;
   target: string | null;            // "<kind>:<slug>" of what the run was dispatched to
   outputs_dir: string | null;       // where the dispatched target was told to write
-  status: "running" | "delivered" | "gate_failed" | "no_match" | "unknown";
+  status: "running" | "delivered" | "gate_failed" | "unknown";
   started_at: string;               // ISO of first event
   last_event_at: string;             // ISO of last event
   event_count: number;              // every event on the trace
@@ -387,10 +387,9 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
       if (!r.outputs_dir && (ev.outputs_dir || ev.outputs_root)) {
         r.outputs_dir = ev.outputs_dir || ev.outputs_root;
       }
-      // Status precedence: gate_failed > delivered > no_match > running
+      // Status precedence: gate_failed > delivered > running
       if (ev.event === "delivered") r.status = "delivered";
       else if (ev.event === "gate_failed" && r.status !== "delivered") r.status = "gate_failed";
-      else if (ev.event === "no_match" && r.status === "unknown") r.status = "no_match";
       else if (r.status === "unknown") r.status = "running";
       // Track artifact paths
       const artifact = ev.artifact_path || (ev.event === "artifact_touched" ? ev.file_path : null);

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -1495,6 +1495,7 @@ export async function startServer(opts: ServerOptions) {
         "/glance.css": "text/css",
         "/glance.js": "application/javascript",
         "/run-event-labels.js": "application/javascript",
+        "/trajectory-card.js": "application/javascript",
         "/settings-panel.js": "application/javascript",
         "/absence.js": "application/javascript",
         "/subsystem-row.js": "application/javascript",

--- a/skills/harness/lib/glance/views/agent-swimlane-renderer.js
+++ b/skills/harness/lib/glance/views/agent-swimlane-renderer.js
@@ -30,12 +30,8 @@
     brief_received: '#94a3b8',       // slate-400
     brief_amplified: '#94a3b8',
     session_started: '#64748b',      // slate-500
-    local_execution_started: '#0ea5e9',  // sky-500
-    local_execution_completed: '#0284c7',  // sky-600
     target_plan_committed: '#7c3aed',
-    humanize_completed: '#a78bfa',
     context_budget_warning: '#f97316',  // orange-500
-    no_match: '#6b7280',             // gray-500
   };
 
   function colorFor(event) {

--- a/skills/harness/lib/glance/views/agent-workspace-renderer.js
+++ b/skills/harness/lib/glance/views/agent-workspace-renderer.js
@@ -24,7 +24,6 @@
     stale: 0xf59e0b,
     completed: 0x10b981,
     failed: 0xef4444,
-    no_match: 0xa3a3a3,
   };
 
   const HOST_LABELS = {

--- a/skills/harness/lib/glance/views/components.css
+++ b/skills/harness/lib/glance/views/components.css
@@ -11,6 +11,22 @@
    Layer 1 — Atoms
    ════════════════════════════════════════════════════════════════════ */
 
+/* ─── Glass sheet (glassmorphism material) ───
+   One class. `--a`/`--b` are the two knobs a modifier turns; both come from
+   the derived scale in tokens.css, never a literal. Adapted from
+   design-tests/glassmorphism ("Pilha") — the recipe, not the markup. */
+.gl {
+  --a: var(--glass-a-1);
+  --b: var(--glass-b-1);
+  background: color-mix(in oklab, var(--glass-tint) calc(var(--a) * 100%), transparent);
+  -webkit-backdrop-filter: blur(var(--b)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--b)) saturate(var(--glass-sat));
+}
+.gl--2 { --a: var(--glass-a-2); --b: var(--glass-b-2); }
+.gl--3 { --a: var(--glass-a-3); --b: var(--glass-b-3); }
+/* the plate: the density that buys body text its WCAG 2.2 AA floor */
+.gl--ink { --a: var(--glass-a-ink); }
+
 /* ─── Badge ─── */
 .badge {
   display: inline-flex;

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -3156,6 +3156,53 @@ svg.icon-inline.lucide {
 .run-step.tone-fail .run-step-icon i, .run-step.tone-fail .run-step-icon svg { color: oklch(55% 0.2 25); opacity: 1; }
 .run-infra-toggle { display: inline-block; margin: 4px 0 0 30px; padding: 0; border: none; background: none; color: var(--text-tertiary); font-size: 11px; cursor: pointer; text-decoration: underline dotted; }
 .run-infra-toggle:hover, .run-infra-toggle:focus-visible { color: var(--text-secondary); }
+
+/* ─── Cartão de Trajetória (trajectory-card.js) ───
+   Single organism shared by the Chat panel and the Runs tab. A plain `event`
+   row reuses `.run-step`/`.tone-*` above unchanged; this block only adds the
+   three molecules layered on top: the judgement strip, the delivery-nuance
+   badge and the runtime-health chip. */
+.trajectory-card { display: flex; flex-direction: column; gap: 2px; position: relative; }
+.trajectory-card::before { content: ''; position: absolute; left: 10px; top: 12px; bottom: 12px; width: 1px; background: var(--border-default); }
+.trajectory-row { position: relative; }
+
+.trajectory-judgement { margin: 4px 0 4px 30px; border-radius: var(--radius-md); overflow: hidden; box-shadow: var(--shadow-1); }
+.trajectory-judgement-head {
+  display: flex; align-items: center; gap: 7px; width: 100%; padding: 6px 10px;
+  border: none; background: none; color: var(--text-primary); font: inherit; text-align: left; cursor: pointer;
+}
+.trajectory-judgement-head:hover { background: color-mix(in oklab, var(--text-primary) 5%, transparent); }
+.trajectory-judgement-head:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.trajectory-judgement-head .icon-inline { width: 14px; height: 14px; opacity: 0.8; }
+.trajectory-judgement-title { font-size: 12.5px; font-weight: 600; }
+.trajectory-judgement-head .text-caption { margin-left: auto; }
+.trajectory-chevron { width: 14px; height: 14px; flex: none; transition: transform var(--dur-fast) var(--ease-out); }
+.trajectory-judgement.is-expanded .trajectory-chevron { transform: rotate(180deg); }
+.trajectory-judgement-body { padding: 2px 10px 8px 10px; }
+
+/* Selo de nuance de entrega: a clickable badge, tone AND text/icon together
+   (WCAG 2.2 AA 1.4.1 — never color alone), expanding a .kv-grid of detail. */
+.delivery-badge {
+  display: inline-flex; align-items: center; gap: 5px; margin-top: 3px; padding: 2px var(--space-2);
+  border-radius: var(--radius-pill); border: 1px solid transparent; font-size: var(--text-xs); font-weight: var(--weight-semibold);
+  cursor: pointer;
+}
+.delivery-badge .icon-inline { width: 12px; height: 12px; }
+.delivery-badge:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.delivery-badge-ok             { background: var(--status-success-bg); color: var(--status-success-fg); border-color: var(--status-success-border); }
+.delivery-badge-warn-detail    { background: var(--status-warn-bg);    color: var(--status-warn-fg);    border-color: var(--status-warn-border); }
+.delivery-badge-fail-reversible{ background: var(--status-danger-bg);  color: var(--status-danger-fg);  border-color: var(--status-danger-border); }
+.delivery-badge-detail { margin-top: 4px; }
+
+/* Chip de saúde de runtime: inline, not a separate banner — the hint is
+   visible without a click (runtime_auth_failed is the most actionable
+   event in the whole taxonomy per the Wave 1 inventory; it does not hide). */
+.runtime-health-chip {
+  display: flex; align-items: center; gap: 6px; margin-top: 4px; padding: 4px var(--space-2);
+  border-radius: var(--radius-sm); background: var(--status-danger-bg); border: 1px solid var(--status-danger-border);
+  color: var(--status-danger-fg); font-size: 11px;
+}
+.runtime-health-chip .icon-inline { width: 13px; height: 13px; flex: none; }
 .run-mt { margin-top: 8px; padding: 8px 10px; border-radius: var(--radius-md); border: 1px solid var(--border-subtle); background: var(--surface-0); }
 .run-mt-head { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 6px; }
 .run-mt-title { display: inline-flex; align-items: center; gap: 5px; font-weight: 600; font-size: 12.5px; }

--- a/skills/harness/lib/glance/views/glance.js
+++ b/skills/harness/lib/glance/views/glance.js
@@ -469,18 +469,9 @@ function glance() {
     },
     runStatusColor(status) {
       if (status === 'delivered') return 'meta-ok';
-      if (status === 'gate_failed' || status === 'no_match') return 'meta-bad';
+      if (status === 'gate_failed') return 'meta-bad';
       if (status === 'running') return 'meta-pending';
       return '';
-    },
-    runEventColor(event) {
-      if (event === 'brief_received' || event === 'brief_amplified') return '#3b82f6';
-      if (event === 'delivered' || event === 'gate_passed') return '#10b981';
-      if (event === 'gate_failed' || event.startsWith('validation_')) return '#ef4444';
-      if (event === 'tool_invoked' || event === 'artifact_touched' || event === 'bash_completed') return '#8b5cf6';
-      if (event.startsWith('dispatch_')) return '#a855f7';
-      if (event === 'cost_emission') return '#9ca3af';
-      return '#64748b';
     },
     runRelTime(iso) {
       if (!iso) return '';
@@ -913,7 +904,7 @@ function glance() {
     get visibleAgentsSummary() {
       if (this.projectFilter !== 'project' || !this.canFilterByProject()) return this.agentsSummary;
       const list = this.visibleAgents;
-      const out = { tool_in_flight: 0, running: 0, idle: 0, waiting: 0, stale: 0, completed: 0, failed: 0, no_match: 0, total: 0 };
+      const out = { tool_in_flight: 0, running: 0, idle: 0, waiting: 0, stale: 0, completed: 0, failed: 0, total: 0 };
       for (const s of list) { out[s.status] = (out[s.status] || 0) + 1; out.total++; }
       return out;
     },
@@ -958,7 +949,6 @@ function glance() {
         stale: '#f59e0b',            // amber-500
         completed: '#10b981',        // emerald-500
         failed: '#ef4444',           // red-500
-        no_match: '#a3a3a3',         // neutral-400
       };
       return colors[status] || '#64748b';
     },
@@ -972,7 +962,6 @@ function glance() {
         stale: 'warn',
         completed: 'success',
         failed: 'danger',
-        no_match: 'neutral',
       })[status] || 'neutral';
     },
     runStatusVariant(status) {
@@ -980,7 +969,6 @@ function glance() {
         running: 'warn',
         delivered: 'success',
         gate_failed: 'danger',
-        no_match: 'danger',
         stale: 'neutral',
         unknown: 'neutral',
       })[status] || 'neutral';
@@ -997,7 +985,6 @@ function glance() {
         stale: 'Stale',
         completed: 'Completed',
         failed: 'Failed',
-        no_match: 'No match',
       };
       return labels[status] || status;
     },
@@ -1106,7 +1093,6 @@ function glance() {
         stall_detected: '⚠', stall_retry: '↻', loop_detected: '∞',
         approval_granted: '✓', approval_rejected: '✗', approval_checkpoint: '◇',
         gate_failed: '✗', validation_failed: '✗', context_budget_warning: '⚡',
-        humanization_applied: '✨', invocation_start: '▶', invocation_end: '■',
         handoff: '↪', resume: '↶',
       };
       return icons[event] || '·';
@@ -1619,14 +1605,25 @@ function glance() {
       const labels = window.NirvanaRunEventLabels;
       return labels ? labels.runEventView(ev) : { icon: 'circle', title: ev.type || ev.event || 'evento', sub: '', tone: '' };
     },
-    // Timeline rows for one message. Infrastructure events (coordinator
-    // snapshots, lease renewals) stay in the stream but are hidden until the
-    // user toggles them; `hidden` feeds the toggle label.
-    chatInfraVisible: false,
+    // Timeline rows, shared by the Chat panel and the Runs tab. Infrastructure
+    // events (coordinator snapshots, lease renewals) stay in the stream but
+    // are hidden until the user toggles them; `hidden` feeds the toggle label.
+    infraEventsVisible: false,
     runTimeline(events) {
       const labels = window.NirvanaRunEventLabels;
-      return labels ? labels.runTimeline(events, this.chatInfraVisible) : { visible: events || [], hidden: 0 };
+      return labels ? labels.runTimeline(events, this.infraEventsVisible) : { visible: events || [], hidden: 0 };
     },
+    // Trajectory Card: the single grouping used by BOTH the Chat panel
+    // (mode 'live') and the Runs tab (mode 'historical') — see trajectory-card.js.
+    // `expandedTrajectoryRows` keys by the row's stable `_seq`, so an expanded
+    // judgement/delivery row survives the infra toggle and re-renders.
+    expandedTrajectoryRows: {},
+    trajectoryRows(events) {
+      const tc = window.NirvanaTrajectoryCard;
+      return tc ? tc.buildTrajectoryRows(events, { showInfra: this.infraEventsVisible }) : { rows: [], hidden: 0 };
+    },
+    isTrajectoryRowExpanded(seq) { return !!this.expandedTrajectoryRows[seq]; },
+    toggleTrajectoryRow(seq) { this.expandedTrajectoryRows[seq] = !this.expandedTrajectoryRows[seq]; },
     // Live header derived from the stream: business/squad/agent, canonical
     // state, Gauntlet decision and cost (see summarizeRunEvents).
     get runSummary() {

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -847,7 +847,7 @@
           <span class="memory-stat"><b x-text="visibleRuns.length"></b> total</span>
           <span class="memory-stat"><b x-text="(visibleRuns.filter(r => r.status === 'running').length)"></b> running</span>
           <span class="memory-stat"><b x-text="(visibleRuns.filter(r => r.status === 'delivered').length)"></b> delivered</span>
-          <span class="memory-stat"><b x-text="(visibleRuns.filter(r => r.status === 'gate_failed' || r.status === 'no_match').length)"></b> issues</span>
+          <span class="memory-stat"><b x-text="(visibleRuns.filter(r => r.status === 'gate_failed').length)"></b> issues</span>
           <span class="memory-stat memory-stat-warn" x-show="visibleRuns.filter(r => r.suspicious).length"><b x-text="(visibleRuns.filter(r => r.suspicious).length)"></b> ⚠ suspicious</span>
         </div>
         <button @click="fetchRuns()" class="icon-btn" title="Refresh"><i data-lucide="rotate-cw"></i></button>
@@ -962,25 +962,89 @@
                 </section>
                 <section>
                   <div class="text-label">Timeline · <span x-text="selectedRun.events.length"></span> events</div>
-                  <ol class="timeline">
-                    <template x-for="(ev, i) in selectedRun.events" :key="i">
-                      <li class="timeline-event">
-                        <span class="dot dot-sm timeline-event-dot" :style="`--dot-color: ${runEventColor(ev.event)}`"></span>
-                        <div class="timeline-event-body">
-                          <div class="timeline-event-head">
-                            <span class="timeline-event-name" x-text="ev.event"></span>
-                            <span class="timeline-event-time" x-text="ev.ts ? ev.ts.slice(11, 19) : ''"></span>
+                  <!-- Trajectory Card (trajectory-card.js) — the SAME organism as the
+                       Chat panel's timeline above; kept in sync by design: both call
+                       trajectoryRows(), never a bespoke per-event x-show chain. -->
+                  <div class="trajectory-card">
+                    <template x-for="row in trajectoryRows(selectedRun.events).rows" :key="row._seq">
+                      <div class="trajectory-row">
+                        <template x-if="row.kind === 'judgement'">
+                          <div class="trajectory-judgement gl gl--ink" :class="isTrajectoryRowExpanded(row._seq) ? 'is-expanded' : ''">
+                            <button type="button" class="trajectory-judgement-head"
+                                    :aria-expanded="isTrajectoryRowExpanded(row._seq) ? 'true' : 'false'" @click="toggleTrajectoryRow(row._seq)">
+                              <i data-lucide="gavel" class="icon-inline"></i>
+                              <span class="trajectory-judgement-title">Faixa de julgamento</span>
+                              <span class="text-caption" x-text="`${row.items.length} evento${row.items.length === 1 ? '' : 's'}${row.terminal ? ' · ' + row.terminal.view.title : ''}`"></span>
+                              <i data-lucide="chevron-down" class="trajectory-chevron icon-inline"></i>
+                            </button>
+                            <div class="trajectory-judgement-body" x-show="isTrajectoryRowExpanded(row._seq)" x-cloak>
+                              <template x-for="item in row.items" :key="item._seq">
+                                <div class="run-step" :class="'tone-' + (item.view.tone || 'none')">
+                                  <span class="run-step-icon"><i :data-lucide="item.view.icon"></i></span>
+                                  <div class="run-step-body">
+                                    <span class="run-step-title" x-text="item.view.title"></span>
+                                    <span class="run-step-sub text-caption" x-show="item.view.sub" x-text="item.view.sub"></span>
+                                  </div>
+                                </div>
+                              </template>
+                              <template x-if="row.terminal">
+                                <div class="run-step" :class="'tone-' + (row.terminal.view.tone || 'none')">
+                                  <span class="run-step-icon"><i :data-lucide="row.terminal.view.icon"></i></span>
+                                  <div class="run-step-body">
+                                    <span class="run-step-title" x-text="row.terminal.view.title"></span>
+                                    <span class="run-step-sub text-caption" x-show="row.terminal.view.sub" x-text="row.terminal.view.sub"></span>
+                                  </div>
+                                </div>
+                              </template>
+                            </div>
                           </div>
-                          <div class="timeline-event-detail" x-show="(ev.event === 'brief_received' || ev.event === 'dispatch_squad' || ev.event === 'dispatch_agent_x') && (ev.brief_excerpt || ev.brief)" x-text="ev.brief_excerpt || ev.brief"></div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'tool_invoked'" x-text="`${ev.action || ''} ${ev.file_path || ev.command || ''}`"></div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'artifact_touched' || ev.event === 'delivered'" x-text="ev.artifact_path || ev.file_path"></div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'cost_emission' && ev.usage" x-text="`tokens in=${ev.usage?.input_tokens || 0} out=${ev.usage?.output_tokens || 0} usd=${(ev.total_cost_usd || 0).toFixed(4)}`"></div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'gate_failed' || ev.event === 'gate_passed'" x-text="`${ev.rubric || ''} ${ev.score != null ? 'score=' + ev.score : ''}`"></div>
-                          <div class="timeline-event-detail" x-show="ev.event === 'routing_decision'" x-text="`signal=${ev.signal || '?'} target=${ev.target || ev.target_id || '?'}`"></div>
-                        </div>
-                      </li>
+                        </template>
+                        <template x-if="row.kind === 'event'">
+                          <div class="run-step" :class="'tone-' + (row.view.tone || 'none')">
+                            <span class="run-step-icon"><i :data-lucide="row.view.icon"></i></span>
+                            <div class="run-step-body">
+                              <span class="run-step-title" x-text="row.view.title"></span>
+                              <span class="run-step-sub text-caption" x-show="row.view.sub" x-text="row.view.sub"></span>
+                              <!-- Delivery-nuance badge: variant + text label always together (WCAG 2.2 AA 1.4.1) -->
+                              <template x-if="row.nuance">
+                                <button type="button" class="delivery-badge" :class="'delivery-badge-' + row.nuance.variant"
+                                        :aria-expanded="isTrajectoryRowExpanded(row._seq) ? 'true' : 'false'" @click="toggleTrajectoryRow(row._seq)">
+                                  <i :data-lucide="row.view.icon" class="icon-inline"></i>
+                                  <span x-text="row.nuance.label"></span>
+                                </button>
+                              </template>
+                              <dl class="kv-grid delivery-badge-detail" x-show="row.nuance && isTrajectoryRowExpanded(row._seq)" x-cloak>
+                                <template x-if="row.nuance?.detail?.ceiling"><dt>teto</dt></template>
+                                <template x-if="row.nuance?.detail?.ceiling"><dd x-text="row.nuance.detail.ceiling"></dd></template>
+                                <template x-if="row.nuance?.detail?.ceiling_reason"><dt>motivo</dt></template>
+                                <template x-if="row.nuance?.detail?.ceiling_reason"><dd x-text="row.nuance.detail.ceiling_reason"></dd></template>
+                                <template x-if="row.nuance?.detail?.gate"><dt>gate</dt></template>
+                                <template x-if="row.nuance?.detail?.gate"><dd x-text="row.nuance.detail.gate"></dd></template>
+                                <template x-if="row.nuance?.detail?.gated_files != null"><dt>arquivos no gate</dt></template>
+                                <template x-if="row.nuance?.detail?.gated_files != null"><dd x-text="row.nuance.detail.gated_files"></dd></template>
+                                <template x-if="row.nuance?.detail?.revisions != null"><dt>revisões</dt></template>
+                                <template x-if="row.nuance?.detail?.revisions != null"><dd x-text="row.nuance.detail.revisions"></dd></template>
+                                <template x-if="row.nuance?.detail?.files != null"><dt>arquivos</dt></template>
+                                <template x-if="row.nuance?.detail?.files != null"><dd x-text="row.nuance.detail.files"></dd></template>
+                              </dl>
+                              <!-- Runtime-health chip: the hint is visible inline, no extra click -->
+                              <template x-if="row.runtimeChip">
+                                <div class="runtime-health-chip">
+                                  <i data-lucide="alert-octagon" class="icon-inline"></i>
+                                  <span x-show="row.runtimeChip.runtime" x-text="row.runtimeChip.runtime"></span>
+                                  <span class="text-caption" x-show="row.runtimeChip.hint" x-text="row.runtimeChip.hint"></span>
+                                </div>
+                              </template>
+                            </div>
+                          </div>
+                        </template>
+                      </div>
                     </template>
-                  </ol>
+                  </div>
+                  <!-- Infrastructure events (coordinator snapshots, lease renewals) stay in the stream, hidden until toggled -->
+                  <button type="button" class="run-infra-toggle text-caption" x-show="infraEventsVisible || trajectoryRows(selectedRun.events).hidden > 0"
+                          :aria-expanded="infraEventsVisible ? 'true' : 'false'" @click="infraEventsVisible = !infraEventsVisible"
+                          x-text="infraEventsVisible ? 'Ocultar eventos de infraestrutura' : `Mostrar ${trajectoryRows(selectedRun.events).hidden} eventos de infraestrutura`"></button>
                 </section>
                 <template x-if="selectedRun.artifact_paths.length">
                   <section>
@@ -1904,21 +1968,89 @@
                     <span class="run-head-cost" x-show="runSummary.cost > 0" x-text="'$' + runSummary.cost.toFixed(2)"></span>
                   </div>
                 </template>
-                <div class="run-steps">
-                  <template x-for="(ev, ei) in runTimeline(m.streaming ? chatRunEvents : m.events).visible" :key="ei">
-                    <div class="run-step" :class="'tone-' + (runEventView(ev).tone || 'none')">
-                      <span class="run-step-icon"><i :data-lucide="runEventView(ev).icon"></i></span>
-                      <div class="run-step-body">
-                        <span class="run-step-title" x-text="runEventView(ev).title"></span>
-                        <span class="run-step-sub text-caption" x-show="runEventView(ev).sub" x-text="runEventView(ev).sub"></span>
-                      </div>
+                <!-- Trajectory Card (trajectory-card.js) — the SAME organism as the
+                     Runs tab's timeline below; kept in sync by design: both call
+                     trajectoryRows(), never a bespoke per-event x-show chain. -->
+                <div class="trajectory-card">
+                  <template x-for="row in trajectoryRows(m.streaming ? chatRunEvents : m.events).rows" :key="row._seq">
+                    <div class="trajectory-row">
+                      <template x-if="row.kind === 'judgement'">
+                        <div class="trajectory-judgement gl gl--ink" :class="isTrajectoryRowExpanded(row._seq) ? 'is-expanded' : ''">
+                          <button type="button" class="trajectory-judgement-head"
+                                  :aria-expanded="isTrajectoryRowExpanded(row._seq) ? 'true' : 'false'" @click="toggleTrajectoryRow(row._seq)">
+                            <i data-lucide="gavel" class="icon-inline"></i>
+                            <span class="trajectory-judgement-title">Faixa de julgamento</span>
+                            <span class="text-caption" x-text="`${row.items.length} evento${row.items.length === 1 ? '' : 's'}${row.terminal ? ' · ' + row.terminal.view.title : ''}`"></span>
+                            <i data-lucide="chevron-down" class="trajectory-chevron icon-inline"></i>
+                          </button>
+                          <div class="trajectory-judgement-body" x-show="isTrajectoryRowExpanded(row._seq)" x-cloak>
+                            <template x-for="item in row.items" :key="item._seq">
+                              <div class="run-step" :class="'tone-' + (item.view.tone || 'none')">
+                                <span class="run-step-icon"><i :data-lucide="item.view.icon"></i></span>
+                                <div class="run-step-body">
+                                  <span class="run-step-title" x-text="item.view.title"></span>
+                                  <span class="run-step-sub text-caption" x-show="item.view.sub" x-text="item.view.sub"></span>
+                                </div>
+                              </div>
+                            </template>
+                            <template x-if="row.terminal">
+                              <div class="run-step" :class="'tone-' + (row.terminal.view.tone || 'none')">
+                                <span class="run-step-icon"><i :data-lucide="row.terminal.view.icon"></i></span>
+                                <div class="run-step-body">
+                                  <span class="run-step-title" x-text="row.terminal.view.title"></span>
+                                  <span class="run-step-sub text-caption" x-show="row.terminal.view.sub" x-text="row.terminal.view.sub"></span>
+                                </div>
+                              </div>
+                            </template>
+                          </div>
+                        </div>
+                      </template>
+                      <template x-if="row.kind === 'event'">
+                        <div class="run-step" :class="'tone-' + (row.view.tone || 'none')">
+                          <span class="run-step-icon"><i :data-lucide="row.view.icon"></i></span>
+                          <div class="run-step-body">
+                            <span class="run-step-title" x-text="row.view.title"></span>
+                            <span class="run-step-sub text-caption" x-show="row.view.sub" x-text="row.view.sub"></span>
+                            <!-- Delivery-nuance badge: variant + text label always together (WCAG 2.2 AA 1.4.1) -->
+                            <template x-if="row.nuance">
+                              <button type="button" class="delivery-badge" :class="'delivery-badge-' + row.nuance.variant"
+                                      :aria-expanded="isTrajectoryRowExpanded(row._seq) ? 'true' : 'false'" @click="toggleTrajectoryRow(row._seq)">
+                                <i :data-lucide="row.view.icon" class="icon-inline"></i>
+                                <span x-text="row.nuance.label"></span>
+                              </button>
+                            </template>
+                            <dl class="kv-grid delivery-badge-detail" x-show="row.nuance && isTrajectoryRowExpanded(row._seq)" x-cloak>
+                              <template x-if="row.nuance?.detail?.ceiling"><dt>teto</dt></template>
+                              <template x-if="row.nuance?.detail?.ceiling"><dd x-text="row.nuance.detail.ceiling"></dd></template>
+                              <template x-if="row.nuance?.detail?.ceiling_reason"><dt>motivo</dt></template>
+                              <template x-if="row.nuance?.detail?.ceiling_reason"><dd x-text="row.nuance.detail.ceiling_reason"></dd></template>
+                              <template x-if="row.nuance?.detail?.gate"><dt>gate</dt></template>
+                              <template x-if="row.nuance?.detail?.gate"><dd x-text="row.nuance.detail.gate"></dd></template>
+                              <template x-if="row.nuance?.detail?.gated_files != null"><dt>arquivos no gate</dt></template>
+                              <template x-if="row.nuance?.detail?.gated_files != null"><dd x-text="row.nuance.detail.gated_files"></dd></template>
+                              <template x-if="row.nuance?.detail?.revisions != null"><dt>revisões</dt></template>
+                              <template x-if="row.nuance?.detail?.revisions != null"><dd x-text="row.nuance.detail.revisions"></dd></template>
+                              <template x-if="row.nuance?.detail?.files != null"><dt>arquivos</dt></template>
+                              <template x-if="row.nuance?.detail?.files != null"><dd x-text="row.nuance.detail.files"></dd></template>
+                            </dl>
+                            <!-- Runtime-health chip: the hint is visible inline, no extra click -->
+                            <template x-if="row.runtimeChip">
+                              <div class="runtime-health-chip">
+                                <i data-lucide="alert-octagon" class="icon-inline"></i>
+                                <span x-show="row.runtimeChip.runtime" x-text="row.runtimeChip.runtime"></span>
+                                <span class="text-caption" x-show="row.runtimeChip.hint" x-text="row.runtimeChip.hint"></span>
+                              </div>
+                            </template>
+                          </div>
+                        </div>
+                      </template>
                     </div>
                   </template>
                 </div>
                 <!-- Infrastructure events (coordinator snapshots, lease renewals) stay in the stream, hidden until toggled -->
-                <button type="button" class="run-infra-toggle text-caption" x-show="chatInfraVisible || runTimeline(m.streaming ? chatRunEvents : m.events).hidden > 0"
-                        :aria-expanded="chatInfraVisible ? 'true' : 'false'" @click="chatInfraVisible = !chatInfraVisible"
-                        x-text="chatInfraVisible ? 'Ocultar eventos de infraestrutura' : `Mostrar ${runTimeline(m.streaming ? chatRunEvents : m.events).hidden} eventos de infraestrutura`"></button>
+                <button type="button" class="run-infra-toggle text-caption" x-show="infraEventsVisible || trajectoryRows(m.streaming ? chatRunEvents : m.events).hidden > 0"
+                        :aria-expanded="infraEventsVisible ? 'true' : 'false'" @click="infraEventsVisible = !infraEventsVisible"
+                        x-text="infraEventsVisible ? 'Ocultar eventos de infraestrutura' : `Mostrar ${trajectoryRows(m.streaming ? chatRunEvents : m.events).hidden} eventos de infraestrutura`"></button>
                 <!-- Multi-target projection of the Run (GET /api/v1/runs/:run/multi-target); rendered only once the coordinator saved a snapshot -->
                 <template x-if="runMultiTarget(m)">
                   <div class="run-mt">
@@ -2076,6 +2208,13 @@
   // a classic script, so the exports are exposed on window for the Alpine app.
   import * as runEventLabels from '/run-event-labels.js?v=__ASSET_VER__';
   window.NirvanaRunEventLabels = runEventLabels;
+</script>
+<script type="module">
+  // trajectory-card.js groups a run's events into the Trajectory Card
+  // rows (judgement strip, delivery nuance, runtime chip) shared by the Runs
+  // tab and the Chat panel. Same adapter pattern as run-event-labels.js.
+  import * as trajectoryCard from '/trajectory-card.js?v=__ASSET_VER__';
+  window.NirvanaTrajectoryCard = trajectoryCard;
 </script>
 <script type="module">
   // settings-panel.js is the pure module behind the engine section of the

--- a/skills/harness/lib/glance/views/observability-handler.ts
+++ b/skills/harness/lib/glance/views/observability-handler.ts
@@ -20,6 +20,10 @@ import { detect, type Anomaly } from "../../anomaly-detector.ts";
 
 const HTML_PATH = join(import.meta.dir, "observability.html");
 
+// The real revision events (see skills/harness/lib/revision-dispatch.ts and
+// delivery-pipeline.ts) — the literal event name "revision" is never emitted.
+const REVISION_EVENTS = new Set(["revision_dispatched", "revision_auto", "revision_requested", "revision_loop_exhausted"]);
+
 interface ParsedQuery {
   days: number;
   limit: number;
@@ -88,7 +92,7 @@ function dashboardForBusiness(traces: TraceTree[], slug: string) {
       sparkline: sparkline(matched.map((t) => t.duration_ms / 1000)),
     },
     revisions: {
-      total: matched.reduce((acc, t) => acc + t.spans.filter((s) => s.event === "revision").length, 0),
+      total: matched.reduce((acc, t) => acc + t.spans.filter((s) => REVISION_EVENTS.has(s.event)).length, 0),
     },
     top_employees: topEmployees(matched),
     recent_traces: matched.slice(0, 10).map((t) => ({

--- a/skills/harness/lib/glance/views/run-event-labels.js
+++ b/skills/harness/lib/glance/views/run-event-labels.js
@@ -29,8 +29,10 @@ const GAUNTLET_STOP_REASON_LABELS = {
   no_progress: 'sem progresso', critical_regression: 'regressão crítica', judge_disagreement: 'juízes divergiram',
   human_required: 'humano necessário', execution_failure: 'falha de execução',
 };
-const VERDICT_LABELS = { pass: 'aprovado', revise: 'revisar', reject: 'rejeitado', indeterminate: 'indeterminado' };
-const VERDICT_TONES = { pass: 'ok', revise: 'active', reject: 'fail' };
+// judge.ts's own verdict is the narrower {pass, fail} — shares this map with
+// the canonical Gauntlet evaluation verdict (superset), which never emits 'fail'.
+const VERDICT_LABELS = { pass: 'aprovado', revise: 'revisar', reject: 'rejeitado', indeterminate: 'indeterminado', fail: 'reprovado' };
+const VERDICT_TONES = { pass: 'ok', revise: 'active', reject: 'fail', fail: 'fail' };
 const PLAN_STATE_LABELS = { ready: 'pronto', running: 'em execução', delivered: 'entregue', withheld: 'retido', failed: 'falhou' };
 const PLAN_STATE_TONES = { delivered: 'ok', running: 'active', withheld: 'fail', failed: 'fail' };
 // How the target of a Run was decided (`payload.route` of `run.prepared`, or of
@@ -165,15 +167,38 @@ function legacyRunEventView(ev) {
     gate_passed:          { icon: 'shield-check', title: 'Gate passou', sub: (ev.rubrics || []).join(', '), tone: 'ok' },
     report_html_generated:{ icon: 'file-text', title: 'HTML gerado', tone: '' },
     report_pdf_generated: { icon: 'file-text', title: 'PDF gerado', tone: '' },
-    artifact_published:    { icon: 'package-check', title: `Artifact: ${ev.artifact_id || ev.path || 'publicado'}`, sub: ev.media_type || '', tone: 'ok' },
-    model_selected:        { icon: 'cpu', title: `Modelo: ${ev.model || ev.model_id || 'selecionado'}`, sub: rt, tone: '' },
-    approval_required:     { icon: 'badge-help', title: 'Aprovação necessária', sub: ev.reason || '', tone: 'active' },
     delivered:            { icon: 'party-popper', title: 'Entregue', tone: 'ok' },
+    // Judgement strip: judge_invoked → critique_generated → revision_* (0..N) → gate_*/revision_loop_exhausted.
+    judge_invoked:        { icon: 'gavel', title: `Julgando: ${ev.rubric_name || 'rubrica'}`, sub: sub(ev.target_model, ev.pass_threshold != null ? `piso ${ev.pass_threshold}` : ''), tone: 'active' },
+    critique_generated:   { icon: 'gavel', title: `Veredito: ${ev.schema_valid === false ? 'schema inválido' : label(VERDICT_LABELS, ev.verdict, 'gerado')}`, sub: sub(ev.total_score != null ? `nota ${ev.total_score}` : '', ev.critique_count != null ? `${ev.critique_count} apontamentos` : ''), tone: ev.schema_valid === false ? 'fail' : (VERDICT_TONES[ev.verdict] || 'active') },
+    revision_dispatched:  { icon: 'rotate-ccw', title: `Revisão despachada · tentativa ${ev.attempt_index ?? '?'}`, sub: sub(ev.previous_score != null ? `nota anterior ${ev.previous_score}` : '', ev.priority_items ? `${ev.priority_items} itens prioritários` : ''), tone: 'active' },
+    revision_auto:        { icon: 'refresh-cw', title: `Auto-revisão${ev.attempt != null ? ' ' + ev.attempt : ''}`, sub: ev.ok === false ? 'falhou' : '', tone: ev.ok === false ? 'fail' : 'active' },
+    revision_loop_exhausted: { icon: 'flag', title: 'Loop de revisão esgotado', sub: sub(ev.total_revisions != null ? `${ev.total_revisions} revisões` : '', ev.final_score != null ? `nota final ${ev.final_score}` : '', ev.reason), tone: 'fail' },
+    // Runtime cascade: unavailable/error/transient are why the system handed off (runtime_handoff already labelled).
     runtime_handoff:      { icon: 'refresh-cw', title: `Trocou runtime → ${ev.to || ev.runtime || ''}`, tone: '' },
     runtime_quota_exhausted: { icon: 'ban', title: 'Cota esgotada', tone: 'fail' },
+    runtime_auth_failed:  { icon: 'key-round', title: `Autenticação falhou: ${ev.runtime || ''}`, sub: ev.hint || '', tone: 'fail' },
+    runtime_unavailable:  { icon: 'power-off', title: `Runtime indisponível: ${ev.runtime || ''}`, tone: 'fail' },
+    runtime_error:        { icon: 'alert-triangle', title: `Erro de runtime: ${ev.runtime || ''}`, sub: ev.hint || '', tone: 'fail' },
+    runtime_transient_retry: { icon: 'refresh-cw', title: `Retentando: ${ev.runtime || ''}`, sub: sub(ev.sleep_ms != null ? `${Math.round(ev.sleep_ms / 1000)}s` : '', ev.hint), tone: 'active' },
     cascade_exhausted:    { icon: 'ban', title: 'Cascata esgotada', tone: 'fail' },
+    x_router_failure_retry:       { icon: 'refresh-cw', title: 'Roteador: retentando', sub: ev.error || '', tone: 'active' },
+    x_router_failure_fail_policy: { icon: 'ban', title: 'Roteador: política de falha acionada', sub: ev.error || '', tone: 'fail' },
+    x_router_failure_cascade:     { icon: 'alert-triangle', title: `Roteador recorreu a ${ev.stage || '?'}`, sub: sub(ev.picked, ev.error), tone: 'fail' },
+    // Delivery nuance: withheld/reservations carry the WHY that a plain `delivered` badge hides.
+    x_delivery_withheld:  { icon: 'pause-circle', title: 'Entrega retida', sub: sub(ev.ceiling === 'completeness' ? ev.ceiling_reason : `gate: ${ev.gate || ''}`, ev.gated_files != null ? `${ev.gated_files} arquivo(s) no gate` : ''), tone: 'fail' },
+    x_delivered_with_reservations: { icon: 'shield-alert', title: 'Entregue com ressalvas', sub: sub(ev.revisions != null ? `${ev.revisions} revisões` : '', ev.ceiling != null ? `teto ${ev.ceiling}` : ''), tone: 'active' },
+    // Ledger terminal/live states not already covered by x_ledger_state_changed.
+    x_ledger_abandoned:   { icon: 'x-octagon', title: 'Ledger: run abandonada', sub: sub(ev.from, ev.reason), tone: 'fail' },
+    x_ledger_stall_observed: { icon: 'alert-triangle', title: 'Run travada (heartbeat)', sub: ev.gap_ms != null ? `sem atividade há ${Math.round(ev.gap_ms / 1000)}s` : '', tone: 'fail' },
     x_ledger_state_changed: { icon: LEDGER_STATE_ICONS[ev.to] || 'arrow-right-circle', title: `Ledger: ${label(LEDGER_STATE_LABELS, ev.to, 'transicionou')}`, sub: ledgerReason(ev), tone: LEDGER_STATE_TONES[ev.to] || '' },
     x_ledger_grace_extended: { icon: 'activity', title: `Prova de vida: ${label(LIVENESS_SOURCE_LABELS, ev.liveness_source, 'lease renovada')}`, sub: sub(ev.child_run_id), tone: 'active' },
+    // Team-mode orchestration.
+    team_director_called: { icon: 'users', title: 'Time: diretor chamado', sub: ev.employees_available != null ? `${ev.employees_available} funcionários disponíveis` : '', tone: '' },
+    team_director_failed: { icon: 'alert-triangle', title: 'Time: diretor falhou', sub: ev.error || '', tone: 'fail' },
+    team_step_failed:     { icon: 'x-circle', title: `Time: ${ev.employee || 'passo'} falhou`, sub: sub(ev.reason, ev.error), tone: 'fail' },
+    team_completed:       { icon: 'flag', title: `Time concluído · ${ev.steps ?? '?'} passo(s)`, sub: sub(usd(ev.total_cost_usd), ev.total_duration_ms != null ? `${Math.round(ev.total_duration_ms / 1000)}s` : ''), tone: 'ok' },
+    session_resume_failed:{ icon: 'unplug', title: `Sessão não retomou: ${ev.entity || ev.runtime || ''}`, sub: 'reiniciando a frio', tone: 'fail' },
   };
   return M[ev.event] || { icon: 'circle', title: chatEventLabel(ev), sub: '', tone: '' };
 }
@@ -205,8 +230,15 @@ export function isInfraEvent(ev) {
 
 // Timeline rows: infrastructure events are hidden by default and counted so
 // the UI can offer a toggle. Nothing is removed from the underlying stream.
+//
+// Stable per-event identity: `_seq` is assigned ONCE per event, from its
+// position in this full (unfiltered) stream, and kept on the object from
+// then on — it is never recomputed from the FILTERED `.visible` list, whose
+// membership (and therefore array index) shifts the instant the infra
+// toggle flips. `:key` bindings must use `ev._seq`, never the loop index.
 export function runTimeline(events, showInfra = false) {
   const all = Array.isArray(events) ? events : [];
+  all.forEach((ev, i) => { if (ev && ev._seq == null) ev._seq = i; });
   if (showInfra) return { visible: all, hidden: 0 };
   const visible = all.filter((ev) => !isInfraEvent(ev));
   return { visible, hidden: all.length - visible.length };

--- a/skills/harness/lib/glance/views/tokens.css
+++ b/skills/harness/lib/glance/views/tokens.css
@@ -100,7 +100,58 @@
   /* === Z-index === */
   --z-base: 0;     --z-sticky: 10;   --z-dropdown: 30;  --z-overlay: 60;
   --z-modal: 80;   --z-toast: 90;    --z-hero: 100;
+
+  /* === Glass material (glassmorphism) ===
+     One recipe: a tint alpha and a blur radius (--sheet-a / --sheet-b, named
+     to match the design-tests/glassmorphism ("Pilha") reference this is
+     adapted from). Every additional depth is DERIVED by the arithmetic of
+     stacking translucent sheets, never chosen by eye:
+       alpha of N sheets   a(N) = 1 - (1-a)^N   -> pow()
+       blur  of N sheets   b(N) = b * sqrt(N)   -> hypot() (Gaussian blurs
+       compose in quadrature, so hypot() is the exact function, not a trick).
+     --floor-field is not aesthetic either: it is the minimum tint alpha at
+     which body text on a glass plate (.gl--ink) still clears WCAG 2.2 AA
+     (4.5:1) against the most saturated token in Glance's OWN palette that
+     could plausibly sit behind it (--accent, --status-danger-solid) —
+     verified by converting OKLCH to sRGB and computing the resulting
+     contrast ratio, not chosen by eye. Glance has no photographic
+     backdrops, so unlike the Pilha reference there is no --floor-photo case
+     to carry (--sheet-a alone already clears AA there by ~9-10:1 headroom;
+     the floor exists as a backstop against --sheet-a being dialed down, not
+     because the default value is at any risk). */
+  --sheet-a: 0.6;      /* tint opacity: ~40% of the backdrop shows through */
+  --sheet-b: 8px;
+  --sheet-sat: 1.2;    /* saturation boost — backdrop-filter blur washes colour out */
+  --glass: 1;          /* 0 turns the whole material opaque; --glass-off enforces it */
+
+  --glass-off: calc(1 - var(--glass));
+  --glass-b: calc(var(--sheet-b) * var(--glass));
+  --glass-a-1: max(var(--sheet-a), var(--glass-off));
+  --glass-a-2: max(calc(1 - pow(1 - var(--sheet-a), 2)), var(--glass-off));
+  --glass-a-3: max(calc(1 - pow(1 - var(--sheet-a), 3)), var(--glass-off));
+  --glass-b-1: var(--glass-b);
+  --glass-b-2: hypot(var(--glass-b), var(--glass-b));
+  --glass-b-3: hypot(var(--glass-b), var(--glass-b), var(--glass-b));
+  --glass-sat: calc(1 + (var(--sheet-sat) - 1) * var(--glass));
+
+  /* Resolved, not chosen — see floor.ts in the PR description for the
+     contrast computation this number comes from. */
+  --floor-field: 0.18;
+  --glass-a-ink: max(var(--sheet-a), var(--floor-field), var(--glass-off));
+  --glass-tint: var(--surface-1);
 }
+
+@property --sheet-a { syntax: "<number>"; inherits: true; initial-value: 0.6; }
+@property --sheet-b { syntax: "<length>"; inherits: true; initial-value: 8px; }
+@property --glass { syntax: "<number>"; inherits: true; initial-value: 1; }
+
+/* Transparency is a preference before it is a style (same mechanism as the
+   Pilha reference): the system asking for less of it wins by default, and a
+   user choice can still override via [data-glass="off"] on the root. */
+@media (prefers-reduced-transparency: reduce) {
+  :root { --glass: 0; }
+}
+:root[data-glass="off"] { --glass: 0; }
 
 [data-theme="apple-dark"] {
   --surface-0: oklch(15% 0.015 260);
@@ -147,6 +198,11 @@
   --shadow-3: 0 12px 32px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.04);
   --shadow-modal: 0 24px 60px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.05);
   --shadow-popover: 0 8px 24px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.05);
+
+  /* Floor re-solved for the dark palette's own worst-case backdrop (same
+     method as :root — see floor.ts in the PR description). */
+  --floor-field: 0.22;
+  --glass-tint: var(--surface-1);
 }
 
 [data-theme="awwwards"] {
@@ -199,6 +255,9 @@
   --shadow-3: 0 12px 32px rgba(0,0,0,0.65), 0 0 0 1px rgba(255,255,255,0.03);
   --shadow-modal: 0 24px 60px rgba(0,0,0,0.75), 0 0 0 1px rgba(255,255,255,0.04);
   --shadow-popover: 0 8px 24px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.04);
+
+  --floor-field: 0.22;
+  --glass-tint: var(--surface-1);
 }
 
 /* Legacy aliases — keep so any rule that still uses --bg, --fg, etc.

--- a/skills/harness/lib/glance/views/tokens.css
+++ b/skills/harness/lib/glance/views/tokens.css
@@ -134,8 +134,15 @@
   --glass-b-3: hypot(var(--glass-b), var(--glass-b), var(--glass-b));
   --glass-sat: calc(1 + (var(--sheet-sat) - 1) * var(--glass));
 
-  /* Resolved, not chosen — see floor.ts in the PR description for the
-     contrast computation this number comes from. */
+  /* Resolved, not chosen: the minimum --sheet-a at which --text-primary on
+     a .gl--ink plate still clears WCAG 2.2 AA (4.5:1) against this theme's
+     most saturated token a plate could plausibly sit on (--accent,
+     --status-danger-solid), composited the way a browser actually paints a
+     translucent background-color layer (alpha-blended in gamma-encoded
+     sRGB, not linear light) then measured via the standard WCAG relative-
+     luminance formula. --sheet-a (0.6) clears this floor with ~9-10:1 to
+     spare — the floor is a backstop against the dial being turned down,
+     not a sign the default is close to the edge. */
   --floor-field: 0.18;
   --glass-a-ink: max(var(--sheet-a), var(--floor-field), var(--glass-off));
   --glass-tint: var(--surface-1);
@@ -199,8 +206,9 @@
   --shadow-modal: 0 24px 60px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.05);
   --shadow-popover: 0 8px 24px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.05);
 
-  /* Floor re-solved for the dark palette's own worst-case backdrop (same
-     method as :root — see floor.ts in the PR description). */
+  /* Floor re-solved for this theme's own colors (same method as :root's
+     --floor-field comment above). --sheet-a (0.6) clears it with ~9-10:1
+     to spare here too. */
   --floor-field: 0.22;
   --glass-tint: var(--surface-1);
 }

--- a/skills/harness/lib/glance/views/trajectory-card.js
+++ b/skills/harness/lib/glance/views/trajectory-card.js
@@ -1,0 +1,120 @@
+/* trajectory-card.js — the Trajectory Card ("Cartão de Trajetória" in the
+ * product briefing): the single organism that renders a run's event stream,
+ * used both in the Chat panel (mode "live", streaming) and the Runs tab
+ * (mode "historical", a finished/in-progress run's full timeline). Wave 2
+ * redesign briefing §3.3 / §4.2.
+ *
+ * Before this module, the two surfaces had two independent implementations
+ * of "what happened in this run" — the Runs tab checked event names against
+ * a 10-name `x-show` chain, the Chat panel used the full `runEventView()`
+ * coverage. This module is the fix: both surfaces call `buildTrajectoryRows()`
+ * and render the SAME row shape. All labelling still comes from
+ * `runEventView()`/`runTimeline()` in run-event-labels.js — this module only
+ * groups adjacent events and classifies rows for the three new molecules; it
+ * never invents an icon/title/tone of its own.
+ *
+ * The three molecules this module produces rows for (briefing §3.2; PT-BR
+ * names are what the UI actually shows, kept here for traceability):
+ *   - Judgement strip ("Faixa de julgamento"): judge_invoked →
+ *     critique_generated → revision_dispatched/revision_auto (0..N) →
+ *     gate_passed/gate_failed/revision_loop_exhausted, nested as one
+ *     collapsible `kind: "judgement"` row.
+ *   - Delivery-nuance badge ("Selo de nuance de entrega"): `delivered` /
+ *     `x_delivered_with_reservations` / `x_delivery_withheld` rows carry a
+ *     `nuance` field (variant + text label, never color alone — WCAG 2.2 AA
+ *     1.4.1).
+ *   - Runtime-health chip ("Chip de saúde de runtime"): `runtime_auth_failed`
+ *     / `runtime_error` / `x_router_failure_cascade` rows carry a
+ *     `runtimeChip` field with the hint visible inline, no extra click.
+ *
+ * Stable identity: every row carries `_seq`, taken from the underlying
+ * event's `_seq` (see runTimeline() in run-event-labels.js) — a judgement
+ * group's `_seq` is its first atom's, so expand/collapse state keyed by
+ * `_seq` survives the infra-events toggle and re-renders.
+ *
+ * Loaded the same way as run-event-labels.js: a <script type="module">
+ * adapter in index.html exposes these exports as window.NirvanaTrajectoryCard,
+ * because glance.js is a classic script.
+ *
+ * Known debt, named rather than fixed here (briefing §3.3 item 2, step 10 of
+ * the implementation brief — out of scope for this change): the row list
+ * returned here is not virtualized. Fine for the common short run; a
+ * multi-hour run with thousands of events will render every row to the DOM.
+ */
+
+import { runEventView, runTimeline } from './run-event-labels.js';
+
+const JUDGEMENT_ATOM_EVENTS = new Set(['judge_invoked', 'critique_generated', 'revision_dispatched', 'revision_auto']);
+const JUDGEMENT_TERMINAL_EVENTS = new Set(['gate_passed', 'gate_failed', 'revision_loop_exhausted']);
+const DELIVERY_NUANCE_EVENTS = new Set(['delivered', 'x_delivered_with_reservations', 'x_delivery_withheld']);
+const RUNTIME_HEALTH_EVENTS = new Set(['runtime_auth_failed', 'runtime_error', 'x_router_failure_cascade']);
+
+function eventName(ev) {
+  if (!ev) return '';
+  if (typeof ev.type === 'string' && ev.type.startsWith('delivery.')) {
+    return ev.payload?.legacyEvent || ev.type.slice('delivery.'.length);
+  }
+  return typeof ev.type === 'string' ? ev.type : (ev.event || '');
+}
+
+// The delivery-nuance badge ("Selo de nuance de entrega"): three tones, each
+// with its OWN text label — never color alone (WCAG 2.2 AA 1.4.1), matching
+// the existing badge pattern
+// at index.html's chat badge (tone + x-text side by side).
+function deliveryNuance(ev, name) {
+  if (name === 'x_delivery_withheld') {
+    return {
+      variant: 'fail-reversible', label: 'Retido',
+      detail: { ceiling: ev.ceiling ?? null, ceiling_reason: ev.ceiling_reason ?? null, gate: ev.gate ?? null, gated_files: ev.gated_files ?? null, revisions: ev.revisions ?? null },
+    };
+  }
+  if (name === 'x_delivered_with_reservations') {
+    return {
+      variant: 'warn-detail', label: 'Com ressalvas',
+      detail: { ceiling: ev.ceiling ?? null, gated_files: ev.gated_files ?? null, revisions: ev.revisions ?? null },
+    };
+  }
+  // Plain `delivered`: gate:"fail-accepted" is the SAME reservations path
+  // (x_delivered_with_reservations fires first) — do not show it as a clean
+  // pass twice; a bare pass shows the ok variant.
+  if (ev.gate === 'fail-accepted') {
+    return { variant: 'warn-detail', label: 'Com ressalvas', detail: { gate: ev.gate, files: ev.files ?? null } };
+  }
+  return { variant: 'ok', label: 'Entregue', detail: { gate: ev.gate ?? null, files: ev.files ?? null } };
+}
+
+function toEventRow(ev) {
+  const name = eventName(ev);
+  const row = { kind: 'event', _seq: ev._seq, view: runEventView(ev) };
+  if (DELIVERY_NUANCE_EVENTS.has(name)) row.nuance = deliveryNuance(ev, name);
+  if (RUNTIME_HEALTH_EVENTS.has(name)) row.runtimeChip = { runtime: ev.runtime || '', hint: ev.hint || ev.error || '' };
+  return row;
+}
+
+// Builds the row list for one Trajectory Card. `opts.showInfra` mirrors
+// the existing infra-events toggle (infraEventsVisible in glance.js).
+export function buildTrajectoryRows(events, opts = {}) {
+  const { visible, hidden } = runTimeline(events, !!opts.showInfra);
+  const rows = [];
+  let i = 0;
+  while (i < visible.length) {
+    const ev = visible[i];
+    if (JUDGEMENT_ATOM_EVENTS.has(eventName(ev))) {
+      const items = [ev];
+      let j = i + 1;
+      while (j < visible.length && JUDGEMENT_ATOM_EVENTS.has(eventName(visible[j]))) { items.push(visible[j]); j++; }
+      let terminal = null;
+      if (j < visible.length && JUDGEMENT_TERMINAL_EVENTS.has(eventName(visible[j]))) { terminal = visible[j]; j++; }
+      rows.push({
+        kind: 'judgement', _seq: ev._seq,
+        items: items.map(toEventRow),
+        terminal: terminal ? toEventRow(terminal) : null,
+      });
+      i = j;
+      continue;
+    }
+    rows.push(toEventRow(ev));
+    i++;
+  }
+  return { rows, hidden };
+}

--- a/skills/harness/lib/trace-builder.ts
+++ b/skills/harness/lib/trace-builder.ts
@@ -29,7 +29,7 @@ import { parseAuditLine } from "../../_shared/lib/cloudevents.js";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 
 const TERMINAL_EVENTS = new Set(["gate_passed", "gate_failed", "validation_failed", "delivered", "dispatch_blocked"]);
-const DISPATCH_EVENTS = new Set(["dispatch_business", "dispatch_squad", "dispatch_skill"]);
+const DISPATCH_EVENTS = new Set(["dispatch_business", "dispatch_squad"]);
 
 export interface TraceSpan {
   event: string;

--- a/skills/harness/tests/glance-run-event-labels.test.ts
+++ b/skills/harness/tests/glance-run-event-labels.test.ts
@@ -118,6 +118,41 @@ describe("Glance run event labels", () => {
     expect(runTimeline(undefined)).toEqual({ visible: [], hidden: 0 });
   });
 
+  test("runTimeline assigns a stable _seq from position in the FULL stream, once, never from the filtered list", () => {
+    const seqEvents = [
+      { type: "multi_target.lease_renewed", payload: {} }, { event: "brief_received" }, { event: "delivered" },
+    ];
+    runTimeline(seqEvents); // filters out event 0; brief_received/delivered must still read 1/2, not 0/1
+    expect(seqEvents.map((e: any) => e._seq)).toEqual([0, 1, 2]);
+    // Calling again (e.g. a re-render after the infra toggle flips) must not reassign.
+    runTimeline(seqEvents, true);
+    expect(seqEvents.map((e: any) => e._seq)).toEqual([0, 1, 2]);
+  });
+
+  test("atom-level events added for the judgement strip, runtime cascade and delivery nuance all resolve to a real label", () => {
+    expect(runEventView({ event: "judge_invoked", rubric_name: "prose-structure", pass_threshold: 0.8 }))
+      .toMatchObject({ icon: "gavel", title: "Julgando: prose-structure", tone: "active" });
+    expect(runEventView({ event: "critique_generated", verdict: "pass", total_score: 0.9, schema_valid: true }))
+      .toMatchObject({ title: "Veredito: aprovado", tone: "ok" });
+    expect(runEventView({ event: "revision_loop_exhausted", total_revisions: 2, final_score: 0.6 }))
+      .toMatchObject({ icon: "flag", tone: "fail" });
+    expect(runEventView({ event: "runtime_auth_failed", runtime: "codex", hint: "token expired" }))
+      .toMatchObject({ title: "Autenticação falhou: codex", sub: "token expired", tone: "fail" });
+    expect(runEventView({ event: "x_router_failure_cascade", stage: "agent-x", error: "no route" }))
+      .toMatchObject({ title: "Roteador recorreu a agent-x", tone: "fail" });
+    expect(runEventView({ event: "x_delivery_withheld", gate: "fail", gated_files: 2 }))
+      .toMatchObject({ icon: "pause-circle", title: "Entrega retida", tone: "fail" });
+    expect(runEventView({ event: "x_delivered_with_reservations", revisions: 1, ceiling: 2 }))
+      .toMatchObject({ icon: "shield-alert", title: "Entregue com ressalvas", tone: "active" });
+    expect(runEventView({ event: "team_completed", steps: 3, total_cost_usd: 1.2, total_duration_ms: 5000 }))
+      .toMatchObject({ title: "Time concluído · 3 passo(s)", sub: "$1.20 · 5s", tone: "ok" });
+    expect(runEventView({ event: "session_resume_failed", entity: "squad:copywriter" }))
+      .toMatchObject({ icon: "unplug", title: "Sessão não retomou: squad:copywriter", tone: "fail" });
+    // Removed from the label map as dead (no emitter anywhere — see the Wave 1/2
+    // inventory): falls back to the generic circle + raw event name.
+    expect(runEventView({ event: "artifact_published" })).toMatchObject({ icon: "circle", title: "artifact_published" });
+  });
+
   test("summary reads canonical state, target, cost and decision", () => {
     const canonical = [
       { type: "run.prepared", payload: { target: { kind: "business", slug: "proof" } } },

--- a/skills/harness/tests/glance-trajectory-card.test.ts
+++ b/skills/harness/tests/glance-trajectory-card.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { buildTrajectoryRows } from "../lib/glance/views/trajectory-card.js";
+
+describe("Trajectory Card row builder", () => {
+  test("groups judge_invoked..revision_* under one collapsible row, closed by the terminal gate event", () => {
+    const events = [
+      { event: "brief_received" },
+      { event: "judge_invoked", rubric_name: "prose-structure", pass_threshold: 0.8 },
+      { event: "critique_generated", verdict: "fail", total_score: 0.55, critique_count: 3, schema_valid: true },
+      { event: "revision_dispatched", attempt_index: 1, previous_score: 0.55, priority_items: 3 },
+      { event: "gate_passed", rubrics: ["prose-structure"] },
+      { event: "delivered", files: 2, gate: "pass" },
+    ];
+    const { rows, hidden } = buildTrajectoryRows(events);
+    expect(hidden).toBe(0);
+    expect(rows.map((r: any) => r.kind)).toEqual(["event", "judgement", "event"]);
+    const group = rows[1] as any;
+    expect(group.items).toHaveLength(3);
+    expect(group.items.map((i: any) => i.view.title)).toEqual([
+      "Julgando: prose-structure", "Veredito: reprovado", "Revisão despachada · tentativa 1",
+    ]);
+    expect(group.terminal.view.title).toBe("Gate passou");
+    // The group's own _seq is its first atom's (judge_invoked), not the group's array position.
+    expect(group._seq).toBe(events.findIndex((e) => e.event === "judge_invoked"));
+    // Delivered gets the ok nuance (a plain pass, not a reservations gate).
+    const delivered = rows[2] as any;
+    expect(delivered.nuance).toEqual({ variant: "ok", label: "Entregue", detail: { gate: "pass", files: 2 } });
+  });
+
+  test("a gate_passed with no preceding judgement atoms stays a plain row (heuristic-mode gate)", () => {
+    const events = [{ event: "gate_passed", rubrics: ["a"] }];
+    const { rows } = buildTrajectoryRows(events);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+  });
+
+  test("delivery nuance: withheld and reservations carry the WHY, distinct from a clean pass", () => {
+    const withheld = buildTrajectoryRows([
+      { event: "x_delivery_withheld", gate: "fail", ceiling: "completeness", ceiling_reason: "manifest not verified", gated_files: 3, revisions: 2 },
+    ]).rows[0] as any;
+    expect(withheld.nuance.variant).toBe("fail-reversible");
+    expect(withheld.nuance.label).toBe("Retido");
+    expect(withheld.nuance.detail).toMatchObject({ ceiling_reason: "manifest not verified", gated_files: 3 });
+
+    const reservations = buildTrajectoryRows([
+      { event: "x_delivered_with_reservations", gated_files: 1, revisions: 2, ceiling: 2 },
+    ]).rows[0] as any;
+    expect(reservations.nuance.variant).toBe("warn-detail");
+    expect(reservations.nuance.label).toBe("Com ressalvas");
+
+    // `delivered` right after fail-accepted reservations reads as reservations
+    // too, not a second, contradicting "clean pass".
+    const deliveredAfterReservations = buildTrajectoryRows([
+      { event: "delivered", gate: "fail-accepted", files: 2 },
+    ]).rows[0] as any;
+    expect(deliveredAfterReservations.nuance).toEqual({ variant: "warn-detail", label: "Com ressalvas", detail: { gate: "fail-accepted", files: 2 } });
+  });
+
+  test("runtime-health events carry the hint inline, no extra click needed", () => {
+    const { rows } = buildTrajectoryRows([
+      { event: "runtime_auth_failed", runtime: "codex", hint: "token expired" },
+    ]);
+    expect((rows[0] as any).runtimeChip).toEqual({ runtime: "codex", hint: "token expired" });
+  });
+
+  test("stable identity survives the infra toggle: a row's _seq never comes from its position in the FILTERED list", () => {
+    const events = [
+      { type: "multi_target.lease_renewed", payload: {} },      // infra, hidden by default
+      { event: "brief_received" },                               // _seq must be 1, not 0
+      { type: "multi_target.lease_renewed", payload: {} },
+      { event: "delivered", gate: "pass" },                      // _seq must be 3, not 1
+    ];
+    const hiddenByDefault = buildTrajectoryRows(events);
+    expect(hiddenByDefault.hidden).toBe(2);
+    expect(hiddenByDefault.rows.map((r: any) => r._seq)).toEqual([1, 3]);
+    // Re-run with infra events shown: the two events that were already
+    // visible keep the EXACT same _seq as before.
+    const withInfra = buildTrajectoryRows(events, { showInfra: true });
+    expect(withInfra.rows.map((r: any) => r._seq)).toEqual([0, 1, 2, 3]);
+    expect(withInfra.rows[1]._seq).toBe(hiddenByDefault.rows[0]._seq);
+    expect(withInfra.rows[3]._seq).toBe(hiddenByDefault.rows[1]._seq);
+  });
+});


### PR DESCRIPTION
## Summary

Implements steps 1-6 (Phase A) of the Glance redesign, scoped by
`.nirvana/briefs/glance-redesign-impl-20260830011547-enriched.md`, which
built on two prior research waves: the technical inventory
(`glance-360-20260829231033/businesses/systems-atelier/inventario-tecnico-glance.md`)
and the UX redesign briefing
(`glance-360-20260829231033/businesses/ux-atelier/briefing-redesign-glance.md`).

- **Dead code cleanup** — the `no_match` agent/run status branch (no event
  is ever literally named `no_match`), the permanently-zero `revisions.total`
  counter, `dispatch_skill`, three dead `ACTION_EVENTS` entries, three
  unreachable icon-map entries, three unreachable label-map entries
  (`artifact_published`/`model_selected`/`approval_required`).
- **Unified `artifact_touched`** between its two producers — the Claude Code
  hook now also reports `size_bytes` (matching the run-ledger heartbeat
  sweep). `run_id` stays a named, documented gap: the hook fires before any
  ledger row may exist, and resolving it would mean a per-tool-call SQLite
  lookup that is almost always a miss.
- **20 previously-invisible atom events** wired into `run-event-labels.js`
  (judge/critique/revision family, runtime cascade, `x_router_failure_*`,
  `x_ledger_abandoned`/`stall_observed`, delivery nuance, team-mode,
  session-resume failure).
- **Three new molecules**: judgement strip (`judge_invoked → critique_generated
  → revision_* (0..N) → gate_*/revision_loop_exhausted`, nested + collapsible),
  delivery-nuance badge (`delivered` / `x_delivered_with_reservations` /
  `x_delivery_withheld` — icon + text always together, WCAG 2.2 AA 1.4.1),
  runtime-health chip (`runtime_auth_failed`/`runtime_error`/
  `x_router_failure_cascade`, hint visible inline).
- **Stable per-event identity** — `runTimeline()` stamps `_seq` once, from
  position in the full unfiltered stream, so expand/collapse state survives
  the infra-events toggle (previously keyed by filtered-array index).
- **Trajectory Card organism** (`trajectory-card.js`) replacing the Runs
  tab's 10-name `x-show` chain and the Chat panel's separate implementation
  with one shared `buildTrajectoryRows()` both surfaces call.
- **Glassmorphism tokens** (`--sheet-a`/`--sheet-b`/`--glass`/`--floor-field`)
  adapted from the `design-tests/glassmorphism` reference — derived
  alpha/blur stacking via `pow()`/`hypot()`, a contrast floor verified
  against Glance's own palette (not eyeballed) — applied to the judgement
  strip via new `.gl`/`.gl--ink` utility classes.

**Scope decision:** shipped as one PR rather than the suggested
cleanup-then-redesign split, because steps 3-6 are tightly coupled (the atom
labels from step 3 feed the molecules in step 4 and the organism in step 6
directly).

**Explicitly out of scope** (named in the briefing, not resolved here): the
other two Wave 2 molecules (route-decision detail, team-chain preview — step
7), the ADR-007 control-plane decision, `observability.html`'s fate, event-list
virtualization (named as debt in a code comment), and Phase B chat
instrumentation (needs hook coverage that does not exist yet).

## Test plan

- [x] `bun test` on all 17 `glance-*.test.ts` files — 135 pass, 0 fail
- [x] `bun test skills/harness/tests skills/_shared/tests` (full suite) —
      2200 pass, 3 skip, 0 fail across 198 files
- [x] `bun run check:all` — exit 0 (English source, changelog parity,
      version parity, audit-parity, organizational non-regression, scope
      guard, engine purity, and the rest)
- [x] Booted `nrv glance` locally and confirmed `/trajectory-card.js` serves
      and the index page wires the new module adapter
- [x] CHANGELOG.md / CHANGELOG.pt-BR.md updated with matching structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk