### PR TITLE
feat(businesses): a business can read itself too — the resource map, shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A business can read itself too
+
+Squads got a resource map and a grant so `references/`, `checklists/` and `templates/` stopped being dead weight. Businesses did not, and there are 63 of them. The employee prompt reads exactly ONE directory of a business — `employees/` — so `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` and `lib/` reached no run at all, and the business directory was never in `addDirs`, so naming a path would not have helped either.
+
+`renderResourceMap` moved to `_shared/lib/entity-resource-map.ts` and now serves both, because a second copy is how the two would drift. Each kind declares what it already inlines — a squad its agents, tasks and workflows; a business its seat and its memory — and the run state each one hides comes from `isRunStatePath`, never a local list. `team-orchestrator` grants the business directory alongside the project and the outputs dir, and `resolveEntityDir` is shared with `employee-prompt` so the tree granted is the tree the map describes: handing an agent the map of one and the key to another is worse than granting nothing.
+
+Measured on the installed library: `business-creator` alone was hiding eight directories — eleven tasks, five schemas, two checklists and its own validation scripts — and `serial-showrunner-nirvana` four playbooks plus its scaffolding.
+
+`RUN_STATE_EXCLUDES.businesses` gains root-level `projects` and `outputs`. Same concept as `memory/projects` one level up, already excluded on the squads side, and four businesses carry an empty scaffolded `projects/`. That list is consulted by the installer, the uninstaller, the migrator, the pack build and now the map, so the day one of them accumulates there, all five agree it is not authored content.
+
 ## 0.12.10 — 2026-09-03
 
 ### A requested mind-clone that does not fit is named, not dropped

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,18 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Uma empresa também consegue se ler
+
+Os squads ganharam um mapa de recursos e a concessão do diretório, e com isso `references/`, `checklists/` e `templates/` deixaram de ser peso morto. As empresas não ganharam — e são 63. O prompt do employee lê exatamente UM diretório da empresa, `employees/`, então `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` e `lib/` não chegavam a execução nenhuma, e o diretório da empresa nunca esteve no `addDirs`, de modo que nomear um caminho também não resolveria.
+
+O `renderResourceMap` foi para `_shared/lib/entity-resource-map.ts` e passa a servir os dois, porque uma segunda cópia é como eles divergiriam. Cada tipo declara o que já traz inline — o squad seus agentes, tasks e workflows; a empresa sua cadeira e sua memória — e o estado de execução que cada um esconde vem do `isRunStatePath`, nunca de uma lista local. O `team-orchestrator` concede o diretório da empresa ao lado do projeto e do diretório de saída, e o `resolveEntityDir` é compartilhado com o `employee-prompt` para que a árvore concedida seja a árvore que o mapa descreve: entregar ao agente o mapa de uma e a chave de outra é pior que não conceder nada.
+
+Medido na biblioteca instalada: só o `business-creator` escondia oito diretórios — onze tasks, cinco schemas, dois checklists e os próprios scripts de validação — e o `serial-showrunner-nirvana`, quatro playbooks mais o scaffolding.
+
+O `RUN_STATE_EXCLUDES.businesses` ganha `projects` e `outputs` na raiz. Mesmo conceito do `memory/projects` um nível acima, já excluído no lado dos squads, e quatro empresas carregam um `projects/` escafoldado vazio. Essa lista é consultada pelo instalador, pelo desinstalador, pelo migrador, pelo build de pack e agora pelo mapa — então, no dia em que uma delas acumular ali, os cinco concordam que aquilo não é conteúdo autoral.
+
 ## 0.12.10 — 2026-09-03
 
 ### Um mind-clone pedido que não cabe é nomeado, não descartado

--- a/skills/_shared/lib/entity-resource-map.ts
+++ b/skills/_shared/lib/entity-resource-map.ts
@@ -1,0 +1,138 @@
+// entity-resource-map.ts — what an entity carries beyond what the prompt inlines.
+//
+// A dispatched agent used to see only the fragment of its entity that the prompt
+// assembled: for a squad, the agents and tasks its workflow names; for a
+// business, the one employee file of the seat running. Everything else the
+// author wrote — `references/`, `checklists/`, `templates/`, `standards/`,
+// `schemas/`, `config/`, `scripts/`, `playbooks/`, `rubrics/`, `lib/` — was
+// invisible, and the entity's own directory was never granted, so naming a path
+// would not have helped either.
+//
+// This is the skill pattern applied to entities: the NAMES travel in the prompt,
+// the BYTES stay on disk, and the agent loads in cascade only what its execution
+// turns out to need. The map is one level deep — files by name, subdirectories
+// with a trailing slash — because the point is to prove the tree exists and give
+// a door into it, not to serialize it.
+//
+// The map is a map, not an instruction. What a step MUST obey stays inlined: a
+// path is a request, and inlined text is a fact. The caller grants the entity
+// directory alongside it, so the door the map names actually opens.
+//
+// It lives here, shared, because it was written for squads first and businesses
+// needed exactly the same thing. A second copy is how the two would drift — the
+// same reason `isRunStatePath` has one owner and this consults it rather than
+// keeping a private list of what run state is called.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isRunStatePath } from "./run-state.ts";
+import { enumerate, resolveScope } from "./scope.ts";
+import { paths } from "./bun-helpers.ts";
+
+/** Directories the map never names, on top of run state.
+ *
+ *  Build and dependency output, never authored content — and `node_modules`
+ *  alone would bury the map it is listed in. Run state is NOT listed here:
+ *  `isRunStatePath` owns that list (`.runs`, `outputs`, `projects`, `.nirvana`,
+ *  …), and keeping a private second copy of it is precisely how a path that
+ *  should never travel starts travelling again.
+ *
+ *  This is a DENYLIST on purpose. The first cut was an allowlist of five
+ *  directory names chosen by hand, and surveying real entities showed what that
+ *  costs: it would have hidden `config/`, `schemas/`, `scripts/`, `data/`,
+ *  `tools/` and `lib/` outright, and `reference/` — the singular spelling some
+ *  authors use — from everyone who spells it that way. A curated list of what an
+ *  agent may see is a list of what one person happened to think of. Everything
+ *  the entity ships, the agent is told about. */
+const MAP_EXCLUDED_DIRS = new Set([
+  "node_modules", "dist", "build", "__pycache__", ".venv", "venv",
+]);
+
+/**
+ * A real cap, and NOT the silent-truncation mistake this codebase spent a day
+ * undoing. That one dropped the documents a step depends on: content the run
+ * cannot proceed without and cannot get any other way. This caps a directory
+ * INDEX — the names are recoverable with one `ls` against a directory the
+ * dispatch has already granted, and the overflow line says exactly that.
+ *
+ * Without a cap the map inherits the failure it replaced from the other side: an
+ * entity with a `data/` of fifty thousand files would push megabytes of
+ * filenames into every prompt it ever runs. A budget belongs where the content
+ * is reproducible; it does not belong where the content is the instruction.
+ */
+const MAP_ENTRIES_PER_DIR = 50;
+
+export interface ResourceMapOptions {
+  /** `squads` or `businesses` — decides which run-state list applies. */
+  kind: "squads" | "businesses";
+  /** Directories the prompt already carries IN FULL, hidden from the map to
+   *  avoid saying twice what was already said. Pass an empty set when the prompt
+   *  carries only a sample of them: a squad's legacy fallback ships an
+   *  alphabetical first-three under a "(top 3)" heading, which is not the same
+   *  thing as carrying the directory, and hiding it there switched the map off
+   *  for the one path with most of itself missing. */
+  inlined?: Iterable<string>;
+  /** Heading noun, e.g. "ESTE SQUAD" / "ESTA EMPRESA". */
+  label: string;
+  /** How the prose names the tree, e.g. "do squad" / "da empresa". Kept explicit
+   *  rather than derived from `label`: a reader who is told "a fonte" and not
+   *  "a fonte do squad" has to infer which tree the read-only rule covers, and
+   *  the rule is exactly the one that must not need inferring. */
+  sourceNoun?: string;
+  /** Where deliverables go, named so the read-only rule has an alternative. */
+  outputsHint?: string;
+}
+
+/**
+ * The entity's other directories, as a map. Returns "" when there is nothing
+ * beyond what the prompt already carries, so the section never appears empty.
+ */
+export function renderResourceMap(entityDir: string, opts: ResourceMapOptions): string {
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(entityDir, { withFileTypes: true }); } catch { return ""; }
+  const inlined = new Set(opts.inlined ?? []);
+  const authored = entries.filter(e =>
+    e.isDirectory() && !inlined.has(e.name) && !MAP_EXCLUDED_DIRS.has(e.name) && !isRunStatePath(e.name, opts.kind));
+
+  const lines: string[] = [];
+  for (const dir of authored.sort((a, b) => a.name.localeCompare(b.name))) {
+    let inner: fs.Dirent[];
+    try { inner = fs.readdirSync(path.join(entityDir, dir.name), { withFileTypes: true }); } catch { continue; }
+    const names = inner
+      .filter(e => !e.name.startsWith("."))
+      .map(e => e.isDirectory() ? `${e.name}/` : e.name)
+      .sort();
+    if (!names.length) continue;
+    const shown = names.slice(0, MAP_ENTRIES_PER_DIR).map(n => `\`${n}\``).join(", ");
+    const rest = names.length - MAP_ENTRIES_PER_DIR;
+    lines.push(`- \`${dir.name}/\` — ${shown}${rest > 0 ? ` … e mais ${rest}: rode \`ls\` nesse diretório para a lista inteira` : ""}`);
+  }
+  if (!lines.length) return "";
+
+  const out = opts.outputsHint ?? "o diretório de saída indicado na sua tarefa";
+  const noun = opts.sourceNoun ? ` ${opts.sourceNoun}` : "";
+  return `## O QUE MAIS ${opts.label} CARREGA
+Tudo abaixo existe em \`${entityDir}\` e **não** está neste prompt. Abra o que precisar, quando precisar, em cascata — nada aqui é obrigatório, e nada aqui foi resumido: o arquivo em disco é o conteúdo. Um nome terminado em \`/\` é subdiretório, desça nele.
+
+Este diretório é a fonte${noun}, compartilhada por todo projeto desta máquina e lida por toda execução futura: **é somente leitura para você**. Não edite, crie nem apague nada aqui, nem para "corrigir" um template ou anotar um resultado. Todo arquivo que você produzir vai para ${out}.
+
+${lines.join("\n")}`;
+}
+
+/**
+ * Where an entity lives for THIS run: the project's copy when scope resolves one,
+ * the global otherwise.
+ *
+ * It lives here because it grew a second consumer. `employee-prompt` uses it to
+ * read the manifest and the seat; `team-orchestrator` needs the exact same path
+ * to grant in the dispatch, and granting a different directory than the prompt
+ * describes is worse than granting none — the agent gets the map of one tree and
+ * the key to another.
+ */
+export function resolveEntityDir(kind: "businesses" | "squads", slug: string, projectDir: string): string {
+  try {
+    const hit = enumerate(resolveScope({ cwd: projectDir }), kind).find(e => e.slug === slug && !e.overridden);
+    if (hit) return hit.dir;
+  } catch { /* cai no global */ }
+  return path.join(kind === "businesses" ? paths.BUSINESSES_DIR : paths.SQUADS_DIR, slug);
+}

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -40,7 +40,13 @@ export const RUN_STATE_EXCLUDES: Record<string, string[]> = {
   // during an audit campaign, and the list did not exclude it, so the next build
   // would have shipped the author's paths to every buyer.
   squads: ["projects", "outputs", ".runs", ".nirvana", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
-  businesses: ["memory/projects", "memory/learned.md", ".nirvana", ".squad-state", ".squads-outputs", ".vercel"],
+  // Root-level `projects` and `outputs` join `memory/projects`: same concept one
+  // level up, and the squads list already excludes both. Four businesses in the
+  // library carry an empty scaffolded `projects/`; empty it is harmless, but this
+  // list is what the installer, the uninstaller, the migrator, the pack build and
+  // now the resource map all consult — and the day one of them accumulates there,
+  // all five have to agree it is not authored content.
+  businesses: ["memory/projects", "memory/learned.md", "projects", "outputs", ".nirvana", ".squad-state", ".squads-outputs", ".vercel"],
   "mind-clones": [],
 };
 

--- a/skills/_shared/tests/entity-resource-map.test.ts
+++ b/skills/_shared/tests/entity-resource-map.test.ts
@@ -1,0 +1,134 @@
+// entity-resource-map.test.ts — the map an entity shows of what it carries.
+//
+// Written for squads first; businesses needed exactly the same thing, which is
+// why there is one implementation. These pin the contract for both consumers,
+// including the two asymmetries that exist on purpose: what each kind already
+// inlines, and the run state each kind calls by a different name.
+//
+// The prompt text asserted below is PT-BR because the dispatched model reads it;
+// these comments are English because whoever maintains this reads them.
+// Runs with: bun test skills/_shared/tests
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { renderResourceMap } from "../lib/entity-resource-map.ts";
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-resmap-")); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+// A fresh root per call: two trees in one test shared the directory, and the
+// second saw what the first had created.
+let seq = 0;
+function tree(spec: Record<string, string[]>): string {
+  const root = path.join(tmp, `entity-${seq++}`);
+  for (const [dir, files] of Object.entries(spec)) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true });
+    for (const f of files) fs.writeFileSync(path.join(root, dir, f), "x");
+  }
+  return root;
+}
+
+const BIZ = { kind: "businesses" as const, inlined: ["employees", "memory"], label: "ESTA EMPRESA", sourceNoun: "da empresa", outputsHint: "o `outputs_root` declarado nos caminhos do projeto" };
+const SQ = { kind: "squads" as const, inlined: ["agents", "tasks", "workflows"], label: "ESTE SQUAD", sourceNoun: "do squad" };
+
+describe("the map names what the prompt does not carry", () => {
+  test("business: playbooks, standards and rubrics appear; employees and memory do not", () => {
+    const dir = tree({
+      employees: ["ceo.md", "cto.md"],
+      memory: ["permanent.md"],
+      playbooks: ["reuse-vs-create.md"],
+      standards: ["PDF.md"],
+      rubrics: ["gate.md"],
+    });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("## O QUE MAIS ESTA EMPRESA CARREGA");
+    expect(m).toContain("`playbooks/` — `reuse-vs-create.md`");
+    expect(m).toContain("`standards/`");
+    expect(m).toContain("`rubrics/`");
+    // The seat is inlined in full; memory lives in `.nirvana` since the
+    // architecture change, and what remains here is a seed already consumed.
+    expect(m).not.toContain("`employees/`");
+    expect(m).not.toContain("`memory/`");
+  });
+
+  test("squad: the same map, with a different inlined set", () => {
+    const dir = tree({ agents: ["a.md"], tasks: ["t.md"], references: ["r.md"] });
+    const m = renderResourceMap(dir, SQ);
+    expect(m).toContain("## O QUE MAIS ESTE SQUAD CARREGA");
+    expect(m).toContain("`references/`");
+    expect(m).not.toContain("`agents/`");
+  });
+
+  test("nothing beyond the inlined: no section at all, rather than an empty one", () => {
+    expect(renderResourceMap(tree({ employees: ["ceo.md"] }), BIZ)).toBe("");
+    expect(renderResourceMap(tree({ agents: ["a.md"] }), SQ)).toBe("");
+  });
+
+  test("an empty directory is a directory with nothing to open", () => {
+    const dir = tree({ employees: ["ceo.md"] });
+    fs.mkdirSync(path.join(dir, "playbooks"), { recursive: true });
+    expect(renderResourceMap(dir, BIZ)).toBe("");
+  });
+});
+
+describe("what the map never names", () => {
+  // Run state has ONE owner, `isRunStatePath`, and it answers differently per
+  // kind: a business accumulates in `memory/projects` and `projects/`, a squad in
+  // `.runs`. A local copy of that list here is the way back to advertising — and
+  // then shipping — what must never travel.
+  test("business: outputs and projects stay out", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"], projects: ["run-1.md"], outputs: ["o.md"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("`playbooks/`");
+    expect(m).not.toContain("`projects/`");
+    expect(m).not.toContain("`outputs/`");
+  });
+
+  test("squad: .runs stays out", () => {
+    const dir = tree({ agents: ["a.md"], references: ["r.md"], ".runs": ["x.md"] });
+    const m = renderResourceMap(dir, SQ);
+    expect(m).toContain("`references/`");
+    expect(m).not.toContain(".runs");
+  });
+
+  test("build and dependency output never enter", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"], node_modules: ["index.js"], dist: ["b.js"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).not.toContain("node_modules");
+    expect(m).not.toContain("`dist/`");
+  });
+});
+
+describe("the index ceiling", () => {
+  // A real cap, and deliberately NOT the silent cut this codebase spent a day
+  // undoing: a directory index is recoverable with one `ls` against a tree the
+  // dispatch already grants, and the overflow line says exactly that.
+  test("a huge directory is capped, and says how many are left and how to see them", () => {
+    const many = Array.from({ length: 130 }, (_, i) => `f-${String(i).padStart(3, "0")}.md`);
+    const dir = tree({ employees: ["ceo.md"], data: many });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("`f-000.md`");
+    expect(m).toContain("e mais 80");
+    expect(m).toContain("`ls`");
+    expect(Buffer.byteLength(m, "utf8")).toBeLessThan(4_096);
+  });
+});
+
+describe("the prose promises nothing it cannot keep", () => {
+  test("it says which tree it means, and that the tree is read-only", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("a fonte da empresa");
+    expect(m).toContain("**é somente leitura para você**");
+    expect(m).toContain("outputs_root");
+    expect(m).toContain(dir);
+    // Nothing here was summarized: the index is names, the content is on disk.
+    expect(m).toContain("o arquivo em disco é o conteúdo");
+  });
+
+  test("an unreadable directory does not take down the prompt", () => {
+    expect(renderResourceMap(path.join(tmp, "does-not-exist"), BIZ)).toBe("");
+  });
+});

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -64,6 +64,7 @@ import { resolveClonePersona, loadCloneRegistry } from "../../_shared/lib/clone-
 import { layersForPhase } from "../../_shared/lib/dna-layer-policy.ts";
 import { hookForPhase } from "../../_shared/lib/hooks.ts";
 import { readEntityMemory } from "../../_shared/lib/entity-memory.ts";
+import { renderResourceMap, resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 import { collectContributions, orderContributions, renderHookBlock, cloneContributionSource } from "../../_shared/lib/contributions.ts";
 
 // Untrusted-input boundary (P0-1 / Batch 3 item 7): security preamble injected
@@ -80,16 +81,11 @@ const BUSINESSES_ROOT = path.join(os.homedir(), "businesses");
  *  project-local business overrides the global same-slug one; the global join
  *  is only the fallback when no scoped hit is found. Walks up from project_dir
  *  to find the project root (same strategy as the squad catalog resolution). */
-function resolveBusinessDir(business_slug: string, project_dir: string): string {
-  try {
-    const hit = enumerate(resolveScope({ cwd: project_dir }), "businesses")
-      .find(e => e.slug === business_slug && !e.overridden);
-    if (hit) return hit.dir;
-  } catch {
-    // fall through to global join
-  }
-  return path.join(BUSINESSES_ROOT, business_slug);
-}
+// Delegated to the shared resolver: `team-orchestrator` needs the SAME path to
+// grant the directory in the dispatch, and granting a different tree than this
+// prompt describes hands the agent the map of one and the key to another.
+const resolveBusinessDir = (business_slug: string, project_dir: string): string =>
+  resolveEntityDir("businesses", business_slug, project_dir);
 
 function appendAuditEvent(project_dir: string, event: Record<string, unknown>): void {
   const today = new Date().toISOString().slice(0, 10);
@@ -493,6 +489,26 @@ export function buildEmployeePrompt(args: BuildArgs): string {
   const squadsBlock = squadCatalogBlock(employeeContent, args.project_dir);
   const mindCloneCatalog = mindCloneCatalogBlock(employeeContent);
 
+  // What the business carries beyond the manifest and the seat that is running.
+  //
+  // The prompt reads ONE directory of the business: `employees/`. Everything else
+  // the author wrote — `playbooks/`, `standards/`, `rubrics/`, `templates/`,
+  // `lib/`, `scripts/` — reached no run at all, and the business directory was
+  // never granted, so naming a path would not have helped either. Squads got this
+  // channel; businesses did not, and there are 63 of them.
+  //
+  // `employees/` stays out of the map because the seat is inlined in full.
+  // `memory/` too: since the architecture change it lives in `.nirvana`, and what
+  // remains inside the business is a seed already consumed — advertising it would
+  // invite the agent to read the stale copy instead of what the owner accumulated.
+  const resourceMap = renderResourceMap(bizDir, {
+    kind: "businesses",
+    inlined: ["employees", "memory"],
+    label: "ESTA EMPRESA",
+    sourceNoun: "da empresa",
+    outputsHint: "o `outputs_root` declarado nos caminhos do projeto",
+  });
+
   const bizYamlPath = path.join(bizDir, "business.yaml");
   const bizYaml = fs.existsSync(bizYamlPath) ? fs.readFileSync(bizYamlPath, "utf8") : "(business.yaml missing)";
 
@@ -721,6 +737,7 @@ ${bizYaml}
 
 ---
 
+${resourceMap ? resourceMap + "\n\n---\n\n" : ""}
 ${memoryBlock}## CURRENT HANDOFF STATE
 
 \`\`\`json

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -32,7 +32,7 @@ import { layersForPhase } from "../../_shared/lib/dna-layer-policy.ts";
 import { findCloneForTask } from "../../_shared/lib/clone-search.ts";
 import { paths } from "../../_shared/lib/bun-helpers.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
-import { isRunStatePath } from "../../_shared/lib/run-state.ts";
+import { renderResourceMap } from "../../_shared/lib/entity-resource-map.ts";
 import { resolveSetting } from "../../_shared/lib/settings.ts";
 
 export type SquadExecMode = "team-mandatory" | "squad-only";
@@ -318,94 +318,11 @@ function renderEventContractBlock(squadSlug: string, traceId?: string): string {
 Emita marcos do seu trabalho com \`nrv audit emit <nome> --squad=${squadSlug} --trace=${trace}\`. Sempre passe \`--squad=${squadSlug}\`: é o que atribui o evento a você no cockpit. O nome não precisa estar na lista fechada do motor — se não estiver, escreva-o já com o prefixo \`x_\` (ex.: \`x_pagina_altura_acima_orcamento\`), assim o nome que chega ao log é o mesmo que você digitou. Payload vai em \`--json='{...}'\`, curto: nunca o brief inteiro, um output completo ou um segredo, só o resumo que o evento precisa carregar.`;
 }
 
-/** Directories the map never names, on top of run state.
- *
- *  `agents`, `tasks` and `workflows` are the three the prompt already carries.
- *  The rest is build and dependency output — never authored content, and
- *  `node_modules` alone would bury the map it is listed in. Run state is NOT
- *  listed here: `isRunStatePath` owns that list (`.runs`, `outputs`, `projects`,
- *  `.nirvana`, …), and keeping a private second copy of it is precisely how a
- *  path that should never travel starts travelling again.
- *
- *  This is a DENYLIST on purpose. The first cut of this map was an allowlist of
- *  five directory names chosen by hand, and surveying real squads showed what
- *  that costs: it would have hidden `config/`, `schemas/`, `scripts/`, `data/`,
- *  `tools/` and `lib/` outright, and `reference/` — the singular spelling some
- *  squads use — from every squad that spells it that way. A curated list of what
- *  an agent may see is a list of what one person happened to think of.
- *  Everything the squad ships, the agent is told about. */
-const MAP_EXCLUDED_DIRS = new Set([
-  "node_modules", "dist", "build", "__pycache__", ".venv", "venv",
-]);
-
 /** The three the prompt carries in full — but only when a capability resolved
- *  and the workflow named them. On the legacy fallback it carries three files
- *  in alphabetical order, which is not the same thing at all. */
-const INLINED_DIRS = new Set(["agents", "tasks", "workflows"]);
-
-/**
- * Everything else the squad carries, as a map rather than as content.
- *
- * The prompt inlines exactly the agents and tasks the workflow names, so the
- * rest of the squad has been invisible to the agent executing it. Most squads
- * ship well beyond those three directories — `references/`, `checklists/`,
- * `templates/`, `standards/`, `schemas/`, `config/`, `scripts/`, `data/`,
- * `tools/`, `lib/` are all common — and every one of those files is content the
- * author wrote and the run never saw.
- *
- * This is the skill pattern applied to squads: the names travel in the prompt,
- * the bytes stay on disk, and the agent loads in cascade only what its execution
- * turns out to need. The map is one level deep — files by name, subdirectories
- * with a trailing slash — because the point is to prove the tree exists and give
- * a door into it, not to serialize it.
- *
- * The map is a map, not an instruction. What a step MUST obey stays inlined:
- * a path is a request, and inlined text is a fact. `runSquadHeadless` grants the
- * squad directory alongside it, so the door the map names actually opens.
- *
- * MAP_ENTRIES_PER_DIR is a real cap, and it is NOT the mistake this file just
- * finished undoing. That one dropped the agent and task documents a step depends
- * on: content the run cannot proceed without and cannot get any other way. This
- * caps a directory INDEX — the names are recoverable with one `ls` against a
- * directory the dispatch has already granted, and the overflow line says exactly
- * that. Without a cap the map inherits the failure it replaced from the other
- * side: a squad with a `data/` of fifty thousand files would push megabytes of
- * filenames into every prompt it ever runs. A budget belongs where the content
- * is reproducible; it does not belong where the content is the instruction.
- */
-const MAP_ENTRIES_PER_DIR = 50;
-function renderResourceMap(squadDir: string, opts: { componentsInlined: boolean }): string {
-  let entries: fs.Dirent[];
-  try { entries = fs.readdirSync(squadDir, { withFileTypes: true }); } catch { return ""; }
-  const lines: string[] = [];
-  // `agents`, `tasks` and `workflows` are hidden ONLY when the workflow actually
-  // put them in the prompt. On the legacy fallback the prompt carries an
-  // alphabetical first-three under a "(top 3)" heading, so hiding them here
-  // switched the map off for the one path that has most of itself missing —
-  // a squad with eight agents showed three and named none of the rest.
-  const inlined = opts.componentsInlined ? INLINED_DIRS : new Set<string>();
-  const authored = entries.filter(e =>
-    e.isDirectory() && !inlined.has(e.name) && !MAP_EXCLUDED_DIRS.has(e.name) && !isRunStatePath(e.name, "squads"));
-  for (const dir of authored.sort((a, b) => a.name.localeCompare(b.name))) {
-    let inner: fs.Dirent[];
-    try { inner = fs.readdirSync(path.join(squadDir, dir.name), { withFileTypes: true }); } catch { continue; }
-    const names = inner
-      .filter(e => !e.name.startsWith("."))
-      .map(e => e.isDirectory() ? `${e.name}/` : e.name)
-      .sort();
-    if (!names.length) continue;
-    const shown = names.slice(0, MAP_ENTRIES_PER_DIR).map(n => `\`${n}\``).join(", ");
-    const rest = names.length - MAP_ENTRIES_PER_DIR;
-    lines.push(`- \`${dir.name}/\` — ${shown}${rest > 0 ? ` … e mais ${rest}: rode \`ls\` nesse diretório para a lista inteira` : ""}`);
-  }
-  if (!lines.length) return "";
-  return `## O QUE MAIS ESTE SQUAD CARREGA
-Tudo abaixo existe em \`${squadDir}\` e **não** está neste prompt. Abra o que precisar, quando precisar, em cascata — nada aqui é obrigatório, e nada aqui foi resumido: o arquivo em disco é o conteúdo. Um nome terminado em \`/\` é subdiretório, desça nele.
-
-Este diretório é a fonte do squad, compartilhada por todo projeto desta máquina e lida por toda execução futura: **é somente leitura para você**. Não edite, crie nem apague nada aqui, nem para "corrigir" um template ou anotar um resultado. Todo arquivo que você produzir vai para o diretório de saída indicado na sua sub-tarefa.
-
-${lines.join("\n")}`;
-}
+ *  and the workflow named them. On the legacy fallback it carries three files in
+ *  alphabetical order, which is not the same thing at all, so the map stays on
+ *  there: that is the path with most of itself missing. */
+const INLINED_DIRS = ["agents", "tasks", "workflows"];
 
 /** The capability block, plus the workflow block when the graph resolved. */
 function renderCapabilityBlock(ctx: SquadCapabilityPromptContext): string {
@@ -489,7 +406,13 @@ export function buildSquadPrompt(args: {
   // capability would withhold it precisely where it is needed most. A squad that
   // ships nothing outside agents/, tasks/ and workflows/ still gets no section,
   // which is what keeps the pin meaningful for the fixtures that have none.
-  const resourceMap = renderResourceMap(squadDir, { componentsInlined: !!capability?.components });
+  const resourceMap = renderResourceMap(squadDir, {
+    kind: "squads",
+    inlined: capability?.components ? INLINED_DIRS : [],
+    label: "ESTE SQUAD",
+    sourceNoun: "do squad",
+    outputsHint: "o diretório de saída indicado na sua sub-tarefa",
+  });
   const resourceSection = resourceMap ? `\n${resourceMap}\n` : "";
 
   const roleLine = mode === "team-mandatory"

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -26,6 +26,7 @@ import { sessionKey, getSession, putSession, dropSession, type EntityKind } from
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
 import { runSquadHeadless } from "./squad-exec.ts";
+import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 
 const SKILLS = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
@@ -225,8 +226,16 @@ function runStep(step: ChainStep, idx: number, total: number, args: TeamRunArgs,
 
   appendAudit({ event: "dispatch_business", trace_id: args.projectId, project_id: args.projectId, business_slug: args.slug, employee: step.employee, mode: "team-step", step: idx + 1, total }, args.projectRoot);
 
+  const bizDir = resolveEntityDir("businesses", args.slug, args.projectDir);
   const res = runWithSession("employee", step.employee, args, {
-    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectRoot, addDirs: [args.projectDir, employeeOutDir],
+    // bizDir is granted so the employee prompt's resource map is a door and not a
+    // sign: `playbooks/`, `standards/`, `rubrics/` and `templates/` live under it,
+    // and on claude-code and agy an ungranted path is simply refused. Same grant
+    // squads already have, with the same caveat: `--add-dir` adds a WORKSPACE root
+    // and this path runs with the permission bypass, so the directory is writable.
+    // The prompt says in words that it is read-only, which is the instrument the
+    // rest of the engine uses to keep deliverables where they belong.
+    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectRoot, addDirs: [args.projectDir, employeeOutDir, bizDir],
     appendSystemPrompt: AUTONOMOUS_DIRECTIVE + (args.rulesDirective ?? ""),
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: employeeOutDir,


### PR DESCRIPTION
Squads got a resource map and a grant, which is what stopped `references/`, `checklists/` and `templates/` from being dead weight. **Businesses did not, and there are 63 of them.**

The employee prompt reads exactly ONE directory of a business — `employees/`. Everything else the author wrote reached no run at all, and the business directory was never in `addDirs`, so naming a path would not have helped either.

## Measured on the real library

| Business | Directories that reached no run |
|---|---|
| `business-creator` | 8 — `checklists/`, `config/`, `data/`, `schemas/` (5 files), `scripts/`, `tasks/` (11 files), `templates/`, `workflows/` |
| `serial-showrunner-nirvana` | 3 — `playbooks/` (4 files), `scaffolding/`, `workflows/` |

## What changed

- `renderResourceMap` moved to `_shared/lib/entity-resource-map.ts` and serves **both** kinds. A second copy is how the two would drift.
- Each kind declares what it already inlines: a squad its agents/tasks/workflows, a business its seat and its memory. The run state each hides comes from `isRunStatePath`, never a local list.
- `team-orchestrator` grants the business directory beside the project and outputs dir.
- `resolveEntityDir` is shared with `employee-prompt`, so **the tree granted is the tree the map describes** — handing an agent the map of one and the key to another is worse than granting nothing.
- `RUN_STATE_EXCLUDES.businesses` gains root-level `projects` and `outputs`.

The squad prompt is unchanged byte for byte: the pinned historical-prompt test still passes.

## Test plan
- [x] `bun run test:fast` — 2071 pass, 0 fail
- [x] `bun run check:quick` — exit 0 (the language gate caught PT-BR code comments on the first pass; converted to English, prompt strings stay PT-BR)
- [x] `tsc --noEmit` — clean
- [x] New `entity-resource-map.test.ts` — 10 tests covering both kinds, run-state exclusion per kind, the index cap, and that the prose names the tree it means
- [x] Rendered against real businesses to confirm the directories above actually surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk