### PR TITLE
fix(team): resolve the business once, and give the chain a test file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A business can read itself too
+
+Squads got a resource map and a grant so `references/`, `checklists/` and `templates/` stopped being dead weight. Businesses did not, and there are 63 of them. The employee prompt reads exactly ONE directory of a business — `employees/` — so `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` and `lib/` reached no run at all, and the business directory was never in `addDirs`, so naming a path would not have helped either.
+
+`renderResourceMap` moved to `_shared/lib/entity-resource-map.ts` and now serves both, because a second copy is how the two would drift. Each kind declares what it already inlines — a squad its agents, tasks and workflows; a business its seat and its memory — and the run state each one hides comes from `isRunStatePath`, never a local list. `team-orchestrator` grants the business directory alongside the project and the outputs dir, and `resolveEntityDir` is shared with `employee-prompt` so the tree granted is the tree the map describes: handing an agent the map of one and the key to another is worse than granting nothing.
+
+Measured on the installed library: `business-creator` alone was hiding eight directories — eleven tasks, five schemas, two checklists and its own validation scripts — and `serial-showrunner-nirvana` four playbooks plus its scaffolding.
+
+`RUN_STATE_EXCLUDES.businesses` gains root-level `projects` and `outputs`. Same concept as `memory/projects` one level up, already excluded on the squads side, and four businesses carry an empty scaffolded `projects/`. That list is consulted by the installer, the uninstaller, the migrator, the pack build and now the map, so the day one of them accumulates there, all five agree it is not authored content.
+
 ## 0.12.10 — 2026-09-03
 
 ### A requested mind-clone that does not fit is named, not dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The chain read the roster from one tree and dispatched into another
+
+`listEmployees` resolved the business as `~/businesses/<slug>`, hardcoded. Nothing else in the run does: the dispatch grants what `resolveEntityDir` returns, which honours the project scope, `BUSINESSES_DIR` and `NIRVANA_HOME`. So a business installed under a redirected home, or living in the project rather than the global library, listed zero seats — and `pickChain` reads zero seats as a one-seat company and hands the whole brief to the intake employee. The company ran as one person and said nothing about it, which is indistinguishable from a company that only has one seat.
+
+Both callers now resolve through one function, and the `employee-prompt` subprocess is handed the library root the run already settled on instead of walking its own resolution. Two independent answers to "where does this business live" is how the prompt ends up describing one directory while the grant opens another.
+
+This surfaced because `team-orchestrator` had no test file. The chain — director, step order, session threading, mandatory squads, the fail-fast abort — was covered only through `buildStepBrief`. It has one now, and the seams it needed (`businessesRoot`, and canned director and cascade runners) are on `TeamRunArgs`.
+
 ### A business can read itself too
 
 Squads got a resource map and a grant so `references/`, `checklists/` and `templates/` stopped being dead weight. Businesses did not, and there are 63 of them. The employee prompt reads exactly ONE directory of a business — `employees/` — so `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` and `lib/` reached no run at all, and the business directory was never in `addDirs`, so naming a path would not have helped either.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,14 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### A cadeia lia o quadro de uma árvore e despachava em outra
+
+O `listEmployees` resolvia a empresa como `~/businesses/<slug>`, na unha. Nada mais na execução faz isso: o despacho concede o que o `resolveEntityDir` devolve, que respeita o escopo do projeto, o `BUSINESSES_DIR` e o `NIRVANA_HOME`. Uma empresa instalada sob um home redirecionado, ou morando no projeto em vez da biblioteca global, listava zero cadeiras — e o `pickChain` lê zero cadeiras como empresa de uma cadeira só e entrega o brief inteiro ao employee de intake. A empresa rodava como uma pessoa e não dizia nada, o que é indistinguível de uma empresa que de fato só tem uma cadeira.
+
+Os dois chamadores passam a resolver por uma função só, e o subprocesso do `employee-prompt` recebe a raiz da biblioteca que a execução já escolheu, em vez de refazer a resolução por conta própria. Duas respostas independentes para "onde mora esta empresa" é como o prompt acaba descrevendo um diretório enquanto a concessão abre outro.
+
+Isso apareceu porque o `team-orchestrator` não tinha arquivo de teste. A cadeia — diretor, ordem dos passos, continuidade de sessão, squads obrigatórios, o aborto no primeiro erro — só era coberta através do `buildStepBrief`. Agora tem, e as costuras de que precisou (`businessesRoot`, mais diretor e cascade encenados) estão no `TeamRunArgs`.
+
 ### Uma empresa também consegue se ler
 
 Os squads ganharam um mapa de recursos e a concessão do diretório, e com isso `references/`, `checklists/` e `templates/` deixaram de ser peso morto. As empresas não ganharam — e são 63. O prompt do employee lê exatamente UM diretório da empresa, `employees/`, então `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` e `lib/` não chegavam a execução nenhuma, e o diretório da empresa nunca esteve no `addDirs`, de modo que nomear um caminho também não resolveria.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,18 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Uma empresa também consegue se ler
+
+Os squads ganharam um mapa de recursos e a concessão do diretório, e com isso `references/`, `checklists/` e `templates/` deixaram de ser peso morto. As empresas não ganharam — e são 63. O prompt do employee lê exatamente UM diretório da empresa, `employees/`, então `playbooks/`, `standards/`, `rubrics/`, `schemas/`, `scripts/`, `templates/` e `lib/` não chegavam a execução nenhuma, e o diretório da empresa nunca esteve no `addDirs`, de modo que nomear um caminho também não resolveria.
+
+O `renderResourceMap` foi para `_shared/lib/entity-resource-map.ts` e passa a servir os dois, porque uma segunda cópia é como eles divergiriam. Cada tipo declara o que já traz inline — o squad seus agentes, tasks e workflows; a empresa sua cadeira e sua memória — e o estado de execução que cada um esconde vem do `isRunStatePath`, nunca de uma lista local. O `team-orchestrator` concede o diretório da empresa ao lado do projeto e do diretório de saída, e o `resolveEntityDir` é compartilhado com o `employee-prompt` para que a árvore concedida seja a árvore que o mapa descreve: entregar ao agente o mapa de uma e a chave de outra é pior que não conceder nada.
+
+Medido na biblioteca instalada: só o `business-creator` escondia oito diretórios — onze tasks, cinco schemas, dois checklists e os próprios scripts de validação — e o `serial-showrunner-nirvana`, quatro playbooks mais o scaffolding.
+
+O `RUN_STATE_EXCLUDES.businesses` ganha `projects` e `outputs` na raiz. Mesmo conceito do `memory/projects` um nível acima, já excluído no lado dos squads, e quatro empresas carregam um `projects/` escafoldado vazio. Essa lista é consultada pelo instalador, pelo desinstalador, pelo migrador, pelo build de pack e agora pelo mapa — então, no dia em que uma delas acumular ali, os cinco concordam que aquilo não é conteúdo autoral.
+
 ## 0.12.10 — 2026-09-03
 
 ### Um mind-clone pedido que não cabe é nomeado, não descartado

--- a/skills/_shared/lib/entity-resource-map.ts
+++ b/skills/_shared/lib/entity-resource-map.ts
@@ -1,0 +1,138 @@
+// entity-resource-map.ts — what an entity carries beyond what the prompt inlines.
+//
+// A dispatched agent used to see only the fragment of its entity that the prompt
+// assembled: for a squad, the agents and tasks its workflow names; for a
+// business, the one employee file of the seat running. Everything else the
+// author wrote — `references/`, `checklists/`, `templates/`, `standards/`,
+// `schemas/`, `config/`, `scripts/`, `playbooks/`, `rubrics/`, `lib/` — was
+// invisible, and the entity's own directory was never granted, so naming a path
+// would not have helped either.
+//
+// This is the skill pattern applied to entities: the NAMES travel in the prompt,
+// the BYTES stay on disk, and the agent loads in cascade only what its execution
+// turns out to need. The map is one level deep — files by name, subdirectories
+// with a trailing slash — because the point is to prove the tree exists and give
+// a door into it, not to serialize it.
+//
+// The map is a map, not an instruction. What a step MUST obey stays inlined: a
+// path is a request, and inlined text is a fact. The caller grants the entity
+// directory alongside it, so the door the map names actually opens.
+//
+// It lives here, shared, because it was written for squads first and businesses
+// needed exactly the same thing. A second copy is how the two would drift — the
+// same reason `isRunStatePath` has one owner and this consults it rather than
+// keeping a private list of what run state is called.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isRunStatePath } from "./run-state.ts";
+import { enumerate, resolveScope } from "./scope.ts";
+import { paths } from "./bun-helpers.ts";
+
+/** Directories the map never names, on top of run state.
+ *
+ *  Build and dependency output, never authored content — and `node_modules`
+ *  alone would bury the map it is listed in. Run state is NOT listed here:
+ *  `isRunStatePath` owns that list (`.runs`, `outputs`, `projects`, `.nirvana`,
+ *  …), and keeping a private second copy of it is precisely how a path that
+ *  should never travel starts travelling again.
+ *
+ *  This is a DENYLIST on purpose. The first cut was an allowlist of five
+ *  directory names chosen by hand, and surveying real entities showed what that
+ *  costs: it would have hidden `config/`, `schemas/`, `scripts/`, `data/`,
+ *  `tools/` and `lib/` outright, and `reference/` — the singular spelling some
+ *  authors use — from everyone who spells it that way. A curated list of what an
+ *  agent may see is a list of what one person happened to think of. Everything
+ *  the entity ships, the agent is told about. */
+const MAP_EXCLUDED_DIRS = new Set([
+  "node_modules", "dist", "build", "__pycache__", ".venv", "venv",
+]);
+
+/**
+ * A real cap, and NOT the silent-truncation mistake this codebase spent a day
+ * undoing. That one dropped the documents a step depends on: content the run
+ * cannot proceed without and cannot get any other way. This caps a directory
+ * INDEX — the names are recoverable with one `ls` against a directory the
+ * dispatch has already granted, and the overflow line says exactly that.
+ *
+ * Without a cap the map inherits the failure it replaced from the other side: an
+ * entity with a `data/` of fifty thousand files would push megabytes of
+ * filenames into every prompt it ever runs. A budget belongs where the content
+ * is reproducible; it does not belong where the content is the instruction.
+ */
+const MAP_ENTRIES_PER_DIR = 50;
+
+export interface ResourceMapOptions {
+  /** `squads` or `businesses` — decides which run-state list applies. */
+  kind: "squads" | "businesses";
+  /** Directories the prompt already carries IN FULL, hidden from the map to
+   *  avoid saying twice what was already said. Pass an empty set when the prompt
+   *  carries only a sample of them: a squad's legacy fallback ships an
+   *  alphabetical first-three under a "(top 3)" heading, which is not the same
+   *  thing as carrying the directory, and hiding it there switched the map off
+   *  for the one path with most of itself missing. */
+  inlined?: Iterable<string>;
+  /** Heading noun, e.g. "ESTE SQUAD" / "ESTA EMPRESA". */
+  label: string;
+  /** How the prose names the tree, e.g. "do squad" / "da empresa". Kept explicit
+   *  rather than derived from `label`: a reader who is told "a fonte" and not
+   *  "a fonte do squad" has to infer which tree the read-only rule covers, and
+   *  the rule is exactly the one that must not need inferring. */
+  sourceNoun?: string;
+  /** Where deliverables go, named so the read-only rule has an alternative. */
+  outputsHint?: string;
+}
+
+/**
+ * The entity's other directories, as a map. Returns "" when there is nothing
+ * beyond what the prompt already carries, so the section never appears empty.
+ */
+export function renderResourceMap(entityDir: string, opts: ResourceMapOptions): string {
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(entityDir, { withFileTypes: true }); } catch { return ""; }
+  const inlined = new Set(opts.inlined ?? []);
+  const authored = entries.filter(e =>
+    e.isDirectory() && !inlined.has(e.name) && !MAP_EXCLUDED_DIRS.has(e.name) && !isRunStatePath(e.name, opts.kind));
+
+  const lines: string[] = [];
+  for (const dir of authored.sort((a, b) => a.name.localeCompare(b.name))) {
+    let inner: fs.Dirent[];
+    try { inner = fs.readdirSync(path.join(entityDir, dir.name), { withFileTypes: true }); } catch { continue; }
+    const names = inner
+      .filter(e => !e.name.startsWith("."))
+      .map(e => e.isDirectory() ? `${e.name}/` : e.name)
+      .sort();
+    if (!names.length) continue;
+    const shown = names.slice(0, MAP_ENTRIES_PER_DIR).map(n => `\`${n}\``).join(", ");
+    const rest = names.length - MAP_ENTRIES_PER_DIR;
+    lines.push(`- \`${dir.name}/\` — ${shown}${rest > 0 ? ` … e mais ${rest}: rode \`ls\` nesse diretório para a lista inteira` : ""}`);
+  }
+  if (!lines.length) return "";
+
+  const out = opts.outputsHint ?? "o diretório de saída indicado na sua tarefa";
+  const noun = opts.sourceNoun ? ` ${opts.sourceNoun}` : "";
+  return `## O QUE MAIS ${opts.label} CARREGA
+Tudo abaixo existe em \`${entityDir}\` e **não** está neste prompt. Abra o que precisar, quando precisar, em cascata — nada aqui é obrigatório, e nada aqui foi resumido: o arquivo em disco é o conteúdo. Um nome terminado em \`/\` é subdiretório, desça nele.
+
+Este diretório é a fonte${noun}, compartilhada por todo projeto desta máquina e lida por toda execução futura: **é somente leitura para você**. Não edite, crie nem apague nada aqui, nem para "corrigir" um template ou anotar um resultado. Todo arquivo que você produzir vai para ${out}.
+
+${lines.join("\n")}`;
+}
+
+/**
+ * Where an entity lives for THIS run: the project's copy when scope resolves one,
+ * the global otherwise.
+ *
+ * It lives here because it grew a second consumer. `employee-prompt` uses it to
+ * read the manifest and the seat; `team-orchestrator` needs the exact same path
+ * to grant in the dispatch, and granting a different directory than the prompt
+ * describes is worse than granting none — the agent gets the map of one tree and
+ * the key to another.
+ */
+export function resolveEntityDir(kind: "businesses" | "squads", slug: string, projectDir: string): string {
+  try {
+    const hit = enumerate(resolveScope({ cwd: projectDir }), kind).find(e => e.slug === slug && !e.overridden);
+    if (hit) return hit.dir;
+  } catch { /* cai no global */ }
+  return path.join(kind === "businesses" ? paths.BUSINESSES_DIR : paths.SQUADS_DIR, slug);
+}

--- a/skills/_shared/lib/run-state.ts
+++ b/skills/_shared/lib/run-state.ts
@@ -40,7 +40,13 @@ export const RUN_STATE_EXCLUDES: Record<string, string[]> = {
   // during an audit campaign, and the list did not exclude it, so the next build
   // would have shipped the author's paths to every buyer.
   squads: ["projects", "outputs", ".runs", ".nirvana", ".squad-state", ".squads-outputs", ".wiki-brain-state", ".vercel", ".omc", "_internal", "SQUAD-DOCTOR-REPORT.md"],
-  businesses: ["memory/projects", "memory/learned.md", ".nirvana", ".squad-state", ".squads-outputs", ".vercel"],
+  // Root-level `projects` and `outputs` join `memory/projects`: same concept one
+  // level up, and the squads list already excludes both. Four businesses in the
+  // library carry an empty scaffolded `projects/`; empty it is harmless, but this
+  // list is what the installer, the uninstaller, the migrator, the pack build and
+  // now the resource map all consult — and the day one of them accumulates there,
+  // all five have to agree it is not authored content.
+  businesses: ["memory/projects", "memory/learned.md", "projects", "outputs", ".nirvana", ".squad-state", ".squads-outputs", ".vercel"],
   "mind-clones": [],
 };
 

--- a/skills/_shared/tests/entity-resource-map.test.ts
+++ b/skills/_shared/tests/entity-resource-map.test.ts
@@ -1,0 +1,134 @@
+// entity-resource-map.test.ts — the map an entity shows of what it carries.
+//
+// Written for squads first; businesses needed exactly the same thing, which is
+// why there is one implementation. These pin the contract for both consumers,
+// including the two asymmetries that exist on purpose: what each kind already
+// inlines, and the run state each kind calls by a different name.
+//
+// The prompt text asserted below is PT-BR because the dispatched model reads it;
+// these comments are English because whoever maintains this reads them.
+// Runs with: bun test skills/_shared/tests
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { renderResourceMap } from "../lib/entity-resource-map.ts";
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-resmap-")); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+// A fresh root per call: two trees in one test shared the directory, and the
+// second saw what the first had created.
+let seq = 0;
+function tree(spec: Record<string, string[]>): string {
+  const root = path.join(tmp, `entity-${seq++}`);
+  for (const [dir, files] of Object.entries(spec)) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true });
+    for (const f of files) fs.writeFileSync(path.join(root, dir, f), "x");
+  }
+  return root;
+}
+
+const BIZ = { kind: "businesses" as const, inlined: ["employees", "memory"], label: "ESTA EMPRESA", sourceNoun: "da empresa", outputsHint: "o `outputs_root` declarado nos caminhos do projeto" };
+const SQ = { kind: "squads" as const, inlined: ["agents", "tasks", "workflows"], label: "ESTE SQUAD", sourceNoun: "do squad" };
+
+describe("the map names what the prompt does not carry", () => {
+  test("business: playbooks, standards and rubrics appear; employees and memory do not", () => {
+    const dir = tree({
+      employees: ["ceo.md", "cto.md"],
+      memory: ["permanent.md"],
+      playbooks: ["reuse-vs-create.md"],
+      standards: ["PDF.md"],
+      rubrics: ["gate.md"],
+    });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("## O QUE MAIS ESTA EMPRESA CARREGA");
+    expect(m).toContain("`playbooks/` — `reuse-vs-create.md`");
+    expect(m).toContain("`standards/`");
+    expect(m).toContain("`rubrics/`");
+    // The seat is inlined in full; memory lives in `.nirvana` since the
+    // architecture change, and what remains here is a seed already consumed.
+    expect(m).not.toContain("`employees/`");
+    expect(m).not.toContain("`memory/`");
+  });
+
+  test("squad: the same map, with a different inlined set", () => {
+    const dir = tree({ agents: ["a.md"], tasks: ["t.md"], references: ["r.md"] });
+    const m = renderResourceMap(dir, SQ);
+    expect(m).toContain("## O QUE MAIS ESTE SQUAD CARREGA");
+    expect(m).toContain("`references/`");
+    expect(m).not.toContain("`agents/`");
+  });
+
+  test("nothing beyond the inlined: no section at all, rather than an empty one", () => {
+    expect(renderResourceMap(tree({ employees: ["ceo.md"] }), BIZ)).toBe("");
+    expect(renderResourceMap(tree({ agents: ["a.md"] }), SQ)).toBe("");
+  });
+
+  test("an empty directory is a directory with nothing to open", () => {
+    const dir = tree({ employees: ["ceo.md"] });
+    fs.mkdirSync(path.join(dir, "playbooks"), { recursive: true });
+    expect(renderResourceMap(dir, BIZ)).toBe("");
+  });
+});
+
+describe("what the map never names", () => {
+  // Run state has ONE owner, `isRunStatePath`, and it answers differently per
+  // kind: a business accumulates in `memory/projects` and `projects/`, a squad in
+  // `.runs`. A local copy of that list here is the way back to advertising — and
+  // then shipping — what must never travel.
+  test("business: outputs and projects stay out", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"], projects: ["run-1.md"], outputs: ["o.md"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("`playbooks/`");
+    expect(m).not.toContain("`projects/`");
+    expect(m).not.toContain("`outputs/`");
+  });
+
+  test("squad: .runs stays out", () => {
+    const dir = tree({ agents: ["a.md"], references: ["r.md"], ".runs": ["x.md"] });
+    const m = renderResourceMap(dir, SQ);
+    expect(m).toContain("`references/`");
+    expect(m).not.toContain(".runs");
+  });
+
+  test("build and dependency output never enter", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"], node_modules: ["index.js"], dist: ["b.js"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).not.toContain("node_modules");
+    expect(m).not.toContain("`dist/`");
+  });
+});
+
+describe("the index ceiling", () => {
+  // A real cap, and deliberately NOT the silent cut this codebase spent a day
+  // undoing: a directory index is recoverable with one `ls` against a tree the
+  // dispatch already grants, and the overflow line says exactly that.
+  test("a huge directory is capped, and says how many are left and how to see them", () => {
+    const many = Array.from({ length: 130 }, (_, i) => `f-${String(i).padStart(3, "0")}.md`);
+    const dir = tree({ employees: ["ceo.md"], data: many });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("`f-000.md`");
+    expect(m).toContain("e mais 80");
+    expect(m).toContain("`ls`");
+    expect(Buffer.byteLength(m, "utf8")).toBeLessThan(4_096);
+  });
+});
+
+describe("the prose promises nothing it cannot keep", () => {
+  test("it says which tree it means, and that the tree is read-only", () => {
+    const dir = tree({ employees: ["ceo.md"], playbooks: ["p.md"] });
+    const m = renderResourceMap(dir, BIZ);
+    expect(m).toContain("a fonte da empresa");
+    expect(m).toContain("**é somente leitura para você**");
+    expect(m).toContain("outputs_root");
+    expect(m).toContain(dir);
+    // Nothing here was summarized: the index is names, the content is on disk.
+    expect(m).toContain("o arquivo em disco é o conteúdo");
+  });
+
+  test("an unreadable directory does not take down the prompt", () => {
+    expect(renderResourceMap(path.join(tmp, "does-not-exist"), BIZ)).toBe("");
+  });
+});

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -64,6 +64,7 @@ import { resolveClonePersona, loadCloneRegistry } from "../../_shared/lib/clone-
 import { layersForPhase } from "../../_shared/lib/dna-layer-policy.ts";
 import { hookForPhase } from "../../_shared/lib/hooks.ts";
 import { readEntityMemory } from "../../_shared/lib/entity-memory.ts";
+import { renderResourceMap, resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 import { collectContributions, orderContributions, renderHookBlock, cloneContributionSource } from "../../_shared/lib/contributions.ts";
 
 // Untrusted-input boundary (P0-1 / Batch 3 item 7): security preamble injected
@@ -80,16 +81,11 @@ const BUSINESSES_ROOT = path.join(os.homedir(), "businesses");
  *  project-local business overrides the global same-slug one; the global join
  *  is only the fallback when no scoped hit is found. Walks up from project_dir
  *  to find the project root (same strategy as the squad catalog resolution). */
-function resolveBusinessDir(business_slug: string, project_dir: string): string {
-  try {
-    const hit = enumerate(resolveScope({ cwd: project_dir }), "businesses")
-      .find(e => e.slug === business_slug && !e.overridden);
-    if (hit) return hit.dir;
-  } catch {
-    // fall through to global join
-  }
-  return path.join(BUSINESSES_ROOT, business_slug);
-}
+// Delegated to the shared resolver: `team-orchestrator` needs the SAME path to
+// grant the directory in the dispatch, and granting a different tree than this
+// prompt describes hands the agent the map of one and the key to another.
+const resolveBusinessDir = (business_slug: string, project_dir: string): string =>
+  resolveEntityDir("businesses", business_slug, project_dir);
 
 function appendAuditEvent(project_dir: string, event: Record<string, unknown>): void {
   const today = new Date().toISOString().slice(0, 10);
@@ -493,6 +489,26 @@ export function buildEmployeePrompt(args: BuildArgs): string {
   const squadsBlock = squadCatalogBlock(employeeContent, args.project_dir);
   const mindCloneCatalog = mindCloneCatalogBlock(employeeContent);
 
+  // What the business carries beyond the manifest and the seat that is running.
+  //
+  // The prompt reads ONE directory of the business: `employees/`. Everything else
+  // the author wrote — `playbooks/`, `standards/`, `rubrics/`, `templates/`,
+  // `lib/`, `scripts/` — reached no run at all, and the business directory was
+  // never granted, so naming a path would not have helped either. Squads got this
+  // channel; businesses did not, and there are 63 of them.
+  //
+  // `employees/` stays out of the map because the seat is inlined in full.
+  // `memory/` too: since the architecture change it lives in `.nirvana`, and what
+  // remains inside the business is a seed already consumed — advertising it would
+  // invite the agent to read the stale copy instead of what the owner accumulated.
+  const resourceMap = renderResourceMap(bizDir, {
+    kind: "businesses",
+    inlined: ["employees", "memory"],
+    label: "ESTA EMPRESA",
+    sourceNoun: "da empresa",
+    outputsHint: "o `outputs_root` declarado nos caminhos do projeto",
+  });
+
   const bizYamlPath = path.join(bizDir, "business.yaml");
   const bizYaml = fs.existsSync(bizYamlPath) ? fs.readFileSync(bizYamlPath, "utf8") : "(business.yaml missing)";
 
@@ -721,6 +737,7 @@ ${bizYaml}
 
 ---
 
+${resourceMap ? resourceMap + "\n\n---\n\n" : ""}
 ${memoryBlock}## CURRENT HANDOFF STATE
 
 \`\`\`json

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -32,7 +32,7 @@ import { layersForPhase } from "../../_shared/lib/dna-layer-policy.ts";
 import { findCloneForTask } from "../../_shared/lib/clone-search.ts";
 import { paths } from "../../_shared/lib/bun-helpers.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
-import { isRunStatePath } from "../../_shared/lib/run-state.ts";
+import { renderResourceMap } from "../../_shared/lib/entity-resource-map.ts";
 import { resolveSetting } from "../../_shared/lib/settings.ts";
 
 export type SquadExecMode = "team-mandatory" | "squad-only";
@@ -318,94 +318,11 @@ function renderEventContractBlock(squadSlug: string, traceId?: string): string {
 Emita marcos do seu trabalho com \`nrv audit emit <nome> --squad=${squadSlug} --trace=${trace}\`. Sempre passe \`--squad=${squadSlug}\`: é o que atribui o evento a você no cockpit. O nome não precisa estar na lista fechada do motor — se não estiver, escreva-o já com o prefixo \`x_\` (ex.: \`x_pagina_altura_acima_orcamento\`), assim o nome que chega ao log é o mesmo que você digitou. Payload vai em \`--json='{...}'\`, curto: nunca o brief inteiro, um output completo ou um segredo, só o resumo que o evento precisa carregar.`;
 }
 
-/** Directories the map never names, on top of run state.
- *
- *  `agents`, `tasks` and `workflows` are the three the prompt already carries.
- *  The rest is build and dependency output — never authored content, and
- *  `node_modules` alone would bury the map it is listed in. Run state is NOT
- *  listed here: `isRunStatePath` owns that list (`.runs`, `outputs`, `projects`,
- *  `.nirvana`, …), and keeping a private second copy of it is precisely how a
- *  path that should never travel starts travelling again.
- *
- *  This is a DENYLIST on purpose. The first cut of this map was an allowlist of
- *  five directory names chosen by hand, and surveying real squads showed what
- *  that costs: it would have hidden `config/`, `schemas/`, `scripts/`, `data/`,
- *  `tools/` and `lib/` outright, and `reference/` — the singular spelling some
- *  squads use — from every squad that spells it that way. A curated list of what
- *  an agent may see is a list of what one person happened to think of.
- *  Everything the squad ships, the agent is told about. */
-const MAP_EXCLUDED_DIRS = new Set([
-  "node_modules", "dist", "build", "__pycache__", ".venv", "venv",
-]);
-
 /** The three the prompt carries in full — but only when a capability resolved
- *  and the workflow named them. On the legacy fallback it carries three files
- *  in alphabetical order, which is not the same thing at all. */
-const INLINED_DIRS = new Set(["agents", "tasks", "workflows"]);
-
-/**
- * Everything else the squad carries, as a map rather than as content.
- *
- * The prompt inlines exactly the agents and tasks the workflow names, so the
- * rest of the squad has been invisible to the agent executing it. Most squads
- * ship well beyond those three directories — `references/`, `checklists/`,
- * `templates/`, `standards/`, `schemas/`, `config/`, `scripts/`, `data/`,
- * `tools/`, `lib/` are all common — and every one of those files is content the
- * author wrote and the run never saw.
- *
- * This is the skill pattern applied to squads: the names travel in the prompt,
- * the bytes stay on disk, and the agent loads in cascade only what its execution
- * turns out to need. The map is one level deep — files by name, subdirectories
- * with a trailing slash — because the point is to prove the tree exists and give
- * a door into it, not to serialize it.
- *
- * The map is a map, not an instruction. What a step MUST obey stays inlined:
- * a path is a request, and inlined text is a fact. `runSquadHeadless` grants the
- * squad directory alongside it, so the door the map names actually opens.
- *
- * MAP_ENTRIES_PER_DIR is a real cap, and it is NOT the mistake this file just
- * finished undoing. That one dropped the agent and task documents a step depends
- * on: content the run cannot proceed without and cannot get any other way. This
- * caps a directory INDEX — the names are recoverable with one `ls` against a
- * directory the dispatch has already granted, and the overflow line says exactly
- * that. Without a cap the map inherits the failure it replaced from the other
- * side: a squad with a `data/` of fifty thousand files would push megabytes of
- * filenames into every prompt it ever runs. A budget belongs where the content
- * is reproducible; it does not belong where the content is the instruction.
- */
-const MAP_ENTRIES_PER_DIR = 50;
-function renderResourceMap(squadDir: string, opts: { componentsInlined: boolean }): string {
-  let entries: fs.Dirent[];
-  try { entries = fs.readdirSync(squadDir, { withFileTypes: true }); } catch { return ""; }
-  const lines: string[] = [];
-  // `agents`, `tasks` and `workflows` are hidden ONLY when the workflow actually
-  // put them in the prompt. On the legacy fallback the prompt carries an
-  // alphabetical first-three under a "(top 3)" heading, so hiding them here
-  // switched the map off for the one path that has most of itself missing —
-  // a squad with eight agents showed three and named none of the rest.
-  const inlined = opts.componentsInlined ? INLINED_DIRS : new Set<string>();
-  const authored = entries.filter(e =>
-    e.isDirectory() && !inlined.has(e.name) && !MAP_EXCLUDED_DIRS.has(e.name) && !isRunStatePath(e.name, "squads"));
-  for (const dir of authored.sort((a, b) => a.name.localeCompare(b.name))) {
-    let inner: fs.Dirent[];
-    try { inner = fs.readdirSync(path.join(squadDir, dir.name), { withFileTypes: true }); } catch { continue; }
-    const names = inner
-      .filter(e => !e.name.startsWith("."))
-      .map(e => e.isDirectory() ? `${e.name}/` : e.name)
-      .sort();
-    if (!names.length) continue;
-    const shown = names.slice(0, MAP_ENTRIES_PER_DIR).map(n => `\`${n}\``).join(", ");
-    const rest = names.length - MAP_ENTRIES_PER_DIR;
-    lines.push(`- \`${dir.name}/\` — ${shown}${rest > 0 ? ` … e mais ${rest}: rode \`ls\` nesse diretório para a lista inteira` : ""}`);
-  }
-  if (!lines.length) return "";
-  return `## O QUE MAIS ESTE SQUAD CARREGA
-Tudo abaixo existe em \`${squadDir}\` e **não** está neste prompt. Abra o que precisar, quando precisar, em cascata — nada aqui é obrigatório, e nada aqui foi resumido: o arquivo em disco é o conteúdo. Um nome terminado em \`/\` é subdiretório, desça nele.
-
-Este diretório é a fonte do squad, compartilhada por todo projeto desta máquina e lida por toda execução futura: **é somente leitura para você**. Não edite, crie nem apague nada aqui, nem para "corrigir" um template ou anotar um resultado. Todo arquivo que você produzir vai para o diretório de saída indicado na sua sub-tarefa.
-
-${lines.join("\n")}`;
-}
+ *  and the workflow named them. On the legacy fallback it carries three files in
+ *  alphabetical order, which is not the same thing at all, so the map stays on
+ *  there: that is the path with most of itself missing. */
+const INLINED_DIRS = ["agents", "tasks", "workflows"];
 
 /** The capability block, plus the workflow block when the graph resolved. */
 function renderCapabilityBlock(ctx: SquadCapabilityPromptContext): string {
@@ -489,7 +406,13 @@ export function buildSquadPrompt(args: {
   // capability would withhold it precisely where it is needed most. A squad that
   // ships nothing outside agents/, tasks/ and workflows/ still gets no section,
   // which is what keeps the pin meaningful for the fixtures that have none.
-  const resourceMap = renderResourceMap(squadDir, { componentsInlined: !!capability?.components });
+  const resourceMap = renderResourceMap(squadDir, {
+    kind: "squads",
+    inlined: capability?.components ? INLINED_DIRS : [],
+    label: "ESTE SQUAD",
+    sourceNoun: "do squad",
+    outputsHint: "o diretório de saída indicado na sua sub-tarefa",
+  });
   const resourceSection = resourceMap ? `\n${resourceMap}\n` : "";
 
   const roleLine = mode === "team-mandatory"

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -30,7 +30,6 @@ import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 
 const SKILLS = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
-const BUSINESSES = path.join(os.homedir(), "businesses");
 
 export interface TeamRunArgs {
   slug: string;
@@ -51,6 +50,23 @@ export interface TeamRunArgs {
   /** The user's USE_* rules block (formatRulesForDirective) — appended to each
    * step's AUTONOMOUS_DIRECTIVE so the maestro honors it when delegating. */
   rulesDirective?: string;
+  /** Where the businesses library lives, overriding scope resolution. Mirrors
+   *  `SquadExecArgs.squadsRoot`, and exists for the same reason: `paths` is
+   *  memoized on first access, so a test that points `BUSINESSES_DIR` at a
+   *  fixture only wins if it is the first thing in the process to touch it —
+   *  which makes the outcome depend on test file order, and makes the env write
+   *  leak into every other file sharing the runner. An argument is honest where
+   *  a process-wide mutation is a race. */
+  businessesRoot?: string;
+  /** Test seam: canned cascade runner (zero-token tests). Same shape
+   *  `SquadExecArgs.runWithCascadeImpl` already uses, so one idiom covers both
+   *  executors. The chain had no test file at all before this — only
+   *  `buildStepBrief` was pinned — so every behaviour of the loop itself was
+   *  unprotected. */
+  runWithCascadeImpl?: typeof runWithCascade;
+  /** Test seam: canned director. Without it `pickChain` reaches a real runtime,
+   *  which is why the chain could not be tested at all. */
+  runHeadlessImpl?: typeof runHeadless;
 }
 
 export interface ChainStep { employee: string; task: string; }
@@ -66,8 +82,27 @@ function appendAudit(payload: Record<string, any>, projectRoot?: string): void {
   } catch { /* non-fatal */ }
 }
 
-function listEmployees(slug: string): { name: string; role: string; description: string }[] {
-  const dir = path.join(BUSINESSES, slug, "employees");
+/** The one place this module decides where the business lives.
+ *
+ *  Both callers must agree: `pickChain` lists the seats from it and `runStep`
+ *  grants it to the dispatch. Resolving separately is how a run gets the roster
+ *  of one tree and the key to another — the failure `entity-resource-map` names
+ *  in its own header. */
+function businessDir(args: TeamRunArgs): string {
+  return args.businessesRoot
+    ? path.join(args.businessesRoot, args.slug)
+    : resolveEntityDir("businesses", args.slug, args.projectDir);
+}
+
+/** The seats the director gets to choose from.
+ *
+ *  The old `path.join(os.homedir(), "businesses")` ignored `BUSINESSES_DIR`,
+ *  `NIRVANA_HOME` and the project scope alike: a business installed under a
+ *  redirected home, or living in the project, listed zero seats — and
+ *  `pickChain` then silently degraded the whole company to its single intake
+ *  employee, which reads like a product decision rather than a missing path. */
+function listEmployees(args: TeamRunArgs): { name: string; role: string; description: string }[] {
+  const dir = path.join(businessDir(args), "employees");
   if (!fs.existsSync(dir)) return [];
   const out: { name: string; role: string; description: string }[] = [];
   for (const f of fs.readdirSync(dir).sort()) {
@@ -84,7 +119,7 @@ function listEmployees(slug: string): { name: string; role: string; description:
 }
 
 function pickChain(args: TeamRunArgs): ChainStep[] {
-  const employees = listEmployees(args.slug);
+  const employees = listEmployees(args);
   if (employees.length <= 1) return [{ employee: args.intakeEmployee, task: "Execute o brief de ponta a ponta. Você é o único employee deste business." }];
 
   const list = employees.map(e => `- ${e.name} (${e.role}): ${e.description}`).join("\n");
@@ -110,7 +145,7 @@ function pickChain(args: TeamRunArgs): ChainStep[] {
   ].join("\n");
 
   appendAudit({ event: "team_director_called", project_id: args.projectId, business_slug: args.slug, employees_available: employees.length }, args.projectRoot);
-  const res = runHeadless({
+  const res = (args.runHeadlessImpl ?? runHeadless)({
     runtime: args.runtime, prompt, cwd: os.tmpdir(),
     allowedTools: [], permissionMode: "default",
     timeoutMs: 5 * 60 * 1000,
@@ -152,10 +187,11 @@ function runWithSession(
   args: TeamRunArgs,
   cascadeArgs: Parameters<typeof runWithCascade>[0],
 ): ReturnType<typeof runWithCascade> {
+  const cascade = args.runWithCascadeImpl ?? runWithCascade;
   const key = sessionKey(args.runtime, kind, slug);
   const prior = getSession(args.projectDir, key);
 
-  let res = runWithCascade(prior ? { ...cascadeArgs, sessionId: prior } : cascadeArgs);
+  let res = cascade(prior ? { ...cascadeArgs, sessionId: prior } : cascadeArgs);
 
   if (!res.ok && prior) {
     // The session may have died outside our control. There is no reliable way
@@ -167,7 +203,7 @@ function runWithSession(
       business_slug: args.slug, entity: `${kind}:${slug}`, runtime: args.runtime, session_id: prior,
     }, args.projectRoot);
     dropSession(args.projectDir, key);
-    res = runWithCascade(cascadeArgs);
+    res = cascade(cascadeArgs);
   } else if (prior && res.ok) {
     appendAudit({
       event: "session_resumed", trace_id: args.projectId, project_id: args.projectId,
@@ -215,10 +251,20 @@ function runStep(step: ChainStep, idx: number, total: number, args: TeamRunArgs,
   const stepBriefFile = path.join(employeeOutDir, ".step-brief.md");
   fs.writeFileSync(stepBriefFile, stepBrief);
 
+  const bizDir = businessDir(args);
+
+  // The child resolves the business independently, and independently is how the
+  // two disagree: this process may have resolved a project-scoped copy while the
+  // subprocess, walking its own resolution, lands on the global one — then the
+  // prompt describes one tree and the grant below opens another. Handing it the
+  // library root this run already settled on removes the second opinion.
   const ep = spawnSync("bun", [
     path.join(SKILLS, "businesses/lib/employee-prompt.ts"),
     args.slug, step.employee, args.projectDir, stepBriefFile, employeeOutDir,
-  ], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+  ], {
+    encoding: "utf8", maxBuffer: 32 * 1024 * 1024,
+    env: { ...process.env, BUSINESSES_DIR: path.dirname(bizDir) },
+  });
   if (ep.status !== 0) {
     appendAudit({ event: "team_step_failed", project_id: args.projectId, business_slug: args.slug, employee: step.employee, reason: "employee-prompt build failed", error: ep.stderr?.slice(0, 500) }, args.projectRoot);
     return { employee: step.employee, ok: false, sessionId: null, costUsd: null, durationMs: 0, outputsDir: employeeOutDir };
@@ -226,7 +272,6 @@ function runStep(step: ChainStep, idx: number, total: number, args: TeamRunArgs,
 
   appendAudit({ event: "dispatch_business", trace_id: args.projectId, project_id: args.projectId, business_slug: args.slug, employee: step.employee, mode: "team-step", step: idx + 1, total }, args.projectRoot);
 
-  const bizDir = resolveEntityDir("businesses", args.slug, args.projectDir);
   const res = runWithSession("employee", step.employee, args, {
     // bizDir is granted so the employee prompt's resource map is a door and not a
     // sign: `playbooks/`, `standards/`, `rubrics/` and `templates/` live under it,
@@ -275,6 +320,9 @@ function runMandatorySquad(squadSlug: string, args: TeamRunArgs): StepResult {
     timeoutMs: args.timeoutMs,
     rulesDirective: args.rulesDirective,
     autonomousDirective: AUTONOMOUS_DIRECTIVE,
+    // The seam travels down: a mandatory squad dispatched from a chain must be
+    // testable from the same fixture that tests the chain.
+    ...(args.runWithCascadeImpl ? { runWithCascadeImpl: args.runWithCascadeImpl } : {}),
   });
   return { employee: `squad:${squadSlug}`, ok: r.ok, sessionId: r.sessionId, costUsd: r.costUsd, durationMs: r.durationMs, outputsDir: r.outputsDir };
 }

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -26,6 +26,7 @@ import { sessionKey, getSession, putSession, dropSession, type EntityKind } from
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
 import { runSquadHeadless } from "./squad-exec.ts";
+import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 
 const SKILLS = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
@@ -225,8 +226,16 @@ function runStep(step: ChainStep, idx: number, total: number, args: TeamRunArgs,
 
   appendAudit({ event: "dispatch_business", trace_id: args.projectId, project_id: args.projectId, business_slug: args.slug, employee: step.employee, mode: "team-step", step: idx + 1, total }, args.projectRoot);
 
+  const bizDir = resolveEntityDir("businesses", args.slug, args.projectDir);
   const res = runWithSession("employee", step.employee, args, {
-    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectRoot, addDirs: [args.projectDir, employeeOutDir],
+    // bizDir is granted so the employee prompt's resource map is a door and not a
+    // sign: `playbooks/`, `standards/`, `rubrics/` and `templates/` live under it,
+    // and on claude-code and agy an ungranted path is simply refused. Same grant
+    // squads already have, with the same caveat: `--add-dir` adds a WORKSPACE root
+    // and this path runs with the permission bypass, so the directory is writable.
+    // The prompt says in words that it is read-only, which is the instrument the
+    // rest of the engine uses to keep deliverables where they belong.
+    runtime: args.runtime, prompt: ep.stdout, cwd: args.projectRoot, addDirs: [args.projectDir, employeeOutDir, bizDir],
     appendSystemPrompt: AUTONOMOUS_DIRECTIVE + (args.rulesDirective ?? ""),
     maxBudgetUsd: args.maxBudgetUsd, timeoutMs: args.timeoutMs,
     brief: args.brief, projectRoot: args.projectRoot, outputsRoot: employeeOutDir,

--- a/skills/harness/tests/team-orchestrator.test.ts
+++ b/skills/harness/tests/team-orchestrator.test.ts
@@ -1,0 +1,255 @@
+// team-orchestrator.test.ts — the business chain: director, loop, handoff.
+//
+// This file did not exist. `runTeam` — chain selection, step sequencing, session
+// threading, mandatory squads, `TeamResult` accumulation — had no coverage at
+// all; only `buildStepBrief` was pinned, by scope-guard-travels.test.ts. Every
+// behaviour of the loop itself was unprotected, which is why it is written
+// before the loop is changed.
+//
+// Zero-token by construction: `runHeadlessImpl` cans the director and
+// `runWithCascadeImpl` cans every step, the same seams squad-exec.test.ts uses.
+// Runs with: bun test skills/harness/tests
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { parseAuditLine } from "../../_shared/lib/cloudevents.js";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runTeam, type TeamRunArgs } from "../lib/team-orchestrator.ts";
+
+// Nothing here writes `process.env`. `bun test` shares one process across
+// files, so an env write at module scope is a write into every other file's
+// run: `BUSINESSES_DIR` here redirected the library out from under the pack
+// tests, and `paths` memoizes on first access, so which file won depended on
+// file order. Two arguments replace both writes — `businessesRoot` for the
+// library, and a `.nirvana` marker in the fixture so `harnessLogsDir` resolves
+// the audit into the fixture instead of the machine's real log directory.
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-team-"));
+  fs.mkdirSync(path.join(tmp, ".nirvana"), { recursive: true });
+});
+afterEach(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+/** A business with N seats; the last one is the intake/synthesizer. */
+function business(slug: string, seats: string[]): string {
+  const dir = path.join(tmp, "businesses", slug);
+  fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "business.yaml"), `name: ${slug}\ndescription: a business\n`, "utf8");
+  seats.forEach((name, i) => {
+    const intake = i === seats.length - 1 ? "is_brief_intake: true\n" : "";
+    fs.writeFileSync(
+      path.join(dir, "employees", `${name}.md`),
+      `---\nname: ${name}\nrole: ${name} role\ndescription: The ${name} seat.\n${intake}---\n\n# ${name}\n\nMethod.\n`,
+      "utf8",
+    );
+  });
+  return dir;
+}
+
+/** A canned director that returns exactly this chain. */
+function director(chain: Array<{ employee: string; task: string }>) {
+  return ((opts: any) => ({
+    ok: true, runtime: opts.runtime, sessionId: null, result: JSON.stringify({ chain }),
+    costUsd: 0, exitCode: 0, stderr: "", durationMs: 1,
+  })) as any;
+}
+
+/** A canned cascade. `failFor` names the employees whose step fails. */
+function cascade(seen: any[], failFor: Set<string> = new Set()) {
+  return ((opts: any) => {
+    seen.push(opts);
+    const who = String(opts.taskHint ?? "");
+    const fails = [...failFor].some(f => who.includes(f));
+    return {
+      ok: !fails, runtime: opts.runtime, sessionId: "s1", result: fails ? "" : "did the work",
+      costUsd: 0.01, exitCode: fails ? 1 : 0, stderr: "", durationMs: 5,
+      handoffs: [], finalRuntime: opts.runtime, error: fails ? "boom" : undefined,
+    };
+  }) as any;
+}
+
+/** The run's own events.
+ *
+ *  Resolved through `harnessLogsDir`, never by rebuilding the path: the helper's
+ *  order puts `$HARNESS_LOGS_DIR` ahead of the project, another file in this
+ *  shared process sets it, and a hand-built path then reads an empty directory
+ *  while the events are written somewhere else. Filtering by `project_id` is the
+ *  other half — when that env does point everyone at one file, the events of
+ *  every test land in it together. */
+function readAudit(projectId: string): any[] {
+  const day = new Date().toISOString().slice(0, 10);
+  const p = path.join(harnessLogsDir({ cwd: tmp }), day, "audit.jsonl");
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, "utf8").split("\n").filter(Boolean)
+    .map(l => parseAuditLine(l))
+    .filter(e => e?.project_id === projectId);
+}
+
+let runSeq = 0;
+function args(slug: string, over: Partial<TeamRunArgs> = {}): TeamRunArgs {
+  return {
+    slug, brief: "monte o relatório", projectId: `proj-team-${++runSeq}`,
+    projectDir: tmp, projectRoot: tmp, outputsRoot: path.join(tmp, "out"),
+    businessesRoot: path.join(tmp, "businesses"),
+    runtime: "claude-code", intakeEmployee: "synth",
+    autonomousDirective: "D ",
+    ...over,
+  } as TeamRunArgs;
+}
+
+describe("runTeam — the chain the director chose", () => {
+  test("runs every step in order and returns one result per step", () => {
+    business("acme", ["researcher", "writer", "synth"]);
+    const seen: any[] = [];
+    const r = runTeam(args("acme", {
+      runHeadlessImpl: director([
+        { employee: "researcher", task: "pesquise" },
+        { employee: "writer", task: "escreva" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade(seen),
+    }));
+
+    expect(r.ok).toBe(true);
+    expect(r.chain.map(s => s.employee)).toEqual(["researcher", "writer", "synth"]);
+    expect(r.steps.map(s => s.employee)).toEqual(["researcher", "writer", "synth"]);
+    expect(seen).toHaveLength(3);
+    // Cost and duration accumulate across the chain, not just the last step.
+    expect(r.totalCostUsd).toBeCloseTo(0.03, 5);
+    expect(r.totalDurationMs).toBe(15);
+  });
+
+  test("the synthesizer is forced last even when the director forgets it", () => {
+    business("acme", ["researcher", "synth"]);
+    const r = runTeam(args("acme", {
+      runHeadlessImpl: director([{ employee: "researcher", task: "pesquise" }]),
+      runWithCascadeImpl: cascade([]),
+    }));
+    expect(r.chain[r.chain.length - 1].employee).toBe("synth");
+  });
+
+  test("a seat the business does not have is dropped, not dispatched", () => {
+    business("acme", ["researcher", "synth"]);
+    const seen: any[] = [];
+    runTeam(args("acme", {
+      runHeadlessImpl: director([
+        { employee: "ghost", task: "não existe" },
+        { employee: "researcher", task: "pesquise" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade(seen),
+    }));
+    expect(seen).toHaveLength(2);
+    expect(seen.some(o => String(o.taskHint).includes("ghost"))).toBe(false);
+  });
+
+  test("a one-seat business skips the director entirely", () => {
+    business("solo", ["synth"]);
+    const seen: any[] = [];
+    const r = runTeam(args("solo", {
+      // A director that would throw proves it is never consulted.
+      runHeadlessImpl: (() => { throw new Error("director must not run for a one-seat business"); }) as any,
+      runWithCascadeImpl: cascade(seen),
+    }));
+    expect(r.ok).toBe(true);
+    expect(r.chain).toHaveLength(1);
+    expect(seen).toHaveLength(1);
+  });
+});
+
+describe("runTeam — what each step is told", () => {
+  test("a later step is handed where the earlier ones wrote", () => {
+    business("acme", ["researcher", "synth"]);
+    const seen: any[] = [];
+    runTeam(args("acme", {
+      runHeadlessImpl: director([
+        { employee: "researcher", task: "pesquise" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade(seen),
+    }));
+    const synthPrompt = String(seen[1].prompt);
+    expect(synthPrompt).toContain("researcher");
+    expect(synthPrompt).toContain(path.join("_team", "researcher"));
+  });
+
+  test("each step writes under _team, and the last writes to the outputs root", () => {
+    business("acme", ["researcher", "synth"]);
+    const seen: any[] = [];
+    runTeam(args("acme", {
+      runHeadlessImpl: director([
+        { employee: "researcher", task: "pesquise" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade(seen),
+    }));
+    expect(seen[0].outputsRoot).toBe(path.join(tmp, "out", "_team", "researcher"));
+    expect(seen[1].outputsRoot).toBe(path.join(tmp, "out"));
+  });
+});
+
+describe("runTeam — the audit chain", () => {
+  test("the director's choice and every step are recorded", () => {
+    business("acme", ["researcher", "synth"]);
+    const a = args("acme", {
+      runHeadlessImpl: director([
+        { employee: "researcher", task: "pesquise" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade([]),
+    });
+    runTeam(a);
+    const ev = readAudit(a.projectId);
+    expect(ev.find(e => e.event === "team_director_called")).toBeTruthy();
+
+    const chosen = ev.find(e => e.event === "team_chain_selected");
+    expect(chosen?.chain?.map((c: any) => c.employee)).toEqual(["researcher", "synth"]);
+
+    // One dispatch_business per step, numbered, so a reader can tell position.
+    const dispatched = ev.filter(e => e.event === "dispatch_business" && e.mode === "team-step");
+    expect(dispatched.map(e => e.step)).toEqual([1, 2]);
+    expect(dispatched.every(e => e.total === 2)).toBe(true);
+
+    expect(ev.filter(e => e.event === "agent_executed")).toHaveLength(2);
+    expect(ev.find(e => e.event === "team_completed")?.steps).toBe(2);
+  });
+
+  test("a director that returns nothing usable fails the run loudly", () => {
+    business("acme", ["researcher", "synth"]);
+    const a = args("acme", {
+      runHeadlessImpl: (() => ({ ok: true, result: "sorry, no JSON here", costUsd: 0, exitCode: 0, stderr: "", durationMs: 1, sessionId: null })) as any,
+      runWithCascadeImpl: cascade([]),
+    });
+    const r = runTeam(a);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/director/);
+    expect(readAudit(a.projectId).find(e => e.event === "team_director_failed")).toBeTruthy();
+  });
+});
+
+// The behaviour this suite exists to change next. Pinned as it is TODAY so the
+// change is deliberate and visible in the diff, not accidental.
+describe("runTeam — failure, as it behaves today", () => {
+  test("a failed step aborts the chain and the synthesizer never runs", () => {
+    business("acme", ["researcher", "writer", "synth"]);
+    const seen: any[] = [];
+    const r = runTeam(args("acme", {
+      runHeadlessImpl: director([
+        { employee: "researcher", task: "pesquise" },
+        { employee: "writer", task: "escreva" },
+        { employee: "synth", task: "consolide" },
+      ]),
+      runWithCascadeImpl: cascade(seen, new Set(["writer"])),
+    }));
+
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/step 2/);
+    // Only two of three ran: the synthesizer was never reached, and the
+    // researcher's work is stranded on disk with nothing to consolidate it.
+    expect(seen).toHaveLength(2);
+    expect(seen.some(o => String(o.taskHint).includes("synth"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What was wrong

`listEmployees` resolved the business as `~/businesses/<slug>`, hardcoded. Nothing else in the run does — the dispatch grants what `resolveEntityDir` returns, which honours the project scope, `BUSINESSES_DIR` and `NIRVANA_HOME`.

So a business installed under a redirected home, or living in the project rather than the global library, listed **zero seats**. `pickChain` reads zero seats as a one-seat company and hands the whole brief to the intake employee. The company ran as one person and said nothing about it, which is indistinguishable from a company that only has one seat.

## What changed

- Both callers resolve through one `businessDir()`.
- The `employee-prompt` subprocess is handed the library root the run already settled on, instead of walking its own resolution. Two independent answers to "where does this business live" is how the prompt describes one directory while the grant opens another.
- `TeamRunArgs` gains `businessesRoot` — mirrors `SquadExecArgs.squadsRoot`, and exists for the same reason: `paths` memoizes on first access, so pointing `BUSINESSES_DIR` at a fixture only wins if it is the first thing in the process to touch it.

## The test file

`skills/harness/tests/team-orchestrator.test.ts` did not exist. The chain — director, step order, session threading, mandatory squads, the fail-fast abort — was covered only through `buildStepBrief`. This adds 9 zero-token tests pinning today's behaviour, so the orchestration work planned on top has a net before it changes any of it.

It writes no `process.env`: `bun test` shares one process across files, and an env write at module scope redirected the library out from under the pack tests.

## Verification

- `bun test skills/harness/tests` — 1687 pass. The 4 remaining failures (3 amplification-bridge, 1 routing-eval) reproduce with this branch's engine change stashed and with the new test file removed: they read the machine's live library and are order-dependent, unrelated to this cut.
- `bun run check:quick` — exit 0 (9 gates).
- Bilingual changelog entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk