### PR TITLE
chore(driver): keep incident specifics out of the shipped notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ### An error verdict now says why
 
-On an error verdict the claude CLI puts the cause in `result` and leaves stderr empty, and the driver only read stderr — so every caller saw the generic "runtime returned an error verdict" while the real cause ("Failed to authenticate. API Error: 401 …") sat unread. Callers retried blind against the same broken credential. The driver now surfaces the result text when stderr is silent.
+On an error verdict the claude CLI puts the cause in `result` and leaves stderr empty, and the driver only read stderr — so every caller saw the generic "runtime returned an error verdict" while the real cause sat unread in the result field, and retried blind against attempts doomed for the same unreported reason. The driver now surfaces the result text when stderr is silent.
 
 ## 0.12.7 — 2026-09-01
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -14,7 +14,7 @@ O `check-seat-sufficiency.ts` imprime `Enrich with: bun …/enrich-employee-meth
 
 ### Um veredito de erro agora diz o porquê
 
-Num veredito de erro o claude CLI põe a causa em `result` e deixa o stderr vazio, e o driver só lia o stderr — então todo chamador via o genérico "runtime returned an error verdict" enquanto a causa real ("Failed to authenticate. API Error: 401 …") ficava sem leitura. Os chamadores tentavam de novo às cegas contra a mesma credencial quebrada. O driver agora expõe o texto do result quando o stderr está em silêncio.
+Num veredito de erro o claude CLI põe a causa em `result` e deixa o stderr vazio, e o driver só lia o stderr — então todo chamador via o genérico "runtime returned an error verdict" enquanto a causa real ficava sem leitura no campo result, e tentava de novo às cegas contra tentativas condenadas pelo mesmo motivo não reportado. O driver agora expõe o texto do result quando o stderr está em silêncio.
 
 ## 0.12.7 — 2026-09-01
 

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -1461,9 +1461,8 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
     stderr,
     durationMs,
     // On an error verdict the claude CLI puts the cause in `result` and leaves
-    // stderr empty ("Failed to authenticate. API Error: 401 …" arrived exactly
-    // that way, 2026-09-01) — so a caller reading `error` saw only the generic
-    // fallback while the real cause sat unread in the result field.
+    // stderr empty — so a caller reading `error` saw only the generic fallback
+    // while the real cause sat unread in the result field.
     error: isError ? salientError(stderr || result, "runtime returned an error verdict") : undefined,
   };
 }

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -323,10 +323,9 @@ describe("driver adapters — failure contract (error envelope on exit 0 → ok:
     expect(r.exitCode).toBe(0);
     expect(r.ok).toBe(false);
     // The claude CLI puts the cause in `result` and leaves stderr empty on an
-    // error verdict ("Failed to authenticate. API Error: 401 …" arrived exactly
-    // that way, 2026-09-01). A truthy-only assertion let the generic fallback
-    // pass while the real cause sat unread — the caller then retried 3 times
-    // against a stale OAuth token with no idea why.
+    // error verdict. A truthy-only assertion let the generic fallback pass
+    // while the real cause sat unread — callers then retried blind, paying for
+    // attempts that were doomed for the same unreported reason.
     expect(r.error).toContain("boom");
   }, spawnBudgetMs(2));
 


### PR DESCRIPTION
The error-surfacing fix stands on the CLI's documented behavior alone (the cause arrives in `result` with stderr empty). Comments and changelog entries now state that behavior impersonally. No functional change; driver-adapters 24 pass, changelog parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk