### PR TITLE
feat(creation): the announced seat enricher exists — and the driver says why it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### `enrich-employee-method.ts` exists now — the announced seat enricher
+
+`check-seat-sufficiency.ts` has printed `Enrich with: bun …/enrich-employee-method.ts` since the admission gate shipped, and no such file existed: a thin seat's `autofix: "agentic"` pointed at nothing, which is one measured reason created businesses read generic — the seat with a 2-line body stayed a 2-line body. The script now exists and follows the proven `enrich-routing-metadata.ts` contract: a headless LLM writes method sections grounded only in what the seat and its business already declare, shape validation rejects heading collisions, placeholders, language mismatches and frontmatter-fence injection, and the SAME deterministic measure the admission gate runs (`seat-sufficiency.js`) gates every candidate BEFORE it touches disk. The original file — frontmatter and existing body — survives byte-identical as a prefix; a business whose loader rejects the result gets every seat reverted. Verified end to end on a real thin seat of the live library.
+
+### An error verdict now says why
+
+On an error verdict the claude CLI puts the cause in `result` and leaves stderr empty, and the driver only read stderr — so every caller saw the generic "runtime returned an error verdict" while the real cause ("Failed to authenticate. API Error: 401 …") sat unread. Callers retried blind against the same broken credential. The driver now surfaces the result text when stderr is silent.
+
 ## 0.12.7 — 2026-09-01
 
 ### No more empty directories under `outputs/`

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,16 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### O `enrich-employee-method.ts` agora existe — o enriquecedor de seat anunciado
+
+O `check-seat-sufficiency.ts` imprime `Enrich with: bun …/enrich-employee-method.ts` desde que o gate de admissão entrou, e esse arquivo não existia: o `autofix: "agentic"` de um seat fino apontava para o nada, uma das razões medidas para empresas criadas soarem genéricas — o seat de corpo de 2 linhas continuava com 2 linhas. O script existe agora e segue o contrato comprovado do `enrich-routing-metadata.ts`: um LLM headless escreve seções de método ancoradas só no que o seat e a empresa já declaram, a validação de forma rejeita colisão de heading, placeholder, língua trocada e injeção de cerca de frontmatter, e a MESMA medida determinística do gate de admissão (`seat-sufficiency.js`) julga cada candidato ANTES de tocar o disco. O arquivo original — frontmatter e corpo existente — sobrevive byte a byte como prefixo; uma empresa cujo loader rejeite o resultado tem todos os seats revertidos. Verificado de ponta a ponta num seat fino real da biblioteca viva.
+
+### Um veredito de erro agora diz o porquê
+
+Num veredito de erro o claude CLI põe a causa em `result` e deixa o stderr vazio, e o driver só lia o stderr — então todo chamador via o genérico "runtime returned an error verdict" enquanto a causa real ("Failed to authenticate. API Error: 401 …") ficava sem leitura. Os chamadores tentavam de novo às cegas contra a mesma credencial quebrada. O driver agora expõe o texto do result quando o stderr está em silêncio.
+
 ## 0.12.7 — 2026-09-01
 
 ### Chega de diretórios vazios em `outputs/`

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -1460,7 +1460,11 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
     exitCode,
     stderr,
     durationMs,
-    error: isError ? salientError(stderr, "runtime returned an error verdict") : undefined,
+    // On an error verdict the claude CLI puts the cause in `result` and leaves
+    // stderr empty ("Failed to authenticate. API Error: 401 …" arrived exactly
+    // that way, 2026-09-01) — so a caller reading `error` saw only the generic
+    // fallback while the real cause sat unread in the result field.
+    error: isError ? salientError(stderr || result, "runtime returned an error verdict") : undefined,
   };
 }
 

--- a/skills/_shared/scripts/enrich-employee-method.ts
+++ b/skills/_shared/scripts/enrich-employee-method.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env bun
+/**
+ * enrich-employee-method.ts — fills a thin seat with its own operating method.
+ *
+ * The per-task clone model (0.7.0) made "no clone" a legitimate outcome of any
+ * dispatch, which turns the employee body into the seat's whole method. The
+ * admission gate measures that body (`seat_thin`, seat-sufficiency.js) and
+ * check-seat-sufficiency.ts has pointed at THIS script since the gate shipped —
+ * but the script did not exist: a thin seat's `autofix: "agentic"` aimed at a
+ * dangling reference, and the owner saw the pointer on screen with nothing
+ * behind it (found 2026-09-01, auditing why created businesses read generic).
+ *
+ * The contract is enrich-routing-metadata.ts's, applied to seat bodies:
+ *
+ *   GENERATE   a headless LLM writes method sections grounded ONLY in what the
+ *              seat and its business already declare — the frontmatter's
+ *              self_score criteria, the authorized squads, the assigned
+ *              clones, the org-chart position. Nothing invented.
+ *   VALIDATE   shape first (section count, heading collisions, placeholders,
+ *              language match, frontmatter-fence injection), then the SAME
+ *              deterministic measure the admission gate runs: the assembled
+ *              file must come out "sufficient" per sufficiencyOfFile.
+ *   SURGICAL   the original file — frontmatter AND existing body — is
+ *              preserved byte-identical as a prefix; generated sections are
+ *              appended after it. A revert is a byte comparison away.
+ *   GATE FIRST the measure is pure computation over text, so unlike the
+ *              routing enricher this gate runs BEFORE the write: a candidate
+ *              that fails never touches disk. Retries carry the signals
+ *              (headings / decision lines) as feedback.
+ *   PROVE      after a business's seats are written, its loader must still
+ *              accept the whole business — a rejection reverts every seat of
+ *              that business.
+ *
+ * No reindex and no self-retrieval gate on purpose: the body is not routing
+ * metadata — BM25 and the agentic router never read past the frontmatter, so
+ * retrieval cannot regress from this write.
+ *
+ * CLI (flags mirror enrich-routing-metadata.ts):
+ *   bun enrich-employee-method.ts --slugs=biz-a,biz-b        [--seats=x,y] [--dry]
+ *   bun enrich-employee-method.ts --missing [--limit=N]
+ *   --attempts=N --runtime=R --model=M --scratch=DIR --timeout-min=N --budget-usd=N
+ *
+ * Exit codes: 0 = batch done (statuses in the report), 2 = bad usage.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { resolveScope } from "../lib/scope.ts";
+import { paths } from "../lib/bun-helpers.ts";
+import { runHeadless, runtimeAvailable, type Runtime } from "../../harness/lib/host-agent-driver.ts";
+import { backupFile, detectLang, extractJson, restoreBackup, type BackupEntry } from "./enrich-routing-metadata.ts";
+
+const require_ = createRequire(import.meta.url);
+const { sufficiencyOfFile, stripFrontmatter } = require_("../lib/seat-sufficiency.js") as {
+  sufficiencyOfFile(content: string): { verdict: "sufficient" | "thin"; signals: SeatSignals };
+  stripFrontmatter(content: string): string;
+};
+
+export interface SeatSignals { headings: number; decisionLines: number; bodyChars: number; nonEmptyLines: number }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pure helpers (unit-tested, no LLM, no filesystem beyond what they receive)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface MethodSection { heading: string; body: string }
+
+const normHeading = (s: string) =>
+  String(s).normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/[^a-z0-9 ]/g, "").trim();
+
+/** H2/H3 and bold-line pseudo-headings of the existing body, normalized —
+ *  the same forms seat-sufficiency.js counts as structure. */
+export function existingHeadings(content: string): Set<string> {
+  const out = new Set<string>();
+  for (const line of stripFrontmatter(content).split(/\r?\n/)) {
+    const t = line.trim();
+    const h = /^#{1,4}\s+(.+)$/.exec(t);
+    if (h) { out.add(normHeading(h[1])); continue; }
+    const p = /^\*\*([^*]{2,60})\*\*:?\s*$/.exec(t);
+    if (p) out.add(normHeading(p[1]));
+  }
+  return out;
+}
+
+/** The language the generated method must be written in: the existing body
+ *  decides when it says anything; the frontmatter description is the fallback;
+ *  PT-BR is the house default (employee content is user-language). */
+export function expectedLang(seatContent: string): "pt" | "en" {
+  const body = stripFrontmatter(seatContent).trim();
+  if (body) {
+    const l = detectLang(body);
+    if (l !== "other") return l;
+  }
+  const desc = /^\s*description:\s*["']?(.+?)["']?\s*$/m.exec(seatContent);
+  if (desc) {
+    const l = detectLang(desc[1]);
+    if (l !== "other") return l;
+  }
+  return "pt";
+}
+
+// TWO regexes on purpose: TODO/FIXME are markers only in UPPERCASE — a
+// case-insensitive \bTODO\b matches "todo", one of the most common words in
+// Portuguese ("todo indicador resolve até a origem" sits in a real seat's own
+// frontmatter), and the first live run burned $5.86 rejecting three honest
+// PT-BR generations for exactly that.
+const PLACEHOLDER_MARKER_RE = /\b(TODO|FIXME)\b/;
+const PLACEHOLDER_PROSE_RE = /\b(placeholder|replace with|lorem ipsum|preencher aqui)\b/i;
+const hasPlaceholder = (s: string) => PLACEHOLDER_MARKER_RE.test(s) || PLACEHOLDER_PROSE_RE.test(s);
+/** Appended-content budget: a seat is a working method, not a book — and the
+ *  employee spawn concatenates every byte of it into the prompt (§6.8). */
+export const MAX_GENERATED_CHARS = 9000;
+
+export function validateSections(
+  raw: unknown,
+  ctx: { seatContent: string; lang: "pt" | "en" },
+): { ok: boolean; errors: string[]; cleaned?: MethodSection[] } {
+  const errors: string[] = [];
+  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const arr = Array.isArray(obj.sections) ? obj.sections : null;
+  if (!arr) return { ok: false, errors: ["sections: missing or not an array"] };
+
+  const taken = existingHeadings(ctx.seatContent);
+  const cleaned: MethodSection[] = [];
+  for (const s of arr) {
+    const sec = (s && typeof s === "object" ? s : {}) as Record<string, unknown>;
+    const heading = typeof sec.heading === "string" ? sec.heading.trim() : "";
+    const body = typeof sec.body === "string" ? sec.body.trim() : "";
+    if (!heading || heading.length < 3 || heading.length > 80) { errors.push(`heading out of 3-80 chars: "${heading.slice(0, 40)}"`); continue; }
+    if (heading.includes("#")) { errors.push(`heading carries markdown marks — plain text only (## is added on assembly): "${heading.slice(0, 40)}"`); continue; }
+    if (!body) { errors.push(`section "${heading.slice(0, 40)}": empty body`); continue; }
+    // A line of exactly --- would read as a frontmatter fence to naive
+    // splitters; a generated section never needs a thematic break.
+    if (/^---\s*$/m.test(body)) { errors.push(`section "${heading.slice(0, 40)}": contains a --- line (frontmatter-fence injection)`); continue; }
+    if (hasPlaceholder(body) || hasPlaceholder(heading)) { errors.push(`section "${heading.slice(0, 40)}": placeholder text — write the real method`); continue; }
+    const norm = normHeading(heading);
+    if (taken.has(norm)) { errors.push(`heading duplicates an existing section: "${heading.slice(0, 40)}"`); continue; }
+    taken.add(norm);
+    cleaned.push({ heading, body });
+  }
+  if (cleaned.length < 2 || cleaned.length > 8) errors.push(`sections: ${cleaned.length} valid — need 2-8`);
+
+  const joined = cleaned.map((s) => `${s.heading}\n${s.body}`).join("\n");
+  if (joined.length > MAX_GENERATED_CHARS) errors.push(`generated method is ${joined.length} chars — cap is ${MAX_GENERATED_CHARS} (a seat is a method, not a book)`);
+  const lang = detectLang(joined);
+  if (lang !== "other" && lang !== ctx.lang) errors.push(`language mismatch: seat is ${ctx.lang}, generated text reads ${lang}`);
+
+  if (errors.length) return { ok: false, errors };
+
+  // The admission measure itself, asked BEFORE any write: the assembled file
+  // must be sufficient, or the attempt never touches disk.
+  const assembled = assembleSeat(ctx.seatContent, cleaned);
+  const verdict = sufficiencyOfFile(assembled);
+  if (verdict.verdict !== "sufficient") {
+    return { ok: false, errors: [sufficiencyFeedback(verdict.signals)] };
+  }
+  return { ok: true, errors: [], cleaned };
+}
+
+/** Original file preserved byte-identical as prefix (minus trailing blank
+ *  lines); generated sections appended as H2 blocks. */
+export function assembleSeat(originalContent: string, sections: MethodSection[]): string {
+  const base = originalContent.replace(/\s+$/, "");
+  const blocks = sections.map((s) => `## ${s.heading}\n\n${s.body}`).join("\n\n");
+  return `${base}\n\n${blocks}\n`;
+}
+
+/** Retry feedback in the measure's own terms, so the model aims at the real
+ *  bar instead of guessing which of the three sufficiency rules to satisfy. */
+export function sufficiencyFeedback(signals: SeatSignals): string {
+  return (
+    `still thin after assembly: headings=${signals.headings} decisionLines=${signals.decisionLines} bodyChars=${signals.bodyChars}. ` +
+    `Sufficiency needs (>=2 headings AND >=5 decision lines) OR >=10 decision lines OR (>=4 headings AND >=1500 chars). ` +
+    `A decision line is a DO/DON'T rule (nunca/sempre/never/always/recuso...), a number or threshold, ` +
+    `a list item with >=30 chars of substance, or a table data row. Write MORE CONCRETE rules, not more prose.`
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Library access + prompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+function businessDirs(): string[] {
+  const scope = resolveScope();
+  return scope.businessDirs.length ? scope.businessDirs : [paths.BUSINESSES_DIR];
+}
+
+function findBusinessDir(slug: string): string | null {
+  for (const root of businessDirs()) {
+    const dir = path.join(root, slug);
+    if (fs.existsSync(path.join(dir, "business.yaml"))) return dir;
+  }
+  return null;
+}
+
+export interface SeatFile { slug: string; file: string; content: string; verdict: "sufficient" | "thin"; signals: SeatSignals }
+
+export function listSeats(bizDir: string): SeatFile[] {
+  const dir = path.join(bizDir, "employees");
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((f) => f.endsWith(".md")).sort().map((f) => {
+    const file = path.join(dir, f);
+    const content = fs.readFileSync(file, "utf8");
+    const s = sufficiencyOfFile(content);
+    return { slug: f.replace(/\.md$/, ""), file, content, verdict: s.verdict, signals: s.signals };
+  });
+}
+
+function readCapped(file: string, cap: number): string {
+  if (!fs.existsSync(file)) return "";
+  const s = fs.readFileSync(file, "utf8");
+  return s.length > cap ? s.slice(0, cap) + "\n…(truncated for prompt)" : s;
+}
+
+const METHOD_CONTRACT_DIGEST = `
+WHAT METHOD CONTENT IS (the admission gate measures exactly this):
+- Decision rules the seat applies alone: thresholds with numbers, DO/DON'T lines
+  (nunca/sempre/recuso...), reject criteria, revision triggers. Digits, not spelled-out numbers.
+- Procedures: the ordered steps of the seat's core loop, each step checkable.
+- Boundaries: what this seat hands to which authorized squad, what escalates to
+  the seat it reports to, what it refuses outright.
+- Acceptance: how the seat judges its OWN output before handoff — anchor every
+  self_score_contract criterion from the frontmatter in at least one concrete rule.
+
+WHAT IS BANNED:
+- Restating the role or description in different words. The frontmatter already says who the seat is.
+- Inventing facts: no metrics presented as measured, no clients, partners, tools or
+  history the business never declared. A threshold is the seat's own working rule, stated as a rule.
+- Generic filler that would fit any business ("garanta a qualidade", "seja estratégico").
+  Every rule must use THIS business's vocabulary.
+- Placeholders, TODOs, headings that duplicate existing sections.
+`.trim();
+
+export function buildSeatPrompt(
+  businessSlug: string,
+  bizDir: string,
+  seat: SeatFile,
+  siblings: SeatFile[],
+  lang: "pt" | "en",
+  retryFeedback: string | null,
+): string {
+  const siblingHeadings = siblings
+    .filter((s) => s.slug !== seat.slug && s.verdict === "sufficient")
+    .slice(0, 3)
+    .map((s) => `--- ${s.slug} ---\n` + stripFrontmatter(s.content).split("\n").filter((l) => /^#{2,3}\s/.test(l)).slice(0, 10).join("\n"))
+    .join("\n") || "(no sufficient sibling to mirror)";
+
+  return [
+    `You are writing the OPERATING METHOD of the seat "${seat.slug}" of the Nirvana-OS business "${businessSlug}".`,
+    "Under the per-task clone model a dispatch may run with no mind-clone, and then the seat executes on its own written method — the body you are about to extend is everything it has.",
+    "Your ONLY output is one JSON object — no prose, no markdown fences:",
+    "",
+    '{ "sections": [ { "heading": string, "body": string } ] }',
+    "",
+    `3-5 sections. Headings are plain text (no # marks). Bodies are markdown, written in ${lang === "pt" ? "Brazilian Portuguese (PT-BR, diacritics intact)" : "English"} — the seat's own language.`,
+    "The sections are APPENDED after the existing body: never repeat what it already says, never duplicate its headings.",
+    "",
+    METHOD_CONTRACT_DIGEST,
+    "",
+    retryFeedback ? `PREVIOUS ATTEMPT FEEDBACK (fix this without breaking the rules above):\n${retryFeedback}\n` : "",
+    "SOURCE MATERIAL (everything you may ground the method in — nothing outside it):",
+    `=== the seat (employees/${seat.slug}.md, frontmatter + current body) ===`,
+    seat.content.length > 8000 ? seat.content.slice(0, 8000) + "\n…(truncated)" : seat.content,
+    "=== business.yaml (excerpt) ===",
+    readCapped(path.join(bizDir, "business.yaml"), 6000),
+    "=== org-chart.yaml (excerpt) ===",
+    readCapped(path.join(bizDir, "org-chart.yaml"), 2500),
+    "=== headings of sufficient sibling seats (shape reference, NOT content to copy) ===",
+    siblingHeadings,
+    "",
+    "Answer with the JSON object only.",
+  ].join("\n");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pipeline
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface GenResult { ok: boolean; json: unknown; costUsd: number | null; error?: string }
+export type GenerateFn = (prompt: string) => GenResult;
+
+export interface RunCtx {
+  attempts: number;
+  backupRoot: string;
+  /** Test seam, same style as verify/agentic.ts `runHeadlessImpl`. */
+  generate: GenerateFn;
+}
+
+export interface SeatReport {
+  business: string;
+  seat: string;
+  status: "enriched" | "gate_failed" | "skipped" | "dry" | "reverted_by_loader";
+  attempts: number;
+  signals_before: SeatSignals;
+  signals_after: SeatSignals | null;
+  cost_usd: number;
+  errors: string[];
+}
+
+export function enrichSeat(businessSlug: string, bizDir: string, seat: SeatFile, siblings: SeatFile[], ctx: RunCtx): { report: SeatReport; backup: BackupEntry | null } {
+  const report: SeatReport = {
+    business: businessSlug, seat: seat.slug, status: "skipped", attempts: 0,
+    signals_before: seat.signals, signals_after: null, cost_usd: 0, errors: [],
+  };
+  const lang = expectedLang(seat.content);
+  let retryFeedback: string | null = null;
+
+  for (let attempt = 1; attempt <= ctx.attempts; attempt++) {
+    report.attempts = attempt;
+    const prompt = buildSeatPrompt(businessSlug, bizDir, seat, siblings, lang, retryFeedback);
+    let gen = ctx.generate(prompt);
+    report.cost_usd += gen.costUsd || 0;
+
+    let validation = validateSections(gen.json, { seatContent: seat.content, lang });
+    if (gen.ok && !validation.ok) {
+      // One in-attempt shape repair: feed the errors back once (sibling pattern).
+      const repairPrompt = prompt + "\n\nYOUR PREVIOUS ANSWER FAILED VALIDATION:\n- " + validation.errors.join("\n- ") + "\n\nAnswer again with a corrected JSON object only.";
+      gen = ctx.generate(repairPrompt);
+      report.cost_usd += gen.costUsd || 0;
+      validation = validateSections(gen.json, { seatContent: seat.content, lang });
+    }
+    if (!gen.ok || !validation.ok) {
+      report.errors.push(...(gen.error ? [`attempt ${attempt}: ${gen.error}`] : []), ...validation.errors.map((e) => `attempt ${attempt}: ${e}`));
+      retryFeedback = validation.errors.join("\n") || gen.error || null;
+      continue;
+    }
+
+    // The gate already passed inside validateSections — this write cannot be thin.
+    const assembled = assembleSeat(seat.content, validation.cleaned!);
+    const backup = backupFile(ctx.backupRoot, seat.file);
+    fs.writeFileSync(seat.file, assembled, "utf8");
+    report.signals_after = sufficiencyOfFile(assembled).signals;
+    report.status = "enriched";
+    return { report, backup };
+  }
+  report.status = "gate_failed";
+  return { report, backup: null };
+}
+
+export async function enrichBusinessSeats(
+  slug: string,
+  ctx: RunCtx,
+  opts: { seats?: string[] } = {},
+): Promise<SeatReport[]> {
+  const bizDir = findBusinessDir(slug);
+  if (!bizDir) {
+    return [{ business: slug, seat: "-", status: "skipped", attempts: 0, signals_before: { headings: 0, decisionLines: 0, bodyChars: 0, nonEmptyLines: 0 }, signals_after: null, cost_usd: 0, errors: ["business dir not found"] }];
+  }
+  const all = listSeats(bizDir);
+  const thin = all.filter((s) => s.verdict === "thin" && (!opts.seats?.length || opts.seats.includes(s.slug)));
+  if (!thin.length) {
+    return [{ business: slug, seat: "-", status: "skipped", attempts: 0, signals_before: { headings: 0, decisionLines: 0, bodyChars: 0, nonEmptyLines: 0 }, signals_after: null, cost_usd: 0, errors: ["no thin seat matched"] }];
+  }
+
+  const reports: SeatReport[] = [];
+  const backups: BackupEntry[] = [];
+  for (const seat of thin) {
+    const { report, backup } = enrichSeat(slug, bizDir, seat, all, ctx);
+    reports.push(report);
+    if (backup) backups.push(backup);
+  }
+
+  // Prove the business still loads whole. Frontmatter was never touched, so a
+  // rejection here means the loader reads deeper than we assumed — revert
+  // EVERY seat of this business rather than ship a business that will not load.
+  if (backups.length) {
+    try {
+      const { loadBusiness } = await import("../../businesses/lib/loader.ts");
+      loadBusiness(bizDir);
+    } catch (e) {
+      for (const b of backups) restoreBackup(b);
+      for (const r of reports) if (r.status === "enriched") {
+        r.status = "reverted_by_loader";
+        r.errors.push(`loadBusiness rejected the enriched business: ${e}`);
+      }
+    }
+  }
+  return reports;
+}
+
+function listBusinessesWithThinSeats(limit: number): string[] {
+  const out: string[] = [];
+  for (const root of businessDirs()) {
+    if (!fs.existsSync(root)) continue;
+    for (const e of fs.readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (!e.isDirectory() || e.name.startsWith(".") || e.name.startsWith("_")) continue;
+      const dir = path.join(root, e.name);
+      if (!fs.existsSync(path.join(dir, "business.yaml"))) continue;
+      if (listSeats(dir).some((s) => s.verdict === "thin")) out.push(e.name);
+      if (out.length >= limit) return out;
+    }
+  }
+  return out;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CLI
+// ═══════════════════════════════════════════════════════════════════════════
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const flag = (name: string): string | null => {
+    const hit = argv.find((a) => a.startsWith(`--${name}=`));
+    return hit ? hit.slice(name.length + 3) : null;
+  };
+  const has = (name: string) => argv.includes(`--${name}`);
+
+  const dry = has("dry");
+  const attempts = Math.max(1, Number(flag("attempts") || 3));
+  const runtime = (flag("runtime") || "claude-code") as Runtime;
+  const model = flag("model") || undefined;
+  const scratch = flag("scratch") || path.join(os.tmpdir(), "nirvana-enrich-seats");
+  const timeoutMs = Math.max(1, Number(flag("timeout-min") || 10)) * 60 * 1000;
+  const budgetUsd = Number(flag("budget-usd") || 2);
+  const seats = (flag("seats") || "").split(",").map((s) => s.trim()).filter(Boolean);
+
+  let slugs: string[];
+  if (flag("slugs")) {
+    slugs = flag("slugs")!.split(",").map((s) => s.trim()).filter(Boolean);
+  } else if (has("missing")) {
+    slugs = listBusinessesWithThinSeats(Number(flag("limit") || 10));
+  } else {
+    console.error("usage: bun enrich-employee-method.ts (--slugs=biz-a,biz-b [--seats=x,y] | --missing [--limit=N]) [--dry] [--attempts=N] [--runtime=R] [--model=M] [--scratch=DIR] [--timeout-min=N] [--budget-usd=N]");
+    process.exit(2);
+  }
+  if (!slugs.length) { console.error("enrich-seats: no business selected (nothing thin?)"); process.exit(0); }
+
+  if (dry) {
+    for (const slug of slugs) {
+      const dir = findBusinessDir(slug);
+      if (!dir) { console.log(`  ${slug}: NOT FOUND`); continue; }
+      const thin = listSeats(dir).filter((s) => s.verdict === "thin" && (!seats.length || seats.includes(s.slug)));
+      console.log(`  ${slug}: ${thin.length ? thin.map((s) => `${s.slug} (h=${s.signals.headings} d=${s.signals.decisionLines})`).join(", ") : "no thin seat"}`);
+    }
+    process.exit(0);
+  }
+
+  if (!runtimeAvailable(runtime)) { console.error(`enrich-seats: runtime '${runtime}' not on PATH`); process.exit(2); }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupRoot = path.join(scratch, `backups-${stamp}`);
+  fs.mkdirSync(backupRoot, { recursive: true });
+
+  const generate: GenerateFn = (prompt) => {
+    const res = runHeadless({
+      runtime, prompt, cwd: os.tmpdir(),
+      allowedTools: [], // pure text generation — no filesystem, no web
+      permissionMode: "default", model,
+      maxBudgetUsd: budgetUsd, timeoutMs,
+    });
+    const json = res.ok ? extractJson(res.result) : null;
+    return { ok: !!json, json, costUsd: res.costUsd, error: res.ok ? (json ? undefined : "no JSON object in the model output") : (res.error || "generation run failed") };
+  };
+
+  const ctx: RunCtx = { attempts, backupRoot, generate };
+  const all: SeatReport[] = [];
+  for (const slug of slugs) {
+    console.log(`[enrich-seats] → ${slug}`);
+    const reports = await enrichBusinessSeats(slug, ctx, { seats });
+    for (const r of reports) {
+      console.log(`[enrich-seats]   ${r.seat}: ${r.status}${r.signals_after ? ` (h=${r.signals_after.headings} d=${r.signals_after.decisionLines})` : ""}${r.errors.length ? ` — ${r.errors[r.errors.length - 1].slice(0, 120)}` : ""}`);
+    }
+    all.push(...reports);
+  }
+
+  const reportPath = path.join(scratch, `enrich-seats-${stamp}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({
+    started_at: stamp, slugs, attempts, runtime, model: model || null,
+    total_cost_usd: all.reduce((n, r) => n + r.cost_usd, 0),
+    seats: all, backup_root: backupRoot,
+  }, null, 2) + "\n", "utf8");
+
+  const counts: Record<string, number> = {};
+  for (const r of all) counts[r.status] = (counts[r.status] || 0) + 1;
+  console.log(`[enrich-seats] ${Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(" · ")} · cost=$${all.reduce((n, r) => n + r.cost_usd, 0).toFixed(2)}`);
+  console.log(`[enrich-seats] report → ${reportPath}`);
+  if (counts.enriched) {
+    console.log(`[enrich-seats] debt shrank — re-record the ceiling: bun skills/_shared/scripts/check-seat-sufficiency.ts --record`);
+  }
+  process.exit(0);
+}

--- a/skills/_shared/tests/enrich-employee-method.test.ts
+++ b/skills/_shared/tests/enrich-employee-method.test.ts
@@ -1,0 +1,295 @@
+/**
+ * enrich-employee-method.test.ts — the announced enricher exists and repairs
+ * without corrupting.
+ *
+ * check-seat-sufficiency.ts printed `Enrich with: bun …/enrich-employee-method.ts`
+ * for weeks while no such file existed — a thin seat's `autofix: "agentic"`
+ * pointed at nothing. These cases pin the contract of the script that now
+ * answers the pointer: shape validation, the deterministic sufficiency gate
+ * asked BEFORE any write, byte-identical preservation of frontmatter and
+ * existing body, retry-with-feedback, and the whole-business loader revert.
+ *
+ * All fixtures are synthetic — no LLM (the generator is injected, the same
+ * seam style verify/agentic.ts uses via runHeadlessImpl), no live library.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import {
+  assembleSeat,
+  buildSeatPrompt,
+  enrichSeat,
+  existingHeadings,
+  expectedLang,
+  listSeats,
+  MAX_GENERATED_CHARS,
+  sufficiencyFeedback,
+  validateSections,
+  type GenResult,
+  type RunCtx,
+  type SeatFile,
+} from "../scripts/enrich-employee-method.ts";
+
+const require_ = createRequire(import.meta.url);
+const { sufficiencyOfFile } = require_("../lib/seat-sufficiency.js");
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), "nrv-enrich-seat-"));
+
+/** A real-shaped thin seat: rich frontmatter, 2-line body — the exact profile
+ *  measured in the live library (ceo.md of atlas-eleitoral-brasil: h=0 d=1). */
+const THIN_SEAT = `---
+name: ceo
+role: electoral_data_director
+description: "Integra dados eleitorais preservando códigos, anos e linhagem."
+reports_to: null
+squads_authorized: [data-pipeline, data-quality-guardian]
+self_score_contract:
+  criteria:
+    - {id: lineage_complete, description: "Todo indicador resolve até a origem.", threshold: 0.95}
+---
+
+# Diretor de dados eleitorais
+
+Você integra dados eleitorais brasileiros. Acione os squads autorizados e entregue lineage e fontes.
+`;
+
+/** Sections that make the assembled seat pass the sufficiency measure:
+ *  2 headings + >=5 decision lines (thresholds, DO/DON'Ts, substantive items). */
+const GOOD_SECTIONS = {
+  sections: [
+    {
+      heading: "Critérios de rejeição",
+      body: [
+        "- Nunca faço join territorial apenas por nome do município — sempre pelo código IBGE de 7 dígitos.",
+        "- Reprovado qualquer indicador cuja linhagem não resolva até a fonte primária com ano explícito.",
+        "- Nunca trato dado agregado como individual; escala menor que 95% de cobertura exige nota metodológica.",
+      ].join("\n"),
+    },
+    {
+      heading: "Handoff e escalonamento",
+      body: [
+        "- Pipeline com mais de 3 fontes vai para o squad data-pipeline; validação de qualidade sempre passa pelo data-quality-guardian.",
+        "- Divergência acima de 2% entre fontes oficiais interrompe a entrega e abre revisão.",
+        "- Antes do handoff, o self-score de lineage_complete precisa estar em 0.95 ou mais.",
+      ].join("\n"),
+    },
+  ],
+};
+
+function seatFixture(dir: string, content: string = THIN_SEAT): SeatFile {
+  const empDir = path.join(dir, "employees");
+  fs.mkdirSync(empDir, { recursive: true });
+  const file = path.join(empDir, "ceo.md");
+  fs.writeFileSync(file, content, "utf8");
+  const s = sufficiencyOfFile(content);
+  return { slug: "ceo", file, content, verdict: s.verdict, signals: s.signals };
+}
+
+function ctxWith(dir: string, answers: GenResult[]): { ctx: RunCtx; calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  return {
+    calls,
+    ctx: {
+      attempts: 3,
+      backupRoot: path.join(dir, "backups"),
+      generate: (prompt) => { calls.push(prompt); return answers[Math.min(i++, answers.length - 1)]; },
+    },
+  };
+}
+
+const ok = (json: unknown): GenResult => ({ ok: true, json, costUsd: 0.01 });
+
+describe("the fixtures agree with the measure", () => {
+  test("the thin fixture is thin and the good sections flip it to sufficient", () => {
+    expect(sufficiencyOfFile(THIN_SEAT).verdict).toBe("thin");
+    const assembled = assembleSeat(THIN_SEAT, GOOD_SECTIONS.sections);
+    expect(sufficiencyOfFile(assembled).verdict).toBe("sufficient");
+  });
+});
+
+describe("validateSections — shape before spend", () => {
+  const ctx = { seatContent: THIN_SEAT, lang: "pt" as const };
+
+  test("good sections pass whole", () => {
+    const v = validateSections(GOOD_SECTIONS, ctx);
+    expect(v.ok).toBe(true);
+    expect(v.cleaned!.length).toBe(2);
+  });
+
+  test("a heading that duplicates an existing section is rejected", () => {
+    const v = validateSections({ sections: [
+      { heading: "Diretor de dados eleitorais", body: "- Nunca aceito fonte sem ano explícito no metadado da entrega." },
+      ...GOOD_SECTIONS.sections,
+    ] }, ctx);
+    expect(v.errors.join("\n")).toContain("duplicates an existing section");
+  });
+
+  test("a --- line inside a body is frontmatter-fence injection", () => {
+    const v = validateSections({ sections: [
+      { heading: "Separador", body: "antes\n---\ndepois" },
+      GOOD_SECTIONS.sections[0],
+    ] }, ctx);
+    expect(v.ok).toBe(false);
+    expect(v.errors.join("\n")).toContain("frontmatter-fence");
+  });
+
+  test("placeholders are not method", () => {
+    const v = validateSections({ sections: [
+      { heading: "Método", body: "TODO: preencher com as regras reais" },
+      GOOD_SECTIONS.sections[0],
+    ] }, ctx);
+    expect(v.errors.join("\n")).toContain("placeholder");
+  });
+
+  test("Portuguese 'todo' is NOT a placeholder — the marker is uppercase-only", () => {
+    // The first live run burned $5.86 rejecting three honest generations
+    // because \bTODO\b/i matched "Todo indicador…". Pin the fix.
+    const v = validateSections({ sections: [
+      {
+        heading: "Cobertura e linhagem",
+        body: [
+          "- Todo indicador entregue resolve até a fonte primária, com ano e órgão explícitos.",
+          "- Nunca aprovo painel em que todo o filtro territorial dependa de nome de município.",
+          "- Cobertura mínima de 95% dos municípios; abaixo disso a entrega sai com nota metodológica.",
+        ].join("\n"),
+      },
+      GOOD_SECTIONS.sections[0],
+    ] }, ctx);
+    expect(v.ok).toBe(true);
+  });
+
+  test("an English method on a PT seat is a language mismatch", () => {
+    const v = validateSections({ sections: [
+      { heading: "Rejection criteria", body: "- Never accept a source without an explicit year attached to the record." },
+      { heading: "Handoff rules", body: "- Always send multi-source pipelines to the data-pipeline squad for review first." },
+    ] }, { seatContent: THIN_SEAT, lang: "pt" });
+    expect(v.errors.join("\n")).toContain("language mismatch");
+  });
+
+  test("sections that stay thin after assembly fail the gate BEFORE any write", () => {
+    const v = validateSections({ sections: [
+      { heading: "Uma seção", body: "Prosa vaga sobre a importância do trabalho bem feito." },
+      { heading: "Outra seção", body: "Mais prosa sem uma única regra concreta de decisão." },
+    ] }, ctx);
+    expect(v.ok).toBe(false);
+    expect(v.errors.join("\n")).toContain("still thin after assembly");
+  });
+
+  test("the generated-size cap holds — a seat is a method, not a book", () => {
+    const huge = "x".repeat(MAX_GENERATED_CHARS);
+    const v = validateSections({ sections: [
+      { heading: "Enciclopédia", body: huge },
+      GOOD_SECTIONS.sections[0],
+    ] }, ctx);
+    expect(v.errors.join("\n")).toContain("cap is");
+  });
+});
+
+describe("assembleSeat — surgical by construction", () => {
+  test("the original file survives byte-identical as a prefix", () => {
+    const assembled = assembleSeat(THIN_SEAT, GOOD_SECTIONS.sections);
+    expect(assembled.startsWith(THIN_SEAT.replace(/\s+$/, ""))).toBe(true);
+    expect(assembled.endsWith("\n")).toBe(true);
+    // Frontmatter parsers still see exactly one fence pair at the top.
+    expect(assembled.match(/^---$/gm)!.length).toBe(2);
+  });
+});
+
+describe("expectedLang and existingHeadings", () => {
+  test("a PT body asks for PT; an EN body asks for EN; empty falls back to description then pt", () => {
+    expect(expectedLang(THIN_SEAT)).toBe("pt");
+    expect(expectedLang('---\nname: x\n---\n\nAlways verify the source of the data before publishing anything.\n')).toBe("en");
+    expect(expectedLang('---\nname: x\ndescription: "Não aprova nada sem fonte."\n---\n')).toBe("pt");
+  });
+
+  test("H1-H3 and bold pseudo-headings are all reserved, accent-folded", () => {
+    const h = existingHeadings('---\nname: x\n---\n\n# Título Principal\n\n## Critérios de Rejeição\n\n**Identidade**\n');
+    expect(h.has("titulo principal")).toBe(true);
+    expect(h.has("criterios de rejeicao")).toBe(true);
+    expect(h.has("identidade")).toBe(true);
+  });
+});
+
+describe("enrichSeat — the loop", () => {
+  test("a good first answer enriches: file sufficient, prefix preserved, cost recorded", () => {
+    const dir = tmp();
+    const seat = seatFixture(dir);
+    const { ctx } = ctxWith(dir, [ok(GOOD_SECTIONS)]);
+    const { report } = enrichSeat("fixture-biz", dir, seat, [seat], ctx);
+
+    expect(report.status).toBe("enriched");
+    expect(report.attempts).toBe(1);
+    expect(report.cost_usd).toBeCloseTo(0.01);
+    const onDisk = fs.readFileSync(seat.file, "utf8");
+    expect(sufficiencyOfFile(onDisk).verdict).toBe("sufficient");
+    expect(onDisk.startsWith(THIN_SEAT.replace(/\s+$/, ""))).toBe(true);
+    expect(report.signals_after!.decisionLines).toBeGreaterThanOrEqual(5);
+  });
+
+  test("a thin answer gets the signals as feedback and the retry succeeds", () => {
+    const dir = tmp();
+    const seat = seatFixture(dir);
+    const thinAnswer = ok({ sections: [
+      { heading: "Prosa", body: "Texto vago sem regras concretas de nenhum tipo aqui." },
+      { heading: "Mais prosa", body: "Outra seção igualmente vaga sem números nem limites." },
+    ] });
+    const { ctx, calls } = ctxWith(dir, [thinAnswer, thinAnswer, ok(GOOD_SECTIONS)]);
+    const { report } = enrichSeat("fixture-biz", dir, seat, [seat], ctx);
+
+    expect(report.status).toBe("enriched");
+    // attempt 1 = generate + one in-attempt repair (both thin), attempt 2 = good.
+    expect(report.attempts).toBe(2);
+    // The repair/retry prompts carry the measure's own vocabulary.
+    expect(calls.slice(1).some((p) => p.includes("still thin after assembly"))).toBe(true);
+    expect(sufficiencyOfFile(fs.readFileSync(seat.file, "utf8")).verdict).toBe("sufficient");
+  });
+
+  test("when every attempt fails the file is byte-identical to the original", () => {
+    const dir = tmp();
+    const seat = seatFixture(dir);
+    const bad = ok({ sections: [{ heading: "Só uma", body: "vaga" }] });
+    const { ctx } = ctxWith(dir, [bad]);
+    const { report } = enrichSeat("fixture-biz", dir, seat, [seat], ctx);
+
+    expect(report.status).toBe("gate_failed");
+    expect(fs.readFileSync(seat.file, "utf8")).toBe(THIN_SEAT);
+  });
+
+  test("a generation failure is reported, never written", () => {
+    const dir = tmp();
+    const seat = seatFixture(dir);
+    const { ctx } = ctxWith(dir, [{ ok: false, json: null, costUsd: null, error: "runtime timed out" }]);
+    const { report } = enrichSeat("fixture-biz", dir, seat, [seat], ctx);
+
+    expect(report.status).toBe("gate_failed");
+    expect(report.errors.join("\n")).toContain("runtime timed out");
+    expect(fs.readFileSync(seat.file, "utf8")).toBe(THIN_SEAT);
+  });
+});
+
+describe("listSeats and the prompt", () => {
+  test("listSeats measures every seat with the admission measure", () => {
+    const dir = tmp();
+    seatFixture(dir);
+    const rich = assembleSeat(THIN_SEAT, GOOD_SECTIONS.sections).replace("name: ceo", "name: rich");
+    fs.writeFileSync(path.join(dir, "employees", "rich.md"), rich, "utf8");
+    const seats = listSeats(dir);
+    expect(seats.map((s) => `${s.slug}:${s.verdict}`).sort()).toEqual(["ceo:thin", "rich:sufficient"]);
+  });
+
+  test("the prompt grounds the model in the seat, the business and the language", () => {
+    const dir = tmp();
+    const seat = seatFixture(dir);
+    fs.writeFileSync(path.join(dir, "business.yaml"), "name: fixture-biz\ndescription: Electoral data integration.\n", "utf8");
+    const prompt = buildSeatPrompt("fixture-biz", dir, seat, [seat], "pt", null);
+    expect(prompt).toContain("self_score_contract");        // the seat travels whole
+    expect(prompt).toContain("Electoral data integration"); // business.yaml travels
+    expect(prompt).toContain("Brazilian Portuguese");       // language is explicit
+    expect(prompt).toContain("sections");                   // output contract
+    const withFeedback = buildSeatPrompt("fixture-biz", dir, seat, [seat], "pt", sufficiencyFeedback({ headings: 1, decisionLines: 2, bodyChars: 100, nonEmptyLines: 4 }));
+    expect(withFeedback).toContain("headings=1 decisionLines=2");
+  });
+});

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -318,11 +318,16 @@ describe("driver adapters — 300KB prompt delivery + cost matrix", () => {
 });
 
 describe("driver adapters — failure contract (error envelope on exit 0 → ok:false)", () => {
-  test("claude-code: is_error:true", () => {
+  test("claude-code: is_error:true — and the CAUSE surfaces in error", () => {
     const r = run("claude-code", "error");
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
-    expect(r.error).toBeTruthy();
+    // The claude CLI puts the cause in `result` and leaves stderr empty on an
+    // error verdict ("Failed to authenticate. API Error: 401 …" arrived exactly
+    // that way, 2026-09-01). A truthy-only assertion let the generic fallback
+    // pass while the real cause sat unread — the caller then retried 3 times
+    // against a stale OAuth token with no idea why.
+    expect(r.error).toContain("boom");
   }, spawnBudgetMs(2));
 
   test("codex: terminal error event", () => {


### PR DESCRIPTION
## Why

Auditing why created businesses read generic (owner report, 2026-09-01), the trail led to a dangling pointer: `check-seat-sufficiency.ts` prints `Enrich with: bun …/enrich-employee-method.ts` — and no such file existed. `seat_thin` is the ONLY depth probe in the whole creation gate (every other check is structural), it is a warning, and its `autofix: "agentic"` aimed at nothing. Measured live: 6 businesses with 19+ thin seats, several at h=0 d=0.

## What ships

**`skills/_shared/scripts/enrich-employee-method.ts`** — the announced enricher, on the `enrich-routing-metadata.ts` contract:

- generation grounded ONLY in what the seat/business declare (self_score criteria, squads_authorized, assigned clones, org position)
- shape validation: heading collisions, placeholders, language mismatch, frontmatter-fence injection, size cap
- **gate BEFORE write**: the admission measure is pure computation, so a failing candidate never touches disk
- surgical: frontmatter + existing body survive byte-identical as a prefix
- whole-business loader check; rejection reverts every seat
- injectable generator (the `runHeadlessImpl` seam style `verify/agentic.ts` uses) — the full loop is tested with no LLM

**Driver fix**: on an error verdict the claude CLI puts the cause in `result` with empty stderr; the driver only read stderr, so callers saw the generic fallback while the real cause sat unread — and retried blind. Now `result` surfaces when stderr is silent, and the adapter test asserts the cause travels (`toContain("boom")` instead of truthy).

**Placeholder rule fix**: `\bTODO\b/i` matches Portuguese "todo" — the first live run burned $5.86 rejecting three honest PT-BR generations. Markers are case-sensitive now; a regression test writes "Todo indicador…" and must pass.

## Verified on the live library

| | before | after |
|---|---|---|
| atlas-eleitoral-brasil/ceo | h=0 d=1 (thin) | **h=9 d=37 (sufficient)** |
| original file | — | byte-identical prefix ✓ |
| `nrv validate business` | seat_thin warning | **ADMITTED, 0 errors** |
| cost | — | $1.95, first attempt |

The generated method is real: join coverage ≥ 99.5% with named orphan handling, SIRGAS 2000 (EPSG:4674) with metric-projection rule, versioned TSE→IBGE de-para, density sanity trigger, minimum handoff package, refusals that offer the nearest neighbor.

## Tests

- `enrich-employee-method.test.ts` 18 pass (new) · `driver-adapters` 24 pass
- `test:shared` 613 · `test:harness` 1670 · `check:all` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk
