### PR TITLE
test(windows): give the heavy teardowns a budget, like the tests already have

### DIFF
--- a/skills/harness/tests/helpers/test-budgets.ts
+++ b/skills/harness/tests/helpers/test-budgets.ts
@@ -22,3 +22,28 @@ export function spawnBudgetMs(processes: number): number {
 /** A test that drives the Run Kernel or a Gauntlet in-process: fsync-bound SQLite, measured up to
  * 5.5 s per test on the slowest runner against 150-350 ms normally. */
 export const KERNEL_BUDGET_MS = 30_000;
+
+/**
+ * An `afterAll`/`afterEach` that deletes a temporary root holding a real engine
+ * install. Bun's 5 s default applies to HOOKS too, and nothing here had ever
+ * given one a budget, so the heaviest teardown in the suite ran on the same
+ * allowance as an assertion.
+ *
+ * The failure it produces is deliberately hard to attribute: Bun reports it as
+ * `(fail) (unnamed)` with `a beforeEach/afterEach hook timed out for this test`,
+ * naming no test, so the only way to find the file is to walk back to the
+ * enclosing `##[group]` in the CI log. Evidence, all windows-latest, all with
+ * every named test in the file PASSING:
+ *   - run 33885817681: windows-path-persist teardown 7428 ms. Same cleanup
+ *     measured ~450 ms on three green main runs (33794184327, 33793067812,
+ *     33754875788); that whole run was ~2.7x slower than a fast pass.
+ *   - run 33789921562: same signature, revise-delivery.
+ *   - run 33317102720: same signature, preflight-index.
+ * Three runs, three different files: the runner's speed picks the victim, not
+ * the test. `removeDir` already retries EBUSY/EPERM/EACCES/ENOTEMPTY, and a
+ * budget INSIDE it would not help — `fs.rmSync` is synchronous and a single
+ * slow call cannot be interrupted. The hook's own timeout is the only lever.
+ *
+ * Headroom, not slack: a teardown that truly wedges still fails, only later.
+ */
+export const TEARDOWN_BUDGET_MS = 60_000;

--- a/skills/harness/tests/preflight-index.test.ts
+++ b/skills/harness/tests/preflight-index.test.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { TEARDOWN_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const REPO_SKILLS = path.join(import.meta.dir, "..", "..");
 const INDEX_TS = path.join(import.meta.dir, "..", "scripts", "index.ts");
@@ -103,7 +104,7 @@ afterAll(() => {
   for (const d of [home, work]) {
     try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
   }
-});
+}, TEARDOWN_BUDGET_MS);
 
 describe("route-entrypoint pre-flight (routing-360 Phase 2.5)", () => {
   test("fresh registries: no reindex, check under the 50ms budget", () => {

--- a/skills/harness/tests/revise-delivery.test.ts
+++ b/skills/harness/tests/revise-delivery.test.ts
@@ -22,13 +22,13 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFakeCli } from "./helpers/fake-cli.ts";
 import { SCOPE_GUARD_PT_BR } from "../../_shared/lib/scope-guard.ts";
-import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { spawnBudgetMs, TEARDOWN_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const SKILLS = path.resolve(import.meta.dir, "..", "..");
 const REVISE = path.join(SKILLS, "harness", "scripts", "revise.ts");
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-revise-test-"));
 
-afterAll(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ } });
+afterAll(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ } }, TEARDOWN_BUDGET_MS);
 
 const PASSING_MD = [
   "# Relatório revisado",

--- a/skills/harness/tests/windows-path-persist.test.ts
+++ b/skills/harness/tests/windows-path-persist.test.ts
@@ -23,6 +23,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fakeHomeEnv } from "./helpers/fake-home.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
+import { TEARDOWN_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const IS_WINDOWS = process.platform === "win32";
 const SKIP_REASON = "Windows only: the registry value HKCU\\Environment\\Path is the thing under test";
@@ -37,7 +38,7 @@ beforeAll(() => {
   home = path.join(root, "home");
   fs.mkdirSync(home, { recursive: true });
 });
-afterAll(() => { if (root) removeDir(root); });
+afterAll(() => { if (root) removeDir(root); }, TEARDOWN_BUDGET_MS);
 
 /** The user PATH as Windows stores it, read without the module under test. */
 function userPath(): string {


### PR DESCRIPTION
## The flake

Bun's 5 s default applies to **hooks** too, and no hook in this suite had ever been given a budget. So the heaviest teardown in the repo — deleting a full engine install from a temporary HOME — ran on the same allowance as an assertion. `windows-path-persist.test.ts` sets `600_000` and `120_000` on its two tests, and left the `afterAll` that cleans up after them on the default.

It is deliberately hard to attribute. Bun reports it as:

```
(fail) (unnamed) [7428.34ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

No test name. The only way to find the file is to walk back to the enclosing `##[group]` in the CI log.

## It is not one test — it is the class

Three windows-latest runs, three **different** files, every named test passing in each:

| run | file | teardown |
|---|---|---|
| 33885817681 | `windows-path-persist` | 7428 ms (~450 ms on three green main runs) |
| 33789921562 | `revise-delivery` | same signature |
| 33317102720 | `preflight-index` | same signature |

That run was ~2.7x slower overall than a fast pass (479 s vs 174 s). The runner's speed picks the victim, not the test.

## Why a budget and not a smarter helper

`removeDir` already retries `EBUSY`/`EPERM`/`EACCES`/`ENOTEMPTY` ten times. A budget **inside** it would not help: `fs.rmSync` is synchronous, so a single slow call cannot be interrupted. The hook's own timeout is the only lever.

`TEARDOWN_BUDGET_MS` joins `spawnBudgetMs` and `KERNEL_BUDGET_MS` in `helpers/test-budgets.ts`, sized the same way that file already documents — wall-clock reality with headroom, not slack for a hang. A teardown that truly wedges still fails, only later.

## Scope

Applied to the three files with an **observed** failure. Sixteen more share the shape (a tree-deleting teardown after a real install); they are left alone until one of them actually fails, rather than churning nineteen files on a guess.

## Verification

The second argument to `afterAll` is honoured, checked both ways rather than assumed: a 1200 ms hook under a 300 ms budget reproduces the exact CI signature; under 9000 ms it passes.

- `bun test` on the three files — 15 pass, 2 skip (the Windows-only pair), 0 fail.
- `bun run check:quick` — exit 0.

No changelog entry: this is test infrastructure, with no change to shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk