### PR TITLE
fix(glance): apply the glass material to the whole shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Glance: the glass material now covers the whole shell, not one accordion
+
+PR #172 shipped the `.gl` / `.gl--2` / `.gl--3` / `.gl--ink` glass recipe
+(alpha and blur derived from stacking translucent sheets, floor-checked
+against WCAG 2.2 AA) but applied it to a single component: the judgement
+strip inside a run's trajectory. Opening Glance afterward showed no visible
+change — nav, the ENGINE subsystem row, the sidebar, run cards, the run
+detail panel and the chat panel were still opaque. This finishes the job:
+those six surfaces now carry the same recipe, unmodified (`--sheet-a`,
+`--sheet-b` and `--floor-field` are untouched), plus a new fixed `.field-bg`
+layer of soft radial gradients in the theme's own accent/status tones —
+without it, a translucent sheet over a flat color reads as `opacity`, not
+glass. `.card` itself (shared by agent, memory and cost views) was left
+alone; a scoped `.runs-list .card.gl` override carries the effect to run
+cards without touching those other views.
+
+The theme toggle also moved from one static icon to three permanent ones
+(`sun` / `moon` / `sparkles`, one per `apple` / `apple-dark` / `awwwards`)
+shown or hidden by a `[data-theme]` CSS rule instead of a script reassigning
+`data-lucide` after Lucide has already replaced the tag with an `<svg>`.
+
 ### Glance: a run's detail panel is readable again
 
 `.run-detail-head` had no `flex-direction`, so it defaulted to `row`: the

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,29 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Glance: o material de vidro agora cobre a casca inteira, não um acordeão
+
+A PR #172 lançou a receita de vidro `.gl` / `.gl--2` / `.gl--3` / `.gl--ink`
+(alpha e blur derivados do empilhamento de folhas translúcidas, com piso
+verificado contra WCAG 2.2 AA), mas a aplicou a um único componente: a faixa
+de julgamento dentro da trajetória de uma run. Abrir o Glance depois disso
+não mostrava nenhuma mudança visível — nav, a faixa de subsistemas ENGINE,
+a sidebar, os cards de run, o painel de detalhe da run e o painel de chat
+continuavam opacos. Isto termina o trabalho: essas seis superfícies agora
+carregam a mesma receita, sem alterações (`--sheet-a`, `--sheet-b` e
+`--floor-field` continuam intocados), mais uma nova camada fixa `.field-bg`
+de gradientes radiais suaves nos tons de accent/status do próprio tema —
+sem ela, uma folha translúcida sobre uma cor lisa lê como `opacity`, não
+como vidro. O `.card` em si (compartilhado pelas views de agente, memória
+e custo) ficou intocado; um override específico `.runs-list .card.gl` leva
+o efeito aos cards de run sem tocar nessas outras views.
+
+O alternador de tema também deixou de usar um ícone estático único e passou
+a usar três ícones permanentes (`sun` / `moon` / `sparkles`, um por tema
+`apple` / `apple-dark` / `awwwards`), mostrados ou ocultados por uma regra
+CSS de `[data-theme]` em vez de um script reatribuindo `data-lucide` depois
+que o Lucide já substituiu a tag por um `<svg>`.
+
 ### Glance: o painel de detalhe de uma run volta a ser legível
 
 `.run-detail-head` não tinha `flex-direction`, então caía no padrão `row`:

--- a/skills/harness/lib/glance/views/components.css
+++ b/skills/harness/lib/glance/views/components.css
@@ -1509,7 +1509,6 @@
   display: flex; align-items: center; gap: var(--space-3);
   flex-wrap: wrap;
   padding: var(--space-1) var(--space-4);
-  background: var(--surface-2);
   border-bottom: 1px solid var(--border-subtle);
   font-size: var(--text-xs);
   font-family: var(--font-mono);

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -15,19 +15,29 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: var(--surface-0);
+  background: transparent;
   color: var(--text-primary);
   font-family: var(--font-sans);
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   -webkit-font-smoothing: antialiased;
 }
 
-.font-inter { font-family: var(--font-sans); }
-.glass {
-  background: var(--surface-glass);
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
+/* ─── Field background — the glass sheets (.gl in components.css) need a
+   backdrop with something to refract, or they read as a flat opacity, not
+   glass. Soft radial blobs in the theme's own accent/status tones, fixed
+   behind the whole shell. ─── */
+.field-bg {
+  position: fixed; inset: 0; z-index: -1;
+  background:
+    radial-gradient(700px 500px at 8% 6%, color-mix(in oklab, var(--accent) 30%, transparent), transparent 60%),
+    radial-gradient(640px 520px at 92% 14%, color-mix(in oklab, var(--status-info-solid) 26%, transparent), transparent 62%),
+    radial-gradient(760px 620px at 20% 96%, color-mix(in oklab, var(--status-success-solid) 20%, transparent), transparent 60%),
+    radial-gradient(600px 520px at 84% 92%, color-mix(in oklab, var(--status-warn-solid) 22%, transparent), transparent 60%),
+    var(--surface-0);
+  filter: saturate(1.05);
 }
+
+.font-inter { font-family: var(--font-sans); }
 
 /* ─── Top nav ─── */
 .glance-nav {
@@ -62,7 +72,6 @@ body {
   width: 300px; flex-shrink: 0;
   border-right: 1px solid var(--border-default);
   display: flex; flex-direction: column;
-  background: var(--surface-1);
 }
 .kind-tabs {
   display: flex; flex-direction: column;
@@ -127,7 +136,6 @@ body {
   padding: 10px var(--space-3);
   border-radius: 10px;
   text-align: left;
-  background: var(--surface-0);
   border: 1px solid var(--border-default);
   cursor: pointer;
   transition: background var(--dur-fast) var(--ease-out),
@@ -1102,6 +1110,16 @@ body {
   overflow-y: auto; padding-right: var(--space-1);
   min-height: 0;
 }
+/* Run cards carry the shared .gl recipe (components.css), but .card's own
+   background there is declared after .gl in that same file and wins at
+   equal specificity. This file loads after components.css, so scoping the
+   override to .runs-list wins without touching the shared .card rule used
+   by agent/memory/cost cards elsewhere. */
+.runs-list .card.gl {
+  background: color-mix(in oklab, var(--glass-tint) calc(var(--a) * 100%), transparent);
+  -webkit-backdrop-filter: blur(var(--b)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--b)) saturate(var(--glass-sat));
+}
 .run-time { font-size: var(--text-sm); color: var(--text-tertiary); }
 .run-brief {
   font-size: var(--text-md); line-height: var(--leading-snug);
@@ -1111,7 +1129,6 @@ body {
 .run-meta-mono { font-family: var(--font-mono); }
 
 .run-detail {
-  background: var(--surface-1);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   padding: var(--space-4);
@@ -1820,6 +1837,21 @@ svg.icon-inline.lucide {
   vertical-align: -2px;
   margin-right: var(--space-1);
 }
+
+/* ─── Theme toggle icon — three permanent icons, one per [data-theme] value,
+   visibility alternated by CSS. Never re-set data-lucide via JS after Lucide
+   has already replaced the <i> with an <svg> — that swap silently stops
+   working once the element is no longer an <i>.
+   Selectors are qualified with .icon-btn (not just the bare .theme-icon-*
+   class) so they out-specify svg.lucide { display: inline-block } above,
+   which would otherwise win post-conversion and show all three at once. */
+.icon-btn .theme-icon-apple-dark, .icon-btn .theme-icon-awwwards { display: none; }
+html[data-theme="apple-dark"] .icon-btn .theme-icon-apple,
+html[data-theme="apple-dark"] .icon-btn .theme-icon-awwwards { display: none; }
+html[data-theme="apple-dark"] .icon-btn .theme-icon-apple-dark { display: inline-block; }
+html[data-theme="awwwards"] .icon-btn .theme-icon-apple,
+html[data-theme="awwwards"] .icon-btn .theme-icon-apple-dark { display: none; }
+html[data-theme="awwwards"] .icon-btn .theme-icon-awwwards { display: inline-block; }
 
 /* ═════════════ Setup view (kind=setup) ═════════════ */
 .setup-view {
@@ -2978,7 +3010,6 @@ svg.icon-inline.lucide {
   width: 100%;
   padding: 12px var(--space-3);
   border-radius: var(--radius-lg);
-  background: var(--surface-0);
   border: 1px solid var(--border-default);
   color: var(--text-primary);
   cursor: pointer; text-align: left;
@@ -3096,7 +3127,6 @@ svg.icon-inline.lucide {
   position: fixed; top: 0; right: 0; bottom: 0;
   width: 460px; max-width: 92vw; z-index: 60;
   display: flex; flex-direction: column;
-  background: var(--surface-1);
   border-left: 1px solid var(--border-default);
   box-shadow: -12px 0 40px rgba(0,0,0,0.16);
   transform: translateX(100%);

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -26,6 +26,8 @@
 </head>
 <body class="font-inter antialiased">
 
+<div class="field-bg" aria-hidden="true"></div>
+
 <div x-data="glance()" x-init="boot()" class="h-screen flex flex-col">
 
   <!-- Awwwards-style hero (only when theme=awwwards, dismissed after 1.8s) -->
@@ -42,7 +44,7 @@
   </template>
 
   <!-- ─── Top nav ─── -->
-  <nav class="glance-nav glass">
+  <nav class="glance-nav gl gl--2">
     <div class="flex items-center gap-3">
       <span class="text-lg">⊚</span>
       <div class="leading-tight">
@@ -120,7 +122,11 @@
       <button @click="chatOpen ? closeChat() : openChat()" :class="chatOpen ? 'icon-btn icon-btn-active' : 'icon-btn'" title="Chat — converse com o Nirvana e opere o sistema"><i data-lucide="message-square"></i></button>
       <button @click="openSettings()" :class="settingsOpen ? 'icon-btn icon-btn-active' : 'icon-btn'" title="Configuração" aria-label="Configuração"><i data-lucide="settings"></i></button>
       <button @click="consoleOpen = !consoleOpen" title="Console" class="icon-btn" :class="jobs.some(j => j.status==='running') ? 'icon-btn-pulse' : ''"><i data-lucide="terminal"></i></button>
-      <button @click="cycleTheme()" title="Toggle theme" class="icon-btn"><i data-lucide="palette"></i></button>
+      <button @click="cycleTheme()" title="Toggle theme" class="icon-btn">
+        <i data-lucide="sun" class="theme-icon-apple"></i>
+        <i data-lucide="moon" class="theme-icon-apple-dark"></i>
+        <i data-lucide="sparkles" class="theme-icon-awwwards"></i>
+      </button>
       <button @click="refreshAll()" title="Refresh" class="icon-btn"><i data-lucide="rotate-cw"></i></button>
     </div>
   </nav>
@@ -128,7 +134,7 @@
   <!-- ─── Subsystems — o que está de pé (não o que rodou) ───
        Cada célula é uma leitura real do disco. Uma que não pôde ser
        determinada mostra — em vez de acender um verde que ninguém mediu. -->
-  <div class="subsystem-row" role="status" aria-label="Subsistemas do engine">
+  <div class="subsystem-row gl" role="status" aria-label="Subsistemas do engine">
     <span class="subsystem-row-title">ENGINE</span>
     <template x-for="cell in subsystemRow.cells" :key="cell.key">
       <span class="subsystem-cell" :title="cell.title">
@@ -153,7 +159,7 @@
 
     <!-- Sidebar — always visible so kind-tabs (Squads/Businesses/…/Memory/Graph/Cost)
          remain reachable. Filter/list/setup chrome inside is gated to per-asset kinds. -->
-    <aside class="sidebar" x-show="sidebarOpen">
+    <aside class="sidebar gl gl--2" x-show="sidebarOpen">
       <div class="sidebar-collapse-row">
         <button class="sidebar-collapse-btn" @click="toggleSidebar()" title="Collapse sidebar (⌘\)">
           <i data-lucide="chevron-left"></i>
@@ -163,6 +169,7 @@
       <div class="kind-cards" x-show="navLevel === 'kinds'" role="tablist" aria-label="Sections">
         <template x-for="k in kinds" :key="k.id">
           <button
+            class="gl gl--ink"
             @click="enterKind(k.id)"
             :class="kind === k.id ? 'kind-card active' : 'kind-card'"
             role="tab"
@@ -265,6 +272,7 @@
           <!-- Rows -->
           <template x-for="item in filteredList" :key="item.id || item.slug">
             <button
+              class="gl gl--ink"
               @click="setupMode ? toggleSetupSelection(kind, item.slug) : select(item)"
               :class="(setupMode ? (isItemPicked(kind, item.slug) ? 'list-row picked' : 'list-row') : (isSelected(item) ? 'list-row active' : 'list-row'))">
               <span x-show="setupMode" class="setup-checkbox" :class="isItemPicked(kind, item.slug) ? 'checked' : ''"></span>
@@ -863,7 +871,7 @@
             </div>
           </template>
           <template x-for="run in visibleRuns" :key="run.trace_id">
-            <button class="card card-interactive"
+            <button class="card card-interactive gl gl--ink"
                     :class="[
                       selectedRun?.trace_id === run.trace_id ? 'card-active' : '',
                       run.suspicious ? 'card-status-warn' : '',
@@ -900,7 +908,7 @@
           </template>
         </aside>
         <!-- RIGHT: selected run detail (timeline + artifacts) -->
-        <section class="run-detail" x-show="selectedRun" x-cloak>
+        <section class="run-detail gl gl--2" x-show="selectedRun" x-cloak>
           <template x-if="selectedRun">
             <div>
               <header class="run-detail-head">
@@ -1060,7 +1068,7 @@
             </div>
           </template>
         </section>
-        <section class="run-detail run-detail-empty" x-show="!selectedRun" x-cloak>
+        <section class="run-detail run-detail-empty gl gl--2" x-show="!selectedRun" x-cloak>
           <div class="empty-state">
             <i data-lucide="mouse-pointer-click" class="empty-state-icon"></i>
             <p>Click a run to see its full timeline.</p>
@@ -1893,7 +1901,7 @@
   </div>
 
   <!-- ══════════════ CHAT PANEL (Fase 3) ══════════════ -->
-  <aside class="chat-panel" :class="chatOpen ? 'open' : ''" x-cloak>
+  <aside class="chat-panel gl gl--2" :class="chatOpen ? 'open' : ''" x-cloak>
     <header class="chat-head">
       <div class="chat-head-title">
         <span class="chat-head-dot"></span>


### PR DESCRIPTION
## Summary
- PR #172 shipped the `.gl`/`.gl--2`/`.gl--3`/`.gl--ink` glass recipe (tokens.css/components.css, alpha+blur derived from stacked translucent sheets, WCAG 2.2 AA floor-checked) but wired it into a single component — the judgement strip inside a run's trajectory. Opening Glance afterward showed no visible change: nav, the ENGINE subsystem row, the sidebar, run cards, the run detail panel and the chat panel were still opaque.
- This PR finishes the job: those six surfaces now carry the same recipe (`--sheet-a`/`--sheet-b`/`--floor-field` untouched, per the brief), plus a new fixed `.field-bg` layer of soft radial gradients in the theme's own accent/status tones — without a backdrop to refract, a translucent sheet reads as flat `opacity`, not glass.
- `.card` itself (shared by agent/memory/cost views, out of scope) is untouched; a scoped `.runs-list .card.gl` override carries the effect to run cards only.
- The theme toggle moved from one static "palette" icon to three permanent icons (`sun`/`moon`/`sparkles`, one per `apple`/`apple-dark`/`awwwards`) shown/hidden by `[data-theme]` CSS instead of reassigning `data-lucide` via JS after Lucide has already replaced the tag with an `<svg>`.
- CHANGELOG.md / CHANGELOG.pt-BR.md updated (parity verified by `check-changelog-parity --strict`).

## Test plan
- [x] `bun test skills/harness/tests/glance-*.test.ts` — 133 pass, 0 fail
- [x] `bun run check:all` — exit 0 (includes changelog/version/english-source/scope-guard/organizational-non-regression, etc.)
- [x] Manual visual check in real Chrome (via claude-in-chrome), all three themes (`apple`, `apple-dark`, `awwwards`): nav/sidebar/ENGINE row/run cards/run-detail/chat panel all render translucent + blurred against the new gradient field; confirmed via computed styles that `background-color` alpha and `backdrop-filter: blur(...)` resolve to the expected derived values (e.g. `.gl--2` → alpha 0.84, blur 11.31px)
- [x] Found and fixed a real bug during verification: the three theme-toggle icons all rendered simultaneously in the default theme because `svg.lucide { display: inline-block }` (specificity 0,1,1) beat the bare `.theme-icon-apple-dark` hide rule (0,1,0) after Lucide converts `<i>` to `<svg>`. Fixed by qualifying the hide rule with `.icon-btn` (0,2,0). Verified all three theme states now show exactly one icon.
- [x] Found a pre-existing, unrelated layout bug in `.run-detail`'s body (kv-grid values render character-wrapped in an extremely narrow column) — confirmed via `git stash` that it reproduces identically on `main` before this change, so left untouched per scope (reported in the task's `_SUMMARY.md`, not fixed here).
- [x] Confirmed Lucide icon sizes unchanged: 16px base, 18px in `.icon-btn`, 14px `.icon-inline`.
- [x] No new browser console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk