### PR TITLE
feat(glance): real page-layout redesign for Runs + Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Glance: real structural page-layout redesign for Runs + Chat, not a visual skin
+
+An earlier round (PR #172/#175) shipped real atom/molecule/organism
+component work — event labels, the judgement strip, the Trajectory Card —
+but never touched the page-level layout: the sidebar, the runs list, the
+Activity pane and the chat panel kept the exact same fixed-width, always-
+visible regions before and after. The owner, looking at the shipped result,
+correctly called this out: a glass treatment on an unchanged skeleton is not
+a redesign.
+
+Six structural changes to `skills/harness/lib/glance/views/`:
+
+1. Sidebar auto-collapses 300px → 64px icon rail when a run is open in
+   detail (pin button persists full width). First auto-collapse fires a
+   one-time hint toast + `aria-live` region (Nielsen H1 — visibility of
+   system status).
+2. Activity: permanent 280px rail → on-demand overlay (`role="dialog"
+   aria-modal`, Esc closes, focus returns to the opening bell). Four
+   sibling containers go `inert` while open (WCAG 2.4.3), not just visually
+   hidden — a real focus-containment guarantee, verified by attempting a
+   programmatic focus into the inert subtree and confirming it fails.
+3. New collapsible "Atividade relacionada" strip inside `run-detail`,
+   scoped to the open run's `business_slug`/`project_id`.
+4. Runs list → searchable, collapsible rail (280px ↔ 56px); every collapsed
+   run stays a real `<button>` with an accessible name, never a mute
+   avatar.
+5. Chat panel resizes 460px ↔ 920px via a real `role="separator"` handle
+   (mouse drag + `ArrowLeft`/`ArrowRight`), a 24px hit area over a 3px
+   visible bar (WCAG 2.5.8 — an 8px handle failed the target-size floor in
+   an earlier draft, caught by an independent ux-qa pass).
+6. Status dots in the collapsed runs rail gain shape (circle/diamond/
+   triangle/square), never color alone (WCAG 1.4.1).
+
+New pure module `panel-layout.js` (`clampChatWidth`, `shouldCollapseSidebar`,
+`filterRunsByQuery`, `filterRelatedActivity`) makes the layout decisions
+unit-testable outside the Alpine app, which is a classic script and can't be
+imported directly by `bun:test`. No token, color, blur, icon or typography
+changed; `.right-pane` and every page besides Runs/Chat are untouched.
+
+Verified live in a real browser, not just against the mockup: sidebar
+measured at a genuine 64px via `getComputedStyle`, a real `ArrowRight`
+keydown moved the chat panel from 460px to 500px, and a direct programmatic
+focus attempt into an `inert` sibling of the open Activity overlay failed as
+expected.
+
 ### Quality gate: `.css` was invisible to the gate entirely
 
 An independent review of the field-bg incident (PR #175, this engine,

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,54 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Glance: redesign estrutural real de layout de página para Runs + Chat, não uma casca visual
+
+Uma rodada anterior (PR #172/#175) entregou trabalho real de átomo/molécula/
+organismo — labels de evento, a faixa de julgamento, o Cartão de Trajetória
+— mas nunca tocou o layout no nível de página: a sidebar, a lista de runs,
+o painel de Activity e o painel de chat mantiveram exatamente as mesmas
+regiões de largura fixa e sempre visíveis antes e depois. O dono, olhando o
+resultado entregue, apontou isso corretamente: um tratamento de vidro sobre
+um esqueleto inalterado não é um redesign.
+
+Seis mudanças estruturais em `skills/harness/lib/glance/views/`:
+
+1. Sidebar colapsa automaticamente de 300px para um rail de ícones de 64px
+   quando uma run está aberta em detalhe (botão de fixar mantém a largura
+   cheia). O primeiro auto-colapso dispara um toast único + região
+   `aria-live` (Nielsen H1 — visibilidade do status do sistema).
+2. Activity: rail permanente de 280px vira overlay sob demanda
+   (`role="dialog" aria-modal`, Esc fecha, foco volta pro sino que abriu).
+   Quatro containers irmãos ficam `inert` enquanto aberto (WCAG 2.4.3), não
+   só escondidos visualmente — uma garantia real de contenção de foco,
+   verificada tentando um foco programático dentro da subárvore inert e
+   confirmando que falha.
+3. Nova faixa colapsável "Atividade relacionada" dentro do `run-detail`,
+   escopada ao `business_slug`/`project_id` da run aberta.
+4. Lista de runs vira rail buscável e colapsável (280px ↔ 56px); cada run
+   colapsada continua um `<button>` real com nome acessível, nunca um
+   avatar mudo.
+5. Painel de chat redimensiona 460px ↔ 920px via uma alça `role="separator"`
+   real (arrasto de mouse + `ArrowLeft`/`ArrowRight`), área de toque de
+   24px sobre uma barra visível de 3px (WCAG 2.5.8 — uma alça de 8px falhou
+   o piso de tamanho de alvo numa versão anterior, achado por uma avaliação
+   independente do ux-qa).
+6. Pontos de status na lista colapsada de runs ganham forma (círculo/
+   losango/triângulo/quadrado), nunca só cor (WCAG 1.4.1).
+
+Novo módulo puro `panel-layout.js` (`clampChatWidth`, `shouldCollapseSidebar`,
+`filterRunsByQuery`, `filterRelatedActivity`) torna as decisões de layout
+testáveis fora do app Alpine, que é um script clássico e não pode ser
+importado diretamente pelo `bun:test`. Nenhum token, cor, blur, ícone ou
+tipografia mudou; `.right-pane` e toda página além de Runs/Chat continuam
+intocadas.
+
+Verificado ao vivo num browser real, não só contra o mockup: sidebar medida
+em 64px de verdade via `getComputedStyle`, um `ArrowRight` real moveu o
+painel de chat de 460px pra 500px, e uma tentativa direta de foco
+programático num irmão `inert` do overlay de Activity aberto falhou como
+esperado.
+
 ### Gate de qualidade: `.css` era invisível pro gate por completo
 
 Uma revisão independente do incidente do field-bg (PR #175, este engine,

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -1515,6 +1515,7 @@ export async function startServer(opts: ServerOptions) {
         "/settings-panel.js": "application/javascript",
         "/absence.js": "application/javascript",
         "/subsystem-row.js": "application/javascript",
+        "/panel-layout.js": "application/javascript",
         "/dag-renderer.js": "application/javascript",
         "/org-chart-renderer.js": "application/javascript",
         "/graph-renderer.js": "application/javascript",

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -2,7 +2,7 @@
    Nirvana Glance — Page-specific layout and chrome.
    Tokens live in tokens.css. Components live in components.css.
    This file holds only:
-     · top-level layout (nav, sidebar, right-pane, activity-pane, panes)
+     · top-level layout (nav, sidebar, right-pane, activity-overlay, panes)
      · per-view layout (runs-grid, agents-grid, cost-charts, graph, …)
      · chart/d3/mermaid chrome
      · animations not bound to a single component
@@ -78,6 +78,37 @@ body {
   width: 300px; flex-shrink: 0;
   border-right: 1px solid var(--border-default);
   display: flex; flex-direction: column;
+  transition: width var(--dur-base) var(--ease-out);
+  overflow: hidden;
+}
+/* Auto-collapses to a 64px icon rail when a run is open in detail and the
+   operator has not pinned the full width (page-layout-redesign.md §1.3). */
+.sidebar.icon-rail { width: 64px; }
+.sidebar.icon-rail .kind-card-label,
+.sidebar.icon-rail .kind-card-meta,
+.sidebar.icon-rail .sidebar-pin-label { display: none; }
+.sidebar.icon-rail .kind-card { justify-content: center; padding: 10px 6px; gap: 0; }
+
+.sidebar-foot { flex: none; padding: var(--space-2); border-top: 1px solid var(--border-default); }
+.sidebar-pin-btn {
+  display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px;
+  border-radius: var(--radius-md); border: 1px solid var(--border-default); background: var(--surface-1);
+  cursor: pointer; font-size: 12px; color: var(--text-secondary); font-family: inherit;
+}
+.sidebar-pin-btn:hover { background: var(--accent-soft); color: var(--accent); }
+.sidebar-pin-btn:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.sidebar.icon-rail .sidebar-pin-btn { justify-content: center; }
+.sidebar-pin-btn[aria-pressed="true"] { border-color: var(--accent); color: var(--accent); }
+.sidebar-pin-btn.hint-pulse { animation: sidebar-pin-pulse 1.4s ease-in-out 2; }
+@keyframes sidebar-pin-pulse { 0%, 100% { box-shadow: none; } 50% { box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent); } }
+
+/* Nielsen H1 (visibility of system status): the sidebar shrinking on its own
+   needs to SAY so — a one-time toast the first time it fires, pointing at
+   the pin escape hatch (ux-qa finding, page-layout-redesign.md §3.1). */
+.sidebar-hint {
+  position: fixed; left: 12px; bottom: 64px; z-index: var(--z-toast); width: 220px;
+  background: var(--surface-2); border: 1px solid var(--border-default); border-radius: var(--radius-md);
+  box-shadow: var(--shadow-1); padding: 10px 12px; font-size: 12px; color: var(--text-secondary);
 }
 .kind-tabs {
   display: flex; flex-direction: column;
@@ -1027,43 +1058,28 @@ body {
 .cost-table tbody tr:hover { background: var(--surface-2); }
 .cost-session-row { cursor: pointer; }
 
-/* Activity feed sidebar */
-.activity-pane {
-  width: 280px; min-width: 280px;
-  border-left: 1px solid var(--border-default);
-  background: var(--surface-0);
+/* Activity: on-demand overlay, not a permanently-reserved rail
+   (page-layout-redesign.md §1.3) — a bell in the topnav opens it. */
+.activity-trigger { position: relative; }
+.activity-badge {
+  position: absolute; top: -3px; right: -3px; background: var(--status-danger-solid); color: var(--text-inverse);
+  font-size: 9px; line-height: 1; padding: 2px 4px; border-radius: var(--radius-pill); font-variant-numeric: tabular-nums;
+}
+.activity-backdrop {
+  position: fixed; inset: 0; z-index: var(--z-modal);
+  background: color-mix(in oklab, var(--text-inverse) 55%, transparent);
+}
+.activity-overlay {
+  position: fixed; top: 0; right: 0; bottom: 0; width: 320px; max-width: 90vw; z-index: var(--z-modal);
+  background: var(--surface-1); border-left: 1px solid var(--border-default); box-shadow: -12px 0 32px rgba(0,0,0,0.18);
   display: flex; flex-direction: column;
-  transition: width var(--dur-base), min-width var(--dur-base);
 }
-.activity-pane.collapsed {
-  width: 18px; min-width: 18px;
-  background: var(--surface-1);
-  border-left: 1px solid var(--border-default);
-}
-.activity-pane.collapsed .activity-header {
-  padding: 0;
-  border-bottom: 0;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-}
-.activity-pane.collapsed .activity-header .icon-btn {
-  width: 100%;
-  height: 100%;
-  border-radius: 0;
-  background: transparent;
-  border: 0;
-  color: var(--text-secondary);
-}
-.activity-pane.collapsed .activity-header .icon-btn:hover {
-  background: color-mix(in oklab, var(--accent) 14%, transparent);
-  color: var(--accent);
-}
-.activity-header {
-  display: flex; align-items: center; justify-content: space-between;
+.activity-overlay-head {
+  display: flex; align-items: center; gap: 8px;
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-default);
 }
+.activity-overlay-head .icon-btn { margin-left: auto; }
 .activity-title { font-size: var(--text-md); font-weight: var(--weight-semibold); letter-spacing: var(--tracking-tight); }
 .activity-counter {
   font-size: var(--text-xs); padding: 2px var(--space-2); border-radius: var(--radius-pill);
@@ -1107,15 +1123,57 @@ body {
 
 /* ─── Runs pane (audit-derived runs grouped by trace_id) ─── */
 .runs-pane { display: flex; flex-direction: column; gap: var(--space-2); }
+/* Runs rail dominant over the detail (page-layout-redesign.md §1.3): flex,
+   not a fixed grid track ratio — the rail is 280px full / 56px collapsed,
+   the detail takes whatever is left. */
 .runs-grid {
-  display: grid; grid-template-columns: minmax(360px, 1fr) 2fr;
+  display: flex;
   gap: var(--space-3); flex: 1; min-height: 0;
 }
 .runs-list {
-  display: flex; flex-direction: column; gap: 6px;
-  overflow-y: auto; padding-right: var(--space-1);
+  flex: none; width: 280px;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  transition: width var(--dur-base) var(--ease-out);
   min-height: 0;
+  border: 1px solid var(--border-default); border-radius: var(--radius-md);
 }
+.runs-list.collapsed { width: 56px; }
+.runs-list-head {
+  flex: none; display: flex; align-items: center; gap: 6px;
+  padding: var(--space-2); border-bottom: 1px solid var(--border-default);
+}
+.runs-list-search {
+  flex: 1; min-width: 0; padding: 6px 9px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default); background: var(--surface-0);
+  color: var(--text-primary); font-size: 12.5px; font-family: inherit;
+}
+.runs-list-collapse-btn {
+  flex: none; width: 28px; height: 28px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default); background: var(--surface-1);
+  color: var(--text-secondary); cursor: pointer; display: grid; place-items: center;
+}
+.runs-list-collapse-btn:hover { background: var(--accent-soft); color: var(--accent); }
+.runs-list-collapse-btn:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.runs-list-scroll {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 6px;
+  padding: var(--space-2);
+}
+.runs-list.collapsed .runs-list-scroll { align-items: center; }
+/* Collapsed rail: icon-strip mode — every run stays a real, labelled button. */
+.runs-list.collapsed .run-row { flex-direction: row; align-items: center; justify-content: center; padding: 8px; gap: 0; width: 40px; }
+.runs-list.collapsed .run-row .card-head,
+.runs-list.collapsed .run-row .card-title,
+.runs-list.collapsed .run-row .card-meta { display: none; }
+/* WCAG 2.2 AA 1.4.1 (Use of color): status carries a SHAPE too, not hue
+   alone — the sighted-but-colorblind case a colored dot alone fails,
+   independent of the aria-label already on the button (ux-qa finding §3.1). */
+.run-row-dot { width: 10px; height: 10px; flex: none; display: inline-block; }
+.run-row-dot-success { background: var(--status-success-solid); border-radius: 50%; }
+.run-row-dot-warn     { background: var(--status-warn-solid); border-radius: 2px; transform: rotate(45deg); }
+.run-row-dot-danger   { background: var(--status-danger-solid); border-radius: 0; clip-path: polygon(50% 0%, 0% 100%, 100% 100%); }
+.run-row-dot-neutral  { background: var(--status-neutral-solid); border-radius: 2px; }
 /* Run cards carry the shared .gl recipe (components.css), but .card's own
    background there is declared after .gl in that same file and wins at
    equal specificity. This file loads after components.css, so scoping the
@@ -1134,6 +1192,24 @@ body {
 .run-meta { display: flex; flex-wrap: wrap; gap: var(--space-1); }
 .run-meta-mono { font-family: var(--font-mono); }
 
+/* "Atividade relacionada" — compact, collapsible strip inside run-detail,
+   before the Trajectory Card (page-layout-redesign.md §1.3). */
+.related-activity { border: 1px solid var(--border-default); border-radius: var(--radius-md); margin-bottom: var(--space-4); overflow: hidden; }
+.related-activity-head {
+  display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px 12px; border: none;
+  background: var(--surface-1); cursor: pointer; font: inherit; text-align: left; color: var(--text-primary);
+}
+.related-activity-head:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.related-activity-chev { margin-left: auto; width: 15px; height: 15px; transition: transform var(--dur-fast); }
+.related-activity-head[aria-expanded="true"] .related-activity-chev { transform: rotate(180deg); }
+.related-activity-body { padding: 6px 12px 10px; display: flex; flex-direction: column; gap: 6px; }
+.related-activity-row { display: flex; gap: 8px; font-size: 12px; color: var(--text-secondary); }
+.related-activity-time { font-family: var(--font-mono); flex: none; }
+.related-activity-empty { padding: 2px 0; }
+
+.run-detail, .run-detail-empty {
+  flex: 1; min-width: 0;
+}
 .run-detail {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -3132,15 +3208,31 @@ html[data-theme="awwwards"] .icon-btn .theme-icon-awwwards { display: inline-blo
 .chat-panel {
   position: fixed; top: 0; right: 0; bottom: 0;
   width: 460px; max-width: 92vw; z-index: 60;
-  display: flex; flex-direction: column;
+  display: flex; flex-direction: row;
   border-left: 1px solid var(--border-default);
   box-shadow: -12px 0 40px rgba(0,0,0,0.16);
   transform: translateX(100%);
   transition: transform var(--dur-base) var(--ease-out);
 }
 .chat-panel.open { transform: translateX(0); }
+/* Resize handle: real drag AND ArrowLeft/ArrowRight keyboard, 460↔920px
+   (page-layout-redesign.md §2.2). The clickable hit area stays 24px even
+   though the visible bar is a slim 3px (WCAG 2.2 AA 2.5.8 — ux-qa finding
+   §3.1: the previous 8px-wide handle failed the target-size floor). */
+.chat-resize-handle {
+  flex: none; width: 24px; cursor: col-resize; background: transparent; border: none; padding: 0;
+  display: flex; align-items: center; justify-content: center; position: relative;
+}
+.chat-resize-handle::before { content: ''; width: 3px; height: 36px; border-radius: 3px; background: var(--border-strong); }
+.chat-resize-handle:hover::before, .chat-resize-handle:focus-visible::before { background: var(--accent); }
+.chat-resize-handle:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.chat-body { flex: 1; min-width: 0; display: flex; flex-direction: column; position: relative; }
+.chat-width-toggle { display: flex; border: 1px solid var(--border-default); border-radius: 8px; overflow: hidden; }
+.chat-width-toggle button { padding: 5px 10px; font-size: 11.5px; border: none; background: var(--surface-1); color: var(--text-secondary); cursor: pointer; font-family: inherit; }
+.chat-width-toggle button[aria-pressed="true"] { background: var(--accent); color: var(--accent-fg); }
+.chat-width-toggle button:focus-visible { outline: none; box-shadow: var(--shadow-focus); position: relative; z-index: 1; }
 .chat-head {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-default);
 }

--- a/skills/harness/lib/glance/views/glance.js
+++ b/skills/harness/lib/glance/views/glance.js
@@ -67,6 +67,16 @@ function glance() {
     runsFilter: 'recent',          // recent | running | delivered | failed
     runsAutoRefresh: null,         // setInterval handle
     selectedRun: null,             // full run detail (events timeline)
+    // Runs rail: searchable, collapsible 280px ⇄ 56px (page-layout-redesign.md
+    // §1.3). Named runsListQuery (not runsFilter, above) to keep the two apart —
+    // runsFilter is an existing recent|running|delivered|failed status enum,
+    // this is free-text search against brief/business/squad.
+    runsRailCollapsed: (typeof localStorage !== 'undefined' && localStorage.getItem('glance.runsRailCollapsed') === '1'),
+    runsListQuery: '',
+    // "Atividade relacionada" strip inside run-detail — one collapsible flag
+    // shared by whichever run is open, same pattern as the Trajectory Card's
+    // own judgement-strip toggle.
+    relatedActivityOpen: true,
     mindClones: [],
     // Memory layer (state.db) — populated lazily when kind === 'memory'
     memorySubTab: 'decisions',  // decisions | gates | audit
@@ -115,13 +125,24 @@ function glance() {
     // Cost dashboard
     cost: null,
     costPeriod: '7d',          // 7d | 30d | all
-    // Activity feed (right sidebar)
-    activityOpen: true,
+    // Activity feed — on-demand overlay (bell in topnav), not a permanent
+    // rail (page-layout-redesign.md §1.3). activityUnseenCount resets to 0
+    // whenever the overlay opens.
+    activityOverlayOpen: false,
+    activityUnseenCount: 0,
     activityEvents: [],
     activityStream: null,
     // Layout chrome — collapsible sidebars + agents fullscreen
     sidebarOpen: (typeof localStorage !== 'undefined' && localStorage.getItem('glance.sidebarOpen') !== '0'),
     rightPaneOpen: (typeof localStorage !== 'undefined' && localStorage.getItem('glance.rightPaneOpen') !== '0'),
+    // Sidebar auto-collapses to a 64px icon rail whenever a run is open in
+    // detail, unless pinned full (page-layout-redesign.md §1.3). The hint
+    // toast is intentionally session-only (not persisted) — it fires once
+    // per page load, the first time the auto-collapse actually happens.
+    sidebarPinnedFull: (typeof localStorage !== 'undefined' && localStorage.getItem('glance.sidebarPinnedFull') === '1'),
+    sidebarHintShown: false,
+    showSidebarHint: false,
+    sidebarLiveMessage: '',
     agentsFullscreen: false,
     // Scope filter: 'all' = entire machine, 'project' = only events whose cwd
     // starts with scope.projectRoot. Disabled when no projectRoot is detected.
@@ -465,7 +486,45 @@ function glance() {
       } catch (e) {}
     },
     selectRun(run) {
+      const wasCollapsed = this.sidebarCollapsed;
       this.selectedRun = run;
+      // Nielsen H1 (visibility of system status): the sidebar auto-collapsing
+      // needs to announce itself the first time it happens, not just silently
+      // change width (ux-qa finding, page-layout-redesign.md §3.1).
+      if (!wasCollapsed && this.sidebarCollapsed && !this.sidebarHintShown) {
+        this.sidebarHintShown = true;
+        this.showSidebarHint = true;
+        this.sidebarLiveMessage = 'Sidebar recolhida para ícones — uma run está aberta em detalhe. Use o botão fixar para mantê-la cheia.';
+        setTimeout(() => { this.showSidebarHint = false; }, 4000);
+      }
+    },
+    // Sidebar auto-collapse to the 64px icon rail (page-layout-redesign.md
+    // §1.3) — driven by whether a run is open in detail, never by `kind`.
+    get sidebarCollapsed() {
+      const pl = window.NirvanaPanelLayout;
+      return pl
+        ? pl.shouldCollapseSidebar({ pinnedFull: this.sidebarPinnedFull, hasSelectedRun: !!this.selectedRun })
+        : (!this.sidebarPinnedFull && !!this.selectedRun);
+    },
+    toggleSidebarPin() {
+      this.showSidebarHint = false;
+      this.sidebarPinnedFull = !this.sidebarPinnedFull;
+      try { localStorage.setItem('glance.sidebarPinnedFull', this.sidebarPinnedFull ? '1' : '0'); } catch {}
+    },
+    // Runs rail: search filter + collapse toggle (page-layout-redesign.md §1.3).
+    get filteredRunsList() {
+      const pl = window.NirvanaPanelLayout;
+      return pl ? pl.filterRunsByQuery(this.visibleRuns, this.runsListQuery) : this.visibleRuns;
+    },
+    toggleRunsRail() {
+      this.runsRailCollapsed = !this.runsRailCollapsed;
+      try { localStorage.setItem('glance.runsRailCollapsed', this.runsRailCollapsed ? '1' : '0'); } catch {}
+    },
+    // "Atividade relacionada" — activity events scoped to this run's
+    // business/project, excluding events already on its own trace.
+    relatedActivity(run) {
+      const pl = window.NirvanaPanelLayout;
+      return pl ? pl.filterRelatedActivity(this.activityEvents, run) : [];
     },
     runStatusColor(status) {
       if (status === 'delivered') return 'meta-ok';
@@ -825,6 +884,18 @@ function glance() {
       try { localStorage.setItem('glance.rightPaneOpen', this.rightPaneOpen ? '1' : '0'); } catch {}
       this.$nextTick(() => { try { window.lucide?.createIcons(); } catch {} });
     },
+    // Activity: on-demand overlay (page-layout-redesign.md §1.3). Opening
+    // moves focus into the panel; closing returns it to the bell that opened
+    // it, so focus is never dropped on <body> (WCAG 2.4.3).
+    openActivity() {
+      this.activityOverlayOpen = true;
+      this.activityUnseenCount = 0;
+      this.$nextTick(() => { this.$refs.activityCloseBtn?.focus(); try { window.lucide?.createIcons(); } catch {} });
+    },
+    closeActivity() {
+      this.activityOverlayOpen = false;
+      this.$nextTick(() => { this.$refs.activityTrigger?.focus(); });
+    },
     // ── Project scope filter ──
     canFilterByProject() {
       return !!(this.scope && this.scope.projectRoot);
@@ -1102,6 +1173,7 @@ function glance() {
           const ev = JSON.parse(e.data);
           this.activityEvents.unshift(ev);
           if (this.activityEvents.length > 50) this.activityEvents.length = 50;
+          if (!this.activityOverlayOpen) this.activityUnseenCount++;
         } catch {}
       });
     },
@@ -1269,6 +1341,15 @@ function glance() {
     chatMode: 'run',           // 'run' (new dispatch) | 'revise' | 'resume'
     chatHistory: [],           // [{id, title, mode, updatedAt}] persisted in localStorage
     chatHistoryOpen: false,    // history drawer inside the panel
+    // Chat panel width — 460..920px, resizable via drag handle or
+    // ArrowLeft/ArrowRight (page-layout-redesign.md §2.2), persisted like the
+    // other Glance layout preferences. chat-history above is unrelated and
+    // unchanged — it stays the on-demand drawer it already was in production.
+    chatWidth: (() => {
+      let saved = null;
+      try { saved = parseInt(localStorage.getItem('glance.chatWidth'), 10); } catch {}
+      return (Number.isFinite(saved) && saved >= 460 && saved <= 920) ? saved : 460;
+    })(),
     canonicalProjectId: null,
 
     // The control plane is canonical when this workspace has been adopted.
@@ -1597,6 +1678,33 @@ function glance() {
     closeChat() {
       this.chatOpen = false;
       if (this.chatRunES) { this.chatRunES.close(); this.chatRunES = null; }
+    },
+    // Chat panel resize — drag handle AND ArrowLeft/ArrowRight keyboard,
+    // clamped to 460..920px (page-layout-redesign.md §2.2), persisted.
+    startChatResize(e) {
+      e.preventDefault();
+      // preventDefault() on mousedown also suppresses the browser's default
+      // click-to-focus behavior — restore it explicitly so the separator
+      // stays keyboard-operable (ArrowLeft/ArrowRight) right after a drag.
+      e.currentTarget.focus();
+      const startX = e.clientX;
+      const startW = this.chatWidth;
+      const pl = window.NirvanaPanelLayout;
+      const clamp = (w) => (pl ? pl.clampChatWidth(w) : Math.min(920, Math.max(460, w)));
+      const onMove = (ev) => { this.chatWidth = clamp(startW - (ev.clientX - startX)); };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        try { localStorage.setItem('glance.chatWidth', String(this.chatWidth)); } catch {}
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    stepChatWidth(delta) { this.setChatWidthPreset(this.chatWidth + delta); },
+    setChatWidthPreset(w) {
+      const pl = window.NirvanaPanelLayout;
+      this.chatWidth = pl ? pl.clampChatWidth(w) : Math.min(920, Math.max(460, w));
+      try { localStorage.setItem('glance.chatWidth', String(this.chatWidth)); } catch {}
     },
     // Subscribe to a trace's audit event stream (live timeline).
     subscribeRun(traceId) {

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -44,7 +44,7 @@
   </template>
 
   <!-- ─── Top nav ─── -->
-  <nav class="glance-nav gl gl--2">
+  <nav class="glance-nav gl gl--2" :inert="activityOverlayOpen">
     <div class="flex items-center gap-3">
       <span class="text-lg">⊚</span>
       <div class="leading-tight">
@@ -119,6 +119,10 @@
         </div>
       </div>
       <button @click="toggleSetupMode()" :class="setupMode ? 'icon-btn icon-btn-active' : 'icon-btn'" x-cloak x-show="health.allow_actions" title="Setup mode — pick squads/businesses/mind-clones to copy to a project"><i data-lucide="package"></i></button>
+      <button @click="openActivity()" x-ref="activityTrigger" :class="activityOverlayOpen ? 'icon-btn icon-btn-active activity-trigger' : 'icon-btn activity-trigger'" :aria-pressed="activityOverlayOpen ? 'true' : 'false'" title="Activity — feed de eventos do sistema">
+        <i data-lucide="bell"></i>
+        <span class="activity-badge" x-show="activityUnseenCount > 0" x-text="activityUnseenCount > 99 ? '99+' : activityUnseenCount"></span>
+      </button>
       <button @click="chatOpen ? closeChat() : openChat()" :class="chatOpen ? 'icon-btn icon-btn-active' : 'icon-btn'" title="Chat — converse com o Nirvana e opere o sistema"><i data-lucide="message-square"></i></button>
       <button @click="openSettings()" :class="settingsOpen ? 'icon-btn icon-btn-active' : 'icon-btn'" title="Configuração" aria-label="Configuração"><i data-lucide="settings"></i></button>
       <button @click="consoleOpen = !consoleOpen" title="Console" class="icon-btn" :class="jobs.some(j => j.status==='running') ? 'icon-btn-pulse' : ''"><i data-lucide="terminal"></i></button>
@@ -134,7 +138,7 @@
   <!-- ─── Subsystems — o que está de pé (não o que rodou) ───
        Cada célula é uma leitura real do disco. Uma que não pôde ser
        determinada mostra — em vez de acender um verde que ninguém mediu. -->
-  <div class="subsystem-row gl" role="status" aria-label="Subsistemas do engine">
+  <div class="subsystem-row gl" role="status" aria-label="Subsistemas do engine" :inert="activityOverlayOpen">
     <span class="subsystem-row-title">ENGINE</span>
     <template x-for="cell in subsystemRow.cells" :key="cell.key">
       <span class="subsystem-cell" :title="cell.title">
@@ -150,7 +154,7 @@
   </div>
 
   <!-- ─── Main columns ─── -->
-  <div class="flex-1 flex min-h-0">
+  <div class="flex-1 flex min-h-0" :inert="activityOverlayOpen">
 
     <!-- Floating handle to expand the left sidebar when collapsed -->
     <button class="sidebar-handle sidebar-handle-left" x-show="!sidebarOpen" @click="toggleSidebar()" title="Expand sidebar (⌘\)">
@@ -159,7 +163,7 @@
 
     <!-- Sidebar — always visible so kind-tabs (Squads/Businesses/…/Memory/Graph/Cost)
          remain reachable. Filter/list/setup chrome inside is gated to per-asset kinds. -->
-    <aside class="sidebar gl gl--2" x-show="sidebarOpen">
+    <aside class="sidebar gl gl--2" :class="sidebarCollapsed ? 'icon-rail' : ''" x-show="sidebarOpen">
       <div class="sidebar-collapse-row">
         <button class="sidebar-collapse-btn" @click="toggleSidebar()" title="Collapse sidebar (⌘\)">
           <i data-lucide="chevron-left"></i>
@@ -174,6 +178,7 @@
             :class="kind === k.id ? 'kind-card active' : 'kind-card'"
             role="tab"
             :aria-selected="kind === k.id ? 'true' : 'false'"
+            :aria-label="k.label"
             :title="auditSummary(k.id) ? `${auditSummary(k.id).total} total · ${auditSummary(k.id).green}g/${auditSummary(k.id).yellow}y/${auditSummary(k.id).red}r · avg ${auditSummary(k.id).avg}` : k.label">
             <i :data-lucide="k.icon" class="kind-card-icon"></i>
             <span class="kind-card-label" x-text="k.label"></span>
@@ -295,7 +300,25 @@
           </div>
         </div>
       </div>
+      <!-- Pin: keeps the sidebar full-width even while a run is open in
+           detail (page-layout-redesign.md §1.3) — persisted like the other
+           Glance layout preferences (glance.sidebarOpen, glance.rightPaneOpen). -->
+      <div class="sidebar-foot">
+        <button type="button" class="sidebar-pin-btn" :class="showSidebarHint ? 'hint-pulse' : ''" @click="toggleSidebarPin()" :aria-pressed="sidebarPinnedFull ? 'true' : 'false'" title="Fixar sidebar cheia mesmo com uma run aberta">
+          <i data-lucide="pin"></i>
+          <span class="sidebar-pin-label" x-text="sidebarPinnedFull ? 'fixada cheia' : 'auto-colapsa'"></span>
+        </button>
+      </div>
     </aside>
+
+    <!-- One-time toast the first time the sidebar auto-collapses, pointing at
+         the pin escape hatch (Nielsen H1 — visibility of system status; ux-qa
+         finding, page-layout-redesign.md §3.1). An aria-live region announces
+         the same change for screen-reader users, independent of the toast. -->
+    <div class="sidebar-hint" x-show="showSidebarHint" x-cloak role="status">
+      Sidebar recolhida para ícones — uma run está aberta em detalhe. Clique <i data-lucide="pin" style="width:12px;height:12px;display:inline;vertical-align:-2px;"></i> para fixá-la cheia.
+    </div>
+    <div class="sr-only" aria-live="polite" x-text="sidebarLiveMessage"></div>
 
     <!-- Detail panel (only when kind is a per-asset view) -->
     <main class="detail-pane" x-show="['squads','businesses','projects','mind-clones'].includes(kind)">
@@ -861,51 +884,67 @@
         <button @click="fetchRuns()" class="icon-btn" title="Refresh"><i data-lucide="rotate-cw"></i></button>
       </header>
       <div class="runs-grid">
-        <!-- LEFT: list of runs -->
-        <aside class="runs-list" :class="selectedRun ? 'has-selection' : ''">
-          <template x-if="runs.length === 0">
-            <div class="runs-empty">
-              <i data-lucide="inbox" class="runs-empty-icon"></i>
-              <p>No runs in the last 7 days.</p>
-              <p class="runs-empty-hint">Runs appear here automatically as agents emit audit events. If you're sure something ran but nothing shows, check that the auto-emit hook is enabled in <code>~/.claude/settings.json</code> (PreToolUse / PostToolUse).</p>
-            </div>
-          </template>
-          <template x-for="run in visibleRuns" :key="run.trace_id">
-            <button class="card card-interactive gl gl--ink"
-                    :class="[
-                      selectedRun?.trace_id === run.trace_id ? 'card-active' : '',
-                      run.suspicious ? 'card-status-warn' : '',
-                      `card-status-${runStatusVariant(run.status)}`
-                    ]"
-                    @click="selectRun(run)">
-              <div class="card-head">
-                <div class="card-head-left">
-                  <span class="badge" :class="`badge-${runStatusVariant(run.status)}`" x-text="run.status"></span>
-                  <span class="badge badge-warn badge-sm" x-show="run.suspicious" :title="`Suspicion score ${run.suspicion_score} — ${run.suspicion_evidence.join('; ')}`">⚠ suspicious</span>
-                </div>
-                <span class="text-caption" x-text="runRelTime(run.last_event_at)"></span>
-              </div>
-              <div class="card-title text-truncate" x-text="run.brief || '(no brief captured)'"></div>
-              <div class="card-meta">
-                <span class="badge badge-neutral badge-sm" x-show="run.business_slug" x-text="`biz: ${run.business_slug}`"></span>
-                <span class="badge badge-neutral badge-sm" x-show="run.squad_name" x-text="`squad: ${run.squad_name}`"></span>
-                <span class="badge badge-neutral badge-sm" x-show="run.project_id" x-text="`proj: ${run.project_id}`"></span>
-                <span class="badge badge-neutral badge-mono badge-sm" x-text="`#${run.trace_id.slice(0, 8)}`"></span>
-                <!-- What the run was dispatched to, read from the dispatch event itself.
-                     `—` when no dispatch event carries it: an inferred target would be a
-                     guess on the one card whose job is to say what actually happened. -->
-                <span class="badge badge-neutral badge-sm" x-text="`→ ${countText(run.target)}`"></span>
-                <!-- Signal first. The total is still there, labelled for what it is: the
-                     hook fires two events per tool call, so it measures how long an agent
-                     ran, not how much the run did. -->
-                <span class="badge badge-neutral badge-sm"
-                      :title="`${run.event_count} events on this trace · ${run.noise_event_count} of them tool calls and heartbeats`"
-                      x-text="`${countText(run.signal_event_count)} signal / ${countText(run.event_count)} events`"></span>
-                <span class="badge badge-neutral badge-sm" x-text="`${countText(run.artifact_paths.length)} artifact${run.artifact_paths.length === 1 ? '' : 's'}`"></span>
-                <span class="badge badge-neutral badge-sm" x-show="run.hosts && run.hosts.length" x-text="run.hosts.join(' · ')"></span>
-              </div>
+        <!-- LEFT: searchable, collapsible rail of runs (280px full ⇄ 56px
+             icon strip — page-layout-redesign.md §1.3, "lista de runs vira
+             rail fino e buscável"). -->
+        <aside class="runs-list" :class="[selectedRun ? 'has-selection' : '', runsRailCollapsed ? 'collapsed' : '']">
+          <div class="runs-list-head">
+            <input type="text" x-model="runsListQuery" x-show="!runsRailCollapsed" class="runs-list-search" placeholder="Filtrar runs…" aria-label="Filtrar runs">
+            <button type="button" class="runs-list-collapse-btn" @click="toggleRunsRail()" :aria-expanded="(!runsRailCollapsed).toString()" :title="runsRailCollapsed ? 'Expandir a lista de runs' : 'Colapsar a lista de runs'">
+              <i :data-lucide="runsRailCollapsed ? 'chevron-right' : 'chevron-left'"></i>
             </button>
-          </template>
+          </div>
+          <div class="runs-list-scroll">
+            <template x-if="runs.length === 0">
+              <div class="runs-empty">
+                <i data-lucide="inbox" class="runs-empty-icon"></i>
+                <p>No runs in the last 7 days.</p>
+                <p class="runs-empty-hint">Runs appear here automatically as agents emit audit events. If you're sure something ran but nothing shows, check that the auto-emit hook is enabled in <code>~/.claude/settings.json</code> (PreToolUse / PostToolUse).</p>
+              </div>
+            </template>
+            <template x-for="run in filteredRunsList" :key="run.trace_id">
+              <button class="card card-interactive gl gl--ink run-row"
+                      :class="[
+                        selectedRun?.trace_id === run.trace_id ? 'card-active' : '',
+                        run.suspicious ? 'card-status-warn' : '',
+                        `card-status-${runStatusVariant(run.status)}`
+                      ]"
+                      :aria-label="`${run.status} · ${run.brief || '(no brief captured)'}`"
+                      :title="`${run.status} · ${run.brief || '(no brief captured)'}`"
+                      @click="selectRun(run)">
+                <!-- Collapsed rail: still a real, labelled button — never a
+                     mute avatar. The dot carries a SHAPE per status too, not
+                     hue alone (WCAG 2.2 AA 1.4.1, ux-qa finding §3.1). -->
+                <span class="run-row-dot" :class="`run-row-dot-${runStatusVariant(run.status)}`" x-show="runsRailCollapsed" aria-hidden="true"></span>
+                <div class="card-head">
+                  <div class="card-head-left">
+                    <span class="badge" :class="`badge-${runStatusVariant(run.status)}`" x-text="run.status"></span>
+                    <span class="badge badge-warn badge-sm" x-show="run.suspicious" :title="`Suspicion score ${run.suspicion_score} — ${run.suspicion_evidence.join('; ')}`">⚠ suspicious</span>
+                  </div>
+                  <span class="text-caption" x-text="runRelTime(run.last_event_at)"></span>
+                </div>
+                <div class="card-title text-truncate" x-text="run.brief || '(no brief captured)'"></div>
+                <div class="card-meta">
+                  <span class="badge badge-neutral badge-sm" x-show="run.business_slug" x-text="`biz: ${run.business_slug}`"></span>
+                  <span class="badge badge-neutral badge-sm" x-show="run.squad_name" x-text="`squad: ${run.squad_name}`"></span>
+                  <span class="badge badge-neutral badge-sm" x-show="run.project_id" x-text="`proj: ${run.project_id}`"></span>
+                  <span class="badge badge-neutral badge-mono badge-sm" x-text="`#${run.trace_id.slice(0, 8)}`"></span>
+                  <!-- What the run was dispatched to, read from the dispatch event itself.
+                       `—` when no dispatch event carries it: an inferred target would be a
+                       guess on the one card whose job is to say what actually happened. -->
+                  <span class="badge badge-neutral badge-sm" x-text="`→ ${countText(run.target)}`"></span>
+                  <!-- Signal first. The total is still there, labelled for what it is: the
+                       hook fires two events per tool call, so it measures how long an agent
+                       ran, not how much the run did. -->
+                  <span class="badge badge-neutral badge-sm"
+                        :title="`${run.event_count} events on this trace · ${run.noise_event_count} of them tool calls and heartbeats`"
+                        x-text="`${countText(run.signal_event_count)} signal / ${countText(run.event_count)} events`"></span>
+                  <span class="badge badge-neutral badge-sm" x-text="`${countText(run.artifact_paths.length)} artifact${run.artifact_paths.length === 1 ? '' : 's'}`"></span>
+                  <span class="badge badge-neutral badge-sm" x-show="run.hosts && run.hosts.length" x-text="run.hosts.join(' · ')"></span>
+                </div>
+              </button>
+            </template>
+          </div>
         </aside>
         <!-- RIGHT: selected run detail (timeline + artifacts) -->
         <section class="run-detail gl gl--2" x-show="selectedRun" x-cloak>
@@ -967,6 +1006,27 @@
                     a real hook (events outside the canonical enum, artificial timestamps, or no host attribution).
                     Don't trust the artifacts from this run without manual verification.
                   </p>
+                </section>
+                <!-- "Atividade relacionada": compact, collapsible, scoped to
+                     THIS run's business/project — replaces the old always-on
+                     global Activity rail (page-layout-redesign.md §1.3). -->
+                <section class="related-activity">
+                  <button type="button" class="related-activity-head" :aria-expanded="relatedActivityOpen ? 'true' : 'false'" @click="relatedActivityOpen = !relatedActivityOpen">
+                    <i data-lucide="activity" class="icon-inline"></i>
+                    <span>Atividade relacionada · <b x-text="relatedActivity(selectedRun).length"></b> evento<span x-show="relatedActivity(selectedRun).length !== 1">s</span><template x-if="selectedRun.business_slug"><span> de <span x-text="selectedRun.business_slug"></span></span></template></span>
+                    <i data-lucide="chevron-down" class="related-activity-chev"></i>
+                  </button>
+                  <div class="related-activity-body" x-show="relatedActivityOpen" x-cloak>
+                    <template x-if="relatedActivity(selectedRun).length === 0">
+                      <div class="text-caption related-activity-empty">Nenhum outro evento recente deste business/projeto — o Cartão de Trajetória abaixo já conta a história inteira.</div>
+                    </template>
+                    <template x-for="a in relatedActivity(selectedRun)" :key="(a.id || a.ts || '') + '-' + a.event">
+                      <div class="related-activity-row">
+                        <span class="text-caption related-activity-time" x-text="activityRelative(a.ts)"></span>
+                        <span x-text="a.event"></span>
+                      </div>
+                    </template>
+                  </div>
                 </section>
                 <section>
                   <div class="text-label">Timeline · <span x-text="selectedRun.events.length"></span> events</div>
@@ -1592,32 +1652,37 @@
         </div>
       </div>
     </aside>
+  </div>
 
-    <!-- ─── Activity feed (live SSE from audit_events) ─── -->
-    <aside class="activity-pane" :class="{ collapsed: !activityOpen }">
-      <header class="activity-header">
-        <span class="activity-title" x-show="activityOpen">Activity</span>
-        <span class="activity-counter" x-show="activityOpen && activityEvents.length > 0" x-text="`${activityEvents.length}`"></span>
-        <button @click="activityOpen = !activityOpen" class="icon-btn" :title="activityOpen ? 'Collapse activity' : 'Expand activity'">
-          <i :data-lucide="activityOpen ? 'chevron-right' : 'chevron-left'"></i>
-        </button>
-      </header>
-      <div class="activity-list" x-show="activityOpen">
-        <template x-for="(e, idx) in visibleActivityEvents" :key="idx + '-' + (e.id || '') + '-' + (e.ts || '')">
-          <div class="activity-card" :class="{ fresh: idx === 0 }" @click="navigateFromActivity(e)">
-            <span class="activity-icon" x-text="activityIcon(e.event)"></span>
-            <div class="activity-body">
-              <div class="activity-event" x-text="e.event"></div>
-              <div class="activity-meta">
-                <span class="activity-time" x-text="activityRelative(e.ts)"></span>
-                <span x-show="e.project_id" x-text="e.project_id"></span>
-              </div>
+  <!-- ─── Activity: on-demand overlay (bell in topnav opens it) — replaces the
+       old always-reserved 280px rail (page-layout-redesign.md §1.3). Lives
+       OUTSIDE the ":inert"-bound main-columns div above (and outside topnav/
+       chat-panel, also :inert while this is open) so it is the one region
+       still reachable — a real focus trap, not just a visual overlay
+       (WCAG 2.4.3, ux-qa finding §3.1: Tab must never escape this dialog). -->
+  <div class="activity-backdrop" x-show="activityOverlayOpen" x-cloak @click="closeActivity()"></div>
+  <div class="activity-overlay" x-show="activityOverlayOpen" x-cloak role="dialog" aria-modal="true" aria-label="Activity"
+       @keydown.escape.window="activityOverlayOpen && closeActivity()">
+    <header class="activity-overlay-head">
+      <span class="activity-title">Activity</span>
+      <span class="activity-counter" x-show="activityEvents.length > 0" x-text="`${activityEvents.length}`"></span>
+      <button type="button" class="icon-btn" x-ref="activityCloseBtn" @click="closeActivity()" title="Fechar (Esc)"><i data-lucide="x"></i></button>
+    </header>
+    <div class="activity-list">
+      <template x-for="(e, idx) in visibleActivityEvents" :key="idx + '-' + (e.id || '') + '-' + (e.ts || '')">
+        <div class="activity-card" :class="{ fresh: idx === 0 }" @click="navigateFromActivity(e)">
+          <span class="activity-icon" x-text="activityIcon(e.event)"></span>
+          <div class="activity-body">
+            <div class="activity-event" x-text="e.event"></div>
+            <div class="activity-meta">
+              <span class="activity-time" x-text="activityRelative(e.ts)"></span>
+              <span x-show="e.project_id" x-text="e.project_id"></span>
             </div>
           </div>
-        </template>
-        <div x-show="activityEvents.length === 0" class="activity-empty">no recent activity</div>
-      </div>
-    </aside>
+        </div>
+      </template>
+      <div x-show="activityEvents.length === 0" class="activity-empty">no recent activity</div>
+    </div>
   </div>
 
   <!-- Setup-mode bottom bar (visible only when setupMode is on) -->
@@ -1901,7 +1966,17 @@
   </div>
 
   <!-- ══════════════ CHAT PANEL (Fase 3) ══════════════ -->
-  <aside class="chat-panel gl gl--2" :class="chatOpen ? 'open' : ''" x-cloak>
+  <aside class="chat-panel gl gl--2" :class="chatOpen ? 'open' : ''" :style="`width:${chatWidth}px`" :inert="activityOverlayOpen" x-cloak>
+    <!-- Resize handle: real drag AND ArrowLeft/ArrowRight keyboard, 460↔920px
+         (page-layout-redesign.md §2.2). The clickable hit area is 24px even
+         though the visible bar is a slim 3px (WCAG 2.2 AA 2.5.8 target size —
+         ux-qa finding §3.1: the previous 8px-wide handle failed the floor). -->
+    <div class="chat-resize-handle"
+         role="separator" aria-orientation="vertical" aria-label="Redimensionar o painel de chat"
+         :aria-valuemin="460" :aria-valuemax="920" :aria-valuenow="chatWidth" tabindex="0"
+         @mousedown="startChatResize($event)"
+         @keydown.left="stepChatWidth(-40)" @keydown.right="stepChatWidth(40)"></div>
+    <div class="chat-body">
     <header class="chat-head">
       <div class="chat-head-title">
         <span class="chat-head-dot"></span>
@@ -1914,6 +1989,10 @@
             <button type="button" class="chat-session-copy" x-show="chatResumeCommand" @click="navigator.clipboard?.writeText(chatResumeCommand); flash('Comando copiado: ' + chatResumeCommand, 2500)" title="Copiar o comando para continuar no terminal">copiar comando</button>
           </div>
         </div>
+      </div>
+      <div class="chat-width-toggle" role="group" aria-label="Largura do painel">
+        <button type="button" :aria-pressed="chatWidth <= 460 ? 'true' : 'false'" @click="setChatWidthPreset(460)">compacto</button>
+        <button type="button" :aria-pressed="chatWidth >= 880 ? 'true' : 'false'" @click="setChatWidthPreset(880)">amplo</button>
       </div>
       <div class="flex items-center gap-2">
         <button @click="openChat()" class="icon-btn" title="Nova conversa"><i data-lucide="plus"></i></button>
@@ -2159,6 +2238,7 @@
     <div class="chat-foot text-caption" x-show="!health.allow_actions">
       Somente leitura — reinicie o Glance com <code>--allow-actions</code> para o chat operar o sistema.
     </div>
+    </div>
   </aside>
 
   <!-- Bottom toast -->
@@ -2240,6 +2320,13 @@
   // subsystem-row.js turns /api/subsystems into the engine row under the header.
   import * as subsystemRow from '/subsystem-row.js?v=__ASSET_VER__';
   window.NirvanaSubsystemRow = subsystemRow;
+</script>
+<script type="module">
+  // panel-layout.js is the pure module behind the Runs+Chat layout redesign
+  // (sidebar auto-collapse, chat resize bounds, runs-rail search, related-
+  // activity filter). Same adapter pattern as the other pure modules here.
+  import * as panelLayout from '/panel-layout.js?v=__ASSET_VER__';
+  window.NirvanaPanelLayout = panelLayout;
 </script>
 <script src="/dag-renderer.js?v=__ASSET_VER__"></script>
 <script src="/org-chart-renderer.js?v=__ASSET_VER__"></script>

--- a/skills/harness/lib/glance/views/panel-layout.js
+++ b/skills/harness/lib/glance/views/panel-layout.js
@@ -1,0 +1,53 @@
+/**
+ * panel-layout.js — pure layout-decision helpers for the Runs+Chat page
+ * layout redesign (trace glance-page-layout-20260830124732 /
+ * glance-page-layout-impl-20260830141256). Kept out of glance.js (a classic
+ * script, not a module — see run-event-labels.js/trajectory-card.js for the
+ * same reason) so bun:test can exercise the decision logic directly instead
+ * of only through a live Alpine app. glance.js reads these through
+ * window.NirvanaPanelLayout, the same adapter pattern as the other pure
+ * modules in this directory (index.html wires the <script type="module">).
+ */
+
+/** Chat panel resize bounds from the approved redesign
+ * (page-layout-redesign.md §2.2): 460px compact floor, 920px wide ceiling.
+ * Both the mouse-drag handler and the ArrowLeft/ArrowRight keyboard step
+ * clamp through clampChatWidth() so neither path can push past them. */
+export const CHAT_WIDTH_MIN = 460;
+export const CHAT_WIDTH_MAX = 920;
+
+export function clampChatWidth(width) {
+  return Math.min(CHAT_WIDTH_MAX, Math.max(CHAT_WIDTH_MIN, width));
+}
+
+/** The sidebar collapses to the 64px icon rail exactly when a run is open in
+ * detail AND the operator has not pinned the full-width version — never
+ * based on which `kind` tab happens to be active (page-layout-redesign.md
+ * §1.3: "a lista de 9 ícones... ainda precisa existir"). */
+export function shouldCollapseSidebar({ pinnedFull, hasSelectedRun }) {
+  return !pinnedFull && !!hasSelectedRun;
+}
+
+/** Runs-list rail filter: matches the free-text query against the same
+ * fields already shown on the card (brief, business, squad), case-
+ * insensitively. An empty/whitespace query returns the list unchanged. */
+export function filterRunsByQuery(runs, query) {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) return runs || [];
+  return (runs || []).filter((r) =>
+    `${r.brief || ''} ${r.business_slug || ''} ${r.squad_name || ''}`.toLowerCase().includes(q)
+  );
+}
+
+/** "Atividade relacionada" strip inside run-detail: activity events scoped
+ * to the open run's business_slug/project_id, excluding events already on
+ * this run's own trace (those are already the Trajectory Card above it). */
+export function filterRelatedActivity(events, run) {
+  if (!run) return [];
+  return (events || []).filter((e) => {
+    if (e.trace_id === run.trace_id) return false;
+    if (run.business_slug && e.business_slug === run.business_slug) return true;
+    if (run.project_id && e.project_id === run.project_id) return true;
+    return false;
+  });
+}

--- a/skills/harness/tests/glance-panel-layout.test.ts
+++ b/skills/harness/tests/glance-panel-layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CHAT_WIDTH_MAX,
+  CHAT_WIDTH_MIN,
+  clampChatWidth,
+  filterRelatedActivity,
+  filterRunsByQuery,
+  shouldCollapseSidebar,
+} from "../lib/glance/views/panel-layout.js";
+
+describe("clampChatWidth — 460..920px resize bounds (page-layout-redesign.md §2.2)", () => {
+  test("a value inside the range passes through unchanged", () => {
+    expect(clampChatWidth(500)).toBe(500);
+  });
+
+  test("a drag or ArrowLeft/ArrowRight step past either edge clamps, never overshoots", () => {
+    expect(clampChatWidth(100)).toBe(CHAT_WIDTH_MIN);
+    expect(clampChatWidth(2000)).toBe(CHAT_WIDTH_MAX);
+  });
+
+  test("the bounds are exactly the ones the orchestrator measured live on the mockup", () => {
+    expect(CHAT_WIDTH_MIN).toBe(460);
+    expect(CHAT_WIDTH_MAX).toBe(920);
+    // ArrowRight from the compact floor, +40px per keypress, must land in range.
+    expect(clampChatWidth(CHAT_WIDTH_MIN + 40)).toBe(500);
+  });
+});
+
+describe("shouldCollapseSidebar — the 64px icon rail (page-layout-redesign.md §1.3)", () => {
+  test("collapses when a run is open and not pinned", () => {
+    expect(shouldCollapseSidebar({ pinnedFull: false, hasSelectedRun: true })).toBe(true);
+  });
+
+  test("pinning wins over an open run — the escape hatch always works", () => {
+    expect(shouldCollapseSidebar({ pinnedFull: true, hasSelectedRun: true })).toBe(false);
+  });
+
+  test("no run open means full width regardless of the pin", () => {
+    expect(shouldCollapseSidebar({ pinnedFull: false, hasSelectedRun: false })).toBe(false);
+    expect(shouldCollapseSidebar({ pinnedFull: true, hasSelectedRun: false })).toBe(false);
+  });
+});
+
+describe("filterRunsByQuery — the runs-rail search box", () => {
+  const runs = [
+    { trace_id: "a1", brief: "Redesign de layout do Glance", business_slug: "ux-atelier", squad_name: null },
+    { trace_id: "b2", brief: "Plano de conteúdo 30 dias", business_slug: "content-social-factory", squad_name: "copywriter-squad" },
+    { trace_id: "c3", brief: null, business_slug: null, squad_name: "seo-geo-aeo" },
+  ];
+
+  test("an empty query returns the list unchanged", () => {
+    expect(filterRunsByQuery(runs, "")).toEqual(runs);
+    expect(filterRunsByQuery(runs, "   ")).toEqual(runs);
+  });
+
+  test("matches the brief, case-insensitively", () => {
+    expect(filterRunsByQuery(runs, "REDESIGN").map((r) => r.trace_id)).toEqual(["a1"]);
+  });
+
+  test("matches business_slug and squad_name too, not just the brief", () => {
+    expect(filterRunsByQuery(runs, "content-social").map((r) => r.trace_id)).toEqual(["b2"]);
+    expect(filterRunsByQuery(runs, "seo-geo").map((r) => r.trace_id)).toEqual(["c3"]);
+  });
+
+  test("a run with every matched field null never throws (the empty run in the fixture)", () => {
+    expect(() => filterRunsByQuery(runs, "nothing matches this")).not.toThrow();
+    expect(filterRunsByQuery(runs, "nothing matches this")).toEqual([]);
+  });
+});
+
+describe("filterRelatedActivity — the run-detail strip scoped to business/project", () => {
+  const run = { trace_id: "this-run", business_slug: "ux-atelier", project_id: "proj-1" };
+
+  test("matches by business_slug", () => {
+    const events = [{ trace_id: "other", business_slug: "ux-atelier", event: "delivered" }];
+    expect(filterRelatedActivity(events, run)).toEqual(events);
+  });
+
+  test("matches by project_id when business_slug differs or is absent", () => {
+    const events = [{ trace_id: "other", project_id: "proj-1", event: "gate_passed" }];
+    expect(filterRelatedActivity(events, run)).toEqual(events);
+  });
+
+  test("excludes events already on this run's own trace — the Trajectory Card already shows those", () => {
+    const events = [{ trace_id: "this-run", business_slug: "ux-atelier", event: "dispatch_business" }];
+    expect(filterRelatedActivity(events, run)).toEqual([]);
+  });
+
+  test("excludes events matching neither field", () => {
+    const events = [{ trace_id: "other", business_slug: "unrelated-biz", project_id: "other-proj", event: "x" }];
+    expect(filterRelatedActivity(events, run)).toEqual([]);
+  });
+
+  test("no selected run means no related activity", () => {
+    expect(filterRelatedActivity([{ trace_id: "x" }], null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Six structural changes to `skills/harness/lib/glance/views/`, implementing the approved redesign (`outputs/glance-page-layout-20260830124732/businesses/ux-atelier/page-layout-redesign.md` + mockup), independently verified live in a browser by the orchestrator before this was commissioned:

1. Sidebar auto-collapses 300px → 64px icon rail when a run is open in detail (pin button persists full width). First auto-collapse fires a one-time hint toast + `aria-live` region (Nielsen H1).
2. Activity: permanent 280px rail → on-demand overlay (`role="dialog" aria-modal`, Esc closes, focus returns to the opening bell). Four siblings go `inert` while open (WCAG 2.4.3) — not just visually hidden.
3. New collapsible "Atividade relacionada" strip inside run-detail, scoped to the open run's business/project.
4. Runs list → searchable, collapsible rail (280px ↔ 56px), every collapsed run stays a real `<button>` with an accessible name.
5. Chat panel resizes 460px ↔ 920px via a real `role="separator"` handle (mouse drag + arrow keys), 24px hit area over a 3px visible bar (WCAG 2.5.8).
6. Status dots in the collapsed runs rail gain shape (circle/diamond/triangle/square), never color alone (WCAG 1.4.1).

New pure module `panel-layout.js` makes the decision logic unit-testable outside the Alpine app. No token, color, blur, icon or typography changed. `.right-pane` and every other page are untouched.

## Verified independently before this PR
- Full `glance-*.test.ts` subset (61 tests) re-run and passing, `check:quick` clean.
- Diff reviewed section by section against the approved design doc.
- **Live in a real browser**: sidebar measured at a genuine 64px (`getComputedStyle`), chat resize handle fired a real `ArrowRight` keydown moving 460px→500px, activity overlay's `inert` blocked an actual programmatic focus attempt, Escape returned focus to the exact triggering bell button.

## Test plan
- [x] New tests: `glance-panel-layout.test.ts` (15 tests)
- [x] `bun run check:quick` clean
- [x] Verified live in a real browser (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk