### PR TITLE
feat(team): let the interactive maestro run a business's org chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A business dispatched from an interactive session ran as one person
+
+Two businesses, 23 seats between them, one `dispatch_business` — and deliverables crediting six named seats that never ran as audited agents. Measured on a live run, 2026-09-04.
+
+It was not a bug in anyone's code. `runTeam` walks the org chart, but it spawns a child runtime per seat and the protocol forbids that on claude-code, codex and antigravity: a child is killed at 20 minutes, and one seat in that run worked for 33. So the interactive maestro is told to dispatch through its own in-process subagents — and had no procedure for walking an org chart with them. It did the only thing available and handed the whole company to a single subagent, which then wrote as if the seats had contributed.
+
+`nrv team` splits the run where it should have been split all along: the engine decides and audits, the runtime executes.
+
+`nrv team plan` runs the same director `runTeam` uses and leaves the same `x_chain_shape_decided` and `team_chain_selected` behind — a chain, and a reason for its length. `nrv team step --index <n>` prints that seat's full prompt, built by the same `employee-prompt.ts` the scripted path uses (persona, mind-clone DNA, resource map, colleagues' output paths, scope guard) and emits `dispatch_business` with the employee on it. The maestro runs each prompt in its own subagent, in order, with no wall-clock kill.
+
+Both paths therefore decide the same way, speak the same vocabulary and leave the same proof. That last part is the point: a reader previously could not tell one path's silence from the other's absence, and the missing event is the one the contract treats as evidence — so the default failure mode of a partial reader was to accuse a healthy run of fraud.
+
+`planChain` is extracted from `runTeam` so there is one director, not two. Phase 4 of the harness protocol carries the procedure, including the rule that closes the hole: never credit a seat with no matching `dispatch_business`.
+
+A business that does not validate is refused before any of this, and the refusal now carries the loader's own words plus `nrv validate business <slug> --fix`, instead of blaming a missing intake seat for whatever the manifest actually got wrong.
+
 ### One seat failing threw away everything the others had finished
 
 A step that failed ended the chain. The seats before it had already produced their work, it was sitting in `_team/`, and the one employee whose entire job is to consolidate it never ran — so the run failed with a full directory and nothing assembled. A transport hiccup on the first breath of a first-ever step cost the whole thing, because `runWithSession` only retried when there was a session to resume.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,22 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Uma empresa despachada de sessão interativa rodava como uma pessoa só
+
+Duas empresas, 23 cadeiras entre elas, um `dispatch_business` — e entregáveis creditando seis cadeiras nomeadas que nunca rodaram como agentes auditados. Medido numa execução real, 04/09/2026.
+
+Não era bug de código de ninguém. O `runTeam` percorre o organograma, mas gera um runtime filho por cadeira, e o protocolo proíbe esse caminho no claude-code, no codex e no antigravity: um filho é morto aos 20 minutos, e uma cadeira daquela execução trabalhou 33. Então o maestro interativo despacha pelos próprios subagentes in-process — e não tinha procedimento nenhum para percorrer um organograma com eles. Fez a única coisa disponível: entregou a empresa inteira a um subagente só, que então escreveu como se as cadeiras tivessem contribuído.
+
+O `nrv team` divide a execução onde ela sempre deveria ter sido dividida: o engine decide e audita, o runtime executa.
+
+O `nrv team plan` roda o mesmo diretor que o `runTeam` usa e deixa os mesmos `x_chain_shape_decided` e `team_chain_selected` — uma cadeia, e um motivo para o tamanho dela. O `nrv team step --index <n>` imprime o prompt completo daquela cadeira, montado pelo mesmo `employee-prompt.ts` do caminho scriptado (persona, DNA do mind-clone, mapa de recursos, caminhos dos colegas, scope guard) e emite `dispatch_business` com o employee. O maestro roda cada prompt no próprio subagente, em ordem, sem limite de relógio.
+
+Os dois caminhos passam a decidir do mesmo jeito, falar o mesmo vocabulário e deixar a mesma prova. É essa última parte que importa: antes, quem lia não distinguia o silêncio de um caminho da ausência do outro — e o evento que falta é justamente o que o contrato trata como evidência, então o modo de falha padrão de um leitor parcial era acusar de fraude uma execução saudável.
+
+O `planChain` foi extraído do `runTeam` para que haja um diretor, não dois. A Fase 4 do protocolo do harness passa a carregar o procedimento, incluindo a regra que fecha o buraco: nunca creditar cadeira sem `dispatch_business` correspondente.
+
+Empresa que não valida é recusada antes de tudo isso, e a recusa agora traz as palavras do próprio loader mais o `nrv validate business <slug> --fix`, em vez de culpar falta de cadeira de intake pelo que o manifesto de fato errou.
+
 ### Uma cadeira falhando jogava fora tudo o que as outras tinham terminado
 
 Um passo que falhava encerrava a cadeia. As cadeiras anteriores já tinham produzido, o trabalho estava em `_team/`, e o employee cuja função inteira é consolidar nunca rodava — a execução falhava com o diretório cheio e nada montado. Um soluço de transporte no primeiro fôlego de um passo inédito custava a coisa toda, porque o `runWithSession` só retentava quando havia sessão para retomar.

--- a/bin/nrv
+++ b/bin/nrv
@@ -232,6 +232,8 @@ case "$cmd" in
     esac ;;
   dispatch)
     exec "$BUN_BIN" "$SKILLS/harness/scripts/dispatch.ts" "$@" ;;
+  team)
+    exec "$BUN_BIN" "$SKILLS/harness/scripts/chain.ts" "$@" ;;
   run|autopilot)
     exec "$BUN_BIN" "$SKILLS/harness/scripts/dispatch.ts" "$@" --exec ;;
   auto)

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -297,6 +297,32 @@ With that settled, pick the targets:
 2. **Squad(s)** — if no business covers the brief, dispatch directly. Match against `~/squads/*/squad.yaml` `capabilities[].domains` / `produces` / `example_briefs`.
 3. **`agent-x`** — if no squad covers either, dispatch to the runtime's `agent-x` at `~/.nirvana/skills/_shared/agents/agent-x.<runtime>.md`. The autonomous generalist fallback; executes end-to-end. **Never produce inline.**
 
+**Dispatching a business means running its ORG CHART — not handing the company to one subagent.**
+
+A business is not a single executor. It is seats with different specialties plus one that consolidates, and the whole point of choosing a business over a squad is that somebody answers for the result. Handing the brief to one subagent and letting it *write as if* the seats had contributed produces a deliverable that names people who never ran. Measured on a live run (2026-09-04): `nexus-council` (9 seats) and `systems-atelier` (14 seats) each emitted ONE `dispatch_business` between them and zero per-employee events, while the artifacts credited six named seats. Work attributed to a seat with no dispatch event is the fiction §Rule 2 exists to prevent.
+
+The engine decides and audits; **you** execute. Two commands:
+
+```bash
+# 1. The director reads the brief against the org chart and answers with a chain
+#    and a reason. Emits x_chain_shape_decided + team_chain_selected.
+nrv team plan --business <slug> --brief .nirvana/briefs/<trace>-enriched.md \
+              --project <projectDir> --outputs <outputsRoot> \
+              --project-id <trace> --save .nirvana/<trace>-chain.json
+
+# 2. For each step, in order: get that seat's full prompt and run it in YOUR OWN
+#    in-process subagent, verbatim. Emits dispatch_business with the employee.
+nrv team step --plan .nirvana/<trace>-chain.json --index 0
+```
+
+`step` prints the seat's prompt on stdout — persona, mind-clone DNA, the resource map, the colleagues' output paths, the scope guard — and the destination on stderr. Run it as-is; paraphrasing it drops the DNA injection, which is the whole reason the seat is not just you with a different label. Steps run **in order**: each one reads what the earlier seats wrote under `_team/<employee>/`, and the last one writes the final deliverables to the outputs root.
+
+The director decides how many seats, and it is free to answer one — a brief that one seat carries whole should cost one dispatch, and `x_chain_shape_decided.reason` is where that judgement gets checked. `--single` skips the director when you already know; `--team` asks for three to six.
+
+**Do NOT use `nrv dispatch --exec` for this.** That path runs the same chain, but it spawns a child runtime per seat and a child is killed at 20 minutes — the run measured above had a seat that worked for 33. Reserve `--exec` for headless and sub-process-only runtimes (see the note further down).
+
+Two seats' worth of honesty: never write, or let a seat write, a deliverable crediting a colleague that has no matching `dispatch_business` in the audit. If you skipped a seat, say the brief did not need it.
+
 **User override:** "use squad X" / "via squad" / "skip empresas" / "use agent-x directly" → honor it, skip earlier cascade steps.
 
 **Every dispatch passes:** (1) a path to `.nirvana/briefs/<trace_id>-enriched.md` — the brief refined, with acceptance criteria, constraints, references; **no code, no prose snippets, no example outputs** — just description + criteria; (2) `output_path`, `trace_id`, `project_dir`.

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -70,6 +70,7 @@ export const COMMANDS: Command[] = [
   { name: "dispatch", target: "harness/scripts/dispatch.ts", category: "dispatch", args: '<business> "<brief>"', summary: "Scaffold a run (brief + DNA injection + audit; no exec)", visibility: "user" },
   { name: "run", aliases: ["autopilot"], custom: true, category: "dispatch", args: '<business> "<brief>" [--zip --pdf --html]', summary: "Autopilot: dispatch + execute + verify + gate", visibility: "user" },
   { name: "auto", custom: true, category: "dispatch", args: '"<brief>" [--zip --pdf --html]', summary: "Autopilot with auto-selected business (= run --auto)", visibility: "user" },
+  { name: "team", target: "harness/scripts/chain.ts", category: "dispatch", args: "plan|step ...", summary: "A business's org chart as data: plan the chain, get each seat's prompt", visibility: "user" },
   { name: "revise", target: "harness/scripts/revise.ts", category: "dispatch", args: '<project> "<change>"', summary: "Apply a change keeping the same runtime session", visibility: "user" },
   { name: "ask", target: "harness/scripts/ask.ts", category: "dispatch", args: "<clone> [question]", summary: "Talk to a single mind-clone (DNA injected)", visibility: "user" },
   { name: "launch", target: "harness/scripts/launch.ts", category: "dispatch", args: "<name> [--pillars=...]", summary: "Scaffold a multi-pillar 360 launch", visibility: "user" },

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -388,23 +388,46 @@ function runMandatorySquad(squadSlug: string, args: TeamRunArgs): StepResult {
   return { employee: `squad:${squadSlug}`, ok: r.ok, sessionId: r.sessionId, costUsd: r.costUsd, durationMs: r.durationMs, outputsDir: r.outputsDir };
 }
 
-export function runTeam(args: TeamRunArgs): TeamResult {
+/**
+ * The chain, decided and audited — with no opinion about who executes it.
+ *
+ * Exported because there are TWO executors and only one of them was ever
+ * getting a chain. `runTeam` (below) spawns a child runtime per step; the
+ * interactive maestro spawns an in-process subagent per step and reaches this
+ * through `nrv chain plan`. Both must decide the same way and leave the same
+ * three events behind, or a reader cannot tell one path's silence from the
+ * other's absence — measured on a live run 2026-09-04, where a business with 14
+ * seats ran as one agent and the deliverable still named six of them.
+ *
+ * Throws on a director that returns nothing usable; the caller decides what a
+ * failed decision means for it.
+ */
+export function planChain(args: TeamRunArgs): { chain: ChainStep[]; reason: string } {
   let chain: ChainStep[];
-  let shapeReason: string;
-  try { ({ chain, reason: shapeReason } = pickChain(args)); }
+  let reason: string;
+  try { ({ chain, reason } = pickChain(args)); }
   catch (e: any) {
     appendAudit({ event: "team_director_failed", project_id: args.projectId, business_slug: args.slug, error: e?.message || String(e) }, args.projectRoot);
-    return { ok: false, steps: [], chain: [], gaps: [], lastSessionId: null, totalCostUsd: 0, totalDurationMs: 0, error: `director: ${e?.message || e}` };
+    throw e;
   }
-  // Why this run costs what it costs. The chain length is now a decision rather
+  // Why this run costs what it costs. The chain length is a decision rather
   // than a flag, so it owes the owner a reason: five dispatches on a brief one
   // seat could have carried is a bill, and reading it back from the audit is how
   // the director's judgement gets checked instead of assumed.
   appendAudit({
     event: "x_chain_shape_decided", project_id: args.projectId, business_slug: args.slug,
-    steps: chain.length, reason: shapeReason, forced: args.forceChain ? "team" : "auto",
+    steps: chain.length, reason, forced: args.forceChain ? "team" : "auto",
   }, args.projectRoot);
   appendAudit({ event: "team_chain_selected", project_id: args.projectId, business_slug: args.slug, chain: chain.map(s => ({ employee: s.employee, task: s.task.slice(0, 120) })) }, args.projectRoot);
+  return { chain, reason };
+}
+
+export function runTeam(args: TeamRunArgs): TeamResult {
+  let chain: ChainStep[];
+  try { ({ chain } = planChain(args)); }
+  catch (e: any) {
+    return { ok: false, steps: [], chain: [], gaps: [], lastSessionId: null, totalCostUsd: 0, totalDurationMs: 0, error: `director: ${e?.message || e}` };
+  }
 
   const steps: StepResult[] = [];
   const priorOutputs: { employee: string; dir: string }[] = [];

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env bun
+/**
+ * chain.ts — the business org chart, as data, for an executor that is not us.
+ *
+ * The engine had exactly one way to run a business's employees: `runTeam`, which
+ * spawns a child runtime per step. On claude-code, codex and antigravity the
+ * protocol says NOT to use that path — a child `claude -p` is killed at 20
+ * minutes and truncates long deliverables — so the interactive maestro dispatches
+ * through its own in-process subagents instead. Which left it with no way to run
+ * the org chart at all, and the maestro did the only thing it could: hand the
+ * whole business to a single subagent.
+ *
+ * Measured on a live run, 2026-09-04: `nexus-council` (9 seats) and
+ * `systems-atelier` (14 seats) each emitted ONE `dispatch_business` and zero
+ * per-employee events — while the deliverables named six of those seats as
+ * contributors. Work attributed to seats that never ran as audited agents is the
+ * exact fiction the audit protocol exists to prevent, and it was not a bug in
+ * anyone's code: no procedure existed.
+ *
+ * So this file does not execute anything. It splits the run in two:
+ *
+ *   the ENGINE decides and audits   →  `team plan`, `team step`
+ *   the RUNTIME executes            →  the maestro's own subagent, in-session
+ *
+ * `plan` runs the same director `runTeam` uses (`planChain`) and leaves the same
+ * three events behind. `step` builds the same employee prompt `runTeam` builds
+ * (`employee-prompt.ts`, DNA injected, resource map, scope guard) and emits the
+ * same `dispatch_business`. Both paths therefore decide the same way, speak the
+ * same vocabulary and leave the same proof — which is the point: a reader could
+ * not previously tell one path's silence from the other's absence.
+ *
+ * Usage:
+ *   nrv team plan --business <slug> --brief <file> --project <dir> \
+ *                  --outputs <dir> [--runtime <rt>] [--team|--single] [--safe] \
+ *                  [--project-id <id>] [--save <plan.json>]
+ *     → the plan on stdout as JSON. Emits x_chain_shape_decided +
+ *       team_chain_selected (or team_director_failed, exit 1).
+ *
+ *   nrv team step --plan <plan.json> --index <n>
+ *     → the employee's full prompt on stdout. Emits dispatch_business.
+ *       Run that prompt in your own subagent; do not paraphrase it.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { spawnSync } from "node:child_process";
+import { planChain, buildStepBrief, type ChainStep, type TeamRunArgs } from "../lib/team-orchestrator.ts";
+import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import type { Runtime } from "../lib/host-agent-driver.ts";
+
+const SKILLS = process.env.NIRVANA_SKILLS_DIR
+  || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
+
+const EXIT_OK = 0, EXIT_FAIL = 1, EXIT_ARGS = 4;
+
+function emitAudit(payload: Record<string, any>, projectRoot?: string): void {
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+  } catch { /* non-fatal */ }
+}
+
+function die(msg: string, code = EXIT_FAIL): never {
+  console.error(`nrv team: ${msg}`);
+  process.exit(code);
+}
+
+function arg(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+/** The plan is the contract between the two halves: everything `step` needs to
+ *  rebuild a step exactly as `runTeam` would, without re-deciding anything. */
+interface ChainPlan {
+  business: string;
+  project_id: string;
+  project_dir: string;
+  project_root: string;
+  outputs_root: string;
+  brief_file: string;
+  businesses_root?: string;
+  intake: string;
+  reason: string;
+  chain: ChainStep[];
+}
+
+/** The seat that consolidates. Resolved through the businesses loader — the same
+ *  owner `brief-business.ts` asks, so a business cannot have two answers. */
+function intakeEmployee(bizDir: string): string {
+  const loader = path.join(SKILLS, "businesses", "lib", "loader.ts");
+  const r = spawnSync("bun", [loader, bizDir, "--field", "intake_employee"], { encoding: "utf8" });
+  const name = (r.stdout || "").trim();
+  if (name) return name;
+
+  // The loader validates the whole manifest, so an empty answer has two very
+  // different causes and only one of them is a missing intake seat. Blaming the
+  // seat for an invalid `business.yaml` sends the reader to edit the right
+  // directory for the wrong reason — pass its own words through instead.
+  //
+  // Note the loader refuses a business with no intake seat itself, with its own
+  // integrity error — so there is no "missing intake" branch to write here. Its
+  // wording is not always actionable ("Integrity check falhou"), which is why
+  // the repair command goes in the same breath rather than being left for the
+  // reader to remember.
+  const why = (r.stderr || "").trim();
+  const fix = `  Repair it with: nrv validate business ${path.basename(bizDir)} --fix`;
+  if (why) die(`business at ${bizDir} could not be loaded:\n  ${why.split("\n").join("\n  ")}\n${fix}`);
+  die(`business at ${bizDir} named no intake employee.\n${fix}`);
+}
+
+function cmdPlan(argv: string[]): void {
+  const slug = arg(argv, "--business");
+  const briefFile = arg(argv, "--brief");
+  const projectDir = arg(argv, "--project");
+  const outputsRoot = arg(argv, "--outputs");
+  if (!slug || !briefFile || !projectDir || !outputsRoot) {
+    die("plan needs --business, --brief, --project and --outputs.", EXIT_ARGS);
+  }
+  if (!fs.existsSync(briefFile)) die(`brief file not found: ${briefFile}`, EXIT_ARGS);
+
+  const projectRoot = arg(argv, "--project-root") ?? projectDir;
+  const projectId = arg(argv, "--project-id") ?? path.basename(projectDir);
+  const businessesRoot = arg(argv, "--businesses-root");
+  const bizDir = businessesRoot ? path.join(businessesRoot, slug) : resolveEntityDir("businesses", slug, projectDir);
+  if (!fs.existsSync(bizDir)) die(`business '${slug}' not found at ${bizDir}`);
+
+  const brief = fs.readFileSync(briefFile, "utf8");
+  const intake = intakeEmployee(bizDir);
+
+  const args: TeamRunArgs = {
+    slug, brief, projectId, projectDir, projectRoot, outputsRoot,
+    runtime: (arg(argv, "--runtime") ?? "claude-code") as Runtime,
+    intakeEmployee: intake,
+    forceChain: argv.includes("--team"),
+    // `--single` skips the director outright: the user already decided, and
+    // paying for a decision call to be told what you just said is waste.
+    yolo: !argv.includes("--safe"),
+    ...(businessesRoot ? { businessesRoot } : {}),
+  };
+
+  let chain: ChainStep[], reason: string;
+  if (argv.includes("--single")) {
+    chain = [{ employee: intake, task: "Carry the brief end to end." }];
+    reason = "--single: the caller chose one seat";
+    emitAudit({
+      event: "x_chain_shape_decided", project_id: projectId, business_slug: slug,
+      steps: 1, reason, forced: "single",
+    }, projectRoot);
+  } else {
+    try { ({ chain, reason } = planChain(args)); }
+    catch (e: any) { die(`director: ${e?.message || e}`); }
+  }
+
+  const plan: ChainPlan = {
+    business: slug, project_id: projectId, project_dir: projectDir, project_root: projectRoot,
+    outputs_root: outputsRoot, brief_file: path.resolve(briefFile),
+    ...(businessesRoot ? { businesses_root: businessesRoot } : {}),
+    intake, reason, chain,
+  };
+
+  const save = arg(argv, "--save");
+  if (save) {
+    fs.mkdirSync(path.dirname(save), { recursive: true });
+    fs.writeFileSync(save, JSON.stringify(plan, null, 2));
+  }
+  console.log(JSON.stringify(plan, null, 2));
+}
+
+function cmdStep(argv: string[]): void {
+  const planFile = arg(argv, "--plan");
+  const indexRaw = arg(argv, "--index");
+  if (!planFile || indexRaw === undefined) die("step needs --plan and --index.", EXIT_ARGS);
+  if (!fs.existsSync(planFile)) die(`plan file not found: ${planFile}`, EXIT_ARGS);
+
+  const plan: ChainPlan = JSON.parse(fs.readFileSync(planFile, "utf8"));
+  const idx = Number(indexRaw);
+  const total = plan.chain.length;
+  if (!Number.isInteger(idx) || idx < 0 || idx >= total) {
+    die(`--index ${indexRaw} is out of range: this plan has ${total} step(s), so 0..${total - 1}.`, EXIT_ARGS);
+  }
+
+  const step = plan.chain[idx];
+  const isLast = idx === total - 1;
+  // Same layout `runTeam` uses: colleagues write under `_team/<employee>/`, the
+  // synthesizer writes the finals to the outputs root itself.
+  const outDir = isLast ? plan.outputs_root : path.join(plan.outputs_root, "_team", step.employee);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  // What the earlier seats produced, as they actually exist on disk. A seat that
+  // was planned and did not run contributes nothing — the same rule the chain
+  // applies, so a later step is never told to read a directory that is empty.
+  const priorOutputs = plan.chain.slice(0, idx)
+    .map(s => ({ employee: s.employee, dir: path.join(plan.outputs_root, "_team", s.employee) }))
+    .filter(p => { try { return fs.readdirSync(p.dir).some(f => !f.startsWith(".")); } catch { return false; } });
+
+  const brief = fs.readFileSync(plan.brief_file, "utf8");
+  const stepBrief = buildStepBrief(step, idx, total, { brief, outputsRoot: plan.outputs_root }, priorOutputs, outDir);
+  const stepBriefFile = path.join(outDir, ".step-brief.md");
+  fs.writeFileSync(stepBriefFile, stepBrief);
+
+  const bizDir = plan.businesses_root
+    ? path.join(plan.businesses_root, plan.business)
+    : resolveEntityDir("businesses", plan.business, plan.project_dir);
+
+  const ep = spawnSync("bun", [
+    path.join(SKILLS, "businesses/lib/employee-prompt.ts"),
+    plan.business, step.employee, plan.project_dir, stepBriefFile, outDir,
+  ], {
+    encoding: "utf8", maxBuffer: 32 * 1024 * 1024,
+    // The child resolves the business independently; handing it the library root
+    // this plan settled on removes the second opinion.
+    env: { ...process.env, BUSINESSES_DIR: path.dirname(bizDir) },
+  });
+  if (ep.status !== 0) {
+    emitAudit({
+      event: "team_step_failed", project_id: plan.project_id, business_slug: plan.business,
+      employee: step.employee, reason: "employee-prompt build failed", error: ep.stderr?.slice(0, 500),
+    }, plan.project_root);
+    die(`could not build the prompt for ${step.employee}: ${ep.stderr?.slice(0, 300) || `exit ${ep.status}`}`);
+  }
+
+  // The proof. Emitted HERE rather than by the caller, because a caller that
+  // must remember to audit is a caller that will eventually forget — which is
+  // how two businesses and 23 seats produced one dispatch event between them.
+  emitAudit({
+    event: "dispatch_business", trace_id: plan.project_id, project_id: plan.project_id,
+    business_slug: plan.business, employee: step.employee,
+    mode: "chain-step", step: idx + 1, total,
+  }, plan.project_root);
+
+  process.stdout.write(ep.stdout);
+  // Where to write, on stderr so it never contaminates the prompt on stdout.
+  console.error(`[chain] step ${idx + 1}/${total} · ${step.employee} → ${outDir}`);
+}
+
+const argv = process.argv.slice(2);
+const sub = argv[0];
+if (!sub || sub === "-h" || sub === "--help") {
+  console.log(`nrv team — run a business's org chart from your own runtime.
+
+  nrv team plan --business <slug> --brief <file> --project <dir> --outputs <dir>
+                 [--project-id <id>] [--project-root <dir>] [--runtime <rt>]
+                 [--team | --single] [--safe] [--save <plan.json>]
+
+      The director reads the brief against the org chart and answers with a
+      chain and a reason. --team asks for 3 to 6 seats; --single skips the
+      director. Prints the plan as JSON.
+
+  nrv team step --plan <plan.json> --index <n>
+
+      Prints the full prompt for step <n> — persona, mind-clone DNA, resource
+      map, the colleagues' output paths and the scope guard. Run it in your own
+      subagent, verbatim. Emits dispatch_business for that seat.
+
+  Loop:
+      nrv team plan … --save .nirvana/chain.json
+      for i in 0 1 2: nrv team step --plan .nirvana/chain.json --index $i
+                      → run each prompt in a subagent, in order.`);
+  process.exit(EXIT_OK);
+}
+if (sub === "plan") cmdPlan(argv.slice(1));
+else if (sub === "step") cmdStep(argv.slice(1));
+else die(`unknown subcommand '${sub}'. Try: plan, step.`, EXIT_ARGS);

--- a/skills/harness/scripts/nrv.ts
+++ b/skills/harness/scripts/nrv.ts
@@ -100,6 +100,7 @@ switch (cmd) {
     if (["--capability", "capability"].includes(sub)) runScript(join(S, "capability-doctor.ts"), rest.slice(1));
     runScript(join(H, "doctor-system.ts"), (sub === "--system" || sub === "system") ? rest.slice(1) : rest);
   }
+  case "team": runScript(join(H, "chain.ts"), rest);
   case "dispatch": runScript(join(H, "dispatch.ts"), rest);
   case "run": case "autopilot": runScript(join(H, "dispatch.ts"), [...rest, "--exec"]);
   case "auto": runScript(join(H, "dispatch.ts"), [...rest, "--exec", "--auto"]);

--- a/skills/harness/tests/chain-cli.test.ts
+++ b/skills/harness/tests/chain-cli.test.ts
@@ -1,0 +1,234 @@
+// chain-cli.test.ts — `nrv team plan` / `nrv team step`, the org chart as data.
+//
+// These two verbs exist so the INTERACTIVE maestro can run a business's
+// employees. It never could: `runTeam` spawns a child runtime per step, the
+// protocol forbids that path on claude-code (20-minute kill, truncated
+// deliverables), and nothing else knew how to walk an org chart. So a business
+// with 14 seats ran as one agent while its deliverable named six of them.
+//
+// What is pinned here is the contract between the two halves: the engine decides
+// and audits, the runtime executes. `--single` needs no LLM, so the whole file
+// is zero-token; the director path is covered by team-orchestrator.test.ts.
+// Runs with: bun test skills/harness/tests
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+
+const CLI = path.resolve(import.meta.dir, "..", "scripts", "chain.ts");
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-chain-cli-"));
+  fs.mkdirSync(path.join(tmp, ".nirvana"), { recursive: true });
+});
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+/** A manifest the businesses loader accepts. It validates the WHOLE file, so a
+ *  two-line fixture is rejected before the intake seat is ever looked up — and
+ *  a fixture that cannot be dispatched proves nothing about dispatching. */
+function manifest(slug: string): string {
+  return [
+    `name: ${slug}`,
+    "author: nirvana-os",
+    "version: 1.0.0",
+    "protocol: '2.0'",
+    `description: A fixture business used by the ${slug} chain tests.`,
+    "domains:",
+    "  - testing",
+    "runtime_requirements:",
+    "  minimum:",
+    "    - runtime: claude-code",
+    "",
+  ].join("\n");
+}
+
+/** The org chart, flat: the intake seat on top, everyone else reporting to it.
+ *  The loader requires this file, and requiring it is right — dispatching a
+ *  business that does not validate is how a run produces confident garbage. */
+function orgChart(seats: string[]): string {
+  const intake = seats[seats.length - 1];
+  const others = seats.filter(s => s !== intake);
+  const lines = ["chart:", `- employee: ${intake}`, "  reports: []"];
+  if (others.length) { lines.push("  direct_reports:"); others.forEach(s => lines.push(`  - ${s}`)); }
+  else lines.push("  direct_reports: []");
+  for (const s of others) lines.push(`- employee: ${s}`, "  reports:", `  - ${intake}`, "  direct_reports: []");
+  return lines.join("\n") + "\n";
+}
+
+/** A business whose LAST seat is the intake/synthesizer. */
+function business(slug: string, seats: string[]): string {
+  const dir = path.join(tmp, "businesses", slug);
+  fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "business.yaml"), manifest(slug), "utf8");
+  fs.writeFileSync(path.join(dir, "org-chart.yaml"), orgChart(seats), "utf8");
+  seats.forEach((name, i) => {
+    const intake = i === seats.length - 1 ? "is_brief_intake: true\n" : "";
+    fs.writeFileSync(
+      path.join(dir, "employees", `${name}.md`),
+      `---\nname: ${name}\nrole: ${name} specialist\ndescription: The ${name} seat of this fixture business.\n${intake}---\n\n# ${name}\n\nMethod of ${name}.\n`,
+      "utf8",
+    );
+  });
+  return dir;
+}
+
+function briefFile(text = "Monte o relatório."): string {
+  const f = path.join(tmp, "brief.md");
+  fs.writeFileSync(f, text, "utf8");
+  return f;
+}
+
+/** The child's environment is pinned, not inherited.
+ *
+ *  `bun test` shares one process across files, and another file setting
+ *  `HARNESS_LOGS_DIR` reaches this child through `process.env` — which sent the
+ *  audit somewhere the assertions were not looking and turned two passing tests
+ *  into two that failed only when run with company. Pinning it here also makes
+ *  the fixture hermetic: nothing this test does can land in the machine's real
+ *  log directory. */
+function run(args: string[]): { code: number; out: string; err: string } {
+  const r = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8", cwd: tmp,
+    env: { ...process.env, HARNESS_LOGS_DIR: path.join(tmp, ".nirvana", "logs", "harness") },
+  });
+  return { code: r.status ?? 1, out: r.stdout ?? "", err: r.stderr ?? "" };
+}
+
+function audit(): any[] {
+  const day = new Date().toISOString().slice(0, 10);
+  const p = path.join(tmp, ".nirvana", "logs", "harness", day, "audit.jsonl");
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, "utf8").split("\n").filter(Boolean).map(l => JSON.parse(l));
+}
+
+const planArgs = (slug: string, extra: string[] = []) => [
+  "plan", "--business", slug, "--brief", briefFile(), "--project", tmp,
+  "--outputs", path.join(tmp, "out"), "--businesses-root", path.join(tmp, "businesses"),
+  "--project-id", "proj-chain-1", ...extra,
+];
+
+describe("nrv team plan", () => {
+  test("--single answers one seat without paying for a director call", () => {
+    business("acme", ["researcher", "synth"]);
+    const r = run(planArgs("acme", ["--single", "--save", path.join(tmp, "plan.json")]));
+    expect(r.code).toBe(0);
+
+    const plan = JSON.parse(r.out);
+    expect(plan.business).toBe("acme");
+    expect(plan.intake).toBe("synth");
+    expect(plan.chain).toHaveLength(1);
+    expect(plan.chain[0].employee).toBe("synth");
+    expect(plan.reason).toMatch(/single/);
+    // The plan is the contract between the two halves; --save writes it verbatim.
+    expect(JSON.parse(fs.readFileSync(path.join(tmp, "plan.json"), "utf8"))).toEqual(plan);
+
+    // Even the shortest chain owes the owner a reason it can read back.
+    const shape = audit().find(e => e.event === "x_chain_shape_decided");
+    expect(shape?.steps).toBe(1);
+    expect(shape?.forced).toBe("single");
+  }, spawnBudgetMs(2));
+
+  // The loader owns this refusal and phrases it its own way ("Integrity check
+  // falhou"), so what is pinned is that the CLI passes the real cause through
+  // AND names the repair command — not a message this file invents.
+  test("a business with no intake seat fails with the cause and the repair", () => {
+    const dir = path.join(tmp, "businesses", "headless");
+    fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "business.yaml"), manifest("headless"), "utf8");
+    fs.writeFileSync(path.join(dir, "org-chart.yaml"), orgChart(["solo-seat"]), "utf8");
+    fs.writeFileSync(path.join(dir, "employees", "solo-seat.md"), "---\nname: solo-seat\nrole: solo specialist\ndescription: The only seat of this fixture business.\n---\n\n# solo-seat\n", "utf8");
+
+    const r = run(planArgs("headless", ["--single"]));
+    expect(r.code).not.toBe(0);
+    expect(r.err).toMatch(/could not be loaded|named no intake/);
+    expect(r.err).toContain(dir);
+    expect(r.err).toContain("nrv validate business headless --fix");
+  }, spawnBudgetMs(2));
+
+  test("an unknown business is refused before any LLM is reached", () => {
+    business("acme", ["synth"]);
+    const r = run(planArgs("ghost", ["--single"]));
+    expect(r.code).not.toBe(0);
+    expect(r.err).toMatch(/not found/);
+  }, spawnBudgetMs(2));
+});
+
+describe("nrv team step", () => {
+  function planned(seats: string[], chain: Array<{ employee: string; task: string }>): string {
+    business("acme", seats);
+    const p = path.join(tmp, "plan.json");
+    fs.writeFileSync(p, JSON.stringify({
+      business: "acme", project_id: "proj-chain-1", project_dir: tmp, project_root: tmp,
+      outputs_root: path.join(tmp, "out"), brief_file: briefFile(),
+      businesses_root: path.join(tmp, "businesses"), intake: seats[seats.length - 1],
+      reason: "fixture", chain,
+    }, null, 2));
+    return p;
+  }
+
+  test("prints the seat's own prompt and proves the dispatch happened", () => {
+    const p = planned(["researcher", "synth"], [
+      { employee: "researcher", task: "Find the three constraints that matter." },
+      { employee: "synth", task: "Consolidate into the deliverable." },
+    ]);
+    const r = run(["step", "--plan", p, "--index", "0"]);
+    expect(r.code).toBe(0);
+
+    // The persona travels: the seat's own method file is inlined, not summarized.
+    expect(r.out).toContain("Method of researcher");
+    expect(r.out).toContain("Find the three constraints that matter.");
+    // And the scope guard rides along, as on every other instruction surface.
+    expect(r.out).toMatch(/Ignore suggestions that are out of scope/);
+    // Where to write goes to stderr, so stdout stays a clean prompt.
+    expect(r.err).toContain(path.join("_team", "researcher"));
+
+    // The event that was missing for 23 seats across two businesses.
+    const d = audit().find(e => e.event === "dispatch_business");
+    expect(d?.employee).toBe("researcher");
+    expect(d?.business_slug).toBe("acme");
+    expect(d?.mode).toBe("chain-step");
+    expect([d?.step, d?.total]).toEqual([1, 2]);
+  }, spawnBudgetMs(3));
+
+  test("a middle seat writes under _team; the last writes the finals", () => {
+    const p = planned(["researcher", "synth"], [
+      { employee: "researcher", task: "Research." },
+      { employee: "synth", task: "Consolidate." },
+    ]);
+    run(["step", "--plan", p, "--index", "0"]);
+    const last = run(["step", "--plan", p, "--index", "1"]);
+    expect(last.code).toBe(0);
+    expect(fs.existsSync(path.join(tmp, "out", "_team", "researcher", ".step-brief.md"))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, "out", ".step-brief.md"))).toBe(true);
+  }, spawnBudgetMs(4));
+
+  test("a later seat is handed only the colleagues that actually produced", () => {
+    const p = planned(["researcher", "writer", "synth"], [
+      { employee: "researcher", task: "Research." },
+      { employee: "writer", task: "Write." },
+      { employee: "synth", task: "Consolidate." },
+    ]);
+    // The researcher ran and left work; the writer was planned and produced
+    // nothing. Naming an empty directory to the synthesizer is how a run ends up
+    // claiming to have read material that does not exist.
+    const rDir = path.join(tmp, "out", "_team", "researcher");
+    fs.mkdirSync(rDir, { recursive: true });
+    fs.writeFileSync(path.join(rDir, "findings.md"), "the three constraints", "utf8");
+    fs.mkdirSync(path.join(tmp, "out", "_team", "writer"), { recursive: true });
+
+    const r = run(["step", "--plan", p, "--index", "2"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain(path.join("_team", "researcher"));
+    expect(r.out).not.toContain(path.join("_team", "writer"));
+  }, spawnBudgetMs(3));
+
+  test("an index outside the plan says what the range is", () => {
+    const p = planned(["synth"], [{ employee: "synth", task: "Do it." }]);
+    const r = run(["step", "--plan", p, "--index", "7"]);
+    expect(r.code).toBe(4);
+    expect(r.err).toMatch(/0\.\.0/);
+  }, spawnBudgetMs(2));
+});


### PR DESCRIPTION
## What was broken

Two businesses, **23 seats** between them, **one** `dispatch_business` — and deliverables crediting six named seats that never ran as audited agents. Measured on a live run, 2026-09-04:

```
business A    9 seats  → 1 dispatch_business, 0 per-employee events
business B   14 seats  → 1 dispatch_business, 0 per-employee events
```

The artifacts credited six seats by name. None of them had a dispatch event.

**It was not a bug in anyone's code.** `runTeam` walks the org chart — but it spawns a child runtime per seat, and the protocol forbids that path on claude-code, codex and antigravity: a child is killed at 20 minutes, and one seat in that run worked for **33**. So the interactive maestro is told to dispatch through its own in-process subagents, and had **no procedure** for walking an org chart with them. It did the only thing available: handed the whole company to a single subagent, which then wrote as if the seats had contributed.

## The split

The engine decides and audits; the runtime executes.

```bash
nrv team plan --business <slug> --brief <file> --project <dir> --outputs <dir> \
              --project-id <trace> --save .nirvana/<trace>-chain.json
nrv team step --plan .nirvana/<trace>-chain.json --index 0   # → run in your own subagent
```

- **`plan`** runs the same director `runTeam` uses. `planChain` is extracted from `runTeam` so there is one director, not two, and it emits the same `x_chain_shape_decided` + `team_chain_selected`. `--single` skips it; `--team` asks for 3 to 6.
- **`step`** prints that seat's full prompt — built by the same `employee-prompt.ts` the scripted path uses (persona, mind-clone DNA, resource map, colleagues' output paths, scope guard) — on stdout, the destination on stderr, and emits `dispatch_business` with the employee on it. Emitted by the command rather than the caller: a caller who must remember to audit is one who will eventually forget, which is how 23 seats produced one event.

Both paths now decide the same way, speak the same vocabulary, and leave the same proof. That last part is the point — the missing event is the one the contract treats as evidence, so the default failure of a partial reader was to **accuse a healthy run of fraud**. (It nearly did, during this very investigation.)

## Protocol

`SKILL.md` Phase 4 gains the procedure, including why not to reach for `nrv dispatch --exec` here (the 20-minute kill) and the rule that closes the hole: **never credit a seat with no matching `dispatch_business`.**

## Also

An invalid business is refused before any of this, and the refusal carries the loader's own words plus `nrv validate business <slug> --fix`. The previous message blamed a missing intake seat for whatever the manifest actually got wrong — and its fallback branch turned out to be unreachable, because the loader refuses a business with no intake itself.

The verb is `team`, not `chain`: `chain` is already a published alias for `validate-chain`.

## Verification

- `bun test skills/harness/tests` — 1700 pass. The 4 remaining failures (3 amplification-bridge, 1 routing-eval) are pre-existing, order-dependent, and read the machine's live library.
- `bun run test:fast` — full sweep green.
- `bun run check:quick` — exit 0.
- 7 new zero-token tests: `--single` needs no LLM, so the CLI contract is pinned without a model. They cover the plan shape, `--save`, the audit reason, an unknown business, an unloadable one, the prompt's persona and scope guard, the `_team/` vs outputs-root layout, prior-output filtering (a planned seat that produced nothing is not named to the next), and an out-of-range index.

One of those tests earned its comment the hard way: the child process inherited `HARNESS_LOGS_DIR` from another test file in the shared runner and wrote its audit somewhere the assertions were not looking — passing alone, failing with company. The child's env is now pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk
