### PR TITLE
fix(scope): a shared temp root is never a project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A shared temp root is never a project root
+
+`resolveProjectRoot()` walks up looking for a marker (`.env`, `.nirvana`, `.git`, `package.json`, `pyproject.toml`) and hardens against `/`, HOME and the Windows system directories — but not against the temp roots. Measured 2026-09-03 on a real machine: `/private/tmp` held a `.nirvana` and a `package.json` left there by unrelated tools, so every scope resolution from a path under it adopted `/private/tmp` as the project. A dispatch launched from a scratch directory then wrote its brief, its kernel and its audit chain into a tree with no contract and no `.nirvana/` of its own, and reported success. The comment above `dispatch.ts`'s `PROJECT_ROOT` already records the earlier version of this bug ("a child runtime told its project was the user's home directory"); the missing temp rule is what kept it reachable.
+
+The rule is `sameDir`, not `isUnder`, exactly like the HOME rule beside it: a directory *created* under temp with its own marker — every fixture in this suite — is still a legitimate project root. It is the shared root itself that cannot be one.
+
+The walk was also duplicated: `harness/lib/run-ledger.ts` carried its own copy with the same HOME hardening, and hardening `_shared/lib/project-root.js` alone left the copy that `dispatch.ts` actually calls still adopting `/private/tmp`. It now imports the shared `isInvalidProjectRoot` instead of reimplementing the predicate.
+
 ## 0.12.9 — 2026-09-03
 
 ### Every dependency installs into `~/.nirvana`, and nowhere else

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,16 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Uma raiz temporária compartilhada nunca é raiz de projeto
+
+O `resolveProjectRoot()` sobe procurando um marcador (`.env`, `.nirvana`, `.git`, `package.json`, `pyproject.toml`) e se protege contra `/`, o HOME e os diretórios de sistema do Windows — mas não contra as raízes temporárias. Medido em 03/09/2026 numa máquina real: `/private/tmp` tinha um `.nirvana` e um `package.json` deixados ali por ferramentas sem relação, então toda resolução de escopo a partir de um caminho abaixo dele adotava `/private/tmp` como projeto. Um despacho lançado de um diretório de rascunho escrevia brief, kernel e cadeia de auditoria numa árvore sem contrato e sem `.nirvana/` próprio — e reportava sucesso. O comentário sobre o `PROJECT_ROOT` do `dispatch.ts` já registra a versão anterior desse bug ("um runtime filho foi informado de que seu projeto era o diretório home do usuário"); a regra de temp que faltava é o que o mantinha alcançável.
+
+A regra é `sameDir`, não `isUnder`, igual à regra de HOME ao lado: um diretório *criado* dentro de temp com marcador próprio — toda fixture desta suíte — continua sendo raiz de projeto legítima. É a raiz compartilhada que não pode ser uma.
+
+O walk também estava duplicado: o `harness/lib/run-ledger.ts` carregava uma cópia própria com o mesmo hardening de HOME, e endurecer só o `_shared/lib/project-root.js` deixava a cópia que o `dispatch.ts` de fato chama ainda adotando `/private/tmp`. Ela passa a importar o `isInvalidProjectRoot` compartilhado em vez de reimplementar o predicado.
+
 ## 0.12.9 — 2026-09-03
 
 ### Toda dependência instala em `~/.nirvana`, e em nenhum outro lugar

--- a/skills/_shared/lib/project-root.js
+++ b/skills/_shared/lib/project-root.js
@@ -88,6 +88,19 @@ function homeDir(opts) {
  * @param {string} dir
  * @param {{home?: string}} [opts] `home` overrides the resolved HOME, for tests.
  */
+/**
+ * The shared scratch roots on this platform. `os.tmpdir()` is the per-user one
+ * (on macOS a path under /var/folders); the literals cover the system-wide ones
+ * that tools write to directly.
+ * @returns {string[]}
+ */
+function tempRootDirs() {
+  const out = [];
+  try { out.push(os.tmpdir()); } catch { /* no tmpdir — nothing to exclude */ }
+  for (const p of ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp']) out.push(p);
+  return out.map((d) => { try { return canonical(d); } catch { return d; } });
+}
+
 function isInvalidProjectRoot(dir, opts) {
   if (!dir) return true;
   if (dir === '/' || dir === '') return true;
@@ -95,6 +108,21 @@ function isInvalidProjectRoot(dir, opts) {
     const resolved = canonical(dir);
     if (resolved === path.parse(resolved).root) return true;
     if (sameDir(resolved, homeDir(opts))) return true;
+    // A temp ROOT is never a project, for the same reason HOME is not: it is
+    // shared scratch space, and anything on the machine may drop a marker in
+    // it. Measured 2026-09-03: `/private/tmp` held a `.nirvana` and a
+    // `package.json` left by unrelated tools, so every scope resolution from a
+    // path under /tmp adopted `/private/tmp` as the project — and a dispatch
+    // launched from a scratch directory wrote its brief, kernel and audit chain
+    // there, believing it was inside a project.
+    //
+    // The rule is `sameDir`, not `isUnder`, exactly like the HOME rule above: a
+    // directory CREATED under temp with its own marker (every test fixture in
+    // this repo) is still a legitimate project root. It is the shared root
+    // itself that cannot be one.
+    for (const t of tempRootDirs()) {
+      if (sameDir(resolved, t)) return true;
+    }
     if (process.platform === 'win32') {
       const systemDirs = [process.env.SystemRoot, process.env.ProgramFiles, process.env['ProgramFiles(x86)']]
         .filter(Boolean)

--- a/skills/_shared/tests/project-root.test.ts
+++ b/skills/_shared/tests/project-root.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
 import { findProjectRoot, isInvalidProjectRoot } from "../lib/project-root.js";
 import { makeTempRoot } from "../../harness/tests/helpers/temp-dirs.ts";
 
@@ -27,6 +28,37 @@ function fixture() {
   fs.mkdirSync(path.join(home, ".nirvana"), { recursive: true });
   return { root, home };
 }
+
+describe("findProjectRoot — a shared temp root is never a project either", () => {
+  // Same reasoning as HOME: /tmp is scratch space every tool on the machine
+  // writes to. Measured 2026-09-03: `/private/tmp` held a `.nirvana` and a
+  // `package.json` left by unrelated tools, so every scope resolution from a
+  // path under it adopted `/private/tmp` as the project — and a dispatch
+  // launched from a scratch directory wrote its brief, kernel and audit chain
+  // there, believing it was inside a project.
+  test("the temp root itself is not a project, even carrying a marker", () => {
+    const tmp = fs.realpathSync(os.tmpdir());
+    fs.writeFileSync(path.join(tmp, ".nrv-marker-probe.json"), "{}");
+    try {
+      // A marker sitting in the temp root must not make the temp root a project.
+      expect(findProjectRoot(tmp, { markers: [".nrv-marker-probe.json"] })).toBeNull();
+    } finally {
+      fs.rmSync(path.join(tmp, ".nrv-marker-probe.json"), { force: true });
+    }
+  });
+
+  test("a project CREATED under temp is still found — every fixture in this repo is one", () => {
+    // The rule is `sameDir`, not `isUnder`: excluding the whole subtree would
+    // break the fixtures that make this suite possible.
+    const root = makeTempRoot("nrv-under-temp-");
+    roots.push(root);
+    const proj = path.join(root, "a-real-project");
+    fs.mkdirSync(path.join(proj, ".nirvana"), { recursive: true });
+    const start = path.join(proj, "src", "deep");
+    fs.mkdirSync(start, { recursive: true });
+    expect(findProjectRoot(start)).toBe(fs.realpathSync(proj));
+  });
+});
 
 describe("findProjectRoot — HOME is never a project, whatever is inside it", () => {
   test("a temp dir physically under HOME finds nothing, not HOME itself", () => {

--- a/skills/harness/lib/run-ledger.ts
+++ b/skills/harness/lib/run-ledger.ts
@@ -207,6 +207,10 @@ function isStrictlyUnder(descendant: string, ancestor: string): boolean {
  * ancestry before it would reach the filesystem root — without this check it
  * keeps going and can match a marker up there instead of correctly reporting
  * "no project in reach" (see log-paths.ts's own history for the same fix). */
+const { isInvalidProjectRoot } = createRequire(import.meta.url)(
+  path.join(import.meta.dir, "..", "..", "_shared", "lib", "project-root.js"),
+) as { isInvalidProjectRoot: (dir: string) => boolean };
+
 export function findProjectRootFrom(start: string): string | null {
   let cur = path.resolve(start);
   const home = normalizeRoot(process.env.HOME || os.homedir());
@@ -215,6 +219,12 @@ export function findProjectRootFrom(start: string): string | null {
     if (norm === path.parse(norm).root) return null;
     if (sameNormalizedRoot(norm, home)) return null;
     if (isStrictlyUnder(home, norm)) return null;
+    // A shared temp ROOT is not a project, for the same reason HOME is not.
+    // The rule comes from project-root.js so the two walks cannot disagree:
+    // this file reimplemented the walk (see the note above findProjectRootFrom)
+    // and hardening only the shared copy left this one adopting `/private/tmp`
+    // as a project the moment an unrelated tool dropped a marker there.
+    if (isInvalidProjectRoot(norm)) return null;
     for (const m of PROJECT_MARKERS) {
       if (fs.existsSync(path.join(cur, m))) return norm;
     }


### PR DESCRIPTION
## What broke

`resolveProjectRoot()` walks up looking for a marker (`.env`, `.nirvana`, `.git`, `package.json`, `pyproject.toml`) and hardens against `/`, HOME and the Windows system directories — **but not against the temp roots**.

Measured on a real machine, 2026-09-03: `/private/tmp` held a `.nirvana` and a `package.json` left there by unrelated tools. Every scope resolution from a path under it therefore adopted `/private/tmp` as the project. A dispatch launched from a scratch directory wrote its brief, its kernel and its audit chain into a tree with no contract and no `.nirvana/` of its own — and reported success.

The comment above `dispatch.ts`'s `PROJECT_ROOT` already records the earlier version of this bug ("a child runtime told its project was the user's home directory"). The missing temp rule is what kept it reachable.

## The rule

`sameDir`, not `isUnder` — exactly like the HOME rule beside it. A directory *created* under temp with its own marker (every fixture in this suite) is still a legitimate project root. It is the shared root itself that cannot be one.

## The duplicated walk

`harness/lib/run-ledger.ts` carried its own copy of the walk with the same HOME hardening, and **it is the one `dispatch.ts` calls** — so hardening `_shared/lib/project-root.js` alone changed nothing where it mattered. It now imports the shared `isInvalidProjectRoot` rather than reimplementing the predicate, so the two cannot disagree again.

## Verification

- Two new tests in the existing suite's idiom: the temp root carrying a marker resolves to `null`; a project created *under* temp still resolves.
- `bun test skills/_shared/tests skills/harness/tests/dispatch-project-root.e2e.test.ts` — 650 pass, 0 fail.
- Before: `resolveProjectRoot()` from the scratch dir returned `/private/tmp`. After: `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk