### PR TITLE
feat(verify): the business gate's agentic findings get a repairer that proves itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### `enrich-business-admission.ts` — the agentic findings of the business gate, repaired and proven
+
+The mechanical fixers raise a business to protocol 2.0 and stop where meaning starts: `routing_metadata_incomplete` (no `not_for`, briefs in one language), `auto_route_never_fires`, `readme_thin`. Measured on the pack sources after a full mechanical pass: 27 businesses, 0 errors, 407 warnings, and 391 of them were exactly those three — 341 routes in the v1 ticket dialect (`type:strategy|approval-gate|…`) that no brief in a human language ever fires. The new script writes that meaning with a headless LLM and keeps the gate's own rules as the bar, asked on the candidate BEFORE any write: `not_for` as 3-25 char tokens (past 25 the router's substring penalty stops firing), briefs classified in both languages by the gate's `classify`, every route `(?i)`-prefixed (the one form the gate and the runtime router compile alike), compiling, naming a real seat and firing on ≥1 brief, every brief firing ≥1 route, README ≥40 lines with the sections the gate looks for and no path into anyone's home. Writes are surgical (`not_for` / `example_briefs` replace their own blocks with the file's indent; `auto_routes` is replaced whole and `brief_intake` survives verbatim), the surface is regenerated, and the gate runs again on disk: errors may not grow and every targeted finding must be gone, or every file is restored. `--dir` and `--pack` reach pack sources, which live outside the scope and have no registry. Verified on a real pack business: 13 warnings → 0, 11 dead routes → 0, one attempt.
+
+### `extractJson` no longer truncates an object that carries fenced code
+
+Fence-first extraction cut a JSON object at the FIRST ``` it contained — and a string value holding a fenced block (a generated README with a ```bash example) contains one, so a complete, bare JSON answer came back as an unparseable fragment. The whole text is tried first now; the fence is the fallback.
+
+### A capped run names its cap
+
+When a budget or turn cap stops the claude CLI before any text, `result` and stderr are both empty and the only cause on offer is the `subtype`. The driver now carries it into `error` (`runtime returned an error verdict (error_max_budget_usd)`) instead of a bare verdict — and no longer reports a stringified empty result as the cause.
+
 ## 0.12.8 — 2026-09-02
 
 ### `enrich-employee-method.ts` exists now — the announced seat enricher

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,20 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### `enrich-business-admission.ts` — os achados agênticos do gate de empresa, reparados e provados
+
+Os fixers mecânicos elevam uma empresa ao protocolo 2.0 e param onde começa o significado: `routing_metadata_incomplete` (sem `not_for`, briefs numa língua só), `auto_route_never_fires`, `readme_thin`. Medido nas fontes de pack depois de uma passada mecânica completa: 27 empresas, 0 erros, 407 warnings, e 391 deles eram exatamente esses três — 341 rotas no dialeto de tickets do v1 (`type:strategy|approval-gate|…`) que nenhum brief em língua humana dispara. O script novo escreve esse significado com um LLM headless e mantém as regras do próprio gate como barra, perguntadas ao candidato ANTES de qualquer escrita: `not_for` como tokens de 3-25 chars (acima de 25 a penalidade por substring do router para de disparar), briefs classificados nas duas línguas pelo `classify` do gate, toda rota com prefixo `(?i)` (a única forma que o gate e o router de runtime compilam igual), compilando, nomeando um seat real e disparando em ≥1 brief, todo brief disparando ≥1 rota, README com ≥40 linhas, as seções que o gate procura e nenhum caminho para a home de ninguém. As escritas são cirúrgicas (`not_for` / `example_briefs` substituem seus próprios blocos com a indentação do arquivo; `auto_routes` é substituído inteiro e `brief_intake` sobrevive verbatim), o surface é regenerado e o gate roda de novo no disco: erros não podem crescer e todo achado alvo tem que sumir, ou todos os arquivos são restaurados. `--dir` e `--pack` alcançam fontes de pack, que vivem fora do escopo e não têm registro. Verificado numa empresa real de pack: 13 warnings → 0, 11 rotas mortas → 0, uma tentativa.
+
+### `extractJson` não trunca mais um objeto que carrega código cercado
+
+A extração fence-first cortava um objeto JSON no PRIMEIRO ``` que ele contivesse — e um valor string com um bloco cercado (um README gerado com um exemplo em ```bash) contém um, então uma resposta JSON completa e sem envelope voltava como fragmento inparseável. Agora o texto inteiro é tentado primeiro; o fence é o fallback.
+
+### Um run cortado por teto diz qual teto
+
+Quando um teto de orçamento ou de turnos para o claude CLI antes de qualquer texto, `result` e stderr ficam vazios e a única causa disponível é o `subtype`. O driver agora o leva para `error` (`runtime returned an error verdict (error_max_budget_usd)`) em vez de um veredito nu — e não reporta mais um result vazio stringificado como causa.
+
 ## 0.12.8 — 2026-09-02
 
 ### O `enrich-employee-method.ts` agora existe — o enriquecedor de seat anunciado

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -1462,8 +1462,12 @@ function runClaudeCode(opts: RunHeadlessOpts): RunHeadlessResult {
     durationMs,
     // On an error verdict the claude CLI puts the cause in `result` and leaves
     // stderr empty — so a caller reading `error` saw only the generic fallback
-    // while the real cause sat unread in the result field.
-    error: isError ? salientError(stderr || result, "runtime returned an error verdict") : undefined,
+    // while the real cause sat unread in the result field. When result is empty
+    // too (a budget or turn cap stops the run before any text), the subtype is
+    // the only thing that says why: `error_max_budget_usd` beats a bare verdict.
+    error: isError
+      ? salientError(stderr || (result === '""' ? "" : result), `runtime returned an error verdict${resultSubtype && resultSubtype !== "success" ? ` (${resultSubtype})` : ""}`)
+      : undefined,
   };
 }
 

