### PR TITLE
fix: select runtime-compatible models for headless execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Runtime-compatible model fallback
+
+Headless execution no longer sends a known foreign model family from `execution.model` or a cascade hint to a native runtime. It warns and uses a compatible configured model or the runtime's own default, while preserving compatible explicit ids and custom-provider selections. The existing audit trail records requested/effective models and the fallback reason. Unknown model families remain delegated to the runtime; no provider model is prescribed by the engine.
+
 ### Less diagnostic noise in `nrv doctor`, `nrv update` and `nrv validate squad`
 
 A few checks in `nrv doctor`, the end of `nrv update`, and `nrv validate squad` were meant only for the owner's own release tooling, never for a regular install — but they ran unconditionally, so every user saw them and had no way to act on what they reported. Removed from user-facing output; the internal tooling that actually needs them moved to internal infrastructure that isn't part of this repository.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Fallback de modelo compatível com o runtime
+
+A execução headless não envia mais uma família de modelo sabidamente incompatível de `execution.model` ou de uma dica da cascata para um runtime nativo. Ela avisa e usa um modelo configurado compatível ou o padrão do próprio runtime, preservando ids explícitos compatíveis e seleções com provider customizado. A trilha de auditoria existente registra os modelos solicitado/efetivo e o motivo do fallback. Famílias desconhecidas continuam sob responsabilidade do runtime; o engine não prescreve modelo de fornecedor algum.
+
 ### Menos ruído de diagnóstico no `nrv doctor`, `nrv update` e `nrv validate squad`
 
 Algumas checagens no `nrv doctor`, no fim do `nrv update` e no `nrv validate squad` eram destinadas só à ferramentaria própria de release do dono, nunca a uma instalação comum — mas rodavam incondicionalmente, então todo usuário via e não tinha como agir sobre o que era reportado. Removidas da saída visível ao usuário; a ferramentaria interna que de fato precisa delas foi para uma infraestrutura interna que não faz parte deste repositório.

--- a/skills/_shared/CONFIGURATION.md
+++ b/skills/_shared/CONFIGURATION.md
@@ -448,6 +448,16 @@ isso é seguro (rejeita a mais, nunca a menos).
 
 ---
 
+## Seleção de modelo na execução headless
+
+`execution.model` (variável `NIRVANA_MODEL`) é um pin para os subprocessos. Um modelo explícito compatível de `LLM_CASCADE` tem precedência. Se a família conhecida não for compatível com o runtime ativo, o driver avisa e tenta o modelo configurado compatível; caso não exista, omite a opção de modelo para preservar o padrão do próprio runtime. `ANTHROPIC_MODEL` e `~/.claude/settings.json` só são herdados por Claude Code.
+
+O engine não fixa um modelo alternativo. As regras reconhecem famílias nativas, mas não bloqueiam famílias futuras desconhecidas. Runtimes multiprovider (`pi`, `opencode`, `kimi-cli`, `qwen-code`) e providers customizados do Codex mantêm o modelo solicitado. O Codex considera o provider explícito ou `model_provider` do perfil ativo/configuração em `CODEX_HOME/config.toml`; os providers nativos `openai` e `azure` não desativam a validação. Ids qualificados como `provider/model` e sufixos como `:high` são preservados. Disponibilidade real, credenciais, modelos customizados e o padrão local continuam sendo validados pelo CLI; se não houver modelo utilizável, o diagnóstico do runtime é mantido.
+
+Cada tentativa via cascata registra `x_runtime_model_selection` na trilha existente: runtime, modelo solicitado, modelo efetivo encaminhado (nulo significa padrão do CLI), fontes e motivo do fallback. Não são registrados prompts nem credenciais nesse evento. A estimativa de custo usa o modelo encaminhado, nunca o rejeitado; sem modelo conhecido, o custo permanece desconhecido, salvo quando o CLI informa o valor nativo.
+
+No OpenCode, ids sem `provider/model` geram aviso e usam o padrão local, pois o CLI exige o prefixo. Claude Code preserva modelos de outras famílias quando `ANTHROPIC_BASE_URL` no ambiente ou em `settings.json.env` aponta para endpoint customizado. Isso reconhece capacidade configurada, sem consultar catálogos remotos nem garantir disponibilidade do modelo.
+
 ## Referências
 
 - **README.md** — overview de _shared + sample usage

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -49,7 +49,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
-import { resolveSystemModel } from "./system-model.ts";
+import { resolveSystemModel, resolveSystemModelSelection, type RuntimeModelSelection } from "./system-model.ts";
 import { resolveSetting } from "./settings.ts";
 
 const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
