### PR TITLE
fix(pack): `.nirvana` inside an entity is run state, and never ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### `.nirvana` inside an entity is run state, and never ships
+
+Running any `nrv` command with the cwd inside a squad materializes a `.nirvana/` there — the registries, the routing digest, the verify state — and those files carry absolute paths into the author's home. `RUN_STATE_EXCLUDES` did not name `.nirvana`, so the pack build would have copied them into every buyer's artifact. Measured 2026-09-03: three squads in the live library had picked one up during an audit campaign; the published packs were clean only because the state was created after the last build.
+
+`.nirvana` now joins the exclusion list for squads and for businesses, which is what the installer, the uninstaller, the migrator and the pack build all consult. `.nirvana-surface.json` is deliberately not covered — it is the contract surface and has to travel.
+
 ## 0.12.9 — 2026-09-03
 
 ### Every dependency installs into `~/.nirvana`, and nowhere else

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,14 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### `.nirvana` dentro de uma entidade é estado de execução, e nunca viaja
+
+Rodar qualquer comando `nrv` com o cwd dentro de um squad materializa um `.nirvana/` ali — os registries, o digest de roteamento, o estado do verify — e esses arquivos carregam caminhos absolutos para a home do autor. O `RUN_STATE_EXCLUDES` não nomeava `.nirvana`, então o build de pack os teria copiado para o artefato de todo comprador. Medido em 03/09/2026: três squads da biblioteca viva tinham pegado um durante uma campanha de auditoria; os packs publicados só estavam limpos porque o estado nasceu depois do último build.
+
+O `.nirvana` entra na lista de exclusão de squads e de businesses, que é o que o instalador, o desinstalador, o migrador e o build de pack consultam. O `.nirvana-surface.json` fica de fora de propósito — ele é a superfície de contrato e precisa viajar.
+
 ## 0.12.9 — 2026-09-03
 
 ### Toda dependência instala em `~/.nirvana`, e em nenhum outro lugar

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -33,8 +33,14 @@
  * `.nirvana/state/squads/<slug>/`; this entry stops the old ones travelling.
  */
 export const RUN_STATE_EXCLUDES: Record<string, string[]> = {
-  squads: ["projects", "outputs", ".runs", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
-  businesses: ["memory/projects", "memory/learned.md", ".squad-state", ".squads-outputs", ".vercel"],
+  // `.nirvana` is project state, never squad content: running any `nrv` command
+  // with the cwd inside a squad materializes one there, carrying the machine's
+  // registries and routing digest — which hold absolute paths into the author's
+  // home. Measured 2026-09-03: 3 squads in the live library had picked one up
+  // during an audit campaign, and the list did not exclude it, so the next build
+  // would have shipped the author's paths to every buyer.
+  squads: ["projects", "outputs", ".runs", ".nirvana", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
+  businesses: ["memory/projects", "memory/learned.md", ".nirvana", ".squad-state", ".squads-outputs", ".vercel"],
   "mind-clones": [],
 };
 

--- a/skills/_shared/tests/run-state-nirvana-dir.test.ts
+++ b/skills/_shared/tests/run-state-nirvana-dir.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `.nirvana` inside an entity is run state, and run state never ships.
+ *
+ * The regression this locks. Running ANY `nrv` command with the cwd inside a
+ * squad materializes a `.nirvana/` there — registries, routing digest, verify
+ * state — and those files carry absolute paths into the author's home
+ * (`/Users/<name>/…`). Measured 2026-09-03: three squads in the live library had
+ * picked one up during an audit campaign, and `RUN_STATE_EXCLUDES` did not name
+ * `.nirvana`, so the next pack build would have copied the author's paths into
+ * every buyer's artifact.
+ *
+ * `isRunStatePath` is what the installer, the uninstaller, the migrator and the
+ * pack build all consult, so the entry has to hold there, not merely in the
+ * array.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { RUN_STATE_EXCLUDES, isRunStatePath } from "../lib/run-state.ts";
+
+describe("`.nirvana` is run state for squads and businesses", () => {
+  test("it is named in the exclusion list of both kinds", () => {
+    expect(RUN_STATE_EXCLUDES.squads).toContain(".nirvana");
+    expect(RUN_STATE_EXCLUDES.businesses).toContain(".nirvana");
+  });
+
+  test("a path inside it is run state, at the root and nested", () => {
+    // The shapes a real leak takes: the registries and the digest the engine
+    // writes when a command runs with the cwd inside the entity.
+    expect(isRunStatePath(".nirvana", "squads")).toBe(true);
+    expect(isRunStatePath(".nirvana/.squads-registry.json", "squads")).toBe(true);
+    expect(isRunStatePath(".nirvana/state/squads/x/verify.json", "squads")).toBe(true);
+    expect(isRunStatePath(".nirvana/.routing-digest.md", "businesses")).toBe(true);
+  });
+
+  test("the entity's own content is untouched by the rule", () => {
+    // The guard must not widen: these are the files a squad ships.
+    for (const p of ["squad.yaml", "agents/x.md", "tasks/y.md", "references/z.md"]) {
+      expect(isRunStatePath(p, "squads")).toBe(false);
+    }
+    // A file that merely starts with the same letters is not the directory.
+    expect(isRunStatePath(".nirvana-surface.json", "squads")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What would have leaked

Running any `nrv` command with the cwd inside a squad materializes a `.nirvana/` there — the registries, the routing digest, the verify state. Those files carry **absolute paths into the author's home** (`/Users/<name>/…`).

`RUN_STATE_EXCLUDES` named `projects`, `outputs`, `.runs`, `.squad-state` and six more — but not `.nirvana`. So the pack build would have copied that state into every buyer's artifact.

Measured 2026-09-03: three squads in the live library had picked one up during an audit campaign. The **published packs are clean**, but only because the state was created after the last build — not because anything stopped it.

## The fix

`.nirvana` joins the exclusion list for squads and for businesses. That list is what `install-content.ts`, `uninstall-pack.ts`, `migrate-squad.ts` and the pack build all consult, so one entry covers every consumer.

`.nirvana-surface.json` is deliberately **not** covered: it is the contract surface and has to travel inside the artifact so a buyer's install can diff what is arriving. The test asserts both halves — the directory is excluded, the surface file is not.

## Verification

- New test: the entry exists for both kinds; `isRunStatePath` returns true at the root and nested (`.nirvana/.squads-registry.json`, `.nirvana/state/squads/x/verify.json`); and false for `squad.yaml`, `agents/x.md` and `.nirvana-surface.json`.
- `bun test skills/_shared/tests/run-state-nirvana-dir.test.ts` — 3 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk