### PR TITLE
fix(quality-gate): .css was outside GATEABLE_EXTS, invisible to the gate entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Quality gate: `.css` was invisible to the gate entirely
+
+An independent review of the field-bg incident (PR #175, this engine,
+2026-08-30 — a decorative gradient composited to ~12% effective alpha under
+a glass sheet, invisible in practice, though the producing agent's own
+`_SUMMARY.md` claimed to have verified it visually in Chrome) found the root
+cause upstream of the bug itself: `.css` was absent from `GATEABLE_EXTS`
+outright, so the file that shipped the regression was never something the
+quality gate could evaluate, pass or fail — not a rubric that missed the
+bug, a file type the gate never looked at. Added `.css` to `GATEABLE_EXTS`
+and a new `css-composite-alpha` rubric that computes the actual compounded
+alpha of a gradient wash rendered behind a declared glass-sheet alpha
+(`decorative_alpha × (1 − sheet_alpha)`) and flags it below a visibility
+floor. It is a lexical smoke test, not a renderer — it cannot confirm a
+gradient actually renders behind a given sheet in the real cascade, so a
+flag is evidence for a human or a browser-capable auditor, not a final
+verdict on its own. Verified against a fixture reproducing the exact field-bg
+percentages (fails) and this branch's actual fix (passes), end to end
+through the real `quality-gate.ts` subprocess, not just the rubric function
+in isolation — and against this engine's own real `tokens.css` to rule out
+false positives against unrelated, correctly-subtle status-tint tokens.
+
+This is the first, narrowest fix from that review; a mandatory return-audit
+stage (separating what a producer *claims* from what an independent auditor
+*observes*) is a larger, separate change still in progress.
+
 ## 0.12.3 — 2026-08-30
 
 ### Glance: the glass material now covers the whole shell, not one accordion

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,36 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Gate de qualidade: `.css` era invisível pro gate por completo
+
+Uma revisão independente do incidente do field-bg (PR #175, este engine,
+30/08/2026 — um gradiente decorativo compondo a ~12% de alpha efetivo sob
+uma folha de vidro, invisível na prática, embora o próprio `_SUMMARY.md` do
+agente produtor afirmasse ter verificado visualmente no Chrome) encontrou a
+causa raiz a montante do próprio bug: `.css` estava ausente de
+`GATEABLE_EXTS` por completo, então o arquivo que carregava a regressão
+nunca foi algo que o gate de qualidade pudesse avaliar, passar ou reprovar —
+não uma rúbrica que deixou passar o bug, um tipo de arquivo que o gate nunca
+olhava. Adicionei `.css` ao `GATEABLE_EXTS` e uma nova rúbrica
+`css-composite-alpha` que calcula o alpha composto real de um gradiente
+decorativo renderizado atrás de um alpha de folha de vidro declarado
+(`decorative_alpha × (1 − sheet_alpha)`) e sinaliza quando fica abaixo de um
+piso de visibilidade. É um teste léxico de fumaça, não um renderizador —
+não confirma que um gradiente realmente renderiza atrás de uma folha
+específica na cascata real, então uma sinalização é evidência para um
+humano ou um auditor com acesso a browser, não um veredito final por si só.
+Verificado contra um fixture reproduzindo os percentuais exatos do
+field-bg (reprova) e a correção real desta branch (passa), ponta a ponta
+através do subprocesso real do `quality-gate.ts`, não só a função da rúbrica
+isolada — e contra o `tokens.css` real deste próprio engine para descartar
+falsos positivos contra tokens de tinta de status corretamente sutis e sem
+relação com o bug.
+
+Esta é a correção mais estreita e imediata dessa revisão; um estágio
+obrigatório de auditoria de volta (separando o que um produtor *afirma* do
+que um auditor independente *observa*) é uma mudança maior, separada, ainda
+em andamento.
+
 ## 0.12.3 — 2026-08-30
 
 ### Glance: o material de vidro agora cobre a casca inteira, não um acordeão

--- a/skills/harness/rubrics/css-composite-alpha.ts
+++ b/skills/harness/rubrics/css-composite-alpha.ts
@@ -1,0 +1,121 @@
+// css-composite-alpha.ts — catches a decorative layer whose visible alpha is
+// compounded away to nothing by a glass sheet stacked on top of it.
+//
+// The incident this rubric exists for (PR #175, this engine, 2026-08-30): a
+// `.field-bg` layer used `color-mix(in oklab, var(--accent) 30%, transparent)`
+// gradients, rendered BEHIND a glass sheet declaring `--sheet-a: 0.6` — the
+// sheet's own tint is 60% opaque, so only (1 − 0.6) = 40% of whatever sits
+// behind it (the gradient) shows through. The producing agent's own
+// _SUMMARY.md claimed to have opened Chrome and read computed styles showing
+// a visible "wash" — but nobody computed the COMPOSITE: 30% × 40% = 12%
+// effective alpha, invisible in practice, especially against a light theme's
+// near-white surfaces. `.css` was not in GATEABLE_EXTS at all, so this file
+// was invisible to the gate before it ever got a chance to check anything.
+//
+// Scope, deliberately narrow: only alpha used INSIDE a gradient function
+// (radial-gradient/linear-gradient/conic-gradient). A gradient wash is the
+// "ambient effect meant to be seen" pattern the incident was about. A flat
+// `--status-success-bg: color-mix(..., 14%, transparent)` token is a
+// different, tolerant-of-subtlety design choice (a small semantic tint, not
+// a page-wide wash) — scanning those too produced false positives against
+// this engine's own real tokens.css on first try, which is exactly the kind
+// of blunt-instrument static check the incident's own report warned against.
+//
+// This is a static-analysis smoke test, not a renderer: it cannot know
+// whether a gradient actually renders BEHIND a given sheet in the real
+// cascade — that needs a browser — so a flag here is evidence for a human or
+// a browser-capable auditor to look at, not a final verdict on its own.
+
+const SHEET_ALPHA_VAR = /--[\w-]*-a\b\s*:\s*([0-9]*\.?[0-9]+)\s*;/g;
+const GRADIENT_START = /(?:radial|linear|conic)-gradient\(/g;
+const COLOR_MIX_ALPHA = /color-mix\([^)]*?,\s*[^,]+?\s+(\d{1,3})%\s*,\s*transparent\s*\)/g;
+const RGBA_ALPHA = /rgba?\([^)]*,\s*([0-9]*\.?[0-9]+)\s*\)/g;
+
+// Below this, the composited color is generally imperceptible against a
+// light-theme near-white surface. Not a WCAG number — WCAG contrast needs the
+// actual colors on both sides, which a lexical scan cannot see. This is a
+// conservative "probably invisible, go check it" floor.
+const VISIBILITY_FLOOR = 0.15;
+
+/** Extract the substrings of every gradient(...) call, matching parens by
+ * hand — regex cannot express arbitrary nesting depth, and a gradient wash
+ * routinely nests color-mix(...)/var(...) calls inside it. */
+function gradientBodies(content: string): string[] {
+  const bodies: string[] = [];
+  for (const m of content.matchAll(GRADIENT_START)) {
+    const openIdx = m.index! + m[0].length - 1; // index of the "(" itself
+    let depth = 1;
+    let i = openIdx + 1;
+    for (; i < content.length && depth > 0; i++) {
+      if (content[i] === "(") depth++;
+      else if (content[i] === ")") depth--;
+    }
+    bodies.push(content.slice(openIdx + 1, i - 1));
+  }
+  return bodies;
+}
+
+export async function evaluate(args: { artifact: string; content: string; offline?: boolean }) {
+  const { content } = args;
+
+  const sheetAlphas: number[] = [];
+  for (const m of content.matchAll(SHEET_ALPHA_VAR)) {
+    const v = Number.parseFloat(m[1]);
+    if (Number.isFinite(v) && v > 0 && v <= 1) sheetAlphas.push(v);
+  }
+
+  const decorativeAlphas: number[] = [];
+  for (const body of gradientBodies(content)) {
+    for (const m of body.matchAll(COLOR_MIX_ALPHA)) {
+      const pct = Number.parseFloat(m[1]);
+      if (Number.isFinite(pct)) decorativeAlphas.push(pct / 100);
+    }
+    for (const m of body.matchAll(RGBA_ALPHA)) {
+      const v = Number.parseFloat(m[1]);
+      if (Number.isFinite(v) && v > 0 && v < 1) decorativeAlphas.push(v);
+    }
+  }
+
+  // Nothing to compound — most CSS never declares a sheet alpha, or never
+  // uses a gradient wash, at all.
+  if (sheetAlphas.length === 0 || decorativeAlphas.length === 0) {
+    return {
+      name: "css-composite-alpha",
+      passed: true,
+      score: 1.0,
+      reasoning: "No glass-sheet alpha stacked with a gradient wash's decorative alpha in this file — nothing to compound.",
+      fix_list: [],
+    };
+  }
+
+  // The worst case is the MOST opaque sheet (highest alpha) — it blocks the
+  // most of what sits behind it, so it passes through the LEAST.
+  const worstSheetAlpha = Math.max(...sheetAlphas);
+  const passThrough = 1 - worstSheetAlpha;
+  const flagged: { decorative: number; composite: number }[] = [];
+  for (const dec of decorativeAlphas) {
+    const composite = dec * passThrough;
+    if (composite < VISIBILITY_FLOOR) flagged.push({ decorative: dec, composite });
+  }
+
+  if (flagged.length === 0) {
+    return {
+      name: "css-composite-alpha",
+      passed: true,
+      score: 1.0,
+      reasoning: `Composited alpha stays above the ${VISIBILITY_FLOOR} visibility floor for every gradient wash found (worst-case sheet at ${worstSheetAlpha} alpha passes through ${(passThrough * 100).toFixed(0)}%).`,
+      fix_list: [],
+    };
+  }
+
+  const worst = flagged.reduce((a, b) => (a.composite < b.composite ? a : b));
+  return {
+    name: "css-composite-alpha",
+    passed: false,
+    score: Math.max(0, worst.composite / VISIBILITY_FLOOR),
+    reasoning: `A gradient wash at ${(worst.decorative * 100).toFixed(0)}% composited behind a glass sheet at ${worstSheetAlpha} alpha (passes through only ${(passThrough * 100).toFixed(0)}%) lands at ~${(worst.composite * 100).toFixed(0)}% effective — likely imperceptible, especially in a light theme. This is a lexical smoke test: it cannot confirm the gradient actually renders behind the sheet, so verify visually before trusting the flag either way.`,
+    fix_list: [
+      `Raise the gradient's own opacity so decorative_alpha × ${passThrough.toFixed(2)} clears ${VISIBILITY_FLOOR}, or verify in a browser that the composite is intentional and visible.`,
+    ],
+  };
+}

--- a/skills/harness/scripts/quality-gate.ts
+++ b/skills/harness/scripts/quality-gate.ts
@@ -54,7 +54,7 @@ export type GateVerdict = {
 export const GATEABLE_EXTS: ReadonlySet<string> = new Set([
   ".md", ".txt", ".json", ".yaml", ".yml",
   ".png", ".jpg", ".jpeg", ".webp",
-  ".html", ".ts", ".js", ".py",
+  ".html", ".css", ".ts", ".js", ".py",
   ".pdf",
 ]);
 
@@ -75,6 +75,8 @@ export function rubricsForExt(ext: string): string[] {
       return ["brief-fidelity"];
     case ".html":
       return ["html-valid"];
+    case ".css":
+      return ["css-composite-alpha"];
     case ".pdf":
       return ["pdf-valid"];
     case ".ts":

--- a/skills/harness/tests/css-composite-alpha.test.ts
+++ b/skills/harness/tests/css-composite-alpha.test.ts
@@ -1,0 +1,104 @@
+// css-composite-alpha.test.ts — the fixture the field-bg incident (PR #175,
+// 2026-08-30) would have failed on had `.css` been gateable at the time.
+//
+// The bug: `.field-bg`'s gradients used `color-mix(in oklab, var(--accent)
+// 30%, transparent)`, rendered behind `--sheet-a: 0.6` (a glass sheet whose
+// own tint is 60% opaque, so only 40% of what's behind it shows through).
+// 30% × 40% = 12% effective alpha — invisible against a light theme, though
+// the producing agent's _SUMMARY.md claimed to have verified it visually in
+// Chrome. `.css` was not in GATEABLE_EXTS at all, so nothing ever ran this
+// check. This file proves the fixed percentages (this branch's actual fix:
+// 30% → 65%, still under the same 0.6 sheet) clear the visibility floor,
+// and the original 30% does not.
+import { describe, expect, test } from "bun:test";
+import { evaluate } from "../rubrics/css-composite-alpha.ts";
+
+const FIELD_BG_ORIGINAL = `
+:root {
+  --sheet-a: 0.6;
+}
+.field-bg {
+  background: radial-gradient(900px 650px at 8% 4%, color-mix(in oklab, var(--accent) 30%, transparent), transparent 70%);
+}
+`;
+
+const FIELD_BG_FIXED = `
+:root {
+  --sheet-a: 0.6;
+}
+.field-bg {
+  background: radial-gradient(900px 650px at 8% 4%, color-mix(in oklab, var(--accent) 65%, transparent), transparent 70%);
+}
+`;
+
+describe("the exact field-bg regression (PR #175)", () => {
+  test("30% decorative mix under a 0.6 sheet alpha composites to ~12% — flagged", async () => {
+    const r = await evaluate({ artifact: "tokens.css", content: FIELD_BG_ORIGINAL });
+    expect(r.passed).toBe(false);
+    expect(r.reasoning).toContain("12%");
+  });
+
+  test("this branch's actual fix (65% mix) clears the visibility floor", async () => {
+    const r = await evaluate({ artifact: "tokens.css", content: FIELD_BG_FIXED });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("no sheet alpha declared", () => {
+  test("a plain gradient with no --*-a variable in the file passes — nothing to compound", async () => {
+    const r = await evaluate({
+      artifact: "plain.css",
+      content: `.hero { background: color-mix(in oklab, blue 10%, transparent); }`,
+    });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("rgba() decorative layers inside a gradient, not just color-mix()", () => {
+  test("a low rgba alpha inside a gradient wash, under a high sheet alpha, is flagged the same way", async () => {
+    const r = await evaluate({
+      artifact: "tokens.css",
+      content: `:root { --sheet-a: 0.7; } .panel { background: linear-gradient(rgba(80, 100, 240, 0.2), transparent); }`,
+    });
+    expect(r.passed).toBe(false);
+  });
+
+  test("a bare rgba() NOT inside a gradient (a flat fill, a different design intent) is out of scope", async () => {
+    const r = await evaluate({
+      artifact: "tokens.css",
+      content: `:root { --sheet-a: 0.7; } .panel { background: rgba(80, 100, 240, 0.2); }`,
+    });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("a flat semantic-tint token is a different design choice than a gradient wash", () => {
+  test("this engine's own real tokens.css shape (--status-success-bg: color-mix(..., 14%, transparent), not a gradient) does not false-positive", async () => {
+    // The first version of this rubric flagged exactly this shape against the
+    // real tokens.css on first run: a deliberately subtle status-tint token,
+    // unrelated to the field-bg gradient-wash incident this rubric targets.
+    const r = await evaluate({
+      artifact: "tokens.css",
+      content: `
+:root {
+  --sheet-a: 0.6;
+  --status-success-bg: color-mix(in oklab, oklch(65% 0.16 145) 14%, transparent);
+  --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+`,
+    });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("a unitful custom property ending in a letter that reads like the alpha suffix", () => {
+  test("a pixel value never gets misread as an alpha (no unit-less number immediately before the semicolon)", async () => {
+    const r = await evaluate({
+      artifact: "tokens.css",
+      // `--space-a` intentionally shaped like the alpha-suffix pattern but
+      // holding a dimensioned value, not a bare 0–1 float.
+      content: `:root { --space-a: 8px; } .hero { background: color-mix(in oklab, blue 10%, transparent); }`,
+    });
+    expect(r.passed).toBe(true);
+  });
+});

--- a/skills/harness/tests/quality-gate-css-extension.test.ts
+++ b/skills/harness/tests/quality-gate-css-extension.test.ts
@@ -1,0 +1,83 @@
+// quality-gate-css-extension.test.ts — .css is now a gateable extension.
+//
+// Before this cut, `.css` was absent from GATEABLE_EXTS entirely (F175's
+// field-bg regression shipped in a .css file the gate never looked at, by
+// construction — see css-composite-alpha.ts's own header for the incident).
+// quality-gate.test.ts only tests rubric NAME selection
+// (selectRubricsForProduces), never a real end-to-end run of scripts/
+// quality-gate.ts against a file on disk — this file closes that specific
+// gap for .css, spawning the real CLI the way delivery-pipeline.ts does.
+// Runs with: bun test skills/harness/tests
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { GATEABLE_EXTS, rubricsForExt } from "../scripts/quality-gate.ts";
+import { gateableFiles, runGateOnce } from "../lib/delivery-pipeline.ts";
+
+const GATE_SCRIPT = path.join(import.meta.dir, "..", "scripts", "quality-gate.ts");
+const SKILLS = path.resolve(import.meta.dir, "..", "..");
+// quality-gate.ts resolves rubrics from NIRVANA_SKILLS_DIR (default: the
+// INSTALLED ~/.nirvana/skills copy) — without this, a rubric that only
+// exists in the repo source (like the one this file tests) is invisible to
+// a spawned subprocess and comes back "not implemented yet", not evaluated.
+const GATE_ENV = { NIRVANA_SKILLS_DIR: SKILLS };
+
+describe(".css is gateable", () => {
+  test("GATEABLE_EXTS now includes .css", () => {
+    expect(GATEABLE_EXTS.has(".css")).toBe(true);
+  });
+
+  test(".css maps to the css-composite-alpha rubric", () => {
+    expect(rubricsForExt(".css")).toEqual(["css-composite-alpha"]);
+  });
+
+  test("gateableFiles() picks up a .css deliverable alongside .html — it did not before this cut", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gate-css-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "styles.css"), ".hero { color: red; }\n".repeat(20));
+      fs.writeFileSync(path.join(tmp, "index.html"), "<html><body>x".repeat(50) + "</body></html>");
+      expect(gateableFiles(tmp, new Set()).map(f => path.basename(f)).sort())
+        .toEqual(["index.html", "styles.css"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the real CLI (not just the rubric function) catches the field-bg shape end to end", () => {
+  test("a gradient wash compounded under a glass sheet to <15% fails the real quality-gate.ts subprocess", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gate-css-e2e-"));
+    try {
+      const cssPath = path.join(tmp, "tokens.css");
+      fs.writeFileSync(cssPath, `
+:root { --sheet-a: 0.6; }
+.field-bg {
+  background: radial-gradient(900px 650px at 8% 4%, color-mix(in oklab, var(--accent) 30%, transparent), transparent 70%);
+}
+`);
+      const result = runGateOnce([cssPath], { gateScript: GATE_SCRIPT, offline: true, env: GATE_ENV });
+      expect(result.pass).toBe(false);
+      expect(result.fails[0]?.fixes.join(" ")).toContain("Raise the gradient's own opacity");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("the same file with the compensated percentage passes the real subprocess", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-gate-css-e2e-pass-"));
+    try {
+      const cssPath = path.join(tmp, "tokens.css");
+      fs.writeFileSync(cssPath, `
+:root { --sheet-a: 0.6; }
+.field-bg {
+  background: radial-gradient(900px 650px at 8% 4%, color-mix(in oklab, var(--accent) 65%, transparent), transparent 70%);
+}
+`);
+      const result = runGateOnce([cssPath], { gateScript: GATE_SCRIPT, offline: true, env: GATE_ENV });
+      expect(result.pass).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
An independent review of the field-bg incident (PR #175) found the root cause upstream of the visual bug itself: `.css` files were never something the quality gate could evaluate, pass or fail. Not a rubric that missed the bug — a file type the gate never looked at.

- Adds `.css` to `GATEABLE_EXTS` and a new `css-composite-alpha` rubric computing the real compounded alpha of a gradient wash behind a declared glass-sheet alpha (`decorative_alpha * (1 - sheet_alpha)`), flagging it below a visibility floor.
- Explicitly a lexical smoke test, not a renderer: a flag is evidence for a human/browser-capable auditor, not a final verdict.

## Verified
- Real end-to-end run through `quality-gate.ts` against a fixture reproducing the exact field-bg percentages (fails) and the actual fix (passes).
- Checked against this engine's own `tokens.css` to rule out false positives against unrelated status-tint tokens (an early version of the rubric false-positived on exactly those before scoping it to gradient-wash context only).

This is the narrowest, first fix from that review. A mandatory return-audit stage (separating producer claims from independently observed evidence) is a larger, separate change (see #179).

## Test plan
- [x] New tests: `css-composite-alpha.test.ts`, `quality-gate-css-extension.test.ts`
- [x] `bun run check:quick` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk