### PR TITLE
feat(glance): live project switcher — rebind the running instance without a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,42 @@ that showed 6 of 8 runs as suspicious now shows 0, with genuine fabrication
 it never had) still caught by a new regression suite
 (`audit-fabrication.test.ts`).
 
+### Glance: switch which project is bound, live, without restarting
+
+One `nrv glance` process was permanently bound to whatever directory it was
+launched from, with no indication anywhere in the UI of which project that
+even was. An owner running several different Nirvana projects, each with
+its own agents dispatching, had to kill and relaunch Glance from a
+different `cwd` just to look at a different project's runs — and had no
+way to tell, looking at the cockpit, which one he was even looking at.
+
+Adds a project switcher to the topnav: an always-visible label showing the
+currently bound project (previously nothing), a dropdown of other Nirvana
+projects discovered on the machine, and a free-text path field for anything
+not discovered. Discovery decodes Claude Code's own transcript-directory
+naming convention (`~/.claude/projects/-Users-guto-nirvana-os`, path
+separators encoded as `-`) by walking the real filesystem and preferring
+the longest real match at each step — a blind `-` → `/` replace misreads a
+hyphenated name like `nirvana-os` as `nirvana/os`; this doesn't, because it
+only descends into segments that actually exist on disk. Only entries that
+resolve to a real, `.nirvana/`-marked directory make the list.
+
+Switching (`POST /api/actions/switch-project`, gated by `--allow-actions`,
+loopback only — a served/`--host` instance stays pinned to its tenant, which
+is the isolation guarantee that mode depends on) rewrites
+`NIRVANA_PROJECT_ROOT` and overrides every `paths.js` key that resolves
+under a project's own `.nirvana/` (registries, squad activation state,
+`state.db`, logs — nine keys in total), live, via the same in-place
+`overridePath()` technique the served-tenancy code already used for two of
+them. An earlier version of this fix only overrode the two logs
+directories; found live, by switching for real and reading `/api/scope`'s
+own `registries`/`state` fields back rather than re-reading the diff, that
+the squad/business registry paths and the activation-state directory kept
+pointing at the old project silently. Verified end to end in a real
+browser afterward: topnav label, dropdown list (56 real projects found on
+the test machine, correctly decoding hyphenated names), and a real switch
+via a UI click — not just the API in isolation.
+
 ## 0.12.3 — 2026-08-30
 
 ### Glance: the glass material now covers the whole shell, not one accordion

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -182,6 +182,45 @@ desconhecido fora de `x_`, ou atividade em formato de hook alegando um host
 que nunca teve) ainda capturada por uma nova suíte de regressão
 (`audit-fabrication.test.ts`).
 
+### Glance: troca de projeto vinculado, ao vivo, sem reiniciar
+
+Um processo `nrv glance` ficava permanentemente vinculado ao diretório de
+onde foi iniciado, sem nenhuma indicação na UI de qual projeto era esse. Um
+dono rodando vários projetos Nirvana diferentes, cada um com agentes
+despachando, tinha que matar e reabrir o Glance de outro `cwd` só pra olhar
+outro projeto — e não tinha como saber, olhando o cockpit, qual projeto
+estava vendo.
+
+Adiciona um seletor de projeto no topnav: um rótulo sempre visível mostrando
+o projeto vinculado agora (antes não existia nada), um dropdown com outros
+projetos Nirvana descobertos na máquina, e um campo de texto livre para
+qualquer um não descoberto. A descoberta decodifica a convenção de
+nomenclatura de diretório de transcrição do próprio Claude Code
+(`~/.claude/projects/-Users-guto-nirvana-os`, separadores de caminho
+codificados como "-") caminhando pelo sistema de arquivos real e preferindo
+o maior trecho real a cada passo — uma substituição cega de "-" por "/" lê
+errado um nome com hífen como `nirvana-os` como `nirvana/os`; isso não
+acontece aqui, porque só desce em segmentos que realmente existem no disco.
+Só entram na lista candidatos que resolvem pra um diretório real, com
+marcador `.nirvana/`.
+
+A troca (`POST /api/actions/switch-project`, protegida por
+`--allow-actions`, só loopback — uma instância served/`--host` continua
+fixada no seu tenant, que é a garantia de isolamento da qual esse modo
+depende) reescreve `NIRVANA_PROJECT_ROOT` e sobrescreve toda chave do
+`paths.js` que resolve dentro do `.nirvana/` de um projeto (registries,
+estado de ativação de squad, `state.db`, logs — nove chaves no total), ao
+vivo, pela mesma técnica de `overridePath()` em-place que o código de
+tenancy served já usava pra duas delas. Uma versão anterior desta correção
+só sobrescrevia os dois diretórios de logs; achado ao vivo, trocando de
+verdade e lendo os próprios campos `registries`/`state` de `/api/scope` de
+volta em vez de reler o diff, que os caminhos de registry de squad/business
+e o diretório de estado de ativação continuavam apontando pro projeto
+antigo em silêncio. Verificado ponta a ponta num browser real depois:
+rótulo do topnav, lista do dropdown (56 projetos reais achados na máquina
+de teste, decodificando nomes com hífen corretamente), e uma troca real via
+clique na UI — não só a API isolada.
+
 ## 0.12.3 — 2026-08-30
 
 ### Glance: o material de vidro agora cobre a casca inteira, não um acordeão