--- a/skills/_shared/scripts/enrich-business-admission.ts
+++ b/skills/_shared/scripts/enrich-business-admission.ts
@@ -1,0 +1,540 @@
+#!/usr/bin/env bun
+/**
+ * enrich-business-admission.ts — repairs what the business admission gate
+ * marks `autofix: "agentic"` on its buyer-facing surface, and proves it with
+ * the gate itself.
+ *
+ * THE FINDINGS IT ANSWERS
+ *
+ *   routing_metadata_incomplete   `not_for` absent, or example_briefs in one
+ *                                 language only (§6.9). The router reads both.
+ *   auto_route_never_fires        a pattern that fires against no example_brief
+ *                                 (§13.2). Measured on the pack sources
+ *                                 2026-09-02: 341 of them across 27 businesses,
+ *                                 all the v1 ticket dialect
+ *                                 (`type:strategy|approval-gate|…`) — routing by
+ *                                 ticket-type token, which no brief written in
+ *                                 a human language ever contains.
+ *   readme_thin                   the README is the scaffold the mechanical
+ *                                 fixer wrote, not the document a buyer opens.
+ *
+ * The mechanical fixers refuse all three on purpose: each one is meaning. This
+ * script writes the meaning with a headless LLM and keeps every deterministic
+ * check the gate would run — on the candidate, BEFORE anything touches disk:
+ *
+ *   not_for          4-20 short token entries, 3-25 chars each (router.js
+ *                    penalises by substring; past 25 chars the fence stops
+ *                    firing), no "(use X)" suffix, no colon.
+ *   example_briefs   existing + new, deduped, ≤30, every new one 20-1000 chars
+ *                    and free of the business's own slug (§5); afterwards the
+ *                    set classifies as BOTH pt and en by the gate's own
+ *                    `classify`.
+ *   routes           3-16, `(?i)` prefix (the gate compiles case-insensitive
+ *                    ONLY with the prefix; the runtime router always does —
+ *                    the prefix is the one form both agree on), compiles, is
+ *                    not a catch-all, names an existing seat, fires on ≥1
+ *                    brief; and every brief fires ≥1 route, so the business is
+ *                    a candidate for each brief it declares as its own.
+ *   readme           ≥40 lines, `## ` sections, ≥3 of the 4 groups the gate
+ *                    looks for, no path into anyone's home directory.
+ *
+ * Writes are surgical: `not_for` and `example_briefs` replace their own
+ * top-level blocks in business.yaml (indentation matched to the file), the
+ * `auto_routes:` block of routing.yaml is replaced whole (the dead routes ARE
+ * the defect; brief_intake and every other key survive verbatim), README.md
+ * is written only when it was the target. Then the gate runs again on disk:
+ * errors may not grow and every targeted finding must be gone, or every file
+ * is restored from its backup and the attempt's failures feed the next prompt.
+ *
+ * `--dir` and `--pack` exist because pack SOURCES are not installed entities:
+ * they live outside the resolved scope and have no registry. Neither mode
+ * reindexes anything or touches a registry — the self-retrieval gate is the
+ * installed library's question, asked by `nrv validate` after install.
+ *
+ * CLI:
+ *   bun enrich-business-admission.ts --slugs=a,b            # installed library
+ *   bun enrich-business-admission.ts --dir=<business-dir>   # one directory
+ *   bun enrich-business-admission.ts --pack=<content-dir>   # every business of a pack source
+ *   --dry --attempts=N --runtime=R --model=M --scratch=DIR --timeout-min=N --budget-usd=N
+ *
+ * Exit codes: 0 = batch done (statuses in the report), 2 = bad usage.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveScope } from "../lib/scope.ts";
+import { paths } from "../lib/bun-helpers.ts";
+import { classify } from "../lib/corpus-language.ts";
+import { checkSync, readBusiness, type BusinessRead } from "../lib/verify/kinds/business.ts";
+import { surfaceRegenFixer } from "../lib/verify/common.ts";
+import { runHeadless, runtimeAvailable, type Runtime } from "../../harness/lib/host-agent-driver.ts";
+import {
+  backupFile, extractJson, restoreBackup, topLevelBlockSpan, verifyYamlSurgical, yamlScalar, type BackupEntry,
+} from "./enrich-routing-metadata.ts";
+
+const YAML = require("yaml");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pure helpers (unit-tested, no LLM, no filesystem beyond what they receive)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export const NOT_FOR_MAX_CHARS = 25;
+export const README_MIN_LINES = 40;
+export const EXAMPLE_BRIEFS_MAX = 30;
+const CATCH_ALL = new Set([".*", ".+", "(?i).*", "(?i).+", "^.*$", "^.+$", "(?i)^.*$", "(?i)^.+$", ".*?"]);
+
+export interface Route { pattern: string; route_to: string; why?: string }
+export interface Generated { not_for: string[]; example_briefs: string[]; routes: Route[]; readme: string | null }
+export interface Needs { notFor: boolean; briefLangs: boolean; routes: boolean; readme: boolean }
+
+/** The gate's own compile: `(?i)` prefix → the i flag, nothing else. */
+export function compileRoute(pattern: string): RegExp | null {
+  try {
+    const ci = pattern.startsWith("(?i)");
+    return new RegExp(ci ? pattern.slice(4) : pattern, ci ? "i" : "");
+  } catch { return null; }
+}
+
+/** What the gate reports as agentic on this business, read from its findings. */
+export function needsOf(findings: Array<{ id: string; evidence?: string }>): Needs {
+  const rmi = findings.find((f) => f.id === "routing_metadata_incomplete");
+  const ev = rmi?.evidence ?? "";
+  return {
+    notFor: /\bnot_for\b/.test(ev),
+    briefLangs: /example_briefs in both/.test(ev),
+    routes: findings.some((f) => f.id === "auto_route_never_fires"),
+    readme: findings.some((f) => f.id === "readme_thin" || f.id === "readme_missing"),
+  };
+}
+
+export function validateGenerated(
+  raw: unknown,
+  ctx: { needs: Needs; slug: string; seats: string[]; existingBriefs: string[]; existingNotFor: string[] },
+): { ok: boolean; errors: string[]; cleaned?: Generated } {
+  const errors: string[] = [];
+  const g = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const strs = (v: unknown) => (Array.isArray(v) ? v.filter((x): x is string => typeof x === "string").map((x) => x.trim()).filter(Boolean) : []);
+
+  // ── not_for ──
+  let notFor = ctx.existingNotFor;
+  if (ctx.needs.notFor) {
+    notFor = [...new Set(strs(g.not_for))];
+    if (notFor.length < 4 || notFor.length > 20) errors.push(`not_for: ${notFor.length} entries — need 4-20`);
+    for (const n of notFor) {
+      if (n.length < 3 || n.length > NOT_FOR_MAX_CHARS) errors.push(`not_for: "${n.slice(0, 30)}" is ${n.length} chars — 3-${NOT_FOR_MAX_CHARS} (the router penalises by substring; longer never fires)`);
+      if (/\(use\b/i.test(n) || n.includes(":")) errors.push(`not_for: "${n.slice(0, 30)}" — no "(use X)" suffix, no colon; a fence is a short token list`);
+    }
+  }
+
+  // ── example_briefs ──
+  const added = strs(g.example_briefs_add);
+  const lowerExisting = new Set(ctx.existingBriefs.map((b) => b.toLowerCase()));
+  const newOnes = added.filter((b) => !lowerExisting.has(b.toLowerCase()));
+  for (const b of newOnes) {
+    if (b.length < 20 || b.length > 1000) errors.push(`example_briefs_add: length out of 20-1000: "${b.slice(0, 40)}"`);
+    if (b.toLowerCase().includes(ctx.slug.toLowerCase())) errors.push(`example_briefs_add: carries the business's own slug — self-retrieval would pass for the wrong reason (§5): "${b.slice(0, 40)}"`);
+  }
+  const briefs = [...ctx.existingBriefs, ...newOnes];
+  if (briefs.length > EXAMPLE_BRIEFS_MAX) errors.push(`example_briefs: ${briefs.length} after merge — cap is ${EXAMPLE_BRIEFS_MAX}; add fewer`);
+  if (ctx.needs.briefLangs || ctx.needs.routes) {
+    const langs = new Set(briefs.map(classify));
+    if (!langs.has("en") || !langs.has("pt")) errors.push(`example_briefs: need BOTH en and pt after merge — found ${[...langs].sort().join("+") || "none"} (the gate's classify counts language markers; write a brief a native would type)`);
+  }
+
+  // ── routes ──
+  let routes: Route[] = [];
+  if (ctx.needs.routes) {
+    const rawRoutes = Array.isArray(g.routes) ? g.routes : [];
+    if (rawRoutes.length < 3 || rawRoutes.length > 16) errors.push(`routes: ${rawRoutes.length} — need 3-16`);
+    const seatSet = new Set(ctx.seats);
+    const compiled: Array<{ route: Route; re: RegExp }> = [];
+    for (const r of rawRoutes) {
+      const o = (r && typeof r === "object" ? r : {}) as Record<string, unknown>;
+      const pattern = typeof o.pattern === "string" ? o.pattern.trim() : "";
+      const route_to = typeof o.route_to === "string" ? o.route_to.trim() : "";
+      const why = typeof o.why === "string" ? o.why.trim().split("\n")[0].slice(0, 160) : undefined;
+      const label = pattern.slice(0, 48) || "(empty)";
+      if (!pattern.startsWith("(?i)")) { errors.push(`routes: ${label} — every pattern starts with (?i); the gate compiles case-insensitive only with the prefix`); continue; }
+      if (CATCH_ALL.has(pattern)) { errors.push(`routes: ${label} matches every brief — a catch-all is ignored and silences every route below it`); continue; }
+      const re = compileRoute(pattern);
+      if (!re) { errors.push(`routes: ${label} does not compile as a JavaScript regex`); continue; }
+      if (!seatSet.has(route_to)) { errors.push(`routes: route_to "${route_to}" is not a seat of ${ctx.slug} (seats: ${ctx.seats.join(", ")})`); continue; }
+      if (!briefs.some((b) => re.test(b))) { errors.push(`routes: ${label} fires against none of the ${briefs.length} example_briefs — add a brief it fires on, or drop the route`); continue; }
+      compiled.push({ route: { pattern, route_to, ...(why ? { why } : {}) }, re });
+    }
+    for (const b of briefs) {
+      if (!compiled.some((c) => c.re.test(b))) errors.push(`routes: no route fires on the brief "${b.slice(0, 70)}" — the business would not be a candidate for its own brief`);
+    }
+    routes = compiled.map((c) => c.route);
+  }
+
+  // ── readme ──
+  let readme: string | null = null;
+  if (ctx.needs.readme) {
+    readme = typeof g.readme === "string" ? g.readme.trim() + "\n" : null;
+    if (!readme) errors.push("readme: missing — a README was requested");
+    else {
+      const lines = readme.split("\n").length;
+      if (lines < README_MIN_LINES) errors.push(`readme: ${lines} lines — the gate wants at least ${README_MIN_LINES}`);
+      const lower = readme.toLowerCase();
+      const groups = [["## "], ["employee", "funcionário", "cargo", "role", "seat"], ["usage", "uso", "como", "getting started"], ["domain", "domínio", "description", "descrição", "sobre", "what it"]];
+      const covered = groups.filter((gr) => gr.some((kw) => lower.includes(kw))).length;
+      if (covered < 3) errors.push(`readme: covers ${covered}/4 of the section groups the gate looks for (headings, employees, usage, domain)`);
+      if (/\/Users\/|\/home\/|~\//.test(readme)) errors.push("readme: points at a path in someone's home directory — a buyer's copy lives elsewhere");
+      if (/\b(TODO|FIXME)\b/.test(readme) || /Replace it with the real thing/.test(readme)) errors.push("readme: still carries scaffold text");
+    }
+  }
+
+  if (errors.length) return { ok: false, errors };
+  return { ok: true, errors: [], cleaned: { not_for: notFor, example_briefs: briefs, routes, readme } };
+}
+
+/** The indent the file already uses for top-level list items ("" or "  "). */
+export function listIndentOf(yamlText: string): string {
+  const m = /^[A-Za-z_][\w.-]*:\s*\n(\s*)- /m.exec(yamlText);
+  return m ? m[1] : "  ";
+}
+
+/** Replace (or append) a top-level list block, matching the file's indent. */
+export function setTopLevelList(text: string, key: string, items: string[]): string {
+  const indent = listIndentOf(text);
+  const emitted = [`${key}:`, ...items.map((it) => `${indent}- ${yamlScalar(it)}`)].join("\n") + "\n";
+  const span = topLevelBlockSpan(text, key);
+  if (span) return text.slice(0, span.start) + emitted + text.slice(span.end);
+  let t = text;
+  if (!t.endsWith("\n")) t += "\n";
+  return t + emitted;
+}
+
+const HEADER = [
+  "# Business Protocol 2.0 §13.2: a route makes the business a candidate AND selects",
+  "# the seat that receives the brief. First pattern that matches wins, so the order",
+  "# below runs specific to general. Every pattern fires against at least one",
+  "# example_brief of this business; a pattern that fires only in the author's head",
+  "# is not a route.",
+];
+
+/** Rewrite the `auto_routes:` block of routing.yaml; every other key survives verbatim. */
+export function setAutoRoutes(routingText: string | null, routes: Route[], intake: string | null): string {
+  const q = (s: string) => `'${s.replace(/'/g, "''")}'`;
+  const body = routes.flatMap((r) => [...(r.why ? [`# ${r.why}`] : []), `- pattern: ${q(r.pattern)}`, `  route_to: ${r.route_to}`]);
+  const block = [...HEADER, "auto_routes:", ...body].join("\n") + "\n";
+  let text = routingText ?? "";
+  if (!text.trim()) return `brief_intake:\n  default_employee: ${intake ?? routes[0]?.route_to ?? ""}\n  alternates: []\n${block}`;
+  if (!text.endsWith("\n")) text += "\n";
+  const span = topLevelBlockSpan(text, "auto_routes");
+  if (!span) return text + block;
+  // A comment run directly above the old block belongs to it: drop it too.
+  let start = span.start;
+  const before = text.slice(0, start).split("\n");
+  before.pop(); // the empty tail after the last \n
+  while (before.length && /^#/.test(before[before.length - 1])) before.pop();
+  start = before.length ? before.join("\n").length + 1 : 0;
+  return text.slice(0, start) + block + text.slice(span.end);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Library access + prompt
+// ═══════════════════════════════════════════════════════════════════════════
+
+function businessDirs(): string[] {
+  const scope = resolveScope();
+  return scope.businessDirs.length ? scope.businessDirs : [paths.BUSINESSES_DIR];
+}
+
+function findBusinessDir(slug: string): string | null {
+  for (const root of businessDirs()) {
+    const dir = path.join(root, slug);
+    if (fs.existsSync(path.join(dir, "business.yaml"))) return dir;
+  }
+  return null;
+}
+
+function readCapped(file: string, cap: number): string {
+  if (!fs.existsSync(file)) return "";
+  const s = fs.readFileSync(file, "utf8");
+  return s.length > cap ? s.slice(0, cap) + "\n…(truncated for prompt)" : s;
+}
+
+function seatDigest(b: BusinessRead): string {
+  return b.seats.map((s) => {
+    const d = s.data ?? {};
+    const pick = (k: string) => (d[k] === undefined ? "" : ` ${k}=${JSON.stringify(d[k])}`);
+    return `- ${s.name}:${pick("role")}${pick("is_brief_intake")}${pick("reports_to")}${pick("manages")}\n    description: ${String(d.description ?? "").slice(0, 320)}`;
+  }).join("\n");
+}
+
+const CONTRACT = `
+THE CONTRACT (Business Protocol 2.0 §6.9 and §13.2, distilled):
+- not_for: 4-20 SHORT entries, 3-25 characters each, 2-4 content words. A fence is a token the
+  router penalises by substring — "recrutar desenvolvedor", "hire developers", "on-call 24x7".
+  PT and EN are SEPARATE entries. Never a sentence, never "(use X)", never a colon. Only what
+  the business genuinely refuses — a defensive fence removes it from a comparison it might win.
+- example_briefs_add: new briefs written as a REAL user types them — first person, symptom
+  language, conjugated AND infinitive verb forms, concrete nouns of the domain. 20-1000 chars.
+  Add what is needed so the set carries BOTH English and Portuguese and so every route below
+  fires on at least one brief. Never include the business's own slug.
+- routes: the auto_routes of routing.yaml, REPLACING the current ones. Each pattern is a regex
+  with the (?i) prefix, PT and EN in one alternation, verb STEMS (escrev\\w* covers
+  escrever/escreva/escrevendo), accent variants where diacritics occur (c[oó]digo), anchored on
+  content nouns — never scaffold words (quero, preciso, please, help). First match wins: order
+  SPECIFIC to GENERAL, and give each route a one-line "why" when its position matters.
+  route_to names a seat that RECEIVES briefs: the intake seat, the leads/heads, and cross-cutting
+  utility seats (QA, security, compliance). An individual contributor is reached through the org
+  chart by its lead, never by routing a whole brief around the lead. Every route MUST fire on at
+  least one example_brief (existing + added), and every example_brief MUST fire at least one route.
+- readme (only when requested): the document a BUYER opens first, in English, 45-75 lines,
+  Markdown with "## " sections (it MAY contain fenced code blocks — keep the JSON valid, newlines as \n): what the business is (2-3 paragraphs, concrete artifacts), the
+  domains, what it produces, the org chart as a list of seats with one line each, the ship gate
+  (what acceptance blocks), usage (how to brief it: \`nrv run <slug> "<brief>"\` and the intake
+  seat), and layout. Never a path into a home directory, never a TODO, never marketing adjectives.
+`.trim();
+
+export function buildPrompt(slug: string, dir: string, b: BusinessRead, needs: Needs, retryFeedback: string | null): string {
+  const wanted: string[] = [];
+  if (needs.notFor) wanted.push('"not_for": string[]');
+  wanted.push('"example_briefs_add": string[]   // may be empty when the existing set already satisfies the rules');
+  if (needs.routes) wanted.push('"routes": [{ "pattern": string, "route_to": string, "why": string|null }]');
+  if (needs.readme) wanted.push('"readme": string   // the full README.md as Markdown');
+  return [
+    `You are completing the buyer-facing surface of the Nirvana-OS business "${slug}" so it passes the admission gate.`,
+    "Your ONLY output is one JSON object — no prose, no markdown fences. UTF-8, PT-BR diacritics intact, no trailing commas.",
+    "",
+    CONTRACT,
+    "",
+    "FIELDS TO GENERATE (JSON object with exactly these keys):",
+    "{",
+    wanted.map((w) => "  " + w).join(",\n"),
+    "}",
+    "",
+    retryFeedback ? `PREVIOUS ATTEMPT FEEDBACK (fix exactly this, without breaking the rules above):\n${retryFeedback}\n` : "",
+    "SOURCE MATERIAL:",
+    "=== business.yaml ===",
+    readCapped(path.join(dir, "business.yaml"), 12000),
+    "=== routing.yaml (current — its auto_routes are the v1 ticket dialect and will be REPLACED by yours) ===",
+    readCapped(path.join(dir, "routing.yaml"), 5000) || "(absent)",
+    "=== org-chart.yaml ===",
+    readCapped(path.join(dir, "org-chart.yaml"), 3000) || "(absent)",
+    `=== seats (${b.seats.length}) — name, role, intake flag, reporting line, description ===`,
+    seatDigest(b),
+    "",
+    "Answer with the JSON object only.",
+  ].join("\n");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pipeline
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface GenResult { ok: boolean; json: unknown; costUsd: number | null; error?: string }
+export type GenerateFn = (prompt: string) => GenResult;
+export interface RunCtx { attempts: number; backupRoot: string; generate: GenerateFn }
+
+export interface BusinessReport {
+  slug: string;
+  dir: string;
+  status: "enriched" | "gate_failed" | "skipped" | "dry";
+  needs: Needs;
+  attempts: number;
+  findings_before: { errors: number; warnings: number; dead_routes: number };
+  findings_after: { errors: number; warnings: number; dead_routes: number } | null;
+  files_written: string[];
+  cost_usd: number;
+  errors: string[];
+}
+
+function summarize(findings: Array<{ id: string; severity: string }>) {
+  return {
+    errors: findings.filter((f) => f.severity === "error").length,
+    warnings: findings.filter((f) => f.severity === "warning").length,
+    dead_routes: findings.filter((f) => f.id === "auto_route_never_fires").length,
+  };
+}
+
+export async function enrichBusinessDir(dir: string, ctx: RunCtx, opts: { dry?: boolean } = {}): Promise<BusinessReport> {
+  const slug = path.basename(dir);
+  const before = checkSync(dir) as Array<{ id: string; severity: string; evidence?: string }>;
+  const needs = needsOf(before);
+  const report: BusinessReport = {
+    slug, dir, status: "skipped", needs, attempts: 0,
+    findings_before: summarize(before), findings_after: null, files_written: [], cost_usd: 0, errors: [],
+  };
+  if (!needs.notFor && !needs.briefLangs && !needs.routes && !needs.readme) {
+    report.errors.push("nothing agentic to repair on the buyer-facing surface");
+    return report;
+  }
+  if (opts.dry) { report.status = "dry"; return report; }
+
+  const b = readBusiness(dir);
+  if (!b.manifest) { report.errors.push(`business.yaml does not load: ${b.parseError}`); return report; }
+  const seats = b.seats.map((s) => s.name);
+  const strs = (v: unknown) => (Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []);
+  const existingBriefs = strs(b.manifest.example_briefs);
+  const existingNotFor = strs(b.manifest.not_for);
+  const intake = b.seats.find((s) => s.data?.is_brief_intake === true)?.name ?? null;
+
+  const bizPath = path.join(dir, "business.yaml");
+  const routingPath = path.join(dir, "routing.yaml");
+  const readmePath = path.join(dir, "README.md");
+  let retryFeedback: string | null = null;
+
+  for (let attempt = 1; attempt <= ctx.attempts; attempt++) {
+    report.attempts = attempt;
+    const prompt = buildPrompt(slug, dir, b, needs, retryFeedback);
+    let gen = ctx.generate(prompt);
+    report.cost_usd += gen.costUsd || 0;
+    const vctx = { needs, slug, seats, existingBriefs, existingNotFor };
+    let validation = validateGenerated(gen.json, vctx);
+    if (gen.ok && !validation.ok) {
+      // One in-attempt shape repair (sibling pattern): feed the errors back once.
+      const repair = prompt + "\n\nYOUR PREVIOUS ANSWER FAILED VALIDATION:\n- " + validation.errors.slice(0, 25).join("\n- ") + "\n\nAnswer again with a corrected JSON object only.";
+      gen = ctx.generate(repair);
+      report.cost_usd += gen.costUsd || 0;
+      validation = validateGenerated(gen.json, vctx);
+    }
+    if (!gen.ok || !validation.ok) {
+      const errs = [...(gen.error ? [gen.error] : []), ...validation.errors];
+      report.errors.push(...errs.map((e) => `attempt ${attempt}: ${e}`));
+      retryFeedback = errs.slice(0, 25).join("\n");
+      continue;
+    }
+    const c = validation.cleaned!;
+
+    // ── write, surgically ──
+    const backups: BackupEntry[] = [];
+    const written: string[] = [];
+    const oldBiz = fs.readFileSync(bizPath, "utf8");
+    let newBiz = oldBiz;
+    const touched: string[] = []; const intended: Record<string, unknown> = {};
+    if (needs.notFor) { newBiz = setTopLevelList(newBiz, "not_for", c.not_for); touched.push("not_for"); intended.not_for = c.not_for; }
+    if (c.example_briefs.length !== existingBriefs.length) { newBiz = setTopLevelList(newBiz, "example_briefs", c.example_briefs); touched.push("example_briefs"); intended.example_briefs = c.example_briefs; }
+    if (touched.length) {
+      const integrity = verifyYamlSurgical(oldBiz, newBiz, touched, intended);
+      if (!integrity.ok) { report.errors.push(...integrity.errors.map((e) => `attempt ${attempt}: integrity: ${e}`)); retryFeedback = integrity.errors.join("\n"); continue; }
+      backups.push(backupFile(ctx.backupRoot, bizPath));
+      fs.writeFileSync(bizPath, newBiz, "utf8"); written.push(`business.yaml (${touched.join(", ")})`);
+    }
+    if (needs.routes) {
+      const oldRouting = fs.existsSync(routingPath) ? fs.readFileSync(routingPath, "utf8") : null;
+      const newRouting = setAutoRoutes(oldRouting, c.routes, intake);
+      const intendedRoutes = c.routes.map((r) => ({ pattern: r.pattern, route_to: r.route_to }));
+      // A routing.yaml written from nothing also gains brief_intake — declare it, or the
+      // integrity check reads it as an unexpected key.
+      const routingTouched = oldRouting ? ["auto_routes"] : ["auto_routes", "brief_intake"];
+      const integrity = verifyYamlSurgical(oldRouting ?? "", newRouting, routingTouched, { auto_routes: intendedRoutes });
+      if (!integrity.ok) {
+        for (const bk of backups) restoreBackup(bk);
+        report.errors.push(...integrity.errors.map((e) => `attempt ${attempt}: routing integrity: ${e}`)); retryFeedback = integrity.errors.join("\n"); continue;
+      }
+      backups.push(backupFile(ctx.backupRoot, routingPath));
+      fs.writeFileSync(routingPath, newRouting, "utf8"); written.push(`routing.yaml (auto_routes ×${c.routes.length})`);
+    }
+    if (needs.readme && c.readme) {
+      backups.push(backupFile(ctx.backupRoot, readmePath));
+      fs.writeFileSync(readmePath, c.readme, "utf8"); written.push("README.md");
+    }
+    // The surface hashes the prose just rewritten; left alone it reads `surface_stale`
+    // on the very next gate run. Same fixer `--fix` uses; restored with the rest on revert.
+    const surfacePath = path.join(dir, ".nirvana-surface.json");
+    backups.push(backupFile(ctx.backupRoot, surfacePath));
+    surfaceRegenFixer("business")({ dir, finding: { id: "surface_stale" } } as never);
+
+    // ── prove with the gate itself, on disk ──
+    const after = checkSync(dir) as Array<{ id: string; severity: string; evidence?: string }>;
+    const afterNeeds = needsOf(after);
+    const sumAfter = summarize(after);
+    const problems: string[] = [];
+    if (sumAfter.errors > report.findings_before.errors) problems.push(`errors grew ${report.findings_before.errors} → ${sumAfter.errors}: ${after.filter((f) => f.severity === "error").map((f) => f.id).join(", ")}`);
+    if (needs.notFor && afterNeeds.notFor) problems.push("not_for still reported missing");
+    if ((needs.briefLangs || needs.routes) && afterNeeds.briefLangs) problems.push("example_briefs still in one language per the gate");
+    if (needs.routes && sumAfter.dead_routes > 0) problems.push(`${sumAfter.dead_routes} route(s) still fire on no brief per the gate`);
+    if (needs.readme && afterNeeds.readme) problems.push("README still thin per the gate");
+    try {
+      const { loadBusiness } = await import("../../businesses/lib/loader.ts");
+      loadBusiness(dir);
+    } catch (e) { problems.push(`loadBusiness rejected the write: ${String(e).split("\n")[0]}`); }
+
+    if (problems.length) {
+      for (const bk of backups) restoreBackup(bk);
+      report.errors.push(...problems.map((p) => `attempt ${attempt}: ${p}`));
+      retryFeedback = problems.join("\n");
+      continue;
+    }
+    report.status = "enriched";
+    report.files_written = written;
+    report.findings_after = sumAfter;
+    return report;
+  }
+  report.status = "gate_failed";
+  return report;
+}
+
+function packBusinessDirs(contentDir: string): string[] {
+  const root = path.join(contentDir, "businesses");
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root).sort().map((s) => path.join(root, s)).filter((d) => fs.existsSync(path.join(d, "business.yaml")));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CLI
+// ═══════════════════════════════════════════════════════════════════════════
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const flag = (name: string): string | null => { const hit = argv.find((a) => a.startsWith(`--${name}=`)); return hit ? hit.slice(name.length + 3) : null; };
+  const has = (name: string) => argv.includes(`--${name}`);
+
+  const dry = has("dry");
+  const attempts = Math.max(1, Number(flag("attempts") || 3));
+  const runtime = (flag("runtime") || "claude-code") as Runtime;
+  const model = flag("model") || undefined;
+  const scratch = flag("scratch") || path.join(os.tmpdir(), "nirvana-enrich-business");
+  const timeoutMs = Math.max(1, Number(flag("timeout-min") || 12)) * 60 * 1000;
+  // The README is most of the output; at $3 a full answer was cut by the cap
+  // mid-generation (measured 2026-09-02: error_max_budget_usd, empty result).
+  const budgetUsd = Number(flag("budget-usd") || 5);
+
+  let dirs: string[] = [];
+  if (flag("dir")) dirs = [path.resolve(flag("dir")!.replace(/^~(?=$|\/)/, os.homedir()))];
+  else if (flag("pack")) dirs = packBusinessDirs(path.resolve(flag("pack")!.replace(/^~(?=$|\/)/, os.homedir())));
+  else if (flag("slugs")) dirs = flag("slugs")!.split(",").map((s) => s.trim()).filter(Boolean).map((s) => findBusinessDir(s) ?? s);
+  else { console.error("usage: bun enrich-business-admission.ts (--slugs=a,b | --dir=<business-dir> | --pack=<content-dir>) [--dry] [--attempts=N] [--runtime=R] [--model=M] [--scratch=DIR] [--timeout-min=N] [--budget-usd=N]"); process.exit(2); }
+  dirs = dirs.filter((d) => { const ok = fs.existsSync(path.join(d, "business.yaml")); if (!ok) console.error(`skip: no business.yaml at ${d}`); return ok; });
+  if (!dirs.length) { console.error("enrich-business: no business selected"); process.exit(2); }
+
+  if (dry) {
+    for (const d of dirs) {
+      const r = await enrichBusinessDir(d, { attempts: 0, backupRoot: "", generate: () => ({ ok: false, json: null, costUsd: 0 }) }, { dry: true });
+      const n = r.needs; const want = [n.notFor && "not_for", n.briefLangs && "briefs-lang", n.routes && `routes(${r.findings_before.dead_routes} dead)`, n.readme && "readme"].filter(Boolean).join(", ");
+      console.log(`  ${r.slug}: ${want || "nothing agentic"}`);
+    }
+    process.exit(0);
+  }
+  if (!runtimeAvailable(runtime)) { console.error(`enrich-business: runtime '${runtime}' not on PATH`); process.exit(2); }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupRoot = path.join(scratch, `backups-${stamp}`);
+  fs.mkdirSync(backupRoot, { recursive: true });
+  const generate: GenerateFn = (prompt) => {
+    const res = runHeadless({ runtime, prompt, cwd: os.tmpdir(), allowedTools: [], permissionMode: "default", model, maxBudgetUsd: budgetUsd, timeoutMs });
+    const json = res.ok ? extractJson(res.result) : null;
+    return { ok: !!json, json, costUsd: res.costUsd, error: res.ok ? (json ? undefined : "no JSON object in the model output") : (res.error || "generation run failed") };
+  };
+  const ctx: RunCtx = { attempts, backupRoot, generate };
+  const reports: BusinessReport[] = [];
+  for (const d of dirs) {
+    console.log(`[enrich-business] → ${path.basename(d)}`);
+    const r = await enrichBusinessDir(d, ctx);
+    reports.push(r);
+    const a = r.findings_after;
+    console.log(`[enrich-business]   ${r.status}${a ? ` — warnings ${r.findings_before.warnings}→${a.warnings}, dead routes ${r.findings_before.dead_routes}→${a.dead_routes}` : ""}${r.files_written.length ? ` · ${r.files_written.join(", ")}` : ""}${r.errors.length && r.status !== "enriched" ? ` — ${r.errors[r.errors.length - 1].slice(0, 140)}` : ""}`);
+  }
+  const reportPath = path.join(scratch, `enrich-business-${stamp}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify({ started_at: stamp, runtime, model: model || null, attempts, total_cost_usd: reports.reduce((n, r) => n + r.cost_usd, 0), businesses: reports, backup_root: backupRoot }, null, 2) + "\n");
+  const counts: Record<string, number> = {};
+  for (const r of reports) counts[r.status] = (counts[r.status] || 0) + 1;
+  console.log(`[enrich-business] ${Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(" · ")} · cost=$${reports.reduce((n, r) => n + r.cost_usd, 0).toFixed(2)}`);
+  console.log(`[enrich-business] report → ${reportPath}`);
+  process.exit(0);
+}

--- a/skills/_shared/scripts/enrich-routing-metadata.ts
+++ b/skills/_shared/scripts/enrich-routing-metadata.ts
@@ -561,13 +561,21 @@ export function restoreBackup(entry: BackupEntry): void {
 // ── LLM plumbing ────────────────────────────────────────────────────────────
 
 export function extractJson(raw: string): any | null {
-  let t = (raw || "").trim();
+  const t = (raw || "").trim();
+  const span = (s: string): any | null => {
+    const start = s.indexOf("{");
+    const end = s.lastIndexOf("}");
+    if (start === -1 || end <= start) return null;
+    try { return JSON.parse(s.slice(start, end + 1)); } catch { return null; }
+  };
+  // The whole text first. Fence-first cut a JSON object at the FIRST ``` it
+  // contained — and a string value that carries fenced code (a README with a
+  // ```bash block) contains one, so the object came back as a truncated
+  // fragment and the parse failed even when the model answered bare JSON.
+  const whole = span(t);
+  if (whole !== null) return whole;
   const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/);
-  if (fence) t = fence[1].trim();
-  const start = t.indexOf("{");
-  const end = t.lastIndexOf("}");
-  if (start === -1 || end <= start) return null;
-  try { return JSON.parse(t.slice(start, end + 1)); } catch { return null; }
+  return fence ? span(fence[1].trim()) : null;
 }
 
 interface GenOptions {

--- a/skills/_shared/tests/enrich-business-admission.test.ts
+++ b/skills/_shared/tests/enrich-business-admission.test.ts
@@ -1,0 +1,277 @@
+/**
+ * enrich-business-admission.test.ts — the buyer-facing surface is repaired
+ * only in the shape the gate admits, and never at the cost of anything else.
+ *
+ * Measured on the pack sources 2026-09-02, after the mechanical fixers had
+ * done everything they own: 27 businesses, 0 errors, 407 warnings — and 391 of
+ * those were three findings the fixers refuse to invent: 341 v1 ticket-dialect
+ * routes (`type:strategy|approval-gate|…`) firing on no brief, 27 businesses
+ * without not_for, 23 README stubs. These cases pin the script that writes
+ * that meaning: every deterministic rule it applies BEFORE writing is the
+ * gate's own, the writes are surgical, and a candidate the gate still rejects
+ * is reverted whole.
+ *
+ * Synthetic fixtures throughout — no LLM (the generator is injected), no live
+ * library. The round-trip case runs the real `checkSync`, which is the point.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  compileRoute, enrichBusinessDir, listIndentOf, needsOf, setAutoRoutes, setTopLevelList, validateGenerated,
+  type GenResult, type Needs, type RunCtx,
+} from "../scripts/enrich-business-admission.ts";
+import { checkSync } from "../lib/verify/kinds/business.ts";
+import { surfaceRegenFixer } from "../lib/verify/common.ts";
+
+const YAML = require("yaml");
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), "nrv-enrich-biz-"));
+
+const SEATS = ["ee-ceo", "ee-k12-head", "ee-qa"];
+const EXISTING_BRIEFS = [
+  "Preciso de um currículo alinhado à BNCC para o ensino fundamental da minha escola",
+  "quero montar a trilha de formação de professores da rede para o próximo semestre",
+  "Revisão pedagógica das aulas antes de publicar no portal dos alunos",
+];
+const ALL: Needs = { notFor: true, briefLangs: true, routes: true, readme: true };
+
+const GOOD = {
+  not_for: ["aula particular", "private tutoring", "reforço escolar", "diploma reconhecimento", "degree accreditation"],
+  example_briefs_add: [
+    "Design a BNCC-aligned curriculum map for grades 6 to 9 at our private school",
+    "Audit the lesson plans for factual errors and fixed-mindset feedback before they go live",
+  ],
+  routes: [
+    { pattern: "(?i)(revis[aã]o\\s+pedag[oó]gica|audit\\w*\\s+the\\s+lesson|factual\\s+errors?|fixed[- ]mindset)", route_to: "ee-qa", why: "QA first: a review brief also names the lesson it reviews" },
+    { pattern: "(?i)(bncc|curr[ií]culo|curriculum|ensino\\s+fundamental|grades?\\s+\\d)", route_to: "ee-k12-head", why: null },
+    { pattern: "(?i)(forma[çc][aã]o\\s+de\\s+professores|teacher\\s+training|trilha\\s+de\\s+forma)", route_to: "ee-ceo", why: null },
+  ],
+  readme: [
+    "# edu-fixture", "",
+    "An education department in a box. It takes a school's brief and returns curriculum",
+    "maps, lesson plans and the review that clears them for publication.", "",
+    "## Domains", "", "- k12", "- teacher training", "",
+    "## What it produces", "", "- curriculum-map", "- lesson-plan", "- pedagogical-review", "",
+    "## The org chart", "", "- `ee-ceo` — intake, owns the plan", "- `ee-k12-head` — K-12 curriculum", "- `ee-qa` — pedagogical review with veto", "",
+    "## The ship gate", "", "Nothing publishes before `ee-qa` clears it for factual errors and feedback language.", "",
+    "## Usage", "", "```bash", 'nrv run edu-fixture "<brief>"', "```", "", "The intake seat is `ee-ceo`; the description in business.yaml is what the router reads.", "",
+    "## Layout", "", "- business.yaml", "- routing.yaml", "- employees/", "- org-chart.yaml", "",
+    "## Method", "", "Mastery learning, deliberate practice and growth-mindset feedback framing.", "",
+    "## Limits", "", "No private tutoring, no degree accreditation, no individual grading of real students.", "", "",
+  ].join("\n"),
+};
+
+const ctxAll = { needs: ALL, slug: "edu-fixture", seats: SEATS, existingBriefs: EXISTING_BRIEFS, existingNotFor: [] as string[] };
+
+describe("compileRoute is the gate's compile", () => {
+  test("(?i) becomes the i flag; without it the regex is case-sensitive; garbage is null", () => {
+    expect(compileRoute("(?i)bncc")!.test("Curriculo BNCC")).toBe(true);
+    expect(compileRoute("bncc")!.test("Curriculo BNCC")).toBe(false);
+    expect(compileRoute("(?i)(unclosed")).toBeNull();
+  });
+});
+
+describe("needsOf reads the gate's findings", () => {
+  test("not_for and the language split come from the evidence string; routes and readme from ids", () => {
+    const n = needsOf([
+      { id: "routing_metadata_incomplete", evidence: "example_briefs in both EN and PT (found pt) · not_for" },
+      { id: "auto_route_never_fires" }, { id: "readme_thin" },
+    ]);
+    expect(n).toEqual({ notFor: true, briefLangs: true, routes: true, readme: true });
+    expect(needsOf([{ id: "routing_metadata_incomplete", evidence: "produces · keywords" }])).toEqual({ notFor: false, briefLangs: false, routes: false, readme: false });
+  });
+});
+
+describe("validateGenerated — the gate's rules, asked before any write", () => {
+  test("a good answer passes whole, and the merged briefs carry both languages", () => {
+    const v = validateGenerated(GOOD, ctxAll);
+    expect(v.errors).toEqual([]);
+    expect(v.ok).toBe(true);
+    expect(v.cleaned!.example_briefs.length).toBe(5);
+    expect(v.cleaned!.routes.length).toBe(3);
+    expect(v.cleaned!.routes[0].why).toContain("QA first");
+  });
+
+  test("a not_for past 25 chars, or with a (use X) suffix, is rejected — the fence would never fire", () => {
+    const v = validateGenerated({ ...GOOD, not_for: ["aula particular", "tarefa pontual de copy isolada (use copy.sales)", "x", "reforço escolar"] }, ctxAll);
+    const e = v.errors.join("\n");
+    expect(e).toContain("chars");
+    expect(e).toContain("(use X)");
+  });
+
+  test("a pattern without (?i) is rejected: the gate would test it case-sensitive", () => {
+    const routes = GOOD.routes.map((r, i) => (i === 1 ? { ...r, pattern: r.pattern.slice(4) } : r));
+    const v = validateGenerated({ ...GOOD, routes }, ctxAll);
+    expect(v.errors.join("\n")).toContain("starts with (?i)");
+  });
+
+  test("a route that fires on no brief, and a brief that fires no route, both fail", () => {
+    const routes = [...GOOD.routes, { pattern: "(?i)(orçamento\\s+anual)", route_to: "ee-ceo", why: null }];
+    let v = validateGenerated({ ...GOOD, routes }, ctxAll);
+    expect(v.errors.join("\n")).toContain("fires against none");
+    v = validateGenerated({ ...GOOD, routes: GOOD.routes.slice(0, 2) }, ctxAll);
+    expect(v.errors.join("\n")).toContain("no route fires on the brief");
+  });
+
+  test("route_to must name a seat; a catch-all is refused", () => {
+    let v = validateGenerated({ ...GOOD, routes: [{ ...GOOD.routes[0], route_to: "ghost" }, ...GOOD.routes.slice(1)] }, ctxAll);
+    expect(v.errors.join("\n")).toContain("not a seat");
+    v = validateGenerated({ ...GOOD, routes: [{ pattern: "(?i).*", route_to: "ee-ceo", why: null }, ...GOOD.routes] }, ctxAll);
+    expect(v.errors.join("\n")).toContain("catch-all");
+  });
+
+  test("a new brief carrying the slug is rejected — self-retrieval would pass for the wrong reason", () => {
+    const v = validateGenerated({ ...GOOD, example_briefs_add: [...GOOD.example_briefs_add, "Please have edu-fixture design our reading program"] }, ctxAll);
+    expect(v.errors.join("\n")).toContain("own slug");
+  });
+
+  test("a README under 40 lines, or pointing into a home directory, is not the buyer's document", () => {
+    let v = validateGenerated({ ...GOOD, readme: "# x\n\n## Usage\n\nrun it\n" }, ctxAll);
+    expect(v.errors.join("\n")).toContain("lines");
+    v = validateGenerated({ ...GOOD, readme: GOOD.readme + "\nSee /Users/someone/businesses/edu-fixture\n" }, ctxAll);
+    expect(v.errors.join("\n")).toContain("home directory");
+  });
+
+  test("only what the gate asked for is required: routes alone needs no README and keeps not_for as is", () => {
+    const v = validateGenerated({ routes: GOOD.routes, example_briefs_add: GOOD.example_briefs_add }, { ...ctxAll, needs: { notFor: false, briefLangs: false, routes: true, readme: false }, existingNotFor: ["kept"] });
+    expect(v.ok).toBe(true);
+    expect(v.cleaned!.not_for).toEqual(["kept"]);
+    expect(v.cleaned!.readme).toBeNull();
+  });
+});
+
+describe("surgical writers", () => {
+  test("setTopLevelList matches the file's own indent and replaces in place", () => {
+    const indented = "name: x\ndomains:\n  - a\n  - b\nnot_for:\n  - old\ndescription: y\n";
+    const out = setTopLevelList(indented, "not_for", ["new one", "another"]);
+    expect(listIndentOf(indented)).toBe("  ");
+    expect(out).toBe("name: x\ndomains:\n  - a\n  - b\nnot_for:\n  - new one\n  - another\ndescription: y\n");
+    const flush = "name: x\ndomains:\n- a\n";
+    expect(setTopLevelList(flush, "not_for", ["z"])).toBe("name: x\ndomains:\n- a\nnot_for:\n- z\n");
+  });
+
+  test("setAutoRoutes replaces the block and its comment run; brief_intake survives verbatim", () => {
+    const old = "brief_intake:\n  default_employee: ee-ceo\n  alternates: []\n# old comment\nauto_routes:\n  - pattern: type:strategy|approval-gate\n    route_to: ee-ceo\n";
+    const out = setAutoRoutes(old, GOOD.routes.slice(0, 2), "ee-ceo");
+    const doc = YAML.parse(out);
+    expect(doc.brief_intake).toEqual({ default_employee: "ee-ceo", alternates: [] });
+    expect(doc.auto_routes).toEqual(GOOD.routes.slice(0, 2).map((r) => ({ pattern: r.pattern, route_to: r.route_to })));
+    expect(out).not.toContain("old comment");
+    expect(out).not.toContain("type:strategy");
+    expect(out).toContain("# QA first");
+  });
+
+  test("setAutoRoutes from nothing writes brief_intake with the intake seat", () => {
+    const doc = YAML.parse(setAutoRoutes(null, GOOD.routes.slice(0, 1), "ee-ceo"));
+    expect(doc.brief_intake.default_employee).toBe("ee-ceo");
+    expect(doc.auto_routes.length).toBe(1);
+  });
+});
+
+// ── a synthetic business that passes the gate with exactly the three agentic findings ──
+
+function fixtureBusiness(root: string): string {
+  const dir = path.join(root, "edu-fixture");
+  fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "memory"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "business.yaml"), [
+    "name: edu-fixture", 'protocol: "2.0"', "version: 1.0.0",
+    "description: Designs BNCC-aligned curricula, lesson plans and the pedagogical review that clears them for a private school network.",
+    "domains:", "  - education",
+    "produces:", "  - curriculum-map", "  - lesson-plan",
+    "keywords:", "  - bncc", "  - curriculo", "  - currículo", "  - curriculum", "  - lesson plan", "  - plano de aula",
+    "example_briefs:", ...EXISTING_BRIEFS.map((b) => `  - "${b}"`),
+    "runtime_requirements:", "  policy: declared", "  minimum:", "    - runtime: claude-code", "",
+  ].join("\n"));
+  const seat = (name: string, role: string, extra: string[]) => fs.writeFileSync(path.join(dir, "employees", `${name}.md`), [
+    "---", `name: ${name}`, `role: ${role}`, `description: "${role} of the fixture business, grounded in the school brief."`, ...extra, "---", "",
+    `# ${role}`, "", "## Regras", "", "- Nunca aprovo material sem a fonte da competência BNCC citada.", "- Sempre entrego o plano com objetivos mensuráveis por aula.",
+    "- Reprovado qualquer feedback que envergonhe o aluno; a linguagem segue growth mindset.", "- Cobertura mínima de 90% das habilidades do ano antes de fechar o mapa.",
+    "- Prazo de revisão: 2 dias úteis por unidade.", "",
+  ].join("\n"));
+  seat("ee-ceo", "Diretor", ["is_brief_intake: true", "manages: [ee-k12-head, ee-qa]", "acceptance:", "  - id: plan_measurable", '    description: "Todo plano traz objetivos mensuráveis por aula"', "    blocking: true", "    minimum_score: 0.9"]);
+  seat("ee-k12-head", "Head K-12", ["reports_to: ee-ceo"]);
+  seat("ee-qa", "Revisão pedagógica", ["reports_to: ee-ceo", "is_antagonist: true"]);
+  fs.writeFileSync(path.join(dir, "org-chart.yaml"), "chart:\n  - employee: ee-ceo\n    reports: []\n    direct_reports: [ee-k12-head, ee-qa]\n  - employee: ee-k12-head\n    reports: [ee-ceo]\n    direct_reports: []\n  - employee: ee-qa\n    reports: [ee-ceo]\n    direct_reports: []\n    is_antagonist: true\n");
+  fs.writeFileSync(path.join(dir, "routing.yaml"), "brief_intake:\n  default_employee: ee-ceo\n  alternates: []\nauto_routes:\n  - pattern: type:strategy|approval-gate|budget\n    route_to: ee-ceo\n  - pattern: type:k12-curriculum|bncc-alignment\n    route_to: ee-k12-head\n");
+  fs.writeFileSync(path.join(dir, "README.md"), "# edu-fixture\n\nScaffolded.\n");
+  fs.writeFileSync(path.join(dir, "memory", "permanent.md"), "# Memory\n");
+  surfaceRegenFixer("business")({ dir, finding: { id: "surface_missing" } } as never);
+  return dir;
+}
+
+function ctxWith(root: string, answers: GenResult[]): { ctx: RunCtx; calls: string[] } {
+  const calls: string[] = []; let i = 0;
+  return { calls, ctx: { attempts: 3, backupRoot: path.join(root, "backups"), generate: (p) => { calls.push(p); return answers[Math.min(i++, answers.length - 1)]; } } };
+}
+const ok = (json: unknown): GenResult => ({ ok: true, json, costUsd: 0.5 });
+
+describe("enrichBusinessDir — the loop, proven by the real gate", () => {
+  test("the fixture starts with exactly the three agentic findings and no error", () => {
+    const root = tmp(); const dir = fixtureBusiness(root);
+    const f = checkSync(dir);
+    const ids = new Set(f.map((x) => x.id));
+    expect(f.filter((x) => x.severity === "error").map((x) => x.id)).toEqual([]);
+    expect(ids.has("routing_metadata_incomplete")).toBe(true);
+    expect(ids.has("auto_route_never_fires")).toBe(true);
+    expect(ids.has("readme_thin")).toBe(true);
+    expect(needsOf(f as never)).toEqual(ALL);
+  });
+
+  test("a good answer enriches: all three findings gone, brief_intake intact, surface fresh, cost recorded", async () => {
+    const root = tmp(); const dir = fixtureBusiness(root);
+    const errorsBefore = checkSync(dir).filter((x) => x.severity === "error").length;
+    const { ctx } = ctxWith(root, [ok(GOOD)]);
+    const r = await enrichBusinessDir(dir, ctx);
+    expect(r.errors).toEqual([]);
+    expect(r.status).toBe("enriched");
+    expect(r.attempts).toBe(1);
+    expect(r.cost_usd).toBeCloseTo(0.5);
+    expect(r.files_written.join(" ")).toContain("routing.yaml");
+    expect(r.files_written.join(" ")).toContain("README.md");
+    const after = checkSync(dir);
+    const ids = new Set(after.map((x) => x.id));
+    expect(ids.has("routing_metadata_incomplete")).toBe(false);
+    expect(ids.has("auto_route_never_fires")).toBe(false);
+    expect(ids.has("readme_thin")).toBe(false);
+    expect(ids.has("surface_stale")).toBe(false);
+    expect(after.filter((x) => x.severity === "error").length).toBe(errorsBefore);
+    const routing = YAML.parse(fs.readFileSync(path.join(dir, "routing.yaml"), "utf8"));
+    expect(routing.brief_intake).toEqual({ default_employee: "ee-ceo", alternates: [] });
+    expect(routing.auto_routes.length).toBe(3);
+    const biz = YAML.parse(fs.readFileSync(path.join(dir, "business.yaml"), "utf8"));
+    expect(biz.not_for.length).toBe(5);
+    expect(biz.example_briefs.length).toBe(5);
+    expect(biz.description).toContain("BNCC-aligned"); // untouched keys survive
+  });
+
+  test("a rejected answer carries the gate's own words back, and the retry succeeds", async () => {
+    const root = tmp(); const dir = fixtureBusiness(root);
+    const bad = ok({ ...GOOD, routes: GOOD.routes.slice(0, 2) }); // one brief left without a route
+    const { ctx, calls } = ctxWith(root, [bad, bad, ok(GOOD)]);
+    const r = await enrichBusinessDir(dir, ctx);
+    expect(r.status).toBe("enriched");
+    expect(r.attempts).toBe(2);
+    expect(calls.slice(1).some((p) => p.includes("no route fires on the brief"))).toBe(true);
+  });
+
+  test("when every attempt fails, every file is byte-identical to the original", async () => {
+    const root = tmp(); const dir = fixtureBusiness(root);
+    const snapshot = Object.fromEntries(["business.yaml", "routing.yaml", "README.md"].map((f) => [f, fs.readFileSync(path.join(dir, f), "utf8")]));
+    const { ctx } = ctxWith(root, [ok({ not_for: ["x"] })]);
+    const r = await enrichBusinessDir(dir, ctx);
+    expect(r.status).toBe("gate_failed");
+    for (const [f, text] of Object.entries(snapshot)) expect(fs.readFileSync(path.join(dir, f), "utf8")).toBe(text);
+  });
+
+  test("a business with nothing agentic to repair is skipped without a call", async () => {
+    const root = tmp(); const dir = fixtureBusiness(root);
+    const { ctx: first } = ctxWith(root, [ok(GOOD)]);
+    await enrichBusinessDir(dir, first);
+    const { ctx, calls } = ctxWith(root, [ok(GOOD)]);
+    const r = await enrichBusinessDir(dir, ctx);
+    expect(r.status).toBe("skipped");
+    expect(calls.length).toBe(0);
+  });
+});

--- a/skills/_shared/tests/enrich-routing-metadata.test.ts
+++ b/skills/_shared/tests/enrich-routing-metadata.test.ts
@@ -302,6 +302,19 @@ describe("pure helpers", () => {
     expect(extractJson("no json at all")).toBeNull();
   });
 
+  test("extractJson: a string value carrying fenced code does not truncate the object", () => {
+    // Measured 2026-09-02: a generated README with a ```bash block inside the
+    // JSON made fence-first extraction cut at the README's own fence — two
+    // attempts, $6.51, "no JSON object in the model output" while the object
+    // was complete. Bare and fenced envelopes both have to survive it.
+    const obj = { not_for: ["a"], readme: "# x\n\n```bash\nnrv run x\n```\n" };
+    const bare = JSON.stringify(obj);
+    expect(extractJson(bare)).toEqual(obj);
+    expect(extractJson("```json\n" + bare + "\n```")).toEqual(obj);
+    // Prose with braces before a fenced object still resolves through the fence.
+    expect(extractJson('Note {this} first.\n```json\n{"a": 2}\n```')).toEqual({ a: 2 });
+  });
+
   test("hasUsableRoutingBlock", () => {
     expect(hasUsableRoutingBlock({ routing: { one_liner: "x", domains: ["a"], serves: "y" } })).toBe(true);
     expect(hasUsableRoutingBlock({ routing: { one_liner: "x", domains: [] } })).toBe(false);

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -60,6 +60,11 @@ beforeAll(() => {
       process.stdout.write(JSON.stringify({ type: "result", subtype: "error_during_execution", is_error: true, result: "boom", session_id: "s1", total_cost_usd: 0.01 }));
       process.exit(0);
     }
+    if (process.env.FAKE_MODE === "budget") {
+      // A cap stops the run before any text: no result, no stderr, only the subtype says why.
+      process.stdout.write(JSON.stringify({ type: "result", subtype: "error_max_budget_usd", is_error: true, session_id: "s1", total_cost_usd: 3.0 }));
+      process.exit(0);
+    }
     process.stdout.write(JSON.stringify({ type: "result", is_error: false, result: "len:" + len, session_id: "s1", total_cost_usd: 0.42 }));
   `);
 
@@ -174,7 +179,7 @@ function assertArgvSafe(cli: string): void {
   }
 }
 
-function run(runtime: Runtime, mode?: "error") {
+function run(runtime: Runtime, mode?: "error" | "budget") {
   if (mode) process.env.FAKE_MODE = mode;
   else delete process.env.FAKE_MODE;
   try {
@@ -327,6 +332,15 @@ describe("driver adapters — failure contract (error envelope on exit 0 → ok:
     // while the real cause sat unread — callers then retried blind, paying for
     // attempts that were doomed for the same unreported reason.
     expect(r.error).toContain("boom");
+  }, spawnBudgetMs(2));
+
+  test("claude-code: a cap that stops the run before any text names itself through the subtype", () => {
+    const r = run("claude-code", "budget");
+    expect(r.ok).toBe(false);
+    // No result and no stderr: the subtype is the only cause on offer, and a
+    // caller retrying blind against a budget cap pays the cap again each time.
+    expect(r.error).toContain("error_max_budget_usd");
+    expect(r.error).not.toContain('""');
   }, spawnBudgetMs(2));
 
   test("codex: terminal error event", () => {


### PR DESCRIPTION
## Why

Raising the pack businesses to protocol 2.0 showed where the mechanical fixers stop. After a full `--fix` pass over 27 pack-source businesses: 0 errors, 407 warnings — **391 of them the three findings declared `autofix: "agentic"`**: `routing_metadata_incomplete` (no `not_for`, briefs in one language), `auto_route_never_fires`, `readme_thin`. The dead routes were all the v1 ticket dialect (`type:strategy|approval-gate|…`) — 341 of them — which no human-language brief ever fires.

## What ships

**`skills/_shared/scripts/enrich-business-admission.ts`** — writes the meaning with a headless LLM, keeps the gate's rules as the bar, asked on the candidate BEFORE any write:

| field | rule (the gate's own) |
|---|---|
| `not_for` | 4-20 tokens, 3-25 chars (router substring penalty), no `(use X)` |
| `example_briefs` | merged set classifies as both `pt` and `en` via the gate's `classify`; no slug; ≤30 |
| routes | `(?i)` prefix (the one form gate + runtime compile alike), compiles, not catch-all, names a real seat, fires on ≥1 brief; **every brief fires ≥1 route** |
| README | ≥40 lines, gate's section groups, no home-directory paths |

Surgical writes (own blocks, file indent, `brief_intake` verbatim, surface regenerated), then `checkSync` again on disk: errors may not grow, targeted findings must be gone — else full restore. `--dir` / `--pack` reach pack sources without touching any registry.

**Two defects found by running it for real:**
- `extractJson` cut at the first ``` inside a string value (a README with a ```bash block) → whole text first, fence as fallback. Cost of finding it: $6.51.
- A budget cap leaves `result`/stderr empty; the driver reported `""` as the cause → the `subtype` (`error_max_budget_usd`) now travels in `error`.

## Verified on a real pack business

`edtech-empire`: 13 warnings → **0**, 11 dead routes → **0**, one attempt, $3.01. Nine `(?i)` routes ordered specific→general with a stated reason per position, twelve genuine refusals PT+EN, a 68-line buyer README, gate **ADMITTED, 0 errors**.

## Tests

`enrich-business-admission` 18 (round-trip through the real `checkSync`) · `enrich-routing-metadata` +1 · `driver-adapters` 25 · `test:shared` 632 · `test:harness` 1672 (one local failure is a live-library watermark moved by a business authored on this machine yesterday, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk