### PR TITLE
fix(glance): the run detail header is a row, not the column it looks like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Glance: a run's detail panel is readable again
+
+`.run-detail-head` had no `flex-direction`, so it defaulted to `row`: the
+three blocks meant to stack (status bar, brief title, metadata grid) were
+squeezed side by side instead, each a third of the panel's width, wrapping
+their text onto dozens of lines. Flex's default `align-items: stretch` then
+made every sibling match whichever wrapped the most — measured at 1816px for
+three short lines on a real run, pushing the event timeline below it entirely
+off-screen with no way to scroll to it. Predates the Trajectory Card work
+(2026-08-11); found live while reviewing that PR, not caused by it.
+
 ## 0.12.2 — 2026-08-30
 
 ### Glance: the Trajectory Card replaces two divergent run timelines

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,18 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Glance: o painel de detalhe de uma run volta a ser legível
+
+`.run-detail-head` não tinha `flex-direction`, então caía no padrão `row`:
+os três blocos que deveriam empilhar (barra de status, título do brief,
+grid de metadados) ficavam espremidos lado a lado, cada um com um terço da
+largura do painel, quebrando o texto em dezenas de linhas. O
+`align-items: stretch` padrão do flex então fazia cada irmão igualar o que
+mais quebrou — medido em 1816px para três linhas curtas numa run real,
+empurrando a timeline de eventos inteira para fora da tela, sem como rolar
+até ela. É anterior ao trabalho do Cartão de Trajetória (11/08/2026);
+achado ao vivo revisando aquela PR, não causado por ela.
+
 ## 0.12.2 — 2026-08-30
 
 ### Glance: o Cartão de Trajetória substitui duas timelines de run divergentes

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -1123,7 +1123,7 @@ body {
   opacity: 0.6;
 }
 .run-detail-head {
-  display: flex; gap: var(--space-3);
+  display: flex; flex-direction: column; gap: var(--space-3);
   margin-bottom: var(--space-4);
   padding-bottom: var(--space-3);
   border-bottom: 1px solid var(--border-default);


### PR DESCRIPTION
## Summary
- `.run-detail-head` had no `flex-direction`, defaulting to `row`: its three stacked-looking children (status bar, brief title, metadata grid) were laid out side by side, each squeezed to roughly a third of the panel width, wrapping text onto dozens of lines.
- Flex's default `align-items: stretch` made every sibling match whichever wrapped the most — measured at 1816px for three short lines on a real run, pushing the event timeline entirely off-screen with no way to scroll to it.
- Predates the Trajectory Card work (2026-08-11) — found live while reviewing PR #172, not caused by it.
- One property: `flex-direction: column`.

## Test plan
- [x] `bun test skills/harness/tests/glance-*.test.ts` — 133 pass, 0 fail
- [x] `bun run check:all` — exit 0, changelog parity clean
- [x] Verified live in a browser: injected the fix as an override on a running `nrv glance` instance against a real run with 200+ events, confirmed the header renders normally and the timeline becomes reachable
- [ ] CI green on ubuntu/macos/windows

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>