@@ -1223,6 +1223,8 @@ export interface RunHeadlessResult {
   stderr: string;
   durationMs: number;
   error?: string;
+  /** Requested and effective model decision. Prompts and credentials are never included. */
+  modelSelection?: RuntimeModelSelection;
 }
 
 /** Conservative allowlist used only when the caller asks for safe mode
@@ -1374,7 +1376,7 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
   // Model: caller's explicit value > system model (what the user's session
   // runs) > CLI default. Without this, the child `claude -p` falls to the
   // default (sonnet) instead of inheriting the interactive session's fable/opus.
-  const ccModel = opts.model ?? resolveSystemModel("claude-code");
+  const ccModel = opts.model;
   if (ccModel) args.push("--model", ccModel);
 
   // Trust by default. EXPLICIT caller settings (allowedTools / permissionMode)
@@ -1484,7 +1486,7 @@ function runCodex(opts: RunHeadlessOpts): RunHeadlessResult {
     ? ["exec", "resume", opts.sessionId]
     : ["exec"];
   const args = [...base, "--json", "--skip-git-repo-check", "-C", opts.cwd, "-o", lastMsg];
-  const cxModel = opts.model ?? resolveSystemModel("codex");
+  const cxModel = opts.model;
   if (cxModel) args.push("--model", cxModel);
   if (opts.providerHint) args.push("--provider", opts.providerHint);
   // Trust by default; --safe (opts.yolo===false) → workspace-write sandbox.
@@ -1554,7 +1556,7 @@ function runGemini(opts: RunHeadlessOpts): RunHeadlessResult {
   const args = ["-p", "", "-o", "json", "--skip-trust"];
   if (opts.sessionId) args.push("-r", opts.sessionId);
   else args.push("--session-id", sid);
-  const gmModel = opts.model ?? resolveSystemModel("gemini-cli");
+  const gmModel = opts.model;
   if (gmModel) args.push("--model", gmModel);
   // Trust by default (--yolo); --safe (opts.yolo===false) → auto_edit.
   args.push("--approval-mode", opts.yolo === false ? "auto_edit" : "yolo");
@@ -1622,7 +1624,7 @@ function runAntigravity(opts: RunHeadlessOpts): RunHeadlessResult {
   const delivery = argvOrPromptFile(withPreamble(opts), (p) => ["-p", p]);
   const args = [...delivery.args, "--output-format", "json"];
   if (opts.sessionId) args.push("--continue");
-  const agyModel = opts.model ?? resolveSystemModel("antigravity-cli");
+  const agyModel = opts.model;
   if (agyModel) args.push("--model", agyModel);
   if (opts.yolo !== false) args.push("--dangerously-skip-permissions");
   for (const d of opts.addDirs ?? []) args.push("--add-dir", d);
@@ -1696,7 +1698,7 @@ function runKimi(opts: RunHeadlessOpts): RunHeadlessResult {
   const sid = opts.sessionId || randomUUID();
   const delivery = argvOrPromptFile(withPreamble(opts), (p) => ["-p", p]);
   const args = [...delivery.args, "--output-format", "stream-json"];
-  const kmModel = opts.model ?? resolveSystemModel("kimi-cli");
+  const kmModel = opts.model;
   if (kmModel) args.push("-m", kmModel);
 
   const spawnOpts = {
@@ -1791,7 +1793,7 @@ function runGrok(opts: RunHeadlessOpts): RunHeadlessResult {
   const buildArgs = (delivery: string[], withFormat: boolean): string[] => {
     const a = [...delivery, ...(withFormat ? ["--output-format", "json"] : []), "--cwd", opts.cwd];
     if (opts.yolo !== false) a.push("--always-approve");
-    const gkModel = opts.model ?? resolveSystemModel("grok-cli");
+    const gkModel = opts.model;
     if (gkModel) a.push("-m", gkModel);
     return a;
   };
@@ -1892,7 +1894,7 @@ function runPi(opts: RunHeadlessOpts): RunHeadlessResult {
   const sid = opts.sessionId || randomUUID();
   const flags: string[] = ["--session-id", sid];
   if (opts.appendSystemPrompt) flags.push("--append-system-prompt", opts.appendSystemPrompt);
-  const piModel = opts.model ?? resolveSystemModel("pi");
+  const piModel = opts.model;
   if (piModel) flags.push("--model", piModel);
   if (opts.providerHint) flags.push("--provider", opts.providerHint);
   flags.push(opts.yolo === false ? "--no-approve" : "--approve");
@@ -1982,7 +1984,7 @@ function runPi(opts: RunHeadlessOpts): RunHeadlessResult {
 function runQwen(opts: RunHeadlessOpts): RunHeadlessResult {
   const started = Date.now();
   const args = ["-p", ""];
-  const qwModel = opts.model ?? resolveSystemModel("qwen-code");
+  const qwModel = opts.model;
   if (qwModel) args.push("--model", qwModel);
   if (opts.yolo !== false) args.push("--approval-mode", "yolo");
 
@@ -2027,6 +2029,8 @@ function runQwen(opts: RunHeadlessOpts): RunHeadlessResult {
 function runOpencode(opts: RunHeadlessOpts): RunHeadlessResult {
   const started = Date.now();
   const delivery = argvOrPromptFile(withPreamble(opts), (p) => ["run", p]);
+  // https://opencode.ai/docs/cli/#run — model ids use provider/model form.
+  if (opts.model) delivery.args.push("--model", opts.model);
 
   let r!: SpawnSyncReturns<string>;
   try {
@@ -2063,6 +2067,9 @@ const BUDGET_CAPABLE: ReadonlySet<Runtime> = new Set<Runtime>(["claude-code"]);
 const _warnedUncappable = new Set<string>();
 
 export function runHeadless(opts: RunHeadlessOpts): RunHeadlessResult {
+  const modelSelection = resolveSystemModelSelection(opts.runtime, opts.model, opts.providerHint);
+  if (modelSelection.warning) console.error(`[driver] AVISO: ${modelSelection.warning}`);
+  opts = { ...opts, model: modelSelection.effectiveModel ?? undefined };
   // The operator's switch outranks the caller: with the bypass disabled every
   // runner takes its restricted path, the same one `--safe` selects.
   if (!headlessSkipPermissions() && opts.yolo !== false) opts = { ...opts, yolo: false };
@@ -2084,8 +2091,10 @@ export function runHeadless(opts: RunHeadlessOpts): RunHeadlessResult {
   }
   // Ledgered runs get the heartbeat sidecar + the 7-day wall-clock backstop;
   // unledgered calls are byte-for-byte the historical behavior.
-  if (opts.ledger?.runId) return runWithLedgerHeartbeat(opts, dispatchToRunner);
-  return dispatchToRunner(opts);
+  const result = opts.ledger?.runId
+    ? runWithLedgerHeartbeat(opts, dispatchToRunner)
+    : dispatchToRunner(opts);
+  return { ...result, modelSelection };
 }
 
 function dispatchToRunner(opts: RunHeadlessOpts): RunHeadlessResult {

--- a/skills/_shared/lib/system-model.ts
+++ b/skills/_shared/lib/system-model.ts
@@ -26,7 +26,7 @@ export function sanitizeModelId(raw: string | null | undefined): string {
   s = s.replace(/\x1b\[[0-9;]*m/g, "");     // real ANSI (ESC [ ... m)
   s = s.replace(/\[[0-9;]*m\]?/g, "");      // leaked fragment "[1m]" / "[22m"
   s = s.replace(/[^\x20-\x7e]/g, "").trim(); // drop non-printables
-  const m = s.match(/^[A-Za-z0-9][A-Za-z0-9._-]*/); // first valid id token
+  const m = s.match(/^[A-Za-z0-9][A-Za-z0-9._:/-]*/); // provider/id and runtime suffixes are valid tokens
   return m ? m[0] : "";
 }
 
@@ -43,23 +43,135 @@ export function toAlias(model: string): string {
   return fam ? fam[1] : model;
 }
 
-// Resolves the system model, ALWAYS as an alias when it is a Claude family.
+type ModelFamilyRule = {
+  family: string;
+  pattern: RegExp;
+  runtimes: ReadonlySet<string>;
+};
+
+// Recognize native model families, not a catalog of available model versions.
+// Unknown ids and configured custom providers remain owned by the child CLI.
+const MODEL_FAMILY_RULES: readonly ModelFamilyRule[] = [
+  { family: "anthropic", pattern: /^(?:claude-|opus(?:-|$)|sonnet(?:-|$)|haiku(?:-|$)|fable(?:-|$))/i, runtimes: new Set(["claude-code"]) },
+  { family: "openai", pattern: /^(?:gpt-|codex(?:-|$)|o[1-9](?:-|$))/i, runtimes: new Set(["codex"]) },
+  { family: "google", pattern: /^gemini(?:-|$)/i, runtimes: new Set(["gemini-cli", "antigravity-cli"]) },
+  { family: "xai", pattern: /^grok(?:-|$)/i, runtimes: new Set(["grok-cli"]) },
+  { family: "moonshot", pattern: /^(?:kimi(?:-|$)|moonshot(?:-|$)|k[23](?:[.-]|$))/i, runtimes: new Set(["kimi-cli"]) },
+  { family: "zhipu", pattern: /^(?:glm(?:-|$)|codegeex(?:-|$))/i, runtimes: new Set<string>() },
+  { family: "alibaba", pattern: /^qwen(?:-|$)/i, runtimes: new Set(["qwen-code"]) },
+];
+
+const MULTI_PROVIDER_RUNTIMES = new Set(["pi", "opencode", "kimi-cli", "qwen-code"]);
+
+// Codex can select an OpenAI-compatible provider in its own config without a
+// cascade @provider hint. Read only selection metadata; never copy credentials.
+function codexProvider(): string | undefined {
+  try {
+    const configPath = path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "config.toml");
+    // Bun's native TOML loader predates Bun.TOML; do not cache user settings.
+    delete require.cache[require.resolve(configPath)];
+    const config = require(configPath) as {
+      model_provider?: string; profile?: string; profiles?: Record<string, { model_provider?: string }>;
+    };
+    return (config.profile && config.profiles?.[config.profile]?.model_provider) || config.model_provider;
+  } catch { return undefined; }
+}
+
+function claudeHasCustomEndpoint(): boolean {
+  try {
+    let endpoint = process.env.ANTHROPIC_BASE_URL;
+    if (!endpoint) {
+      const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+      endpoint = JSON.parse(fs.readFileSync(path.join(configDir, "settings.json"), "utf8")).env?.ANTHROPIC_BASE_URL;
+    }
+    return !!endpoint && new URL(endpoint).hostname !== "api.anthropic.com";
+  } catch { return false; }
+}
+
+export interface RuntimeModelSelection {
+  runtime: string | null;
+  requestedModel: string | null;
+  effectiveModel: string | null;
+  source: "explicit" | "setting" | "anthropic-env" | "claude-settings" | "runtime-default";
+  effectiveSource: RuntimeModelSelection["source"];
+  /** Whether the requested model itself fits the runtime, before fallback. */
+  compatible: boolean;
+  fallback: boolean;
+  reason: "compatible" | "runtime_default" | "incompatible_model_family" | "incompatible_model_format";
+  family: string | null;
+  warning: string | null;
+}
+
+export function selectRuntimeModel(
+  runtime: string | undefined,
+  requestedModel: string | null | undefined,
+  source: RuntimeModelSelection["source"] = "explicit",
+  providerHint?: string,
+): RuntimeModelSelection {
+  const requested = sanitizeModelId(requestedModel);
+  const normalized = source !== "explicit" && (!runtime || runtime === "claude-code") ? toAlias(requested) : requested;
+  const modelName = normalized.split("/").at(-1)!;
+  const rule = MODEL_FAMILY_RULES.find(candidate => candidate.pattern.test(modelName));
+  const customCodexProvider = runtime === "codex" && !!providerHint && !["openai", "azure"].includes(providerHint.toLowerCase());
+  const compatible = !runtime || !rule || MULTI_PROVIDER_RUNTIMES.has(runtime)
+    || customCodexProvider || (runtime === "claude-code" && claudeHasCustomEndpoint()) || rule.runtimes.has(runtime);
+  if (!normalized) {
+    return { runtime: runtime ?? null, requestedModel: null, effectiveModel: null, source: "runtime-default", effectiveSource: "runtime-default",
+      compatible: true, fallback: false, reason: "runtime_default", family: null, warning: null };
+  }
+  if (runtime === "opencode" && !/^[^/]+\/.+/.test(normalized)) {
+    return { runtime, requestedModel: requested, effectiveModel: null, source, effectiveSource: "runtime-default",
+      compatible: false, fallback: true, reason: "incompatible_model_format", family: rule?.family ?? null,
+      // i18n-user-facing: OpenCode requires a provider-qualified id, never guess a provider.
+      warning: `Modelo '${requested}' sem formato provider/model exigido pelo OpenCode; usando o modelo padrão do runtime.` };
+  }
+  if (compatible) {
+    return { runtime: runtime ?? null, requestedModel: requested, effectiveModel: normalized, source, effectiveSource: source,
+      compatible: true, fallback: false, reason: "compatible", family: rule?.family ?? null, warning: null };
+  }
+  // i18n-user-facing: model compatibility warnings use the default PT-BR locale.
+  const warning = `Modelo '${requested}' da família ${rule!.family} incompatível com o runtime '${runtime}'; usando o modelo padrão do runtime.`;
+  return { runtime: runtime ?? null, requestedModel: requested, effectiveModel: null, source, effectiveSource: "runtime-default",
+    compatible: false, fallback: true, reason: "incompatible_model_family", family: rule!.family, warning };
+}
+
+// Resolves the system model. Inherited Claude settings retain their historical
+// alias normalization; explicit ids and other runtimes keep their full ids.
 // Priority:
 //   1. the `execution.model` setting — env NIRVANA_MODEL, else the project or
 //      global config (_shared/lib/settings.ts): the explicit pin for Nirvana spawns
-//   2. ANTHROPIC_MODEL — standard env some setups use
+//   2. ANTHROPIC_MODEL — only for Claude Code
 //   3. ~/.claude/settings.json "model" — the model the user set via /model
 // settings.json belongs to Claude Code; only valid for claude-code children.
-// Returns null when nothing resolves (the CLI decides — behavior unchanged).
-export function resolveSystemModel(runtime?: string): string | null {
-  const fromEnv = sanitizeModelId(resolveSetting("execution.model").value) || sanitizeModelId(process.env.ANTHROPIC_MODEL);
-  if (fromEnv) return toAlias(fromEnv);
-  if (runtime && runtime !== "claude-code") return null;
+// Incompatible pins fall back to the active runtime's configured/default model.
+// A null effective model means the CLI decides, never a prescribed engine model.
+export function resolveSystemModelSelection(runtime?: string, explicitModel?: string | null, providerHint?: string): RuntimeModelSelection {
+  if (runtime === "codex" && !providerHint) providerHint = codexProvider();
+  if (explicitModel !== undefined) {
+    const selection = selectRuntimeModel(runtime, explicitModel, "explicit", providerHint);
+    if (!selection.fallback) return selection;
+    const configured = resolveSystemModelSelection(runtime, undefined, providerHint);
+    if (configured.effectiveModel) {
+      return { ...selection, effectiveModel: configured.effectiveModel, effectiveSource: configured.effectiveSource,
+        // i18n-user-facing: explain the configured fallback without hiding the requested model.
+        warning: `Modelo '${selection.requestedModel}' incompatível com o runtime '${runtime}'; usando o modelo configurado '${configured.effectiveModel}'.` };
+    }
+    return selection;
+  }
+  const configured = sanitizeModelId(resolveSetting("execution.model").value);
+  if (configured) return selectRuntimeModel(runtime, configured, "setting", providerHint);
+  if (runtime && runtime !== "claude-code") return selectRuntimeModel(runtime, null, "runtime-default");
+  const anthropicModel = sanitizeModelId(process.env.ANTHROPIC_MODEL);
+  if (anthropicModel) return selectRuntimeModel(runtime, anthropicModel, "anthropic-env");
   try {
     const cfg = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
     const j = JSON.parse(fs.readFileSync(path.join(cfg, "settings.json"), "utf8"));
     const m = sanitizeModelId(j.model);
-    if (m) return toAlias(m);
+    if (m) return selectRuntimeModel(runtime, m, "claude-settings");
   } catch { /* no settings / unreadable — no system model */ }
-  return null;
+  return selectRuntimeModel(runtime, null, "runtime-default");
+}
+
+export function resolveSystemModel(runtime?: string): string | null {
+  return resolveSystemModelSelection(runtime).effectiveModel;
 }

--- a/skills/harness/lib/cascade-runner.ts
+++ b/skills/harness/lib/cascade-runner.ts
@@ -36,6 +36,26 @@ function emitAudit(payload: Record<string, any>, projectRoot: string): void {
   } catch { /* non-fatal */ }
 }
 
+function runSelected(opts: RunHeadlessOpts, args: Pick<CascadeRunArgs, "projectRoot" | "projectId">): RunHeadlessResult {
+  const result = runHeadless(opts);
+  const selection = result.modelSelection;
+  if (selection) {
+    emitAudit({
+      event: "x_runtime_model_selection",
+      project_id: args.projectId ?? null,
+      runtime: opts.runtime,
+      requested_model: selection.requestedModel,
+      effective_model: selection.effectiveModel,
+      model_source: selection.source,
+      effective_model_source: selection.effectiveSource,
+      requested_family: selection.family,
+      fallback_reason: selection.fallback ? selection.reason : null,
+      warning: selection.warning,
+    }, args.projectRoot);
+  }
+  return result;
+}
+
 export interface CascadeRunArgs extends RunHeadlessOpts {
   /** The user's brief — needed to rebuild the handoff prompt for the next runtime. */
   brief: string;
@@ -74,7 +94,7 @@ export function runWithCascade(args: CascadeRunArgs): CascadeRunResult {
 
   // No cascade configured → behave like plain runHeadless.
   if (!cascade.length) {
-    const r = runHeadless(args);
+    const r = runSelected(args, args);
     return { ...r, handoffs: [], finalRuntime: args.runtime };
   }
 
@@ -93,7 +113,7 @@ export function runWithCascade(args: CascadeRunArgs): CascadeRunResult {
       event: "cascade_no_entry_available", project_id: args.projectId ?? null,
       cascade_explained: explainCascade(args.projectRoot, cascade),
     }, args.projectRoot);
-    return { ...runHeadless(args), handoffs, finalRuntime: args.runtime };
+    return { ...runSelected(args, args), handoffs, finalRuntime: args.runtime };
   }
   if (currentEntry.runtime !== args.runtime) {
     // Diagnose WHY the requested runtime was skipped — budget? cooldown? not in cascade?
@@ -159,12 +179,12 @@ export function runWithCascade(args: CascadeRunArgs): CascadeRunResult {
       continue;
     }
 
-    const r = runHeadless(currentOpts);
+    const r = runSelected(currentOpts, args);
     const verdict = classify(chosen, r);
 
     if (verdict.kind === "ok") {
       // Estimate spend and accumulate. Null cost = unknown → no enforcement.
-      const cost = estimateCostUsd(chosen, chosenModel, r);
+      const cost = estimateCostUsd(chosen, r.modelSelection?.effectiveModel ?? null, r);
       if (cost != null) {
         const key = entryKey(currentEntry!);
         addSpend(args.projectRoot, key, cost);

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -68,6 +68,10 @@ beforeAll(() => {
     const len = await stdinLen();
     const oi = argv.indexOf("-o");
     const out = oi >= 0 ? argv[oi + 1] : "";
+    if (process.env.FAKE_MODE === "no-model") {
+      console.log(JSON.stringify({ type: "turn.failed", error: { message: "No compatible default model is configured for this runtime." } }));
+      process.exit(1);
+    }
     if (process.env.FAKE_MODE === "error") {
       console.log(JSON.stringify({ type: "error", message: "upstream 500" }));
       process.exit(0);
@@ -203,6 +207,110 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
     expect(r.costUsd).toBeNull();
     expect(r.costUnavailable).toBe(true);
     assertArgvSafe("codex");
+  }, spawnBudgetMs(2));
+
+  test("codex does not receive a Claude-only configured model", () => {
+    const before = process.env.NIRVANA_MODEL;
+    process.env.NIRVANA_MODEL = "fable-5";
+    try {
+      const r = run("codex");
+      expect(r.ok).toBe(true);
+      expect(r.modelSelection).toMatchObject({
+        requestedModel: "fable-5",
+        effectiveModel: null,
+        fallback: true,
+        reason: "incompatible_model_family",
+      });
+      const args = capturedArgs("codex");
+      expect(args).not.toContain("--model");
+      expect(args).not.toContain("fable-5");
+    } finally {
+      if (before === undefined) delete process.env.NIRVANA_MODEL;
+      else process.env.NIRVANA_MODEL = before;
+    }
+  }, spawnBudgetMs(2));
+
+  test("compatible explicit runtime models are preserved", () => {
+    const codex = runHeadless({ runtime: "codex", model: "gpt-5.5", prompt: "hi", cwd: TMP, yolo: true, timeoutMs: 20_000 });
+    expect(codex.ok).toBe(true);
+    const codexArgs = capturedArgs("codex");
+    expect(codexArgs[codexArgs.indexOf("--model") + 1]).toBe("gpt-5.5");
+
+    const claude = runHeadless({ runtime: "claude-code", model: "fable-5", prompt: "hi", cwd: TMP, yolo: true, timeoutMs: 20_000 });
+    expect(claude.ok).toBe(true);
+    const claudeArgs = capturedArgs("claude");
+    expect(claudeArgs[claudeArgs.indexOf("--model") + 1]).toBe("fable-5");
+
+    const providerModel = runHeadless({ runtime: "codex", model: "glm-4.7", providerHint: "custom-provider", prompt: "hi", cwd: TMP, yolo: true, timeoutMs: 20_000 });
+    expect(providerModel.ok).toBe(true);
+    const providerArgs = capturedArgs("codex");
+    expect(providerArgs[providerArgs.indexOf("--provider") + 1]).toBe("custom-provider");
+    expect(providerArgs[providerArgs.indexOf("--model") + 1]).toBe("glm-4.7");
+  }, spawnBudgetMs(4));
+
+  test("OpenCode forwards the effective qualified model recorded in its selection", () => {
+    const result = runHeadless({ runtime: "opencode", model: "anthropic/claude-sonnet-4-6", prompt: "hi", cwd: TMP, timeoutMs: 20_000 });
+    expect(result.ok).toBe(true);
+    const args = capturedArgs("opencode");
+    expect(args[args.indexOf("--model") + 1]).toBe(result.modelSelection?.effectiveModel!);
+  }, spawnBudgetMs(2));
+
+  test("OpenCode keeps its local default when an inherited model lacks a provider", () => {
+    const before = process.env.NIRVANA_MODEL;
+    process.env.NIRVANA_MODEL = "gpt-5.5";
+    try {
+      const result = runHeadless({ runtime: "opencode", prompt: "hi", cwd: TMP, timeoutMs: 20_000 });
+      expect(result.ok).toBe(true);
+      expect(result.modelSelection?.effectiveModel).toBeNull();
+      expect(result.modelSelection?.warning).toContain("provider/model");
+      expect(capturedArgs("opencode")).not.toContain("--model");
+    } finally {
+      if (before === undefined) delete process.env.NIRVANA_MODEL; else process.env.NIRVANA_MODEL = before;
+    }
+  }, spawnBudgetMs(2));
+
+  test("a rejected model is not re-resolved with a different configured provider", () => {
+    const before = { CODEX_HOME: process.env.CODEX_HOME, NIRVANA_MODEL: process.env.NIRVANA_MODEL };
+    const configDir = fs.mkdtempSync(path.join(TMP, "codex-provider-"));
+    fs.writeFileSync(path.join(configDir, "config.toml"), 'model_provider = "custom"\n');
+    process.env.CODEX_HOME = configDir;
+    process.env.NIRVANA_MODEL = "fable-5";
+    try {
+      const result = runHeadless({ runtime: "codex", providerHint: "openai", prompt: "hi", cwd: TMP, timeoutMs: 20_000 });
+      expect(result.modelSelection?.effectiveModel).toBeNull();
+      expect(capturedArgs("codex")).not.toContain("--model");
+    } finally {
+      for (const [key, value] of Object.entries(before)) {
+        if (value === undefined) delete process.env[key]; else process.env[key] = value;
+      }
+    }
+  }, spawnBudgetMs(2));
+
+  test("an incompatible explicit model uses a compatible configured fallback", () => {
+    const before = process.env.NIRVANA_MODEL;
+    process.env.NIRVANA_MODEL = "gpt-5.5";
+    try {
+      const result = runHeadless({ runtime: "codex", model: "fable-5", prompt: "hi", cwd: TMP, timeoutMs: 20_000 });
+      expect(result.ok).toBe(true);
+      expect(result.modelSelection).toMatchObject({ requestedModel: "fable-5", effectiveModel: "gpt-5.5", fallback: true });
+      const args = capturedArgs("codex");
+      expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.5");
+    } finally {
+      if (before === undefined) delete process.env.NIRVANA_MODEL;
+      else process.env.NIRVANA_MODEL = before;
+    }
+  }, spawnBudgetMs(2));
+
+  test("a runtime with no compatible default still reports its precise failure", () => {
+    process.env.FAKE_MODE = "no-model";
+    try {
+      const result = runHeadless({ runtime: "codex", model: "fable-5", prompt: "hi", cwd: TMP, timeoutMs: 20_000 });
+      expect(result.ok).toBe(false);
+      expect(result.modelSelection?.fallback).toBe(true);
+      expect(result.error).toBe("No compatible default model is configured for this runtime.");
+    } finally {
+      delete process.env.FAKE_MODE;
+    }
   }, spawnBudgetMs(2));
 
   test("gemini-cli: STDIN via -p ''; costUnavailable", () => {

--- a/skills/harness/tests/runtime-failover.test.ts
+++ b/skills/harness/tests/runtime-failover.test.ts
@@ -87,11 +87,13 @@ describe("cascade — a dead runtime hands off instead of ending the run", () =>
   const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-failover-test-"));
   const BIN = path.join(TMP, "bin");
   const PROJ = path.join(TMP, "project");
+  const MODEL_PROJ = path.join(TMP, "model-project");
   const ENV_BEFORE = { PATH: process.env.PATH, HARNESS_LOGS_DIR: process.env.HARNESS_LOGS_DIR };
 
   beforeAll(() => {
     fs.mkdirSync(BIN, { recursive: true });
     fs.mkdirSync(path.join(PROJ, "outputs"), { recursive: true });
+    fs.mkdirSync(path.join(MODEL_PROJ, "outputs"), { recursive: true });
     // `gemini` reproduces the retired tier: the real stderr, exit 1. On Windows
     // these land as `.cmd` launchers — the same shape npm installs a real agent
     // CLI as — so the driver's own .cmd handling is exercised, not assumed.
@@ -106,7 +108,17 @@ describe("cascade — a dead runtime hands off instead of ending the run", () =>
       console.log(JSON.stringify({ response: "guide written" }));
       process.exit(0);
     `);
+    writeFakeCli(BIN, "codex", `
+      import * as fs from "node:fs";
+      try { await Bun.stdin.text(); } catch {}
+      const argv = Bun.argv.slice(2);
+      const out = argv[argv.indexOf("-o") + 1];
+      if (out) fs.writeFileSync(out, "completed with runtime default");
+      console.log(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1, output_tokens: 1 } }));
+      process.exit(0);
+    `);
     fs.writeFileSync(path.join(PROJ, ".env"), "LLM_CASCADE=gemini-cli,antigravity-cli\n");
+    fs.writeFileSync(path.join(MODEL_PROJ, ".env"), "LLM_CASCADE=codex:haiku\n");
     process.env.PATH = `${BIN}${path.delimiter}${process.env.PATH}`;
     process.env.HARNESS_LOGS_DIR = path.join(TMP, "logs");
   });
@@ -172,5 +184,31 @@ describe("cascade — a dead runtime hands off instead of ending the run", () =>
     expect(auth.runtime).toBe("gemini-cli");
     expect(auth.hint).toContain("antigravity-cli");
     expect(events.some(e => e.event === "runtime_handoff" && e.to === "antigravity-cli")).toBe(true);
+  });
+
+  test("an incompatible model fallback records requested and effective selection", () => {
+    const res = runWithCascade({
+      runtime: "codex",
+      prompt: "write the artifact",
+      brief: "write the artifact",
+      cwd: MODEL_PROJ,
+      projectRoot: MODEL_PROJ,
+      outputsRoot: path.join(MODEL_PROJ, "outputs"),
+      projectId: "runtime-model-fallback-test",
+    });
+
+    expect(res.ok).toBe(true);
+    const dir = path.join(TMP, "logs", new Date().toISOString().slice(0, 10));
+    const events = fs.readFileSync(path.join(dir, "audit.jsonl"), "utf8")
+      .split("\n").filter(Boolean).map(l => parseAuditLine(l));
+    expect(events).toContainEqual(expect.objectContaining({
+      event: "x_runtime_model_selection",
+      project_id: "runtime-model-fallback-test",
+      runtime: "codex",
+      requested_model: "haiku",
+      effective_model: null,
+      fallback_reason: "incompatible_model_family",
+    }));
+    expect(events.some(e => e.event === "dispatch_cost_recorded" && e.project_id === "runtime-model-fallback-test")).toBe(false);
   });
 });

--- a/skills/harness/tests/settings-readers.test.ts
+++ b/skills/harness/tests/settings-readers.test.ts
@@ -113,14 +113,16 @@ describe("each reader: global, project over global, variable over both", () => {
     expect(headlessSkipPermissions()).toBe(false);
   });
 
-  test("execution.model (system-model.ts), always as the family alias", () => {
+  test("execution.model (system-model.ts), aliases compatible models and rejects cross-runtime families", () => {
     expect(resolveSystemModel("claude-code")).toBeNull();
     globalConfig("execution:\n  model: claude-opus-4-7\n");
     expect(resolveSystemModel("claude-code")).toBe("opus");
     projectConfig('execution:\n  model: "sonnet"\n');
-    expect(resolveSystemModel("codex")).toBe("sonnet");
+    expect(resolveSystemModel("codex")).toBeNull();
     process.env.NIRVANA_MODEL = "haiku";
-    expect(resolveSystemModel("codex")).toBe("haiku");
+    expect(resolveSystemModel("codex")).toBeNull();
+    process.env.NIRVANA_MODEL = "gpt-5.5";
+    expect(resolveSystemModel("codex")).toBe("gpt-5.5");
   });
 
   test("updates.check (update-check.ts): global only, the opt-out variable wins", () => {

--- a/skills/harness/tests/system-model.test.ts
+++ b/skills/harness/tests/system-model.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sanitizeModelId, resolveSystemModel, toAlias } from "../../_shared/lib/system-model.ts";
+import { sanitizeModelId, resolveSystemModel, selectRuntimeModel, toAlias } from "../../_shared/lib/system-model.ts";
 
 describe("toAlias (sempre o alias para família Claude)", () => {
   test("ids completos → alias", () => {
@@ -34,10 +34,36 @@ describe("sanitizeModelId", () => {
     expect(sanitizeModelId("opus")).toBe("opus");
     expect(sanitizeModelId("gpt-5.3-codex")).toBe("gpt-5.3-codex");
   });
+  test("provider-qualified ids and runtime model suffixes stay intact", () => {
+    expect(sanitizeModelId("openrouter/z-ai/glm-4.7")).toBe("openrouter/z-ai/glm-4.7");
+    expect(sanitizeModelId("provider/model:high")).toBe("provider/model:high");
+  });
   test("vazio/nulo → string vazia", () => {
     expect(sanitizeModelId("")).toBe("");
     expect(sanitizeModelId(null)).toBe("");
     expect(sanitizeModelId(undefined)).toBe("");
+  });
+});
+
+describe("explicit runtime model selections", () => {
+  test("native provider hints do not bypass known family mismatches", () => {
+    expect(selectRuntimeModel("codex", "fable-5", "explicit", "openai").fallback).toBe(true);
+  });
+  test("qualified models still receive family validation", () => {
+    expect(selectRuntimeModel("codex", "anthropic/claude-sonnet-4-6").fallback).toBe(true);
+  });
+  test("OpenCode does not replace its local default with an unqualified model", () => {
+    expect(selectRuntimeModel("opencode", "fable-5", "setting")).toMatchObject({
+      effectiveModel: null, fallback: true, reason: "incompatible_model_format",
+    });
+  });
+  test("configured multi-provider runtimes accept non-native families", () => {
+    expect(selectRuntimeModel("kimi-cli", "gpt-5.5").effectiveModel).toBe("gpt-5.5");
+  });
+  test("keeps compatible full ids and multi-provider model families unchanged", () => {
+    expect(selectRuntimeModel("claude-code", "claude-opus-4-7").effectiveModel).toBe("claude-opus-4-7");
+    expect(selectRuntimeModel("pi", "claude-opus-4-7").effectiveModel).toBe("claude-opus-4-7");
+    expect(selectRuntimeModel("pi", "glm-4.7").effectiveModel).toBe("glm-4.7");
   });
 });
 
@@ -47,8 +73,38 @@ describe("resolveSystemModel", () => {
     delete process.env.NIRVANA_MODEL;
     delete process.env.ANTHROPIC_MODEL;
     delete process.env.CLAUDE_CONFIG_DIR;
+    process.env.CODEX_HOME = mkdtempSync(join(tmpdir(), "codex-model-"));
   });
   afterEach(() => { process.env = { ...saved }; });
+
+  test("a configured custom Codex provider keeps its model without a provider hint", () => {
+    writeFileSync(join(process.env.CODEX_HOME!, "config.toml"), 'model_provider = "custom"\n[model_providers.custom]\nbase_url = "https://example.invalid/v1"\n');
+    process.env.NIRVANA_MODEL = "glm-4.7";
+    expect(resolveSystemModel("codex")).toBe("glm-4.7");
+  });
+
+  test("Codex provider config works without the newer TOML API and refreshes changes", () => {
+    const savedToml = Bun.TOML;
+    const configPath = join(process.env.CODEX_HOME!, "config.toml");
+    process.env.NIRVANA_MODEL = "glm-4.7";
+    try {
+      Object.assign(Bun, { TOML: undefined });
+      writeFileSync(configPath, 'model_provider = "custom"\n');
+      expect(resolveSystemModel("codex")).toBe("glm-4.7");
+      writeFileSync(configPath, 'model_provider = "openai"\n');
+      expect(resolveSystemModel("codex")).toBeNull();
+    } finally { Object.assign(Bun, { TOML: savedToml }); }
+  });
+
+  test("Claude custom endpoints preserve an explicit non-native model", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://router.huggingface.co";
+    expect(selectRuntimeModel("claude-code", "zai-org/GLM-5.1").effectiveModel).toBe("zai-org/GLM-5.1");
+    delete process.env.ANTHROPIC_BASE_URL;
+    const cfg = mkdtempSync(join(tmpdir(), "claude-provider-"));
+    process.env.CLAUDE_CONFIG_DIR = cfg;
+    writeFileSync(join(cfg, "settings.json"), JSON.stringify({ env: { ANTHROPIC_BASE_URL: "https://router.huggingface.co" } }));
+    expect(selectRuntimeModel("claude-code", "zai-org/GLM-5.1").effectiveModel).toBe("zai-org/GLM-5.1");
+  });
 
   test("NIRVANA_MODEL tem prioridade máxima (aliasado)", () => {
     process.env.NIRVANA_MODEL = "claude-opus-4-8";
@@ -79,9 +135,28 @@ describe("resolveSystemModel", () => {
     expect(resolveSystemModel("codex")).toBeNull();
     expect(resolveSystemModel("gemini-cli")).toBeNull();
   });
-  test("mas NIRVANA_MODEL vale para qualquer runtime", () => {
-    process.env.NIRVANA_MODEL = "opus";
-    expect(resolveSystemModel("codex")).toBe("opus");
+  test("a model configured for Claude falls back to the active Codex default", () => {
+    process.env.NIRVANA_MODEL = "fable-5";
+    expect(resolveSystemModel("codex")).toBeNull();
+  });
+  test("compatible configured models stay attached to their active runtime", () => {
+    const cases = [
+      ["codex", "gpt-5.5"],
+      ["gemini-cli", "gemini-3-pro"],
+      ["grok-cli", "grok-4"],
+      ["kimi-cli", "kimi-k2.5"],
+      ["qwen-code", "qwen3-coder"],
+    ] as const;
+    for (const [runtime, model] of cases) {
+      process.env.NIRVANA_MODEL = model;
+      expect(resolveSystemModel(runtime)).toBe(model);
+    }
+  });
+  test("known cross-provider models fall back without blocking unknown future families", () => {
+    process.env.NIRVANA_MODEL = "glm-4.7";
+    expect(resolveSystemModel("codex")).toBeNull();
+    process.env.NIRVANA_MODEL = "future-provider-model-v1";
+    expect(resolveSystemModel("codex")).toBe("future-provider-model-v1");
   });
   test("sem env e sem settings → null (não força model, comportamento inalterado)", () => {
     const cfg = mkdtempSync(join(tmpdir(), "cc-empty-"));


### PR DESCRIPTION
## What this changes

Corrige a propagação de modelos Claude para subprocessos de outros runtimes, como Codex recebendo `fable-5`. A seleção agora preserva modelos compatíveis, avisa sobre incompatibilidades e usa uma configuração compatível ou o padrão do próprio CLI, sem fixar um modelo alternativo no engine.

- Restringe `ANTHROPIC_MODEL` e as configurações Claude ao runtime apropriado.
- Reconhece famílias conhecidas sem bloquear ids futuros, providers customizados do Codex, endpoints customizados de Claude e runtimes multiprovider.
- Preserva ids qualificados e exige `provider/model` no OpenCode antes de encaminhar `--model`.
- Registra pedido, modelo encaminhado e motivo do fallback na auditoria existente; estima custo pelo modelo encaminhado, nunca pelo rejeitado.
- Usa o loader TOML nativo do Bun sem elevar a versão mínima ou adicionar dependências.

## How it was tested

Windows, Bun 1.4.0. Regressões reproduzidas em RED antes das correções; revisão independente final aprovada.

- `bun test skills/harness/tests/system-model.test.ts skills/harness/tests/settings-readers.test.ts skills/harness/tests/driver-adapters.test.ts skills/harness/tests/runtime-failover.test.ts --timeout 30000`: **79 pass, 0 fail, 300 expectativas**, saída 0.
- `bun run check:quick`: aprovado, saída 0.
- `git diff --check`: aprovado, saída 0.
- `bun run test:fast`: interrompido, saída 1, após degradação do host, `SQLITE_IOERR_TRUNCATE` e timeout de 60s em doctor-clones-staleness.
- `bun run test:harness`: interrompido, saída 1, após quatro timeouts de 15–20s em doctor-vestigial-triggers. A suíte da área ficou incompleta; não foi comprovado que essas falhas são preexistentes.
- `bun run check:all`: saída 1 em check-not-for-fires, `No ceiling recorded`. Nenhuma baseline foi criada para contornar o resultado.

Não se declara aprovação da suíte completa. Não houve execução paga com provedores reais. Disponibilidade, credenciais e existência do modelo continuam sendo responsabilidade do CLI; modelo efetivo nulo significa padrão local desconhecido, não um modelo presumido. A seleção é auditada após o retorno do subprocesso; uma interrupção abrupta pode impedir esse evento.

## Checklist

- [ ] `bun test skills/harness/tests` passes (execução interrompida; detalhes acima)
- [x] No hardcoded model names (the engine never prescribes a model — it inherits the runtime's)
- [x] No paid pack content, secrets, or `.env` values added to the engine
- [ ] **I have read and agree to the Nirvana-OS CLA** ([CLA.md](../CLA.md))

Nenhuma nova assinatura, aceite ou sign-off foi feito automaticamente. O check CLA existente passou no snapshot inicial do CI; o checkbox permanece sem aceite automático. O template menciona v1, enquanto o arquivo vigente é v2.