--- a/skills/harness/lib/glance/project-discovery.ts
+++ b/skills/harness/lib/glance/project-discovery.ts
@@ -1,0 +1,116 @@
+/**
+ * project-discovery.ts — finds OTHER Nirvana project directories on this
+ * machine, for the Glance project switcher (`/api/known-projects`,
+ * `POST /api/actions/switch-project`).
+ *
+ * Source: Claude Code's own transcript-storage convention. A session run
+ * from `/Users/guto/nirvana-os` gets its transcripts stored under
+ * `~/.claude/projects/-Users-guto-nirvana-os/` — every path separator
+ * turned into "-", with a leading "-" for the leading "/". That encoding is
+ * LOSSY: a real directory name can itself contain "-" (`nirvana-os`,
+ * `systems-atelier`), so it is not reversible by a blind
+ * `replace(/-/g, "/")` — that would misread `nirvana-os` as `nirvana/os`.
+ *
+ * `decodeClaudeProjectDirName()` recovers the real path by walking the
+ * filesystem instead of guessing blind: at each step it prefers the LONGEST
+ * run of remaining dash-separated tokens that names a real directory under
+ * the path resolved so far, then descends into it. A name whose real
+ * boundaries can't be recovered this way is simply dropped — not an error,
+ * one fewer suggestion, degrading gracefully (a project can still be added
+ * via the free-text path field the UI offers alongside this list).
+ *
+ * A decoded candidate only makes the list when it exists on disk AND has a
+ * `.nirvana/` marker — this scan is about NIRVANA projects the owner can
+ * switch Glance into, not every folder Claude Code ever ran a session in.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { paths, expandPath } from "../../../_shared/lib/bun-helpers.ts";
+
+const NIRVANA_MARKER = ".nirvana";
+// Bounds the worst case of the O(tokens^2) filesystem-guided decode below —
+// no real project path encodes to more dash-separated tokens than this.
+const MAX_DECODE_TOKENS = 60;
+
+export function hasNirvanaMarker(dir: string): boolean {
+  try { return fs.statSync(path.join(dir, NIRVANA_MARKER)).isDirectory(); }
+  catch { return false; }
+}
+
+/** `baseRoot` is the filesystem root the first token resolves against — always
+ *  `path.sep` in production (a real absolute path); overridable so tests can
+ *  point the walk at a temp fixture tree instead of the real "/". */
+export function decodeClaudeProjectDirName(encoded: string, baseRoot: string = path.sep): string | null {
+  const tokens = encoded.split("-");
+  if (tokens[0] === "") tokens.shift(); // leading "-" encodes the leading "/"
+  if (tokens.length === 0 || tokens.length > MAX_DECODE_TOKENS) return null;
+
+  let resolved = baseRoot;
+  let i = 0;
+  while (i < tokens.length) {
+    let advanced = false;
+    // Longest-run-first: prefer the biggest chunk of tokens that is a real
+    // directory here, so a hyphenated leaf name (`nirvana-os`) wins over the
+    // shorter, wrong split (`nirvana` then a separate `os`).
+    for (let j = tokens.length; j > i; j--) {
+      const candidateName = tokens.slice(i, j).join("-");
+      const candidatePath = path.join(resolved, candidateName);
+      try {
+        if (fs.statSync(candidatePath).isDirectory()) {
+          resolved = candidatePath;
+          i = j;
+          advanced = true;
+          break;
+        }
+      } catch { /* not a real segment at this length — try shorter */ }
+    }
+    if (!advanced) return null;
+  }
+  return resolved;
+}
+
+export interface DiscoveredProject {
+  path: string;
+  name: string;
+}
+
+/** Scans `~/.claude/projects/` (or `claudeProjectsDir`, for tests) and
+ *  returns every decodable entry that is a real, `.nirvana/`-marked
+ *  directory. Sorted by name; no duplicates. `decodeBaseRoot` overrides the
+ *  filesystem root the decode walk starts from (tests only; always `path.sep`
+ *  in production, since transcript dir names encode a real absolute path). */
+export function discoverKnownProjects(claudeProjectsDir?: string, decodeBaseRoot: string = path.sep): DiscoveredProject[] {
+  const dir = claudeProjectsDir || path.join(paths.CLAUDE_CONFIG_DIR, "projects");
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return []; }
+
+  const seen = new Set<string>();
+  const out: DiscoveredProject[] = [];
+  for (const entry of entries) {
+    try { if (!fs.statSync(path.join(dir, entry)).isDirectory()) continue; } catch { continue; }
+    const decoded = decodeClaudeProjectDirName(entry, decodeBaseRoot);
+    if (!decoded || seen.has(decoded) || !hasNirvanaMarker(decoded)) continue;
+    seen.add(decoded);
+    out.push({ path: decoded, name: path.basename(decoded) });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+export type ValidatedProjectPath = { ok: true; path: string } | { ok: false; error: string };
+
+/** Validates a free-text (or discovered) path for the project switcher: it
+ *  must exist, be a directory, and carry a `.nirvana/` marker. Same bar as
+ *  discovery, applied to a path the owner typed by hand. */
+export function validateProjectPath(input: unknown): ValidatedProjectPath {
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) return { ok: false, error: "project_root is required" };
+  const resolved = path.resolve(expandPath(raw));
+  let stat: fs.Stats;
+  try { stat = fs.statSync(resolved); }
+  catch { return { ok: false, error: `path does not exist: ${resolved}` }; }
+  if (!stat.isDirectory()) return { ok: false, error: `not a directory: ${resolved}` };
+  if (!hasNirvanaMarker(resolved)) return { ok: false, error: `no .nirvana/ marker found in ${resolved} — run \`nrv init\` there first` };
+  return { ok: true, path: resolved };
+}

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -49,6 +49,7 @@ import {
 import { validateMindCloneFile, type ValidationResult } from "../../../_shared/lib/mindclone-validator.ts";
 import { mindCloneModule, verifyAll, verifyEntity, type VerifyReport } from "../../../_shared/lib/verify/index.ts";
 import { handleObservabilityRoute } from "./views/observability-handler.ts";
+import { discoverKnownProjects, validateProjectPath } from "./project-discovery.ts";
 import { AgentXCanaryQueue, ConversationService, MaestroTurnQueue, ProjectService, resumeCommand, type Conversation, type GlanceAgentXCanaryAdapter, type GlanceExecutionRunner, type MessageRouter, type TurnView } from "../control-plane/index.ts";
 import { createRun as createKernelRun, getRun as getKernelRun, listEvents as listKernelEvents, openKernel } from "../run-kernel/index.ts";
 import { getGauntlet, listCandidateRevisions, listScorecards, projectMultiTargetRun } from "../gauntlet/index.ts";
@@ -283,6 +284,16 @@ export async function startServer(opts: ServerOptions) {
   const isLoopback = LOOPBACK_HOSTS.has(host);
   const url = `http://${isLoopback ? "localhost" : host}:${port}`;
   const projectRoot = path.resolve(process.env.NIRVANA_PROJECT_ROOT || process.cwd());
+  // Live project root: reflects `POST /api/actions/switch-project` without a restart.
+  // `resolveScope()` (via `getScope()`) already re-reads `process.env.NIRVANA_PROJECT_ROOT`
+  // fresh on every call (scope.ts's own doc comment) — switching writes that env var, so this
+  // getter sees the new root on the very next call. The `projectRoot` const above stays frozen
+  // by closure at boot on purpose (it seeds controlPlaneDb/kernelDb/maestroTurns, which are NOT
+  // part of this cut — see the brief's explicit out-of-scope note); every request-handler call
+  // site that must reflect a live switch reads `currentProjectRoot()` instead. Falls back to the
+  // boot-time root on the same terms every other `scope.projectRoot || ...` site in this file
+  // already uses (global scope with no marker up the cwd tree).
+  const currentProjectRoot = (): string => getScope().projectRoot || projectRoot;
   const controlPlaneDb = path.join(projectRoot, ".nirvana", "control-plane.sqlite");
   const kernelDb = path.join(projectRoot, ".nirvana", "run-kernel.sqlite");
   const projectService = new ProjectService();
@@ -534,21 +545,22 @@ export async function startServer(opts: ServerOptions) {
         if (p === "/api/v1/projects/plan" && req.method === "POST") {
           const body = await req.json().catch(() => ({})) as any;
           if (body.relative_root && (path.isAbsolute(body.relative_root) || body.relative_root.includes(".."))) return problem(400, "Invalid path", "relative_root must be confined to the Glance workspace");
-          const target = path.resolve(projectRoot, body.relative_root || ".");
-          if (target !== projectRoot && !target.startsWith(projectRoot + path.sep)) return problem(400, "Invalid path", "project path escapes the workspace");
+          const root = currentProjectRoot();
+          const target = path.resolve(root, body.relative_root || ".");
+          if (target !== root && !target.startsWith(root + path.sep)) return problem(400, "Invalid path", "project path escapes the workspace");
           return json(projectService.planCreate({ projectRoot: target, displayName: body.display_name, scope: body.scope, orchestrationMode: body.orchestration_mode }));
         }
         if (p === "/api/v1/projects" && req.method === "POST") {
           const body = await req.json().catch(() => ({})) as any;
           const relative = body.relative_root || ".";
           if (path.isAbsolute(relative) || relative.includes("..")) return problem(400, "Invalid path", "relative_root must be confined to the Glance workspace");
-          const project = projectService.create({ projectRoot: path.resolve(projectRoot, relative), displayName: body.display_name, scope: body.scope, orchestrationMode: body.orchestration_mode }, body.plan_hash);
+          const project = projectService.create({ projectRoot: path.resolve(currentProjectRoot(), relative), displayName: body.display_name, scope: body.scope, orchestrationMode: body.orchestration_mode }, body.plan_hash);
           return json(project, 201);
         }
         if (p === "/api/v1/projects:adopt" && req.method === "POST") {
           const body = await req.json().catch(() => ({})) as any;
           if (!body.plan_hash) return problem(400, "Missing plan hash", "Adoption requires a preview plan_hash");
-          const project = projectService.adopt({ projectRoot, displayName: body.display_name, scope: body.scope, orchestrationMode: body.orchestration_mode }, body.plan_hash);
+          const project = projectService.adopt({ projectRoot: currentProjectRoot(), displayName: body.display_name, scope: body.scope, orchestrationMode: body.orchestration_mode }, body.plan_hash);
           return json(project, 201);
         }
         const projectMatch = p.match(/^\/api\/v1\/projects\/(prj_[A-Za-z0-9-]+)$/);
@@ -597,7 +609,7 @@ export async function startServer(opts: ServerOptions) {
               // sends, makes the Message one turn of the project's runtime session.
               if (body.mode === "run") {
                 const receipt = await agentXQueue().submit({ projectId: body.project_id, conversationId: messagesMatch[1], messageId: message.message_id,
-                  brief: message.content, projectRoot, idempotencyKey });
+                  brief: message.content, projectRoot: currentProjectRoot(), idempotencyKey });
                 return json({ message: receipt.message, run: receipt.run, queued: receipt.queued, capability: receipt.capability }, receipt.queued ? 202 : 200);
               }
               const receipt = maestroTurns().submit({ projectId: body.project_id, conversationId: messagesMatch[1], messageId: message.message_id, prompt: message.content });
@@ -781,6 +793,7 @@ export async function startServer(opts: ServerOptions) {
         if (!opts.allowActions) {
           return json({ error: "actions disabled; restart Glance with --allow-actions to enable", action: p }, 403);
         }
+        if (p === "/api/actions/switch-project") return await handleSwitchProject(req, isLoopback);
         return handleAction(req, p, opts);
       }
 
@@ -1542,10 +1555,15 @@ export async function startServer(opts: ServerOptions) {
       }
       if (p === "/api/scope") return json(getScope());
 
+      // Other Nirvana projects on this machine — for the topnav project switcher.
+      // Read-only (no allowActions gate; discovery has no side effects), same
+      // `.nirvana/`-marker bar `POST /api/actions/switch-project` validates against.
+      if (p === "/api/known-projects" && req.method === "GET") return json({ projects: discoverKnownProjects() });
+
       // Which engine subsystems are standing. Read-only, no spawn, no network;
       // a subsystem whose health cannot be determined answers `status: null` and
       // the view renders `—` rather than a green light nobody measured.
-      if (p === "/api/subsystems") return json({ subsystems: readSubsystems(projectRoot) });
+      if (p === "/api/subsystems") return json({ subsystems: readSubsystems(currentProjectRoot()) });
 
       if (p === "/api/audit/report") {
         const sc = getScope();
@@ -2050,7 +2068,7 @@ export async function startServer(opts: ServerOptions) {
 
   console.error(`[glance] up on ${url}  (scope=${getScope().mode}, allow_actions=${opts.allowActions}, theme=${opts.theme})`);
   console.error(`[glance] auto-shutdown after ${opts.idleMin}min idle  ·  Ctrl+C to exit`);
-  if (!isLoopback) console.error(`[glance] served on ${host} — authentication required (Authorization: Bearer <token from \`nrv serve keygen --glance\`>); tenant = ${projectRoot}`);
+  if (!isLoopback) console.error(`[glance] served on ${host} — authentication required (Authorization: Bearer <token from \`nrv serve keygen --glance\`>); tenant = ${currentProjectRoot()}`);
   // A served instance is a VPS process with no display attached to it, most of the time; even
   // when one exists, opening a browser aimed at a bare non-TLS network address is not this
   // cut's call to make. Loopback keeps today's behavior unchanged.
@@ -2077,7 +2095,7 @@ export async function startServer(opts: ServerOptions) {
 
   const inspection = projectInspection();
   const recovery = inspection.kind === "project" && inspection.project
-    ? agentXQueue().recover(inspection.project.project_id, projectRoot)
+    ? agentXQueue().recover(inspection.project.project_id, currentProjectRoot())
     : { enqueued: [], reattached: [], redispatched: [], skipped: [] };
 
   // Releases what an embedding host or a test holds through this instance: the queue detaches,
@@ -2275,6 +2293,55 @@ const ACTIONS: Record<string, ActionDef> = {
     },
   },
 };
+
+/**
+ * POST /api/actions/switch-project — live-rebinds this LOOPBACK Glance
+ * instance to a different Nirvana project, no restart required. Local case
+ * only: a served instance (`--host`, `isLoopback === false`) is pinned to
+ * one tenant for its whole life by the tenancy block near the top of
+ * `startServer` — that pin is the isolation guarantee a served,
+ * authenticated, potentially multi-caller instance relies on, so this
+ * action refuses outright when it isn't loopback.
+ *
+ * Mutates `NIRVANA_PROJECT_ROOT` and overrides `HARNESS_LOGS_DIR` /
+ * `MAESTRO_LOGS_DIR` via the exact same `overridePath()` technique the
+ * served-tenancy block already uses (skills/_shared/lib/bun-helpers.ts:73),
+ * just triggered by this user action instead of at boot. `getScope()` /
+ * `resolveScope()` re-read `process.env.NIRVANA_PROJECT_ROOT` fresh on
+ * every call, so the new root is live for every other endpoint starting
+ * with the very next request — no cache to invalidate.
+ */
+async function handleSwitchProject(req: Request, isLoopback: boolean): Promise<Response> {
+  if (!isLoopback) {
+    return json({ error: "switch-project is a local (loopback) action; a served instance is pinned to its tenant for its whole life" }, 403);
+  }
+  let body: any = {};
+  try { body = await req.json(); } catch { /* empty/invalid body — validateProjectPath rejects it below */ }
+
+  const validated = validateProjectPath(body?.project_root);
+  if (!validated.ok) return json({ error: validated.error }, 400);
+
+  const from = getScope().projectRoot;
+  const to = validated.path;
+  const tenantHarnessLogsDir = path.join(to, ".nirvana", "logs", "harness");
+  const tenantMaestroLogsDir = path.join(to, ".nirvana", "logs", "maestro");
+  process.env.NIRVANA_PROJECT_ROOT = to;
+  // Both the env var AND overridePath(), exactly like the served-tenancy block above (~455-461):
+  // audit.js/log-paths.ts re-check `process.env.HARNESS_LOGS_DIR` on every call, while everything
+  // else reads the frozen `paths.js` object overridePath() mutates in place.
+  process.env.HARNESS_LOGS_DIR = tenantHarnessLogsDir;
+  process.env.MAESTRO_LOGS_DIR = tenantMaestroLogsDir;
+  overridePath("HARNESS_LOGS_DIR", tenantHarnessLogsDir);
+  overridePath("MAESTRO_LOGS_DIR", tenantMaestroLogsDir);
+
+  try {
+    createRequire(import.meta.url)("../audit.js").emit("x_glance_project_switched", { from, to, actor: "glance" }, { cwd: to });
+  } catch (error) {
+    console.error(`[glance] audit not written (${(error as Error).message})`);
+  }
+
+  return json({ ok: true, from, to, scope: getScope() });
+}
 
 async function handleAction(req: Request, p: string, opts: any): Promise<Response> {
   const name = p.replace(/^\/api\/actions\//, "");

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -2303,13 +2303,28 @@ const ACTIONS: Record<string, ActionDef> = {
  * authenticated, potentially multi-caller instance relies on, so this
  * action refuses outright when it isn't loopback.
  *
- * Mutates `NIRVANA_PROJECT_ROOT` and overrides `HARNESS_LOGS_DIR` /
- * `MAESTRO_LOGS_DIR` via the exact same `overridePath()` technique the
- * served-tenancy block already uses (skills/_shared/lib/bun-helpers.ts:73),
- * just triggered by this user action instead of at boot. `getScope()` /
- * `resolveScope()` re-read `process.env.NIRVANA_PROJECT_ROOT` fresh on
- * every call, so the new root is live for every other endpoint starting
- * with the very next request — no cache to invalidate.
+ * Mutates `NIRVANA_PROJECT_ROOT` and overrides every `paths.js` key that
+ * resolves under `<project>/.nirvana/` via the exact same `overridePath()`
+ * technique the served-tenancy block already uses
+ * (skills/_shared/lib/bun-helpers.ts:73), just triggered by this user
+ * action instead of at boot. `getScope()`/`resolveScope()` re-read
+ * `process.env.NIRVANA_PROJECT_ROOT` fresh on every call, so `scope.
+ * projectRoot`/`squadDirs`/`businessDirs` (the GLOBAL capability
+ * libraries, e.g. `~/squads`) are live immediately with no extra work —
+ * but `paths.js` resolves its OWN properties once at require time (its own
+ * comment says so) and hands back that frozen object forever after, so
+ * every key `paths.js` derives from `projectPath(sub)` — the registries/
+ * state/logs that live INSIDE a project's own `.nirvana/`, a different
+ * thing from the global capability directories — needs its own
+ * `overridePath()` call or it silently keeps pointing at the OLD project.
+ * This list must stay in sync with every `projectPath(...)` call in
+ * `skills/_shared/lib/paths.js` — verified against it directly while
+ * writing this (2026-08-30): HARNESS_LOGS_DIR, MAESTRO_LOGS_DIR,
+ * BUSINESSES_REGISTRY_PATH, SQUADS_REGISTRY_PATH, ROUTING_DIGEST_PATH,
+ * KEYWORD_ALIASES_PATH, SQUADS_STATE_DIR, STATE_DB, PROJECTS_OUTPUT_DIR.
+ * An earlier version of this fix only overrode the first two — found live,
+ * by switching for real and reading `/api/scope`'s `registries`/`state`
+ * fields back, not by re-reading the diff.
  */
 async function handleSwitchProject(req: Request, isLoopback: boolean): Promise<Response> {
   if (!isLoopback) {
@@ -2323,16 +2338,28 @@ async function handleSwitchProject(req: Request, isLoopback: boolean): Promise<R
 
   const from = getScope().projectRoot;
   const to = validated.path;
-  const tenantHarnessLogsDir = path.join(to, ".nirvana", "logs", "harness");
-  const tenantMaestroLogsDir = path.join(to, ".nirvana", "logs", "maestro");
+  const dotNirvana = path.join(to, ".nirvana");
+  // sub-path per key, mirroring paths.js's own `projectPath(sub)` calls exactly.
+  const PROJECT_SCOPED_PATHS: Record<string, string> = {
+    HARNESS_LOGS_DIR: "logs/harness",
+    MAESTRO_LOGS_DIR: "logs/maestro",
+    BUSINESSES_REGISTRY_PATH: ".businesses-registry.json",
+    SQUADS_REGISTRY_PATH: ".squads-registry.json",
+    ROUTING_DIGEST_PATH: ".routing-digest.md",
+    KEYWORD_ALIASES_PATH: ".keyword-aliases.json",
+    SQUADS_STATE_DIR: "state/squads",
+    STATE_DB: "state.db",
+    PROJECTS_OUTPUT_DIR: "outputs",
+  };
   process.env.NIRVANA_PROJECT_ROOT = to;
-  // Both the env var AND overridePath(), exactly like the served-tenancy block above (~455-461):
-  // audit.js/log-paths.ts re-check `process.env.HARNESS_LOGS_DIR` on every call, while everything
-  // else reads the frozen `paths.js` object overridePath() mutates in place.
-  process.env.HARNESS_LOGS_DIR = tenantHarnessLogsDir;
-  process.env.MAESTRO_LOGS_DIR = tenantMaestroLogsDir;
-  overridePath("HARNESS_LOGS_DIR", tenantHarnessLogsDir);
-  overridePath("MAESTRO_LOGS_DIR", tenantMaestroLogsDir);
+  for (const [key, sub] of Object.entries(PROJECT_SCOPED_PATHS)) {
+    const value = path.join(dotNirvana, sub);
+    // audit.js/log-paths.ts re-check these two specific env vars on every call; everything
+    // else (including these same two, for OTHER readers) reads the frozen `paths.js` object
+    // overridePath() mutates in place — set both so no reader is left on the old project.
+    if (key === "HARNESS_LOGS_DIR" || key === "MAESTRO_LOGS_DIR") process.env[key] = value;
+    overridePath(key, value);
+  }
 
   try {
     createRequire(import.meta.url)("../audit.js").emit("x_glance_project_switched", { from, to, actor: "glance" }, { cwd: to });

--- a/skills/harness/lib/glance/views/glance.css
+++ b/skills/harness/lib/glance/views/glance.css
@@ -646,6 +646,13 @@ body {
 .actions-menu-item.warning { color: var(--status-warn-fg); }
 .actions-menu-item.warning:hover { background: var(--status-warn-bg); }
 
+/* ─── Project switcher (topnav) ─── */
+.project-switcher-menu { width: 320px; }
+.project-switcher-item { display: flex; flex-direction: column; gap: 2px; }
+.project-switcher-item span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.project-switcher-other { display: flex; gap: var(--space-2); padding: var(--space-1) 10px var(--space-2); }
+.project-switcher-other .glance-search-input { flex: 1; }
+
 /* ─── Per-squad action buttons ─── */
 .detail-actions {
   display: flex; flex-wrap: wrap; gap: var(--space-1);

--- a/skills/harness/lib/glance/views/glance.js
+++ b/skills/harness/lib/glance/views/glance.js
@@ -147,6 +147,13 @@ function glance() {
     // Scope filter: 'all' = entire machine, 'project' = only events whose cwd
     // starts with scope.projectRoot. Disabled when no projectRoot is detected.
     projectFilter: (typeof localStorage !== 'undefined' && localStorage.getItem('glance.projectFilter')) || '',  // '' = not decided yet; fetchScope picks project-first
+    // ── Project switcher (topnav) — rebinds this Glance instance to a DIFFERENT
+    // project (distinct from projectFilter above, which only filters WITHIN the
+    // one bound project). Requires --allow-actions: it's a mutating action.
+    // Dropdown open/close and the free-text path live in the control's own
+    // local x-data (index.html), same convention as the existing actions menu.
+    knownProjects: [],
+    projectSwitching: false,
     // Setup mode (project scaffolding via Glance)
     // Setup mode (project scaffolding via Glance)
     setupMode: false,
@@ -389,6 +396,7 @@ function glance() {
         this.fetchSetupSources(),
         this.fetchSetupStatus(),
         this.fetchSubsystems(),
+        this.fetchKnownProjects(),
       ]);
       this.flash(`refreshed · ${this.squads.length} squads, ${this.businesses.length} bus`);
     },
@@ -467,6 +475,13 @@ function glance() {
     async fetchSubsystems() {
       try { this.subsystems = (await api('/api/subsystems')).subsystems; }
       catch (e) { this.subsystems = null; }
+    },
+    // ─── Project switcher (topnav) — OTHER Nirvana projects on this machine,
+    // distinct from projectFilter above (which only filters within the ONE
+    // project this instance is bound to). Read-only; always available.
+    async fetchKnownProjects() {
+      try { this.knownProjects = (await api('/api/known-projects')).projects || []; }
+      catch (e) { this.knownProjects = []; }
     },
     async fetchSquads()   { this.listLoading.squads = true; this.listError.squads = null; try { const r = await api('/api/squads'); this.squads = r.squads; this.counts.squads = r.squads.length; } catch(e) { this.listError.squads = e.message || 'failed'; this.flash(`✗ squads: ${e.message || 'load failed'}`, 3000); } finally { this.listLoading.squads = false; } },
     async fetchBusinesses(){ this.listLoading.businesses = true; this.listError.businesses = null; try { const r = await api('/api/businesses'); this.businesses = r.businesses; this.counts.businesses = r.businesses.length; } catch(e) { this.listError.businesses = e.message || 'failed'; this.flash(`✗ businesses: ${e.message || 'load failed'}`, 3000); } finally { this.listLoading.businesses = false; } },
@@ -907,6 +922,20 @@ function glance() {
       if (this.projectFilter !== 'project' || !this.canFilterByProject()) return '';
       return `${prefix}project=${encodeURIComponent(this.scope.projectRoot)}`;
     },
+    // Refetch every backend-aggregated view so Cost / Runs / Memory match what's
+    // shown for Agents / Activity. Squads/businesses/mind-clones intentionally
+    // NOT refetched — those stay global. Shared by setProjectFilter (All↔Project
+    // MODE change, within one bound project) and switchProject (rebinding to a
+    // DIFFERENT project) — same list either way, so it lives in one place.
+    refetchProjectScopedViews() {
+      try { this.fetchRuns && this.fetchRuns(); } catch {}
+      try { this.fetchCost && this.fetchCost(); } catch {}
+      try { this.fetchMemory && this.fetchMemory(); } catch {}
+      try { this.fetchProjects && this.fetchProjects(); } catch {}
+      try { this.fetchGraph && this.fetchGraph(); } catch {}
+      try { this.restartAgentsStream && this.restartAgentsStream(); } catch {}
+      try { this.restartActivityStream && this.restartActivityStream(); } catch {}
+    },
     setProjectFilter(mode, persist = true) {
       // 'all' | 'project' — silently ignore 'project' if no root detected
       if (mode === 'project' && !this.canFilterByProject()) return;
@@ -915,19 +944,35 @@ function glance() {
       // persist=false for the AUTOMATIC (project-first) choice: it doesn't become
       // a stored preference, so it re-evaluates by projectRoot on every session.
       if (persist) { try { localStorage.setItem('glance.projectFilter', mode); } catch {} }
-      if (changed) {
-        // Refetch every backend-aggregated view so Cost / Runs / Memory match
-        // what's shown for Agents / Activity. Squads/businesses/mind-clones
-        // intentionally NOT refetched — those stay global.
-        try { this.fetchRuns && this.fetchRuns(); } catch {}
-        try { this.fetchCost && this.fetchCost(); } catch {}
-        try { this.fetchMemory && this.fetchMemory(); } catch {}
-        try { this.fetchProjects && this.fetchProjects(); } catch {}
-        try { this.fetchGraph && this.fetchGraph(); } catch {}
-        try { this.restartAgentsStream && this.restartAgentsStream(); } catch {}
-        try { this.restartActivityStream && this.restartActivityStream(); } catch {}
-      }
+      if (changed) this.refetchProjectScopedViews();
       this.$nextTick(() => this.renderAllSwimlanes && this.renderAllSwimlanes());
+    },
+    // ── Project switcher: rebinds this Glance INSTANCE to a different project
+    // (POST /api/actions/switch-project), unlike setProjectFilter above which only
+    // filters within the one project already bound. Requires --allow-actions.
+    async switchProject(targetPath) {
+      const path = (targetPath || '').trim();
+      if (!path || this.projectSwitching) return;
+      this.projectSwitching = true;
+      try {
+        const r = await fetch('/api/actions/switch-project', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ project_root: path }),
+        });
+        const data = await r.json();
+        if (!r.ok) { this.flash(`✗ switch project: ${data.error || r.status}`, 4000); return; }
+        this.scope = data.scope;
+        this.flash(`▶ switched to ${(data.to || '').split('/').slice(-1)[0] || data.to}`, 2000);
+        this.refetchProjectScopedViews();
+        try { this.fetchSubsystems && this.fetchSubsystems(); } catch {}
+        try { this.fetchSetupStatus && this.fetchSetupStatus(); } catch {}
+        try { this.fetchKnownProjects && this.fetchKnownProjects(); } catch {}
+      } catch (e) {
+        this.flash(`✗ ${e.message}`, 4000);
+      } finally {
+        this.projectSwitching = false;
+      }
     },
     matchesCurrentProject(item) {
       if (this.projectFilter !== 'project' || !this.canFilterByProject()) return true;

--- a/skills/harness/lib/glance/views/index.html
+++ b/skills/harness/lib/glance/views/index.html
@@ -98,10 +98,39 @@
           <i data-lucide="folder-open"></i><span>Project</span>
         </button>
       </div>
-      <div class="scope-pill" :class="`scope-${scope?.mode || 'global'}`">
+      <!-- Always-visible: which project THIS Glance instance is bound to right now.
+           There used to be no indication of this at all — the mode dot alone (global/
+           project/merge) doesn't say WHICH project, which is what confused the owner. -->
+      <div class="scope-pill" :class="`scope-${scope?.mode || 'global'}`" :title="scope?.projectRoot || 'No project bound — Glance is scoped globally'">
         <span class="scope-dot"></span>
         <span x-text="scope?.mode || '…'"></span>
-        <span class="text-zinc-500 text-[11px] ml-1" x-show="scope?.projectRoot" x-text="scope?.projectRoot ? `· ${scope.projectRoot.split('/').slice(-2).join('/')}` : ''"></span>
+        <span class="text-zinc-500 text-[11px] ml-1" x-text="scope?.projectRoot ? `· ${scope.projectRoot.split('/').slice(-1)[0]}` : '· no project bound'"></span>
+      </div>
+      <!-- Project switcher — rebinds this Glance INSTANCE to a DIFFERENT project, live,
+           no restart (POST /api/actions/switch-project). Distinct from the All/Project
+           toggle above, which only filters WITHIN the one project already bound.
+           Mutating, so it needs --allow-actions like the rest of the actions menu. -->
+      <div x-cloak class="relative" x-data="{ open: false, otherPath: '' }" @click.outside="open = false" x-show="health.allow_actions">
+        <button @click="open = !open; if (open) fetchKnownProjects()" title="Switch project" :class="open ? 'icon-btn icon-btn-active' : 'icon-btn'">
+          <i data-lucide="folder-symlink"></i>
+        </button>
+        <div x-show="open" x-transition class="actions-menu project-switcher-menu">
+          <div class="actions-menu-section">Switch project</div>
+          <template x-for="p in knownProjects" :key="p.path">
+            <button @click="switchProject(p.path); open = false" class="actions-menu-item project-switcher-item" :disabled="projectSwitching" :title="p.path">
+              <span x-text="p.name"></span>
+              <span class="text-zinc-500 text-[11px]" x-text="p.path"></span>
+            </button>
+          </template>
+          <div x-show="knownProjects.length === 0" class="actions-menu-item text-zinc-500">No other .nirvana/ projects found</div>
+          <div class="actions-menu-section">Other path…</div>
+          <div class="project-switcher-other">
+            <input type="text" x-model="otherPath" placeholder="/absolute/path/to/project"
+                   class="glance-search-input" @keydown.enter="switchProject(otherPath); open = false; otherPath = ''">
+            <button @click="switchProject(otherPath); open = false; otherPath = ''" class="btn btn-ghost btn-xs"
+                    :disabled="!otherPath.trim() || projectSwitching">Go</button>
+          </div>
+        </div>
       </div>
       <!-- Actions menu (only when --allow-actions) -->
       <div x-cloak class="relative" x-data="{ open: false }" @click.outside="open = false" x-show="health.allow_actions">

--- a/skills/harness/tests/glance-project-switcher.test.ts
+++ b/skills/harness/tests/glance-project-switcher.test.ts
@@ -1,0 +1,259 @@
+// glance-project-switcher.test.ts — POST /api/actions/switch-project
+// live-rebinds a running, LOOPBACK Glance instance to a different Nirvana
+// project without a restart.
+//
+// Regression target: before this cut, `const projectRoot = ...` in
+// startServer() was captured by closure at boot (server.ts, above
+// `async fetch(req) {...}`) and read directly by a handful of request-handler
+// call sites instead of a live source. `getScope()`/`resolveScope()` were
+// already fresh on every call (no cache of their own) — the bug was only in
+// those closure reads. This file boots one real server, switches project,
+// and hits both a live-by-construction endpoint (`/api/scope`) and two of
+// the PREVIOUSLY-FROZEN call sites (`/api/subsystems`, and
+// `/api/v1/projects/plan`, which resolves a target path off the frozen
+// const) to confirm both now reflect the new root — a test that only checks
+// `getScope()` would not have caught the frozen-const bug at all.
+//
+// Hermetic: two temp project roots, a temp NIRVANA_HOME. No LLM, no network
+// beyond loopback. Runs with: bun test skills/harness/tests
+import { afterEach, beforeAll, afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { SETTINGS_SCHEMA } from "../../_shared/lib/settings.ts";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+import { decodeClaudeProjectDirName, discoverKnownProjects, validateProjectPath } from "../lib/glance/project-discovery.ts";
+
+const SCHEMA_VARIABLES = SETTINGS_SCHEMA.flatMap((spec) => [spec.env, ...(spec.envAliases ?? [])]).filter((name): name is string => !!name);
+const SCRUBBED = [...SCHEMA_VARIABLES, "NIRVANA_PROJECT_ROOT", "NIRVANA_HOME", "HARNESS_LOGS_DIR", "MAESTRO_LOGS_DIR"];
+const saved = new Map<string, string | undefined>();
+beforeAll(() => { for (const name of SCRUBBED) { saved.set(name, process.env[name]); delete process.env[name]; } });
+afterAll(() => { for (const [name, value] of saved) { if (value === undefined) delete process.env[name]; else process.env[name] = value; } });
+
+const roots: string[] = [];
+const servers: Array<{ close: () => void }> = [];
+afterEach(() => {
+  while (servers.length) { try { servers.pop()!.close(); } catch {} }
+  for (const name of SCRUBBED) delete process.env[name];
+  while (roots.length) removeDir(roots.pop()!);
+});
+
+function fixture() {
+  const root = makeTempRoot("nrv-glance-switcher-");
+  roots.push(root);
+  const home = path.join(root, "home");
+  const projectA = path.join(root, "project-a");
+  const projectB = path.join(root, "project-b");
+  fs.mkdirSync(path.join(home, ".nirvana"), { recursive: true });
+  fs.mkdirSync(path.join(projectA, ".nirvana"), { recursive: true });
+  fs.mkdirSync(path.join(projectB, ".nirvana"), { recursive: true });
+  process.env.NIRVANA_HOME = home;
+  process.env.NIRVANA_PROJECT_ROOT = projectA;
+  return { root, home, projectA, projectB };
+}
+
+// Explicit, incrementing ports rather than `port: 0` (which routes through
+// startServer's own findFreePort()): that helper probes with a plain
+// Bun.serve() bind-then-stop, which on this OS can report a port "free" via
+// SO_REUSEPORT even while another process already holds it (observed live
+// against a real `nrv glance` on 3737 while writing this test) — the probe
+// binds "successfully" and the REAL bind two lines later throws EADDRINUSE.
+// Pre-existing, unrelated to this cut; sidestepped here rather than fixed.
+let nextPort = 58201;
+async function start(opts: { host?: string; allowActions?: boolean } = {}) {
+  const { startServer } = await import("../lib/glance/server.ts");
+  const server = await startServer({ port: nextPort++, open: false, idleMin: 60, allowActions: opts.allowActions ?? true, theme: "apple", host: opts.host });
+  servers.push(server);
+  return server;
+}
+
+const get = (server: { port: number }, p: string) => fetch(`http://127.0.0.1:${server.port}${p}`);
+// Idempotency-Key on every POST: `/api/v1/*` writes require it (writeAuthorized());
+// `/api/actions/*` ignores it. One header works for both call sites this file exercises.
+const post = (server: { port: number }, p: string, body: unknown) =>
+  fetch(`http://127.0.0.1:${server.port}${p}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "idempotency-key": crypto.randomUUID() },
+    body: JSON.stringify(body ?? {}),
+  });
+
+describe("POST /api/actions/switch-project", () => {
+  test("rejects when Glance actions are disabled", async () => {
+    const setup = fixture();
+    const server = await start({ allowActions: false });
+    const res = await post(server, "/api/actions/switch-project", { project_root: setup.projectB });
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects a target with no .nirvana/ marker", async () => {
+    const setup = fixture();
+    const server = await start();
+    const bareDir = path.join(setup.root, "not-a-project");
+    fs.mkdirSync(bareDir, { recursive: true });
+    const res = await post(server, "/api/actions/switch-project", { project_root: bareDir });
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(String(body.error)).toContain(".nirvana");
+  });
+
+  test("rejects a target that does not exist on disk", async () => {
+    const setup = fixture();
+    const server = await start();
+    const res = await post(server, "/api/actions/switch-project", { project_root: path.join(setup.root, "nowhere") });
+    expect(res.status).toBe(400);
+  });
+
+  test("rebinds /api/scope, /api/subsystems, and a previously-frozen endpoint to the new project — no restart", async () => {
+    const setup = fixture();
+    const server = await start();
+
+    // Baseline: everything still answers for project A.
+    const scopeBefore = await (await get(server, "/api/scope")).json() as any;
+    expect(scopeBefore.projectRoot).toBe(setup.projectA);
+
+    const subsystemsBefore = await (await get(server, "/api/subsystems")).json() as any;
+    const kernelBefore = subsystemsBefore.subsystems.find((s: any) => s.key === "run-kernel");
+    expect(kernelBefore.source).toBe(path.join(setup.projectA, ".nirvana", "run-kernel.sqlite"));
+
+    // `/api/v1/projects/plan` resolves its target off the const that used to be captured by
+    // closure at boot (server.ts, `path.resolve(projectRoot, body.relative_root || ".")`) —
+    // exactly the frozen-projectRoot bug this test exists to catch.
+    const planBefore = await (await post(server, "/api/v1/projects/plan", {})).json() as any;
+    expect(planBefore.project_root).toBe(setup.projectA);
+
+    // Switch, no restart.
+    const switchRes = await post(server, "/api/actions/switch-project", { project_root: setup.projectB });
+    expect(switchRes.status).toBe(200);
+    const switchBody = await switchRes.json() as any;
+    expect(switchBody.ok).toBe(true);
+    expect(switchBody.from).toBe(setup.projectA);
+    expect(switchBody.to).toBe(setup.projectB);
+    expect(switchBody.scope.projectRoot).toBe(setup.projectB);
+
+    // process.env + paths.js both moved, live, in this same process.
+    expect(process.env.NIRVANA_PROJECT_ROOT).toBe(setup.projectB);
+    expect(process.env.HARNESS_LOGS_DIR).toBe(path.join(setup.projectB, ".nirvana", "logs", "harness"));
+
+    // The audit event landed under the NEW project's own harness logs, not the old one
+    // (audit.js: <HARNESS_LOGS_DIR>/<YYYY-MM-DD, UTC>/audit.jsonl).
+    const todayUtc = new Date().toISOString().slice(0, 10);
+    const auditFile = path.join(setup.projectB, ".nirvana", "logs", "harness", todayUtc, "audit.jsonl");
+    expect(fs.existsSync(auditFile)).toBe(true);
+    const auditLines = fs.readFileSync(auditFile, "utf8").trim().split("\n");
+    expect(auditLines.some(l => l.includes("x_glance_project_switched"))).toBe(true);
+
+    // Already-fresh endpoint (getScope() has no cache of its own).
+    const scopeAfter = await (await get(server, "/api/scope")).json() as any;
+    expect(scopeAfter.projectRoot).toBe(setup.projectB);
+
+    // Previously-frozen endpoint #1 — the regression this file exists to catch.
+    const subsystemsAfter = await (await get(server, "/api/subsystems")).json() as any;
+    const kernelAfter = subsystemsAfter.subsystems.find((s: any) => s.key === "run-kernel");
+    expect(kernelAfter.source).toBe(path.join(setup.projectB, ".nirvana", "run-kernel.sqlite"));
+
+    // Previously-frozen endpoint #2.
+    const planAfter = await (await post(server, "/api/v1/projects/plan", {})).json() as any;
+    expect(planAfter.project_root).toBe(setup.projectB);
+  });
+
+  // Brief's explicit out-of-scope note, verified rather than assumed: squads/businesses/
+  // mind-clones stay global libraries by design — the switch must not special-case them —
+  // but a project's OWN local overrides (`.nirvana/squads` etc., NIRVANA_SCOPE=merge in that
+  // project's own `.env`) already pick up on a switch for free, because they run through the
+  // exact same resolveScope() call `getScope().projectRoot` does. No new code for this; this
+  // test only confirms the existing mechanism actually reaches the new root.
+  test("a project's own local scope override (.nirvana/squads, NIRVANA_SCOPE=merge) takes effect on switch — confirmed, not assumed", async () => {
+    const setup = fixture();
+    // Project A stays global (no .env, no local squads dir).
+    // Project B declares merge scope and a local squad — nothing project-switcher-specific;
+    // this is the pre-existing scope.ts mechanism.
+    fs.writeFileSync(path.join(setup.projectB, ".env"), "NIRVANA_SCOPE=merge\n", "utf8");
+    fs.mkdirSync(path.join(setup.projectB, ".nirvana", "squads", "test-squad-b"), { recursive: true });
+
+    const server = await start();
+    const scopeBefore = await (await get(server, "/api/scope")).json() as any;
+    expect(scopeBefore.mode).toBe("global");
+    expect(scopeBefore.squadDirs).not.toContain(path.join(setup.projectB, ".nirvana", "squads"));
+
+    await post(server, "/api/actions/switch-project", { project_root: setup.projectB });
+
+    const scopeAfter = await (await get(server, "/api/scope")).json() as any;
+    expect(scopeAfter.mode).toBe("merge");
+    expect(scopeAfter.squadDirs).toContain(path.join(setup.projectB, ".nirvana", "squads"));
+  });
+});
+
+describe("GET /api/known-projects", () => {
+  test("is available without --allow-actions (read-only discovery)", async () => {
+    fixture();
+    const server = await start({ allowActions: false });
+    const res = await get(server, "/api/known-projects");
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(Array.isArray(body.projects)).toBe(true);
+  });
+});
+
+describe("decodeClaudeProjectDirName", () => {
+  test("recovers a hyphenated leaf directory name (the case a blind replace(/-/g,'/') gets wrong)", () => {
+    const root = makeTempRoot("nrv-decode-");
+    roots.push(root);
+    fs.mkdirSync(path.join(root, "Users", "guto", "nirvana-os"), { recursive: true });
+    // Claude Code encoding of "<root>/Users/guto/nirvana-os": every "/" -> "-".
+    const encoded = "-Users-guto-nirvana-os";
+    expect(decodeClaudeProjectDirName(encoded, root)).toBe(path.join(root, "Users", "guto", "nirvana-os"));
+  });
+
+  test("prefers the longest real match, so a hyphenated name beats the wrong shorter split even when both exist", () => {
+    const root = makeTempRoot("nrv-decode-");
+    roots.push(root);
+    // Both "a/b-c" and "a/b" exist; the encoded name should resolve to the
+    // longer, correct one rather than stopping at the first match.
+    fs.mkdirSync(path.join(root, "a", "b"), { recursive: true });
+    fs.mkdirSync(path.join(root, "a", "b-c"), { recursive: true });
+    expect(decodeClaudeProjectDirName("-a-b-c", root)).toBe(path.join(root, "a", "b-c"));
+  });
+
+  test("degrades gracefully (returns null, not a throw) when no real path can be recovered", () => {
+    const root = makeTempRoot("nrv-decode-");
+    roots.push(root);
+    expect(decodeClaudeProjectDirName("-nothing-here-at-all", root)).toBeNull();
+  });
+});
+
+describe("discoverKnownProjects / validateProjectPath", () => {
+  test("lists only decoded entries that exist AND carry a .nirvana/ marker", () => {
+    const root = makeTempRoot("nrv-discover-");
+    roots.push(root);
+    const claudeProjects = path.join(root, "claude-projects");
+    fs.mkdirSync(claudeProjects, { recursive: true });
+
+    // A real Nirvana project — should be listed.
+    fs.mkdirSync(path.join(root, "Users", "guto", "nirvana-os", ".nirvana"), { recursive: true });
+    fs.mkdirSync(path.join(claudeProjects, "-Users-guto-nirvana-os"), { recursive: true });
+
+    // A real directory, but no .nirvana/ marker — must NOT be listed.
+    fs.mkdirSync(path.join(root, "Users", "guto", "not-a-project"), { recursive: true });
+    fs.mkdirSync(path.join(claudeProjects, "-Users-guto-not-a-project"), { recursive: true });
+
+    // An encoded name that doesn't decode to anything real — dropped, not an error.
+    fs.mkdirSync(path.join(claudeProjects, "-nothing-here-at-all"), { recursive: true });
+
+    const found = discoverKnownProjects(claudeProjects, root);
+    expect(found).toEqual([{ path: path.join(root, "Users", "guto", "nirvana-os"), name: "nirvana-os" }]);
+  });
+
+  test("validateProjectPath accepts a real .nirvana/-marked directory and rejects everything else", () => {
+    const root = makeTempRoot("nrv-validate-");
+    roots.push(root);
+    const good = path.join(root, "project");
+    fs.mkdirSync(path.join(good, ".nirvana"), { recursive: true });
+
+    expect(validateProjectPath(good)).toEqual({ ok: true, path: good });
+    expect(validateProjectPath(path.join(root, "missing"))).toEqual({ ok: false, error: expect.stringContaining("does not exist") } as any);
+    expect(validateProjectPath("")).toEqual({ ok: false, error: expect.stringContaining("required") } as any);
+
+    const noMarker = path.join(root, "bare");
+    fs.mkdirSync(noMarker, { recursive: true });
+    expect(validateProjectPath(noMarker)).toEqual({ ok: false, error: expect.stringContaining(".nirvana") } as any);
+  });
+});

--- a/skills/harness/tests/glance-project-switcher.test.ts
+++ b/skills/harness/tests/glance-project-switcher.test.ts
@@ -153,6 +153,15 @@ describe("POST /api/actions/switch-project", () => {
     // Previously-frozen endpoint #2.
     const planAfter = await (await post(server, "/api/v1/projects/plan", {})).json() as any;
     expect(planAfter.project_root).toBe(setup.projectB);
+
+    // Every OTHER paths.js key that resolves under <project>/.nirvana/ (registries, squad
+    // activation state) — not just the two logs dirs. An earlier version of this fix only
+    // called overridePath() for HARNESS_LOGS_DIR/MAESTRO_LOGS_DIR; scope.registries/scope.state
+    // silently kept pointing at project A until this was caught by live verification, reading
+    // /api/scope's own response back, not by re-reading the diff.
+    expect(scopeAfter.registries.squads).toBe(path.join(setup.projectB, ".nirvana", ".squads-registry.json"));
+    expect(scopeAfter.registries.businesses).toBe(path.join(setup.projectB, ".nirvana", ".businesses-registry.json"));
+    expect(scopeAfter.state.squads).toBe(path.join(setup.projectB, ".nirvana", "state", "squads"));
   });
 
   // Brief's explicit out-of-scope note, verified rather than assumed: squads/businesses/


### PR DESCRIPTION
## Summary
One `nrv glance` process was permanently bound to whatever directory it was launched from, with no indication anywhere in the UI of which project that even was. An owner running several different Nirvana projects had to kill and relaunch Glance from a different `cwd` just to look at a different project.

- Adds a project switcher to the topnav: an always-visible label showing the currently bound project (previously nothing), a dropdown of other Nirvana projects discovered on the machine, and a free-text path field.
- Discovery decodes Claude Code's own transcript-directory naming convention by walking the real filesystem and preferring the longest real match at each step — a blind `-` → `/` replace misreads a hyphenated name like `nirvana-os` as `nirvana/os`; this doesn't.
- Switching (`POST /api/actions/switch-project`, `--allow-actions`, loopback only — a served/`--host` instance stays pinned) rewrites `NIRVANA_PROJECT_ROOT` and overrides every `paths.js` key that resolves under a project's own `.nirvana/` (nine keys total: logs, registries, squad state, `state.db`, outputs).

## Verified independently before this PR
- An earlier version only overrode 2 of the 9 keys — found by switching for real via curl and reading `/api/scope`'s own `registries`/`state` fields back, not by re-reading the diff. Fixed and covered with a regression test.
- **Live in a real browser**: opened the dropdown (56 real projects found, hyphenated names decoded correctly), clicked `nirvana-os`, watched the topnav label update live with a toast confirmation and the scope panel reflect the new project — no restart.

## Test plan
- [x] New tests: `glance-project-switcher.test.ts` (11 tests, including the frozen-path regression)
- [x] Full suite green except the pre-existing, unrelated port-3737 collision from a live dev instance (confirmed identical against unmodified `main` via `git stash`)
- [x] `bun run check:quick` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk