### PR TITLE
fix(outputs): stop creating directories nothing ever writes to

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ When you (the LLM) read this file, you are the **orchestrator**, not the executo
 Your output is **dispatches**, never artifacts. You:
 
 - ✅ Read the brief, refine and clarify it, pick targets via the dispatch cascade, dispatch them, verify.
-- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `.nirvana/outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
+- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
 - ❌ Never write the deliverable yourself: no code, no prose, no HTML, no markdown content, no images, no PDFs.
 - ❌ Never create files in the `output_path` / `outputs_root` of the brief — that path belongs to the dispatched agent.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### No more empty directories under `outputs/`
+
+Every brief used to pre-create directories on the chance something would land in them. `brief-business.ts` made `handoffs/`, `tickets/` and `employees/`; `brief-squad.ts` made `handoffs/`. Most runs write to none of them, so each brief left empty folders behind: 13 of the 15 empties measured in one real project came from here. `tickets/` was the worst of them, because the protocol retired it and `nrv validate` rejects a business that ships one, while the brief script created it on every single run. Each script now creates only the directory it actually writes into.
+
+A second and larger source is fixed with it. The outputs root moved from `<project>/.nirvana/outputs` to `<project>/outputs` in 0.3.3, and the contract files never followed. For three weeks the orchestrator read `.nirvana/outputs/` from its own instructions and built a mirror tree there while every script wrote to `outputs/`. In one project that mirror held five files, all of them `.DS_Store`, beside a real tree of 6,101 files and 265 MB. The five contract copies and the template `nrv init` writes into new projects now name the real root.
+
+Output trees written before 0.3.3 are untouched, and the compatibility fallbacks that read them stay in place.
+
 ### Less diagnostic noise in `nrv doctor`, `nrv update` and `nrv validate squad`
 
 A few checks in `nrv doctor`, the end of `nrv update`, and `nrv validate squad` were meant only for the owner's own release tooling, never for a regular install — but they ran unconditionally, so every user saw them and had no way to act on what they reported. Removed from user-facing output; the internal tooling that actually needs them moved to internal infrastructure that isn't part of this repository.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,14 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Chega de diretórios vazios em `outputs/`
+
+Todo brief criava diretórios de antemão, na hipótese de algo vir a cair neles. O `brief-business.ts` criava `handoffs/`, `tickets/` e `employees/`; o `brief-squad.ts` criava `handoffs/`. A maioria das runs não escreve em nenhum, então cada brief deixava pastas vazias para trás: 13 dos 15 vazios medidos num projeto real vinham daqui. O `tickets/` era o pior deles, porque o protocolo o aposentou e o `nrv validate` reprova uma empresa que traga um, enquanto o script de brief o criava em toda run. Agora cada script cria apenas o diretório em que de fato escreve.
+
+Junto com isso, some uma segunda fonte, maior. A raiz de output mudou de `<projeto>/.nirvana/outputs` para `<projeto>/outputs` na 0.3.3, e os arquivos de contrato não acompanharam. Por três semanas o orquestrador leu `.nirvana/outputs/` das próprias instruções e montou uma árvore espelho ali, enquanto todos os scripts escreviam em `outputs/`. Num projeto esse espelho guardava cinco arquivos, todos `.DS_Store`, ao lado de uma árvore real de 6.101 arquivos e 265 MB. As cinco cópias do contrato e o template que o `nrv init` escreve em projetos novos agora apontam para a raiz real.
+
+Árvores de output escritas antes da 0.3.3 ficam intactas, e os fallbacks de compatibilidade que as leem continuam no lugar.
+
 ### Menos ruído de diagnóstico no `nrv doctor`, `nrv update` e `nrv validate squad`
 
 Algumas checagens no `nrv doctor`, no fim do `nrv update` e no `nrv validate squad` eram destinadas só à ferramentaria própria de release do dono, nunca a uma instalação comum — mas rodavam incondicionalmente, então todo usuário via e não tinha como agir sobre o que era reportado. Removidas da saída visível ao usuário; a ferramentaria interna que de fato precisa delas foi para uma infraestrutura interna que não faz parte deste repositório.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When you (the LLM) read this file, you are the **orchestrator**, not the executo
 Your output is **dispatches**, never artifacts. You:
 
 - ✅ Read the brief, refine and clarify it, pick targets via the dispatch cascade, dispatch them, verify.
-- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `.nirvana/outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
+- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
 - ❌ Never write the deliverable yourself: no code, no prose, no HTML, no markdown content, no images, no PDFs.
 - ❌ Never create files in the `output_path` / `outputs_root` of the brief — that path belongs to the dispatched agent.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@ When you (the LLM) read this file, you are the **orchestrator**, not the executo
 Your output is **dispatches**, never artifacts. You:
 
 - ✅ Read the brief, refine and clarify it, pick targets via the dispatch cascade, dispatch them, verify.
-- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `.nirvana/outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
+- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
 - ❌ Never write the deliverable yourself: no code, no prose, no HTML, no markdown content, no images, no PDFs.
 - ❌ Never create files in the `output_path` / `outputs_root` of the brief — that path belongs to the dispatched agent.
 

--- a/skills/_shared/templates/AGENTS.md
+++ b/skills/_shared/templates/AGENTS.md
@@ -22,7 +22,7 @@ When you (the LLM) read this file, you are the **orchestrator**, not the executo
 Your output is **dispatches**, never artifacts. You:
 
 - ✅ Read the brief, refine and clarify it, pick targets via the dispatch cascade, dispatch them, verify.
-- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `.nirvana/outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
+- ✅ Write to: `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `outputs/<trace>/audit.jsonl`, and `HANDOFF.json`.
 - ❌ Never write the deliverable yourself: no code, no prose, no HTML, no markdown content, no images, no PDFs.
 - ❌ Never create files in the `output_path` / `outputs_root` of the brief — that path belongs to the dispatched agent.
 

--- a/skills/businesses/scripts/brief-business.ts
+++ b/skills/businesses/scripts/brief-business.ts
@@ -69,14 +69,21 @@ if (!projectId) {
 }
 
 // Resolve outputs root via canonical scope helper. Defaults to
-// <projectRoot>/.nirvana/outputs (or HOME fallback when not in a project).
+// <projectRoot>/outputs (or HOME fallback when not in a project).
 // Honors NIRVANA_OUTPUTS_DIR override. Reuses the single `scope` resolved above.
 const outputsRoot = outputsDir(scope);
 
+// Only the dir we are about to write into. `handoffs/`, `tickets/` and
+// `employees/` used to be pre-created here on the chance something landed in
+// them; most runs write to none of the three, so every brief left empty
+// directories behind — 13 of the 15 empties measured in one real project.
+// Whoever writes a handoff creates it then, with `recursive: true`, and the
+// only reader (artifact-indexer) already guards with existsSync. `tickets`
+// was the worst of the three: the protocol retired it (RETIRED_MANIFEST_FIELDS
+// and RETIRED_FILES in verify/kinds/business.ts), so the brief was creating a
+// directory the validator rejects.
 const projectDir = path.join(outputsRoot, projectId, "businesses", slug);
-fs.mkdirSync(path.join(projectDir, "handoffs"), { recursive: true });
-fs.mkdirSync(path.join(projectDir, "tickets"), { recursive: true });
-fs.mkdirSync(path.join(projectDir, "employees"), { recursive: true });
+fs.mkdirSync(projectDir, { recursive: true });
 
 const briefFile = path.join(outputsRoot, projectId, "brief.md");
 fs.mkdirSync(path.dirname(briefFile), { recursive: true });

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -82,7 +82,7 @@ A budget cap may be set for cost, tokens, handoffs, or wall-clock. **A cap of `0
 Your tools (Write, Edit, Bash) are for **trace artifacts only**: audit logs, briefs at `.nirvana/briefs/<trace_id>-enriched.md`, plans at `.nirvana/plans/<trace_id>.json`, target_plan files. Never for the user's deliverable.
 
 **Self-test before every Write call:**
-- Writing to `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `.nirvana/outputs/<trace>/audit.jsonl`, or `HANDOFF.json`? → ✅ proceed.
+- Writing to `~/.harness-logs/`, `.nirvana/briefs/`, `.nirvana/plans/`, `outputs/<trace>/audit.jsonl`, or `HANDOFF.json`? → ✅ proceed.
 - Writing anywhere else (code, prose, HTML, markdown content, images, anything the user asked for)? → 🛑 STOP. You're making. Reformulate as dispatch.
 
 **Self-test before every turn you send the user:**

--- a/skills/harness/lib/chunk-writer.ts
+++ b/skills/harness/lib/chunk-writer.ts
@@ -6,7 +6,7 @@
  * Phase 7 da nirvana-evolution.
  *
  * Layout: <chunks_root>/<trace_id>/<NNN-seq>.<ext>
- *   ex: ~/Projects/myproj/.nirvana/outputs/<trace>/chunks/0001.md
+ *   ex: ~/Projects/myproj/outputs/<trace>/chunks/0001.md
  *
  * Aggregation: finalize(trace_id) concatenates all chunks (sorted by seq)
  * into one file `<trace_id>.final.<ext>` and optionally deletes the chunk

--- a/skills/harness/tests/brief-scaffold.test.ts
+++ b/skills/harness/tests/brief-scaffold.test.ts
@@ -1,0 +1,204 @@
+// brief-scaffold.test.ts — a brief leaves no empty directory behind.
+//
+// The owner, looking at a real project in Finder on 2026-09-01, quoted as data:
+// i18n-user-facing
+// "por que o nirvana-os gera vários diretórios vazios? Uma zona de organização de output que não tem porra nenhuma coerente!"
+//
+// He was right, and the count was measurable. In ~/mastery-makers, 15 of the
+// 514 directories under the two output roots were empty, and 13 of those came
+// from one place: brief-business.ts pre-created `handoffs/`, `tickets/` and
+// `employees/` at brief time, and brief-squad.ts pre-created `handoffs/`,
+// before any work had happened and on the chance something would land there.
+// Most runs write to none of them.
+//
+// `tickets` was the worst of the three. The protocol retired it — it sits in
+// both RETIRED_MANIFEST_FIELDS and RETIRED_FILES in verify/kinds/business.ts,
+// so `nrv validate` rejects a business that ships one — while the brief script
+// created it on every single run.
+//
+// Removing the mkdirs outright would have broken the thing they were
+// accidentally holding up: `fs.appendFileSync` does not create parent
+// directories, and audit.jsonl is written into projectDir. So the fix creates
+// projectDir itself — the one directory a file actually goes into — and
+// nothing else. These cases pin both halves: the audit still lands, and no
+// speculative child comes back.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { businessV1 } from "../../_shared/tests/fixtures/protocol-entities.ts";
+
+const SKILLS = path.resolve(import.meta.dir, "..", "..");
+const TMP = makeTempRoot("nrv-brief-scaffold-");
+
+afterAll(() => removeDir(TMP));
+
+/** Every directory under `dir` that holds no file anywhere beneath it. */
+function emptyDirs(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (d: string): boolean => {
+    let hasFile = false;
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      if (e.isDirectory()) hasFile = walk(path.join(d, e.name)) || hasFile;
+      else hasFile = true;
+    }
+    if (!hasFile) out.push(path.relative(dir, d));
+    return hasFile;
+  };
+  walk(dir);
+  return out;
+}
+
+function runBrief(script: string, args: string[], home: string, projectRoot: string, logs: string) {
+  const r = spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      SQUADS_DIR: path.join(home, "squads"),
+      BUSINESSES_DIR: path.join(home, "businesses"),
+      NIRVANA_HOME: home,
+      NIRVANA_PROJECT_ROOT: projectRoot,
+      NIRVANA_SKILLS_DIR: SKILLS,
+      NIRVANA_RUN_LEDGER_DB: path.join(TMP, `${path.basename(projectRoot)}-ledger.sqlite`),
+      HARNESS_LOGS_DIR: logs,
+    },
+  });
+  if (r.status !== 0) throw new Error(`${path.basename(script)} failed (${r.status}): ${r.stdout}\n${r.stderr}`);
+  return r;
+}
+
+describe("a squad brief creates the dir it writes into, and nothing else", () => {
+  const home = path.join(TMP, "sq-home");
+  const projectRoot = path.join(TMP, "sq-project");
+  let outputs: string;
+
+  beforeAll(() => {
+    const squad = path.join(home, "squads", "fixture-squad");
+    fs.mkdirSync(path.join(squad, "agents"), { recursive: true });
+    fs.writeFileSync(path.join(squad, "agents", "fixture.md"), "# fixture\n");
+    fs.writeFileSync(path.join(squad, "squad.yaml"), [
+      "name: fixture-squad",
+      "version: 1.0.0",
+      'protocol: "5.0"',
+      "description: A fixture squad used by the brief scaffold test.",
+      "experimental_domains: true",
+      "components:",
+      "  agents: [fixture.md]",
+      "  tasks: []",
+      "  workflows: []",
+      "capabilities:",
+      "  - id: general.fixture.run",
+      "    description: Do the fixture thing.",
+      "    domains: [fixture]",
+      "    produces: [nothing]",
+      '    examples: ["rode o fixture"]',
+      "    invoke:",
+      "      type: agent",
+      "      ref: fixture",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(projectRoot, { recursive: true });
+
+    runBrief(
+      path.join(SKILLS, "squads", "scripts", "brief-squad.ts"),
+      ["fixture-squad", "Um brief qualquer para a fixture", "--project", "proj-sq"],
+      home, projectRoot, path.join(TMP, "sq-logs"),
+    );
+    outputs = path.join(projectRoot, "outputs");
+  }, spawnBudgetMs(1));
+
+  test("the brief lands, so the run is real and not a no-op", () => {
+    expect(fs.existsSync(path.join(outputs, "proj-sq", "brief.md"))).toBe(true);
+  });
+
+  test("audit.jsonl lands in projectDir — appendFileSync has a parent to write into", () => {
+    const audit = path.join(outputs, "proj-sq", "squads", "fixture-squad", "audit.jsonl");
+    expect(fs.existsSync(audit)).toBe(true);
+    expect(fs.readFileSync(audit, "utf8")).toContain("brief_received");
+  });
+
+  test("no empty directory is left behind", () => {
+    expect(emptyDirs(outputs)).toEqual([]);
+  });
+
+  test("the speculative handoffs/ is gone specifically", () => {
+    expect(fs.existsSync(path.join(outputs, "proj-sq", "squads", "fixture-squad", "handoffs"))).toBe(false);
+  });
+});
+
+describe("a business brief creates the dir it writes into, and nothing else", () => {
+  const home = path.join(TMP, "biz-home");
+  const projectRoot = path.join(TMP, "biz-project");
+  let outputs: string;
+
+  beforeAll(() => {
+    const biz = businessV1(path.join(home, "businesses"), "fixture-biz");
+    // The shared fixture still writes the pre-6.0 chart shape (`id` /
+    // `reports_to`), which the current validator rejects. Overwrite it here
+    // rather than editing the fixture: this test is about empty directories,
+    // and every other consumer of businessV1 passes as-is.
+    fs.writeFileSync(path.join(biz, "org-chart.yaml"), [
+      "chart:",
+      "  - employee: intake",
+      "    reports: []",
+      "    direct_reports: []",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(projectRoot, { recursive: true });
+
+    runBrief(
+      path.join(SKILLS, "businesses", "scripts", "brief-business.ts"),
+      ["fixture-biz", "Um brief qualquer para a fixture", "--project", "proj-biz"],
+      home, projectRoot, path.join(TMP, "biz-logs"),
+    );
+    outputs = path.join(projectRoot, "outputs");
+  }, spawnBudgetMs(1));
+
+  test("audit.jsonl lands in projectDir", () => {
+    const audit = path.join(outputs, "proj-biz", "businesses", "fixture-biz", "audit.jsonl");
+    expect(fs.existsSync(audit)).toBe(true);
+    expect(fs.readFileSync(audit, "utf8")).toContain("brief_received");
+  });
+
+  test("no empty directory is left behind", () => {
+    expect(emptyDirs(outputs)).toEqual([]);
+  });
+
+  test("tickets/ is never created — the protocol retired it", () => {
+    const dir = path.join(outputs, "proj-biz", "businesses", "fixture-biz");
+    for (const speculative of ["tickets", "handoffs", "employees"]) {
+      expect(fs.existsSync(path.join(dir, speculative))).toBe(false);
+    }
+  });
+});
+
+describe("the contract points agents at the real outputs root", () => {
+  // The root moved from <project>/.nirvana/outputs to <project>/outputs on
+  // 2026-08-11 (engine 0.3.3, 63e4f4c). The contract files were not updated
+  // with it, so for three weeks the orchestrator read `.nirvana/outputs/` from
+  // its own instructions and created a mirror tree there while every script
+  // wrote to `outputs/`. Measured in ~/mastery-makers: the mirror held 5 files,
+  // all of them .DS_Store, beside a real tree of 6,101 files and 265 MB. 52
+  // projects on the owner's machine carried the ghost, 28 carried both.
+  const CONTRACTS = [
+    "AGENTS.md", "CLAUDE.md", "GEMINI.md",
+    path.join("skills", "_shared", "templates", "AGENTS.md"),
+    path.join("skills", "harness", "SKILL.md"),
+  ];
+  const REPO = path.resolve(SKILLS, "..");
+
+  test("no contract tells an agent to write under .nirvana/outputs", () => {
+    for (const rel of CONTRACTS) {
+      const body = fs.readFileSync(path.join(REPO, rel), "utf8");
+      expect(`${rel}: ${body.includes(".nirvana/outputs")}`).toBe(`${rel}: false`);
+    }
+  });
+
+  test("the template nrv init copies names the real root, so new projects start correct", () => {
+    const tpl = fs.readFileSync(path.join(REPO, "skills", "_shared", "templates", "AGENTS.md"), "utf8");
+    expect(tpl).toContain("`outputs/<trace>/audit.jsonl`");
+  });
+});

--- a/skills/squads/scripts/brief-squad.ts
+++ b/skills/squads/scripts/brief-squad.ts
@@ -75,8 +75,12 @@ if (!projectId) {
 }
 
 const outputsRoot = outputsDir(scope);
+// Only the dir we are about to write into: `handoffs/` was pre-created on the
+// chance a handoff landed there, and most runs write none, so every brief left
+// an empty directory behind. Whoever writes one creates it then, and the only
+// reader (artifact-indexer) already guards with existsSync.
 const projectDir = path.join(outputsRoot, projectId, "squads", slug);
-fs.mkdirSync(path.join(projectDir, "handoffs"), { recursive: true });
+fs.mkdirSync(projectDir, { recursive: true });
 
 const briefFile = path.join(outputsRoot, projectId, "brief.md");
 fs.mkdirSync(path.dirname(briefFile), { recursive: true });


### PR DESCRIPTION
Two independent sources of empty directories, both measured on the owner's machine.

## 1. Speculative scaffolding

`brief-business.ts` pre-created `handoffs/`, `tickets/` and `employees/` at brief time; `brief-squad.ts` pre-created `handoffs/`. Most runs write to none of them — 13 of the 15 empty directories under `~/mastery-makers` came from these four `mkdirSync` calls.

`tickets/` was the worst of the four: the protocol retired it (it sits in both `RETIRED_MANIFEST_FIELDS` and `RETIRED_FILES` in `verify/kinds/business.ts`, so `nrv validate` rejects a business that ships one) while the brief script created it on every single run.

Removing them outright would have broken what they were accidentally holding up: `appendFileSync` does not create parent directories, and `audit.jsonl` is written into `projectDir`. Each script now creates `projectDir` itself and nothing else. The only reader of `handoffs/` (`artifact-indexer`) already guards with `existsSync`.

## 2. Contract/code drift

`outputsDir()` moved from `<project>/.nirvana/outputs` to `<project>/outputs` on 2026-08-11 (0.3.3, 63e4f4c). The contract files never followed, so for three weeks the orchestrator read `.nirvana/outputs/<trace>/` from its own instructions and built a mirror tree there while every script wrote to `outputs/`.

Measured in `~/mastery-makers`, same trace id in both:

| tree | files | size |
|---|---|---|
| `.nirvana/outputs/5572237c…` | 5, **all `.DS_Store`** | ~0 |
| `outputs/5572237c…` | 6,101 | 265 MB |

Across the machine: 52 projects carry the ghost tree, 28 carry both.

Fixed in all five copies of the line — `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `skills/harness/SKILL.md`, and the `skills/_shared/templates/AGENTS.md` that `nrv init` writes into every new project — plus the stale example in `chunk-writer.ts` and the stale comment in `brief-business.ts` that still described the pre-0.3.3 path.

## Not touched

Output trees written before 0.3.3 hold real history. The `compat: runs antigos` fallbacks in `verify-deliverable.ts` and `validate-chain.ts` that read them stay.

## Verification

New `brief-scaffold.test.ts` fails 4 of 9 against the old code and passes 9/9 against the fix, so it pins the regression rather than describing it.

- `test:businesses` 98 pass · `test:squads` 96 pass · `test:harness` 1670 pass
- `check:all` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk