### PR TITLE
fix(team): the org chart is the contract, and the prep step now says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ### The prep step told the maestro to spawn one employee
 
-`brief-business.ts` is the step every business dispatch runs first, and its output ended with `Next step: Spawn employee '<intake>' with the brief above as context.` One seat. A business with fourteen of them did exactly that, credited six in the deliverable, and left a single `dispatch_business` behind — measured 2026-09-04 on `software-forge`.
+`brief-business.ts` is the step every business dispatch runs first, and its output ended with `Next step: Spawn employee '<intake>' with the brief above as context.` One seat. A business with fourteen of them did exactly that, credited six in the deliverable, and left a single `dispatch_business` behind, measured 2026-09-04 on an installed business.
 
 The procedure for running an org chart lived in `SKILL.md`, which only reaches a session that re-read it. The session that produced that run had been open since before the file changed. So the instruction was in the right document and the wrong place: the caller was reading the command's output, not the protocol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The prep step told the maestro to spawn one employee
+
+`brief-business.ts` is the step every business dispatch runs first, and its output ended with `Next step: Spawn employee '<intake>' with the brief above as context.` One seat. A business with fourteen of them did exactly that, credited six in the deliverable, and left a single `dispatch_business` behind — measured 2026-09-04 on `software-forge`.
+
+The procedure for running an org chart lived in `SKILL.md`, which only reaches a session that re-read it. The session that produced that run had been open since before the file changed. So the instruction was in the right document and the wrong place: the caller was reading the command's output, not the protocol.
+
+The prep step now names the seats and prints the two commands that walk the chart, fully formed and ready to run, plus the one rule that closes the hole — spawning the intake alone is correct only when `team plan` says so, and a seat credited with no `dispatch_business` behind it is the fiction the audit exists to prevent. The `Intake:` line keeps its format; `dispatch.ts` parses it.
+
+### The director asked who was capable instead of whose job it was
+
+The rule read: call a colleague when the brief needs a specialty the synthesizer does not have. The same model sits in every chair, so "the synthesizer could do this" is always true — and every chain collapsed to one seat. A studio with a screenwriter had its head write the screenplay, because it could.
+
+It now asks whose JOB it is: the org chart is the contract, and the synthesizer works alone only when no seat's role covers the work. Cost is the tie-breaker between two defensible chains, never the test for whether to delegate.
+
+The second half matters as much: a seat is how a mind-clone reaches the work, because personas are ranked against the SEAT'S task, not against the company. Skipping the seat deletes the persona the brief needed — a comedy scene written by the head of the studio has no screenwriter's voice in it, and no `mind_clone_injected` in the log to show what was lost.
+
 ### A business dispatched from an interactive session ran as one person
 
 Two businesses, 23 seats between them, one `dispatch_business` — and deliverables crediting six named seats that never ran as audited agents. Measured on a live run, 2026-09-04.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -10,7 +10,7 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ### O passo de preparação mandava o maestro rodar um employee só
 
-O `brief-business.ts` é o passo que todo despacho de empresa executa primeiro, e a saída dele terminava com `Next step: Spawn employee '<intake>' with the brief above as context.` Uma cadeira. Uma empresa com catorze fez exatamente isso, creditou seis no entregável e deixou um único `dispatch_business` — medido em 04/09/2026 no `software-forge`.
+O `brief-business.ts` é o passo que todo despacho de empresa executa primeiro, e a saída dele terminava com `Next step: Spawn employee '<intake>' with the brief above as context.` Uma cadeira. Uma empresa com catorze fez exatamente isso, creditou seis no entregável e deixou um único `dispatch_business`, medido em 04/09/2026 numa empresa instalada.
 
 O procedimento para percorrer o organograma morava no `SKILL.md`, que só alcança sessão que releu o arquivo. A sessão daquela execução estava aberta desde antes de o arquivo mudar. A instrução estava no documento certo e no lugar errado: quem chamava estava lendo a saída do comando, não o protocolo.
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,22 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O passo de preparação mandava o maestro rodar um employee só
+
+O `brief-business.ts` é o passo que todo despacho de empresa executa primeiro, e a saída dele terminava com `Next step: Spawn employee '<intake>' with the brief above as context.` Uma cadeira. Uma empresa com catorze fez exatamente isso, creditou seis no entregável e deixou um único `dispatch_business` — medido em 04/09/2026 no `software-forge`.
+
+O procedimento para percorrer o organograma morava no `SKILL.md`, que só alcança sessão que releu o arquivo. A sessão daquela execução estava aberta desde antes de o arquivo mudar. A instrução estava no documento certo e no lugar errado: quem chamava estava lendo a saída do comando, não o protocolo.
+
+O passo agora nomeia as cadeiras e imprime os dois comandos que percorrem o organograma, prontos para rodar, mais a regra que fecha o buraco — rodar o intake sozinho só é correto quando o `team plan` disser, e cadeira creditada sem `dispatch_business` é a ficção que a auditoria existe para impedir. A linha `Intake:` mantém o formato; o `dispatch.ts` faz parse dela.
+
+### O diretor perguntava quem era capaz, e não de quem era o trabalho
+
+A regra dizia: chame um colega quando o brief precisar de uma especialidade que o synthesizer não tem. O mesmo modelo senta em todas as cadeiras, então "o synthesizer daria conta" é sempre verdade — e toda cadeia desabava para uma cadeira. Um estúdio com roteirista tinha o roteiro escrito pelo chefe da casa, porque ele conseguiria.
+
+Agora ele pergunta de quem é o TRABALHO: o organograma é contrato, e o synthesizer roda sozinho só quando nenhum papel cobre a obra. Custo é critério de desempate entre duas cadeias defensáveis, nunca o teste para decidir se delega.
+
+A segunda metade importa tanto quanto: a cadeira é o caminho pelo qual um mind-clone chega ao trabalho, porque personas são rankeadas contra a tarefa DA CADEIRA, não contra a empresa. Pular a cadeira apaga a persona que o brief pedia — uma cena de comédia escrita pelo chefe do estúdio não tem a voz de roteirista nenhum, e não deixa `mind_clone_injected` no log para mostrar o que se perdeu.
+
 ### Uma empresa despachada de sessão interativa rodava como uma pessoa só
 
 Duas empresas, 23 cadeiras entre elas, um `dispatch_business` — e entregáveis creditando seis cadeiras nomeadas que nunca rodaram como agentes auditados. Medido numa execução real, 04/09/2026.

--- a/docs/architecture/hierarchical-review.md
+++ b/docs/architecture/hierarchical-review.md
@@ -1,0 +1,275 @@
+# Hierarchical review — the superior is the reviewer
+
+**Status:** proposal · **Date:** 2026-09-04 · **Language:** English (engine documentation)
+
+A business runs its org chart. Each seat's work is reviewed by its immediate
+superior, against the criteria that seat declares. Approved work rises; the head
+of the house signs for the delivery and hands the orchestrator a short receipt.
+
+This document says how it works, what it touches, what is already built, what
+proves it will work — and what would prove it will not.
+
+---
+
+## 1. Why, in one measurement
+
+A run on 2026-09-04, on two installed businesses with 23 seats between them:
+
+```
+business A    9 seats  →  1 dispatch_business, 0 per-employee events, 0 clones
+business B   14 seats  →  1 dispatch_business, 0 per-employee events, 0 clones
+```
+
+The deliverables credited six seats by name. None had a dispatch event behind it.
+Work attributed to people who did not work is the fiction the audit exists to
+prevent, and it was not anyone's bug: no procedure existed for walking an org
+chart from an interactive session.
+
+Two separate defects produced it, both now fixed:
+
+- The prep step every business dispatch runs (`brief-business.ts`) ended with
+  *"Next step: Spawn employee `<intake>`"* — one seat, in the output the caller
+  actually reads.
+- The director's rule asked who was **capable**. The same model sits in every
+  chair, so "the synthesizer could do this" is always true, and every chain
+  collapsed to one seat.
+
+Fixing those makes the chain form. This document is about what happens next: who
+checks the work.
+
+## 2. The gap this closes
+
+Today the quality gate is a rubric-driven judge that is not a seat and has no
+domain. It asks whether a document is well-formed, not whether the argument
+holds. A backend lead reading a backend engineer's diff knows things a rubric
+cannot express, and the business already declares who that lead is.
+
+The review also gives the org chart a job. It is validated on every business and
+read by nothing — `fromOrgChart()` in `dag-planner.ts` has zero callers, because
+it maps `deps = reports[]`, which is backwards for execution. For **review** it
+is exactly right: the result rises through `reports`.
+
+## 3. How it works
+
+```
+orchestrator picks the business
+   │
+   ├─ team plan → route: which seat executes, and the review path above it
+   │              (derived from org-chart.yaml, not invented)
+   │
+   ├─ team step --index n        → the executor's prompt, clone injected
+   │     └─ executor works, writes to its outputs dir
+   │
+   ├─ team step --review --of <seat>   → the IMMEDIATE superior's prompt:
+   │        the brief (company-level and seat-level), the subordinate's
+   │        declared acceptance[], and the artifact. Returns a verdict object.
+   │
+   │     rejected → back to the executor IN THE SAME SESSION, with the
+   │                unconfirmed criteria and the evidence gap named
+   │     approved → rises one level
+   │
+   ├─ each level above countersigns (cheap: aggregate, not a re-read)
+   │
+   └─ the head returns a receipt to the orchestrator:
+      what passed, who did what, where the files are — three lines
+         │
+         └─ engine gate (unchanged, fail-closed) → delivered
+```
+
+### 3.1 The reviewer answers a form, not a question
+
+The rubber-stamp risk is the whole design problem: the same model asked "is your
+subordinate's work good?" says yes. The defence is to make approval **expensive
+to fake and cheap to verify** — the reviewer fills a structured object, and an
+entry exists only when it was confirmed with evidence.
+
+```json
+{
+  "seat": "sf-backend-lead",
+  "reviewing": "sf-backend-engineer",
+  "confirmed": [
+    {
+      "id": "objections_specific_and_falsifiable",
+      "evidence": "src/queue/consumer.ts:88 — retry has no ceiling; test at tests/queue.test.ts:41 reproduces",
+      "note": ""
+    }
+  ],
+  "unconfirmed": [
+    { "id": "test_strategy_by_layer_with_targets", "why": "no coverage target stated for any critical module" }
+  ],
+  "verdict": "rejected",
+  "score": 0.66
+}
+```
+
+Rules that make this work:
+
+- **`id` must match an acceptance id from the subordinate's own frontmatter,
+  verbatim.** An id that does not exist is dropped and logged; a review of
+  invented criteria is not a review.
+- **A criterion appears under `confirmed` only with evidence** — a path, a line,
+  a quote. Empty evidence moves it to `unconfirmed`. Silence is not approval.
+- **Anything not mentioned counts as unconfirmed.** A reviewer that writes
+  `{"verdict":"approved"}` and nothing else scores zero and fails. This is the
+  property that defeats the stamp: laziness produces rejection, not approval.
+- **`score` = confirmed ÷ total applicable, floor 0.90.** Not 1.0: one
+  unconfirmable micro-check should not block a good delivery. The author keeps
+  the escape hatch already in the protocol — a criterion marked
+  `blocking: true` must be confirmed regardless of score, which is how a business
+  says "this one is absolute."
+- **The engine recomputes the score.** The reviewer reports observations; the
+  arithmetic is not its opinion.
+
+`readAcceptance(bizDir, [seat])` already returns exactly this list, deduped, with
+`blocking` and `minimum_score` per entry, and defaults its floor to 0.92 — one
+line from the 0.90 proposed here.
+
+### 3.2 Correction keeps the session
+
+A rejected step goes back to the executor through `runWithSession`, which already
+resumes the entity's session per project and falls back to one cold attempt when
+the resume fails. The executor does not re-derive its context; it is told which
+criteria came back unconfirmed and what evidence was missing.
+
+Ceilings already exist and apply unchanged: `NIRVANA_MAX_GATE_RETRIES` and the
+loop guard (`max_steps`, `max_repeat`, `max_flat_steps`). A review loop that will
+not converge ends in delivery **with reservations**, not in a stall.
+
+### 3.3 Only the immediate superior reads
+
+Every level above aggregates and countersigns. Without this rule a five-level
+chart reads the same artifact five times, and the cost argument in §5 collapses.
+
+### 3.4 The engine gate stays, last
+
+The superior answers *is this good work in my domain, and does it match what was
+asked*. The engine's gate answers *is there a deliverable at all, is it a stub,
+does it match the promised manifest* — deterministically, fail-closed, for free.
+
+A model asked "is this a stub?" is usually right and fails **open**;
+`isDeliverable` fails **closed** and cannot be talked out of a verdict. The
+superior judging it too is more eyes, not a replacement. Losing fail-closed would
+give back something this engine earned the hard way: `gateableFiles`, exit 2 for
+withheld, `_QA-RESERVATIONS.md`, and the completeness ceiling that outranks
+acceptance.
+
+## 4. What it touches
+
+### Already built — no work
+
+| Piece | Where | State |
+|---|---|---|
+| `org-chart.yaml` with `reports` | every business | validated, loaded, unused |
+| `fromOrgChart(chart)` → `deps = reports[]` | `dag-planner.ts:134` | written, zero callers, right shape for review |
+| `readAcceptance(bizDir, [seat])` | `businesses/lib/acceptance.ts:78` | written and tested |
+| session reuse + cold retry | `runWithSession`, `team-orchestrator.ts:239` | in use |
+| per-seat prompt with clone ranked by task | `employee-prompt.ts` + `nrv team step` | shipped 2026-09-04 |
+| retry ceiling, loop guard, ledger, supervisor | across the engine | in use |
+| fail-closed delivery gate | `delivery-pipeline.ts` | untouched by this |
+
+### To build — engine only
+
+| Change | Size |
+|---|---|
+| `team plan` returns a route (executor + review path) instead of a flat chain | small |
+| `team step --review --of <seat>` — the superior's prompt and the verdict schema | medium |
+| verdict parser + score recomputation + id validation against the real acceptance list | small |
+| rejection path: same session, unconfirmed criteria in the follow-up | small |
+| audit: `x_review_requested`, `x_review_rejected` (with the ids it cites), `x_review_approved`, `x_review_ceiling_reached` | small |
+| `SKILL.md` Phase 4 + `brief-business.ts` output describe the loop | small |
+
+### The businesses — measured, not assumed
+
+```
+businesses with org-chart.yaml ....................... 65 / 65
+with exactly one root, every seat under a superior ... 64 / 65
+with more than one orphan seat ....................... 0
+employees ............................................ 611
+declaring acceptance[] ............................... 611  (100%)
+```
+
+**No business needs restructuring.** The route exists and the contract exists,
+everywhere.
+
+One open question, worth measuring before committing to a date: the *quality* of
+those 611 acceptance blocks. They are present universally; if a seat's criteria
+are vague, its superior reviews against vagueness and the verdict becomes taste.
+That is a curation pass, not a rewrite, and it is measurable mechanically — a
+criterion with no `path`, no falsifiable verb, or under a length floor.
+
+## 5. Cost, honestly
+
+Today a business costs **one** agent call. Under this model, per executing seat:
+
+```
+1 executor
++ 1 immediate superior (substantive review)
++ k countersignatures (cheap aggregation)
++ r rejection rounds × (1 executor + 1 review)
+```
+
+A three-level chart with one rejection is roughly **5 calls against today's 1**.
+That is the price of a review that has a name attached, and it is the main thing
+to decide before building.
+
+Three things hold it down, and all three already exist: only the immediate
+superior reads (§3.3); the director decides how many seats run at all and must
+justify the count (`x_chain_shape_decided`); and the rejection ceiling ends the
+loop in a delivery rather than a spiral.
+
+## 6. What proves it will work
+
+Measured, not argued:
+
+1. **The route is derivable today.** 65/65 charts, 64/65 single-root, zero
+   orphans. No business blocks this.
+2. **The contract exists today.** 611/611 seats declare `acceptance[]` with
+   `blocking` and `minimum_score`.
+3. **The pieces are written.** `readAcceptance`, `runWithSession`,
+   `fromOrgChart`, per-seat prompts with clone injection — all present, four of
+   them already in production paths.
+4. **Delegation now happens when the org chart says so.** With the mandate rule,
+   a comedy-scene brief routed to the screenwriter seat and the head of the house
+   only signed, declining the researcher with a specific reason. Before the
+   change, the same brief collapsed to one seat.
+5. **The failure mode is already instrumented.** `dispatch_business` carries the
+   employee; a deliverable crediting a seat with no such event is detectable
+   mechanically, which is what makes item 4 checkable rather than anecdotal.
+
+## 7. What would prove it will NOT work
+
+Written down first, so the answer is not decided after the fact.
+
+**The falsification test.** Give `studio-probe` a brief, then hand the reviewer a
+deliberately weak artifact — a scene that is an outline, with no joke, ignoring
+the reference. The superior must reject it, and the rejection must cite the
+acceptance id and name what is missing.
+
+- If it approves → the structured form is not enough, and the design needs
+  something stronger than a checklist (an adversarial second reader, or the
+  engine seeding the form with criteria the reviewer must actively knock down).
+- If it rejects but cites nothing → the id-validation and evidence rules are not
+  binding, and the verdict parser must reject the verdict itself.
+- If the loop does not converge within the ceiling on a *fixable* artifact → the
+  rejection message is not actionable, and the follow-up needs the missing
+  evidence spelled out rather than the criterion named.
+
+**The cost test.** Run the same brief through the probe with and without review.
+If a three-seat chart costs more than ~5x the single-seat run, §3.3 is not being
+honored and the countersignatures are doing substantive reads.
+
+Both probes are installed and cost cents: `chain-probe` (4 seats, relay, proves
+the hierarchy from the artifact) and `studio-probe` (3 seats, separate mandates,
+proves delegation happens because the chart asked).
+
+## 8. Order
+
+1. **The chain must actually form.** Shipped 2026-09-04; awaiting a fresh session
+   to confirm the instruction reaches a maestro that did not read it before.
+2. **Review by the immediate superior**, bound to declared acceptance, engine
+   gate kept last.
+3. **Full route with countersignature to the head**, and the head's receipt to
+   the orchestrator.
+
+Step 2 has nothing to review while a business still runs as one agent. Step 1 is
+not a prerequisite by taste; it is the thing being reviewed.

--- a/skills/businesses/scripts/brief-business.ts
+++ b/skills/businesses/scripts/brief-business.ts
@@ -234,6 +234,21 @@ if (!intake) {
   process.exit(EXIT.FAILURES);
 }
 
+// The org chart, named in the output the caller is already reading. Until
+// 2026-09-04 this block told the caller to "spawn employee '<intake>'" — one
+// seat — and a business with fourteen of them did exactly that, crediting six
+// in the deliverable with a single dispatch event behind them. An instruction
+// in SKILL.md only reaches a session that re-read it; this reaches the session
+// that ran the command.
+let seatSummary = "(no employees/ directory)";
+try {
+  const names = fs.readdirSync(path.join(target, "employees"))
+    .filter(f => f.endsWith(".md")).map(f => path.basename(f, ".md")).sort();
+  seatSummary = names.length
+    ? `${names.length} seat(s) — ${names.join(", ")}`
+    : "(no seats declared)";
+} catch { /* keep the fallback */ }
+
 console.log(`OK: brief registered.
 
   Project ID:    ${projectId}
@@ -244,9 +259,22 @@ console.log(`OK: brief registered.
   Audit log:     ${auditFile}
   Run ID:        ${runId ?? (trackedByDispatch ? "(tracked by the dispatch that spawned this step)" : "(not tracked — see the warning above)")}
 
-Next step (run by the skill via the Agent tool):
-  Spawn employee '${intake}' with the brief above as context. Wait for the handoff
-  artifact in ${projectDir}/handoffs/.
+Org chart:     ${seatSummary}
+
+Next step — a business runs its ORG CHART, not one agent:
+  nrv team plan --business ${slug} --brief ${briefFile} \\
+                --project ${projectDir} --outputs ${projectDir}/outputs \\
+                --project-id ${projectId} --save ${projectDir}/chain.json
+
+  Then, for each step it returns, in order:
+  nrv team step --plan ${projectDir}/chain.json --index <n>
+  → run the printed prompt in your own subagent, verbatim. Each step emits
+    dispatch_business with the seat on it, and injects that seat's mind-clone.
+
+  Spawning '${intake}' alone is correct ONLY when \`team plan\` returns a
+  one-step chain — and then it says why. Do not decide that yourself: a seat
+  credited in a deliverable with no dispatch_business behind it is the fiction
+  the audit exists to prevent.
 ${runId ? `
 REQUIRED when you finish (this is what tells the owner it is done):
   nrv run-track close ${runId} --state delivered|withheld|failed [--error "<reason>"]` : ""}`);

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -166,14 +166,18 @@ function pickChain(args: TeamRunArgs): { chain: ChainStep[]; reason: string } {
     `- "${args.intakeEmployee}" is the intake/synthesizer and MUST be LAST in the chain (it consolidates the colleagues' outputs into the final deliverables).`,
     args.forceChain
       ? "- Include 3 to 6 employees in the chain (the synthesizer counts). Skip employees irrelevant to the brief."
-      : "- HOW MANY seats is your call, and it is the most important decision here. A brief one seat can carry whole should get ONE — a chain of a single step, the synthesizer alone — because every extra step costs money and one more handoff of context. Call a colleague when the brief needs a specialty the synthesizer does not have, not to look thorough. Six at most.",
+      : "- THE ORG CHART IS THE CONTRACT, not a suggestion. If a seat's declared role covers part of this brief, THAT SEAT does that part. You are not judging who is capable: the same model sits in every chair, so \"the synthesizer could do this\" is always true and is never the question. Ask instead whose JOB it is. The synthesizer works alone only when NO seat's role covers the work.",
+    args.forceChain ? "" : "- A seat is also how a mind-clone reaches the work: personas are ranked against the SEAT'S task, not against the company. Skip the seat and the persona the brief needed is never injected — a comedy screenplay written by the CEO because it could is a screenplay with no screenwriter's voice in it.",
+    args.forceChain ? "" : "- Six seats at most, and skip any whose role the brief does not touch. Cost is the tie-breaker between two defensible chains, never the test for whether to delegate.",
     "- Order by logical dependency: whoever produces an input comes before whoever needs it.",
     "- Each sub-task: the expected result and what is mandatory about it. The path belongs to whoever executes.",
     "- The DELIVERABLE follows the language of the client brief above. These instructions are in English; what the business ships is not.",
     "",
     'Answer with ONE valid JSON object only: {"reason":"<one sentence: why THIS number of steps>","chain":[{"employee":"<exact-name>","task":"<1-2 sentences: what has to exist at the end, and what is non-negotiable>"}, ...]}',
     "No markdown, no fences, no comment before or after.",
-  ].join("\n");
+    // The two mandate rules above are chain-only, so they render as "" under
+    // --team; dropping the empties keeps the rule list from growing blank lines.
+  ].filter(line => line !== "").join("\n");
 
   appendAudit({ event: "team_director_called", project_id: args.projectId, business_slug: args.slug, employees_available: employees.length }, args.projectRoot);
   // The director makes the most consequential call of the run — who works, and

--- a/skills/harness/tests/team-orchestrator.test.ts
+++ b/skills/harness/tests/team-orchestrator.test.ts
@@ -207,7 +207,13 @@ describe("runTeam — the director decides how many seats", () => {
 
     runTeam(args("acme", { runHeadlessImpl: spy, runWithCascadeImpl: cascade([]) }));
     expect(prompts[1]).not.toContain("Include 3 to 6 employees");
-    expect(prompts[1]).toContain("a chain of a single step");
+    // The default asks WHOSE JOB it is, not who is capable. The distinction is
+    // the whole rule: the same model sits in every chair, so "the synthesizer
+    // could do this" is always true and collapsed every chain to one seat.
+    expect(prompts[1]).toContain("THE ORG CHART IS THE CONTRACT");
+    expect(prompts[1]).toContain("whose JOB it is");
+    // And why skipping a seat is not merely a shortcut: it deletes the persona.
+    expect(prompts[1]).toContain("personas are ranked against the SEAT'S task");
   });
 });
 


### PR DESCRIPTION
## The measurement

Two installed businesses, 23 seats between them, on a live run 2026-09-04:

```
business A    9 seats  →  1 dispatch_business, 0 per-employee events, 0 clones
business B   14 seats  →  1 dispatch_business, 0 per-employee events, 0 clones
```

The deliverables credited six seats by name. None had a dispatch event behind it.

## Two defects, one outcome

**1. The prep step told the caller to run one seat.** `brief-business.ts` — which every business dispatch runs first — ended its output with `Next step: Spawn employee '<intake>' with the brief above as context.`

The procedure for walking an org chart lived in `SKILL.md`, and `SKILL.md` only reaches a session that re-read it. The session that produced that run had been open since before the file changed (verified: one session id spanning 17:19→20:10, with the install at 18:45). So the instruction was in the right document and the wrong place — the caller reads the command's output, not the protocol.

The prep step now names the seats and prints the `nrv team plan` / `nrv team step` commands fully formed, plus the rule that spawning the intake alone is correct only when the plan says so. The `Intake:` line keeps its exact format — `dispatch.ts:1538` parses it, and that was verified both ways.

**2. The director asked who was CAPABLE.** The rule read: *call a colleague when the brief needs a specialty the synthesizer does not have.* The same model sits in every chair, so "the synthesizer could do this" is always true — and every chain collapsed to one seat.

It now asks whose **job** it is: the org chart is the contract, and the synthesizer works alone only when no seat's role covers the work. Cost is the tie-breaker between two defensible chains, never the test for whether to delegate.

The half that is easy to miss: **a seat is how a mind-clone reaches the work.** Personas are ranked against the *seat's* task, not the company's. Skip the seat and the persona the brief needed is never injected — which is why the run above shows zero `mind_clone_injected`.

## Verified against two probe businesses

Installed for this and kept: `chain-probe` (4 seats, a relay where each seat must quote the previous seat's stamp, so the hierarchy is provable from the artifact) and `studio-probe` (3 seats with genuinely separate mandates, and a brief that never mentions seats).

With the new rule, a comedy-scene brief routes to the **screenwriter**, with the head of the studio only signing — and the researcher declined with a specific reason ("references would only add a handoff to a premise that already carries its own comic engine"). Before the change, the same brief collapsed to one seat.

## Also in this PR

`docs/architecture/hierarchical-review.md` — the design for the next step (the immediate superior as reviewer, bound to each seat's declared `acceptance[]`), written **before** building it, including the test that would prove it does not work.

## Verification

- `bun test skills/harness/tests skills/businesses/tests` — 1800 pass. The 4 remaining failures are pre-existing, order-dependent, and read the machine's live library.
- `bun run check:quick` — exit 0.
- The director-rule change is pinned in `team-orchestrator.test.ts`; the old assertion was rewritten deliberately, since it pinned the rule being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk