### PR TITLE
feat(team): the immediate superior reviews, and silence rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The floor is 0.90, not 1.0: one unconfirmable micro-check should not sink a good
 
 Every verdict emits `x_review_approved` or `x_review_rejected` carrying the trace, the pair, the score, the floor, what was confirmed and every gap with its reason. That is deliberate: gate verdicts today carry no trace at all, so "did this run pass" cannot be answered by a join. These can.
 
+The business signs off with a receipt the engine **computes**: `nrv team receipt` reads the run's own events and reports, per seat, whether it was dispatched, who reviewed it, the verdict and where its files are. Exit 3 when a planned seat never ran or a review is unresolved, with the instruction not to report the business as delivered. A receipt assembled from the audit cannot credit a seat that has no `dispatch_business` behind it — which is the exact failure this whole path exists to prevent, and the reason the head does not write it.
+
 The engine's own gate is untouched and still runs last. The superior answers whether the work is good and matches what was asked; the pipeline answers whether a deliverable exists, is not a stub and matches the manifest — deterministically, fail-closed, for free. A model asked "is this a stub?" fails open; `isDeliverable` fails closed.
 
 Measured before building: 65 of 65 installed businesses carry a usable review route, and 611 of 611 seats already declare `acceptance[]`. No business needed changing. Design and falsification test: `docs/architecture/hierarchical-review.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The immediate superior reviews the work, and silence rejects
+
+A business declares who reports to whom, and until now nothing read it. It does now: each seat's work is reviewed by the seat above it in `org-chart.yaml`, against the criteria that seat declared for itself.
+
+`nrv team review` builds the superior's prompt — its own persona and mind-clone, the client's brief, what the subordinate was asked, where the work is, and the subordinate's `acceptance[]` verbatim with the blocking ones marked. `nrv team verdict` judges the answer and exits 0 for approved, 3 for rejected, so the caller branches on the code.
+
+The design problem is that a reviewer asked "is your subordinate's work good?" says yes — same model, no incentive to object. So approval is never asked for. The reviewer reports only what it **confirmed**, each with evidence, and four rules do the rest:
+
+- Anything unmentioned counts as unconfirmed. **Silence rejects.** A reviewer that answers `{"confirmed":[]}` scores zero and fails, so the lazy path is the rejecting path.
+- Evidence under twelve characters is a shrug, not evidence, and the criterion stays unconfirmed.
+- An id the seat never declared is dropped and named in the log — a review of invented criteria is not a review.
+- The engine computes the score; the reviewer only observes. A reviewer that grades itself grades generously.
+
+The floor is 0.90, not 1.0: one unconfirmable micro-check should not sink a good delivery. A criterion the author marked `blocking` must be confirmed regardless of score, which is how a business says "this one is absolute".
+
+Every verdict emits `x_review_approved` or `x_review_rejected` carrying the trace, the pair, the score, the floor, what was confirmed and every gap with its reason. That is deliberate: gate verdicts today carry no trace at all, so "did this run pass" cannot be answered by a join. These can.
+
+The engine's own gate is untouched and still runs last. The superior answers whether the work is good and matches what was asked; the pipeline answers whether a deliverable exists, is not a stub and matches the manifest — deterministically, fail-closed, for free. A model asked "is this a stub?" fails open; `isDeliverable` fails closed.
+
+Measured before building: 65 of 65 installed businesses carry a usable review route, and 611 of 611 seats already declare `acceptance[]`. No business needed changing. Design and falsification test: `docs/architecture/hierarchical-review.md`.
+
 ### The prep step told the maestro to spawn one employee
 
 `brief-business.ts` is the step every business dispatch runs first, and its output ended with `Next step: Spawn employee '<intake>' with the brief above as context.` One seat. A business with fourteen of them did exactly that, credited six in the deliverable, and left a single `dispatch_business` behind, measured 2026-09-04 on an installed business.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### An event the engine wrote is now distinguishable from one an agent typed
+
+The audit is the engine's evidence and it is a text file any agent with Write can append to. On 2026-09-04 one did: a maestro wrote `dispatch_business`, `gate_passed` and an event name the engine has never emitted (`business_completed`) into a run's audit, with timestamps rounded to the minute. The real pipeline ran too, minutes later — so the file held a self-issued verdict and a real one, and **nothing in their shape told them apart**.
+
+That is the defect, and it is not "an agent can write to the file". It can, and forbidding it would break the open `x_` namespace the protocol depends on. The defect is that a typed line was indistinguishable from an emitted one, which made every count downstream — `validate-chain`, the receipt, the improver, `nrv baseline` — a count of claims rather than of events.
+
+Emitted events now carry an HMAC over their own bytes, keyed by a per-install secret at `~/.nirvana/audit-key` (overridable with `NIRVANA_AUDIT_KEY`, created on first use, never in a pack). A reader gets three answers: `engine` (signed and matching), `unsigned` (no stamp — a narrator, or an engine that could not reach its key), `tampered` (stamped but edited afterwards, which is worse than a fake). `nrv team receipt` counts only what the engine signed and lists the rest under `not_counted`.
+
+**What this buys, exactly:** it defeats casual narration — an agent writing plausible lines because it believes it should, which is the failure that happened and the common one. It does **not** defeat a determined forger: anything running as the user can read the key. Saying otherwise would be the same species of dishonesty this closes. What changes is that forging becomes a deliberate act instead of a side effect of an agent being helpful.
+
+### A Windows fixture timed out and called it a failure
+
+`preflight-index.test.ts` seeds three registries with the real indexers under a hardcoded 120 s. A slow windows-latest runner exceeded it, and `spawnSync` returns `status: null` when it kills the child — so the error read `fixture seed index failed (exit null)` with an empty stderr, which describes a broken index rather than a slow machine. It now has a budget sized like the others in the suite, and a timeout says it timed out.
+
 ### The immediate superior reviews the work, and silence rejects
 
 A business declares who reports to whom, and until now nothing read it. It does now: each seat's work is reviewed by the seat above it in `org-chart.yaml`, against the criteria that seat declared for itself.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,20 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Evento que o engine escreveu agora se distingue de evento que um agente digitou
+
+A auditoria é a evidência do engine e é um arquivo de texto em que qualquer agente com Write acrescenta linha. Em 04/09/2026 um acrescentou: um maestro escreveu `dispatch_business`, `gate_passed` e um nome de evento que o engine nunca emitiu (`business_completed`) dentro da auditoria de uma execução, com horários cravados no minuto. O pipeline real também rodou, minutos depois — então o arquivo ficou com um veredito auto-emitido e um real, e **nada no formato deles os distinguia**.
+
+O defeito é esse, e não é "um agente consegue escrever no arquivo". Consegue, e proibir quebraria o namespace aberto `x_` de que o protocolo depende. O defeito é que a linha digitada era indistinguível da emitida, o que tornava toda contagem a jusante — `validate-chain`, o recibo, o improver, o `nrv baseline` — contagem de afirmações em vez de eventos.
+
+Os eventos emitidos passam a carregar um HMAC sobre os próprios bytes, com segredo por instalação em `~/.nirvana/audit-key` (sobrescrevível por `NIRVANA_AUDIT_KEY`, criado no primeiro uso, nunca dentro de um pack). Quem lê recebe três respostas: `engine` (assinado e conferindo), `unsigned` (sem carimbo — um narrador, ou um engine que não alcançou a chave), `tampered` (assinado e editado depois, o que é pior que falsificado). O `nrv team receipt` conta só o que o engine assinou e lista o resto em `not_counted`.
+
+**O que isso compra, exatamente:** derrota a narração casual — um agente escrevendo linhas plausíveis porque acha que deve, que é a falha que aconteceu e a comum. **Não** derrota um falsificador decidido: qualquer coisa rodando como o usuário lê a chave. Dizer o contrário seria a mesma espécie de desonestidade que isto fecha. O que muda é que falsificar vira ato deliberado em vez de efeito colateral de um agente prestativo.
+
+### Um fixture do Windows estourou o tempo e chamou isso de falha
+
+O `preflight-index.test.ts` semeia três registries com os indexadores reais sob 120 s cravados. Um runner lento do windows-latest passou disso, e o `spawnSync` devolve `status: null` quando mata o filho — então o erro dizia `fixture seed index failed (exit null)` com stderr vazio, o que descreve índice quebrado em vez de máquina lenta. Agora tem budget dimensionado como os outros da suíte, e timeout diz que foi timeout.
+
 ### O superior imediato revisa o trabalho, e o silêncio reprova
 
 Uma empresa declara quem se reporta a quem, e até agora nada lia isso. Agora lê: o trabalho de cada cadeira é revisado pela cadeira acima dela no `org-chart.yaml`, contra os critérios que a própria cadeira declarou.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,27 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O superior imediato revisa o trabalho, e o silêncio reprova
+
+Uma empresa declara quem se reporta a quem, e até agora nada lia isso. Agora lê: o trabalho de cada cadeira é revisado pela cadeira acima dela no `org-chart.yaml`, contra os critérios que a própria cadeira declarou.
+
+O `nrv team review` monta o prompt do superior — a persona e o mind-clone dele, o brief do cliente, o que foi pedido ao subordinado, onde está o trabalho, e o `acceptance[]` do subordinado na íntegra, com os bloqueantes marcados. O `nrv team verdict` julga a resposta e sai com 0 para aprovado e 3 para reprovado, então quem chama decide pelo código de saída.
+
+O problema de desenho é que um revisor perguntado "o trabalho do seu subordinado está bom?" responde que sim — mesmo modelo, nenhum incentivo para objetar. Então aprovação nunca é pedida. O revisor reporta só o que **confirmou**, cada item com evidência, e quatro regras fazem o resto:
+
+- O que não for mencionado conta como não confirmado. **Silêncio reprova.** Um revisor que responde `{"confirmed":[]}` tira zero e reprova — o caminho preguiçoso passa a ser o que rejeita.
+- Evidência com menos de doze caracteres é um dar de ombros, não evidência, e o critério continua não confirmado.
+- Id que a cadeira nunca declarou é descartado e nomeado no log — revisão de critério inventado não é revisão.
+- O engine calcula a nota; o revisor só observa. Revisor que se dá a própria nota se dá uma nota generosa.
+
+O piso é 0,90, não 1,0: um micro-check impossível de confirmar não deve afundar uma entrega boa. Critério que o autor marcou como `blocking` precisa ser confirmado independentemente da nota — é assim que uma empresa diz "esse é absoluto".
+
+Todo veredito emite `x_review_approved` ou `x_review_rejected` com o trace, o par revisor/revisado, a nota, o piso, o que foi confirmado e cada lacuna com o motivo. Isso é de propósito: os vereditos de gate hoje não carregam trace nenhum, então "esta execução passou?" não tem como ser respondido por join. Estes têm.
+
+O gate do engine não foi tocado e continua rodando por último. O superior responde se o trabalho é bom e bate com o que foi pedido; o pipeline responde se existe entregável, se não é stub e se bate com o manifesto — de forma determinística, fail-closed, de graça. Um modelo perguntado "isso é stub?" erra aberto; o `isDeliverable` erra fechado.
+
+Medido antes de construir: 65 das 65 empresas instaladas têm rota de revisão utilizável, e 611 de 611 cadeiras já declaram `acceptance[]`. Nenhuma empresa precisou mudar. Desenho e teste de falseamento: `docs/architecture/hierarchical-review.md`.
+
 ### O passo de preparação mandava o maestro rodar um employee só
 
 O `brief-business.ts` é o passo que todo despacho de empresa executa primeiro, e a saída dele terminava com `Next step: Spawn employee '<intake>' with the brief above as context.` Uma cadeira. Uma empresa com catorze fez exatamente isso, creditou seis no entregável e deixou um único `dispatch_business`, medido em 04/09/2026 numa empresa instalada.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -25,6 +25,8 @@ O piso é 0,90, não 1,0: um micro-check impossível de confirmar não deve afun
 
 Todo veredito emite `x_review_approved` ou `x_review_rejected` com o trace, o par revisor/revisado, a nota, o piso, o que foi confirmado e cada lacuna com o motivo. Isso é de propósito: os vereditos de gate hoje não carregam trace nenhum, então "esta execução passou?" não tem como ser respondido por join. Estes têm.
 
+A empresa assina com um recibo que o engine **calcula**: o `nrv team receipt` lê os eventos da própria execução e reporta, por cadeira, se foi despachada, quem revisou, o veredito e onde estão os arquivos. Sai com 3 quando uma cadeira planejada não rodou ou uma revisão ficou em aberto, com a instrução de não reportar a empresa como entregue. Recibo montado a partir da auditoria não consegue creditar cadeira sem `dispatch_business` — que é exatamente a falha que esta linha de trabalho existe para impedir, e a razão de o chefe não escrevê-lo.
+
 O gate do engine não foi tocado e continua rodando por último. O superior responde se o trabalho é bom e bate com o que foi pedido; o pipeline responde se existe entregável, se não é stub e se bate com o manifesto — de forma determinística, fail-closed, de graça. Um modelo perguntado "isso é stub?" erra aberto; o `isDeliverable` erra fechado.
 
 Medido antes de construir: 65 das 65 empresas instaladas têm rota de revisão utilizável, e 611 de 611 cadeiras já declaram `acceptance[]`. Nenhuma empresa precisou mudar. Desenho e teste de falseamento: `docs/architecture/hierarchical-review.md`.

--- a/docs/architecture/hierarchical-review.md
+++ b/docs/architecture/hierarchical-review.md
@@ -240,6 +240,30 @@ Measured, not argued:
 
 Written down first, so the answer is not decided after the fact.
 
+### Result of the falsification test — run 2026-09-04
+
+It was run before this document was merged, exactly as written below, and the
+review held.
+
+A real `studio-head` was handed a deliberately weak artifact: six lines, a
+slugline and one sentence of description, `usou_referencia: none`. It returned
+`confirmed: []` and an `unconfirmed` entry citing the criterion by id, with:
+the line count and byte size, a quote of the offending line, the observation
+that "algo engraçado" is *the promise of a joke, not the joke*, and — the part
+that matters — **the criterion's own words turned back on the artifact**: *"o
+próprio critério declarado diz que 'a summary or an outline instead of a scene
+fails'; é exatamente esse o caso."* Its note caught that `usou_referencia: none`
+means the researcher's file was never read: a placeholder, not a weak draft.
+
+Thirty seconds. Fed through `team verdict`: score 0.00, blocking unconfirmed,
+exit 3, and the instruction to return it to the seat in the same session.
+
+So the risk the design was built against — a boss who waves work through — did
+not materialise on the first honest attempt. What remains unproven is the
+opposite failure: a reviewer so strict that a good artifact never converges
+within the ceiling. That is what the ceiling and the reservations path are for,
+and it is the next thing worth measuring.
+
 **The falsification test.** Give `studio-probe` a brief, then hand the reviewer a
 deliberately weak artifact — a scene that is an outline, with no joke, ignoring
 the reference. The superior must reject it, and the rejection must cite the

--- a/skills/_shared/lib/audit-provenance.ts
+++ b/skills/_shared/lib/audit-provenance.ts
@@ -1,0 +1,140 @@
+// audit-provenance.ts — telling an event the engine wrote from one an agent typed.
+//
+// The audit is the engine's evidence, and it is a text file any agent with Write
+// can append to. On 2026-09-04 one did: a maestro wrote `dispatch_business`,
+// `gate_passed` and an event name the engine has never emitted
+// (`business_completed`) straight into a run's audit, with timestamps rounded to
+// the minute and a JSON style the engine does not produce. The real pipeline ran
+// too, minutes later — so the file ended up holding a self-issued verdict and a
+// real one, and NOTHING in their shape told them apart.
+//
+// That is the defect this closes. Not "an agent can write to the file" — it can,
+// and forbidding it would break the open `x_` namespace the protocol depends on.
+// The defect is that a hand-written line is INDISTINGUISHABLE from an emitted
+// one, which makes every count downstream (validate-chain, the receipt, the
+// improver, `nrv baseline`) a count of claims rather than of events.
+//
+// The stamp is an HMAC over the event's own bytes, keyed by a secret that lives
+// outside the audit. An emitter has the key; a narrator does not.
+//
+// ## What this does and does not buy
+//
+// It defeats CASUAL NARRATION — an agent writing plausible lines because it
+// believes it should. That is the failure that actually happened, and it is the
+// common one.
+//
+// It does NOT defeat a determined forger: anything running as the user can read
+// `~/.nirvana/audit-key` and sign whatever it likes. Claiming otherwise would be
+// the same species of dishonesty this file exists to detect. What it buys is
+// that forging becomes a deliberate act — reading a key file and computing a MAC
+// — instead of a side effect of an agent being helpful.
+//
+// The key is per-install, never travels in a pack, and is not a secret worth
+// protecting beyond file permissions: it authenticates the writer to the reader
+// on one machine. Losing it invalidates old stamps, which reads as "unverified",
+// which is the honest answer after a key rotation.
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { paths } from "./bun-helpers.ts";
+
+/** The field the stamp lives in. Short, so it does not dominate a log line. */
+export const STAMP_FIELD = "sig";
+
+/** Where the per-install key lives. Never inside a project, never in a pack.
+ *
+ *  `NIRVANA_AUDIT_KEY` overrides it, and is read on every call rather than once:
+ *  `paths` memoizes, so a test that redirected `NIRVANA_HOME` would only win if
+ *  it were the first thing in the process to touch it — and a test that has to
+ *  win a race writes a key into the owner's real home when it loses. */
+export function auditKeyPath(): string {
+  return process.env.NIRVANA_AUDIT_KEY || path.join(paths.NIRVANA_HOME, ".nirvana", "audit-key");
+}
+
+let cached: Buffer | null = null;
+let cachedFrom = "";
+
+/**
+ * The install's signing key, created on first use.
+ *
+ * Unreadable or uncreatable (a read-only home, a sandbox) returns null rather
+ * than throwing: an engine that cannot sign must still run and still log. The
+ * events come out unstamped, a reader reports them as unverified, and nothing
+ * pretends otherwise.
+ */
+export function auditKey(): Buffer | null {
+  const p = auditKeyPath();
+  if (cached && cachedFrom === p) return cached;
+  try {
+    if (fs.existsSync(p)) {
+      const raw = fs.readFileSync(p, "utf8").trim();
+      if (raw.length >= 32) { cached = Buffer.from(raw, "hex"); cachedFrom = p; return cached; }
+    }
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const key = crypto.randomBytes(32);
+    fs.writeFileSync(p, key.toString("hex"), { mode: 0o600 });
+    cached = key; cachedFrom = p;
+    return cached;
+  } catch { return null; }
+}
+
+/** Test seam: forget the cached key so a fixture can point at its own home. */
+export function resetAuditKeyCache(): void { cached = null; cachedFrom = ""; }
+
+/**
+ * The bytes that get signed: the event minus its own stamp, with keys sorted.
+ *
+ * Sorted because `JSON.stringify` preserves insertion order, and an emitter that
+ * builds the same event with its keys in a different order would produce a
+ * different MAC for identical content — a false "tampered" on honest data.
+ */
+function canonical(event: Record<string, any>): string {
+  const { [STAMP_FIELD]: _drop, ...rest } = event;
+  return JSON.stringify(rest, Object.keys(rest).sort());
+}
+
+/** Add the stamp. Returns the event unchanged when there is no key to sign with. */
+export function stamp<T extends Record<string, any>>(event: T): T {
+  const key = auditKey();
+  if (!key) return event;
+  const sig = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
+  return { ...event, [STAMP_FIELD]: sig };
+}
+
+export type Provenance = "engine" | "unsigned" | "tampered";
+
+/**
+ * Who wrote this event.
+ *
+ *  - `engine`    — signed, and the signature matches its own content.
+ *  - `unsigned`  — no stamp. Either a narrator, or an engine that could not
+ *                  reach its key, or a line written before this existed. All
+ *                  three mean the same thing to a reader: not evidence.
+ *  - `tampered`  — stamped, but the content does not match the stamp. Someone
+ *                  edited a real event, which is worse than writing a fake one.
+ */
+export function provenanceOf(event: Record<string, any>): Provenance {
+  const sig = event?.[STAMP_FIELD];
+  if (typeof sig !== "string" || !sig) return "unsigned";
+  const key = auditKey();
+  if (!key) return "unsigned";
+  const expect = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
+  // Length-safe compare; a mismatch here is a finding, not an error.
+  const a = Buffer.from(sig), b = Buffer.from(expect);
+  return a.length === b.length && crypto.timingSafeEqual(a, b) ? "engine" : "tampered";
+}
+
+/** Count a file's events by provenance — what a reader needs before trusting it. */
+export function auditProvenanceSummary(file: string): { engine: number; unsigned: number; tampered: number; total: number } {
+  const out = { engine: 0, unsigned: 0, tampered: 0, total: 0 };
+  let lines: string[];
+  try { lines = fs.readFileSync(file, "utf8").split("\n").filter(Boolean); } catch { return out; }
+  for (const l of lines) {
+    let e: any;
+    try { e = JSON.parse(l); } catch { continue; }
+    out.total++;
+    out[provenanceOf(e)]++;
+  }
+  return out;
+}

--- a/skills/_shared/tests/audit-provenance.test.ts
+++ b/skills/_shared/tests/audit-provenance.test.ts
@@ -1,0 +1,47 @@
+// audit-provenance.test.ts — telling an emitted event from a typed one.
+//
+// The case in the second test is REAL: it is the line an agent wrote into a
+// run's audit on 2026-09-04, claiming a gate verdict minutes before the actual
+// pipeline emitted one. Nothing in its shape distinguished it. Now something does.
+//
+// The key is redirected with NIRVANA_AUDIT_KEY so no test ever writes into the
+// owner's real install — the engine owns that path, tests do not.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { stamp, provenanceOf, resetAuditKeyCache } from "../lib/audit-provenance.ts";
+
+let tmp: string;
+const saved = process.env.NIRVANA_AUDIT_KEY;
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-prov-"));
+  process.env.NIRVANA_AUDIT_KEY = path.join(tmp, "audit-key");
+  resetAuditKeyCache();
+});
+afterAll(() => {
+  if (saved === undefined) delete process.env.NIRVANA_AUDIT_KEY; else process.env.NIRVANA_AUDIT_KEY = saved;
+  resetAuditKeyCache();
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("provenance", () => {
+  test("what the engine wrote verifies", () => {
+    const e = stamp({ ts: "2026-09-04T22:26:42.100Z", event: "gate_passed", trace_id: "t1" });
+    expect(provenanceOf(e)).toBe("engine");
+  });
+  test("the line an agent typed does not — this is the real one from 2026-09-04", () => {
+    const narrated = JSON.parse('{"ts": "2026-09-04T22:23:00Z", "event": "gate_passed", "trace_id": "4fbc24c9", "business_slug": "software-forge", "rubrics": ["tests-pass"]}');
+    expect(provenanceOf(narrated)).toBe("unsigned");
+  });
+  test("editing a real event after the fact is caught, and named differently", () => {
+    const e: any = stamp({ ts: "2026-09-04T22:26:42.100Z", event: "gate_failed", trace_id: "t1" });
+    e.event = "gate_passed";
+    expect(provenanceOf(e)).toBe("tampered");
+  });
+  test("key order does not change the verdict", () => {
+    const a = stamp({ ts: "x", event: "e", trace_id: "t" });
+    const b: any = { event: "e", trace_id: "t", ts: "x", sig: (a as any).sig };
+    expect(provenanceOf(b)).toBe("engine");
+  });
+});

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -315,6 +315,22 @@ nrv team plan --business <slug> --brief .nirvana/briefs/<trace>-enriched.md \
 nrv team step --plan .nirvana/<trace>-chain.json --index 0
 ```
 
+**Each seat's work is reviewed by the seat above it**, and the business is signed off by a receipt the engine computes rather than one you write:
+
+```bash
+nrv team review  --plan <plan.json> --index <n>            # the superior's prompt
+nrv team verdict --plan <plan.json> --index <n> --verdict <file.json>
+#   exit 0 approved · exit 3 rejected → hand the gaps back to that seat IN ITS
+#   OWN SESSION, let it fix, then re-review. The ceiling is the loop guard.
+nrv team receipt --plan <plan.json>                        # the business signs off
+#   exit 0 complete · exit 3 → do NOT report it delivered, and do not credit a
+#   seat the receipt lists as never dispatched.
+```
+
+The reviewer is the seat's immediate superior in `org-chart.yaml`, and it arrives as itself — its own persona, its own mind-clone. It is given the client brief, what the seat was asked, where the work is, and the criteria that seat declared for itself. It reports only what it CONFIRMED, with evidence; the engine computes the score, because a reviewer that grades itself grades generously. Anything the reviewer does not mention counts as unconfirmed, so a lazy review rejects rather than waving work through.
+
+The receipt is built from the audit, not from a summary. That is deliberate: a receipt cannot credit a seat with no `dispatch_business` behind it, which is the exact failure this whole path exists to prevent. Report to the user what the receipt says, not what the seats claim.
+
 `step` prints the seat's prompt on stdout — persona, mind-clone DNA, the resource map, the colleagues' output paths, the scope guard — and the destination on stderr. Run it as-is; paraphrasing it drops the DNA injection, which is the whole reason the seat is not just you with a different label. Steps run **in order**: each one reads what the earlier seats wrote under `_team/<employee>/`, and the last one writes the final deliverables to the outputs root.
 
 The director decides how many seats, and it is free to answer one — a brief that one seat carries whole should cost one dispatch, and `x_chain_shape_decided.reason` is where that judgement gets checked. `--single` skips the director when you already know; `--team` asks for three to six.

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -70,7 +70,7 @@ export const COMMANDS: Command[] = [
   { name: "dispatch", target: "harness/scripts/dispatch.ts", category: "dispatch", args: '<business> "<brief>"', summary: "Scaffold a run (brief + DNA injection + audit; no exec)", visibility: "user" },
   { name: "run", aliases: ["autopilot"], custom: true, category: "dispatch", args: '<business> "<brief>" [--zip --pdf --html]', summary: "Autopilot: dispatch + execute + verify + gate", visibility: "user" },
   { name: "auto", custom: true, category: "dispatch", args: '"<brief>" [--zip --pdf --html]', summary: "Autopilot with auto-selected business (= run --auto)", visibility: "user" },
-  { name: "team", target: "harness/scripts/chain.ts", category: "dispatch", args: "plan|step ...", summary: "A business's org chart as data: plan the chain, get each seat's prompt", visibility: "user" },
+  { name: "team", target: "harness/scripts/chain.ts", category: "dispatch", args: "plan|step|review|verdict ...", summary: "A business's org chart: plan the chain, get each seat's prompt, review it", visibility: "user" },
   { name: "revise", target: "harness/scripts/revise.ts", category: "dispatch", args: '<project> "<change>"', summary: "Apply a change keeping the same runtime session", visibility: "user" },
   { name: "ask", target: "harness/scripts/ask.ts", category: "dispatch", args: "<clone> [question]", summary: "Talk to a single mind-clone (DNA injected)", visibility: "user" },
   { name: "launch", target: "harness/scripts/launch.ts", category: "dispatch", args: "<name> [--pillars=...]", summary: "Scaffold a multi-pillar 360 launch", visibility: "user" },

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -24,6 +24,7 @@ import { runHeadless, AUTONOMOUS_DIRECTIVE, type Runtime } from "./host-agent-dr
 import { runWithCascade } from "./cascade-runner.ts";
 import { sessionKey, getSession, putSession, dropSession, type EntityKind } from "./session-store.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
 import { runSquadHeadless } from "./squad-exec.ts";
 import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
@@ -101,7 +102,7 @@ function appendAudit(payload: Record<string, any>, projectRoot?: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -48,6 +48,7 @@ import { spawnSync } from "node:child_process";
 import { planChain, buildStepBrief, type ChainStep, type TeamRunArgs } from "../lib/team-orchestrator.ts";
 import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { stamp, provenanceOf } from "../../_shared/lib/audit-provenance.ts";
 import type { Runtime } from "../lib/host-agent-driver.ts";
 import * as YAML from "yaml";
 import { readAcceptance } from "../../businesses/lib/acceptance.ts";
@@ -62,7 +63,7 @@ function emitAudit(payload: Record<string, any>, projectRoot?: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 
@@ -495,10 +496,21 @@ function cmdReceipt(argv: string[]): void {
   const day = new Date().toISOString().slice(0, 10);
   const auditFile = path.join(harnessLogsDir({ cwd: plan.project_root }), day, "audit.jsonl");
   let events: any[] = [];
+  let narrated: Array<{ event: string; why: string }> = [];
   try {
-    events = fs.readFileSync(auditFile, "utf8").split("\n").filter(Boolean)
+    const all = fs.readFileSync(auditFile, "utf8").split("\n").filter(Boolean)
       .map(l => { try { return JSON.parse(l); } catch { return null; } })
       .filter(e => e && (e.trace_id === plan.project_id || e.project_id === plan.project_id));
+    // Only what the ENGINE signed counts. An unsigned or altered line is a claim
+    // someone typed, and a receipt that counts claims is the thing this receipt
+    // exists to replace: on 2026-09-04 an agent wrote its own dispatch_business
+    // and its own gate_passed into a run's audit, minutes before the real
+    // pipeline emitted the same names. Nothing in their shape told them apart.
+    for (const e of all) {
+      const p = provenanceOf(e);
+      if (p === "engine") events.push(e);
+      else narrated.push({ event: String(e.event ?? "(unnamed)"), why: p });
+    }
   } catch { /* no events yet — every seat reads as not dispatched, which is true */ }
 
   const seatOf = (e: any) => e?.employee;
@@ -534,6 +546,7 @@ function cmdReceipt(argv: string[]): void {
     complete,
     ...(missing.length ? { never_dispatched: missing } : {}),
     ...(unresolved.length ? { review_unresolved: unresolved } : {}),
+    ...(narrated.length ? { not_counted: narrated } : {}),
   }, null, 2));
 
   emitAudit({
@@ -545,6 +558,10 @@ function cmdReceipt(argv: string[]): void {
     ...(unresolved.length ? { review_unresolved: unresolved } : {}),
   }, plan.project_root);
 
+  if (narrated.length) {
+    console.error(`[receipt] ${narrated.length} event(s) in this trace were NOT written by the engine and were not counted: `
+      + narrated.map(n => `${n.event} (${n.why})`).join(", "));
+  }
   if (!complete) {
     if (missing.length) console.error(`[receipt] ${missing.length} seat(s) in the plan never ran: ${missing.join(", ")}`);
     if (unresolved.length) console.error(`[receipt] ${unresolved.length} seat(s) not approved by their superior: ${unresolved.join(", ")}`);

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -474,6 +474,86 @@ function cmdVerdict(argv: string[]): void {
   console.error(`[verdict] approved — score ${score.toFixed(2)} ≥ ${floor}`);
 }
 
+
+/** The receipt the head hands back to the orchestrator — COMPUTED, not narrated.
+ *
+ *  Asking the head to write "everyone did their part" is asking for the failure
+ *  this whole line of work started from: a deliverable crediting six seats with
+ *  one dispatch event behind them. A receipt built from the audit cannot credit a
+ *  seat that has no `dispatch_business`, because there is nothing to read.
+ *
+ *  Exit 0 when every planned seat dispatched and every reviewed seat was
+ *  approved; exit 3 otherwise, with the gaps named. */
+function cmdReceipt(argv: string[]): void {
+  const planFile = arg(argv, "--plan");
+  if (!planFile) die("receipt needs --plan.", EXIT_ARGS);
+  if (!fs.existsSync(planFile!)) die(`plan file not found: ${planFile}`, EXIT_ARGS);
+  const plan: ChainPlan = JSON.parse(fs.readFileSync(planFile!, "utf8"));
+
+  // Read the run's own events. Same resolution the writers use, so a reader can
+  // never be looking at a different file than the one being written.
+  const day = new Date().toISOString().slice(0, 10);
+  const auditFile = path.join(harnessLogsDir({ cwd: plan.project_root }), day, "audit.jsonl");
+  let events: any[] = [];
+  try {
+    events = fs.readFileSync(auditFile, "utf8").split("\n").filter(Boolean)
+      .map(l => { try { return JSON.parse(l); } catch { return null; } })
+      .filter(e => e && (e.trace_id === plan.project_id || e.project_id === plan.project_id));
+  } catch { /* no events yet — every seat reads as not dispatched, which is true */ }
+
+  const seatOf = (e: any) => e?.employee;
+  const dispatched = new Set(events.filter(e => e.event === "dispatch_business").map(seatOf).filter(Boolean));
+  const approved = new Map(events.filter(e => e.event === "x_review_approved").map(e => [seatOf(e), e]));
+  const rejected = new Map(events.filter(e => e.event === "x_review_rejected").map(e => [seatOf(e), e]));
+
+  const rows = plan.chain.map((step, i) => {
+    const isLast = i === plan.chain.length - 1;
+    const dir = isLast ? plan.outputs_root : path.join(plan.outputs_root, "_team", step.employee);
+    let files: string[] = [];
+    try { files = fs.readdirSync(dir).filter(f => !f.startsWith(".")); } catch { /* nothing written */ }
+    const ok = approved.get(step.employee);
+    const no = rejected.get(step.employee);
+    return {
+      seat: step.employee,
+      dispatched: dispatched.has(step.employee),
+      reviewer: step.reviewer ?? null,
+      review: ok ? "approved" : no ? "rejected" : step.reviewer ? "not reviewed" : "signs (no superior)",
+      score: (ok ?? no)?.score ?? null,
+      files: files.length,
+      output_dir: dir,
+    };
+  });
+
+  const missing = rows.filter(r => !r.dispatched).map(r => r.seat);
+  const unresolved = rows.filter(r => r.reviewer && r.review !== "approved").map(r => r.seat);
+  const complete = missing.length === 0 && unresolved.length === 0;
+
+  console.log(JSON.stringify({
+    business: plan.business, trace_id: plan.project_id, outputs_root: plan.outputs_root,
+    chain_reason: plan.reason, seats: rows,
+    complete,
+    ...(missing.length ? { never_dispatched: missing } : {}),
+    ...(unresolved.length ? { review_unresolved: unresolved } : {}),
+  }, null, 2));
+
+  emitAudit({
+    event: complete ? "x_business_signed_off" : "x_business_incomplete",
+    trace_id: plan.project_id, project_id: plan.project_id, business_slug: plan.business,
+    seats: rows.length, dispatched: rows.filter(r => r.dispatched).length,
+    approved: rows.filter(r => r.review === "approved").length,
+    ...(missing.length ? { never_dispatched: missing } : {}),
+    ...(unresolved.length ? { review_unresolved: unresolved } : {}),
+  }, plan.project_root);
+
+  if (!complete) {
+    if (missing.length) console.error(`[receipt] ${missing.length} seat(s) in the plan never ran: ${missing.join(", ")}`);
+    if (unresolved.length) console.error(`[receipt] ${unresolved.length} seat(s) not approved by their superior: ${unresolved.join(", ")}`);
+    console.error("[receipt] do NOT report this business as delivered, and do not credit a seat listed above.");
+    process.exit(3);
+  }
+  console.error(`[receipt] ${plan.business}: ${rows.length} seat(s), all dispatched, all reviews resolved.`);
+}
+
 const argv = process.argv.slice(2);
 const sub = argv[0];
 if (!sub || sub === "-h" || sub === "--help") {
@@ -520,4 +600,5 @@ if (sub === "plan") cmdPlan(argv.slice(1));
 else if (sub === "step") cmdStep(argv.slice(1));
 else if (sub === "review") cmdReview(argv.slice(1));
 else if (sub === "verdict") cmdVerdict(argv.slice(1));
-else die(`unknown subcommand '${sub}'. Try: plan, step, review, verdict.`, EXIT_ARGS);
+else if (sub === "receipt") cmdReceipt(argv.slice(1));
+else die(`unknown subcommand '${sub}'. Try: plan, step, review, verdict, receipt.`, EXIT_ARGS);

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -49,6 +49,8 @@ import { planChain, buildStepBrief, type ChainStep, type TeamRunArgs } from "../
 import { resolveEntityDir } from "../../_shared/lib/entity-resource-map.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import type { Runtime } from "../lib/host-agent-driver.ts";
+import * as YAML from "yaml";
+import { readAcceptance } from "../../businesses/lib/acceptance.ts";
 
 const SKILLS = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
@@ -86,7 +88,9 @@ interface ChainPlan {
   businesses_root?: string;
   intake: string;
   reason: string;
-  chain: ChainStep[];
+  /** Each step plus the seat that reviews it, from the org chart. A step with no
+   *  `reviewer` is the root: it signs, it is not signed off. */
+  chain: Array<ChainStep & { reviewer?: string }>;
 }
 
 /** The seat that consolidates. Resolved through the businesses loader — the same
@@ -112,6 +116,43 @@ function intakeEmployee(bizDir: string): string {
   if (why) die(`business at ${bizDir} could not be loaded:\n  ${why.split("\n").join("\n  ")}\n${fix}`);
   die(`business at ${bizDir} named no intake employee.\n${fix}`);
 }
+
+// ── review: the immediate superior, bound to what the seat declared ────────
+
+/** The seat that reviews `employee`, read from the org chart — never invented.
+ *
+ *  `reports[0]` is the immediate superior. The chart is validated on every
+ *  business and, until this, read by nothing: `fromOrgChart` in dag-planner maps
+ *  `deps = reports[]`, which is backwards for execution and exactly right here,
+ *  because the result rises through `reports`. Measured across the installed
+ *  library: 65/65 businesses carry a chart, 64/65 have a single root, and no
+ *  business has an orphan seat — so this resolves for every one of them. */
+function reviewerOf(bizDir: string, employee: string): string | null {
+  try {
+    const chart = YAML.parse(fs.readFileSync(path.join(bizDir, "org-chart.yaml"), "utf8"))?.chart ?? [];
+    const row = chart.find((e: any) => e?.employee === employee);
+    const up = (row?.reports ?? [])[0];
+    return typeof up === "string" && up !== employee ? up : null;
+  } catch { return null; }
+}
+
+/** One criterion the reviewer must answer for, as the seat declared it. */
+interface ReviewCriterion { id: string; description: string; blocking: boolean; employee: string; }
+
+function criteriaFor(bizDir: string, employee: string): ReviewCriterion[] {
+  try {
+    return readAcceptance(bizDir, [employee]).entries.map(e => ({
+      id: e.id, description: e.description, blocking: e.blocking, employee: e.employee,
+    }));
+  } catch { return []; }
+}
+
+/** The floor a review has to clear. Not 1.0 on purpose: one unconfirmable
+ *  micro-check should not sink a good delivery. A criterion the author marked
+ *  `blocking` is the escape hatch in the other direction — it must be confirmed
+ *  whatever the score says. `readAcceptance` defaults its own floor to 0.92; this
+ *  is the same idea, one notch more forgiving, and overridable per business. */
+const REVIEW_SCORE_FLOOR = 0.90;
 
 function cmdPlan(argv: string[]): void {
   const slug = arg(argv, "--business");
@@ -156,11 +197,19 @@ function cmdPlan(argv: string[]): void {
     catch (e: any) { die(`director: ${e?.message || e}`); }
   }
 
+  // Each step carries WHO REVIEWS IT, resolved from the org chart rather than
+  // decided here. A step whose seat is the root has no reviewer: the head of the
+  // house signs for the delivery instead of being reviewed by someone above it.
+  const chainWithReviewers = chain.map(step => {
+    const reviewer = reviewerOf(bizDir, step.employee);
+    return reviewer ? { ...step, reviewer } : { ...step };
+  });
+
   const plan: ChainPlan = {
     business: slug, project_id: projectId, project_dir: projectDir, project_root: projectRoot,
     outputs_root: outputsRoot, brief_file: path.resolve(briefFile),
     ...(businessesRoot ? { businesses_root: businessesRoot } : {}),
-    intake, reason, chain,
+    intake, reason, chain: chainWithReviewers,
   };
 
   const save = arg(argv, "--save");
@@ -238,6 +287,193 @@ function cmdStep(argv: string[]): void {
   console.error(`[chain] step ${idx + 1}/${total} · ${step.employee} → ${outDir}`);
 }
 
+
+/** The brief the reviewer reads: what the company was asked for, what THIS seat
+ *  was asked for, where its work is, and the criteria it declared for itself.
+ *
+ *  The verdict form is the whole defence against a rubber stamp. A reviewer that
+ *  writes `{"verdict":"approved"}` and nothing else scores zero and fails, because
+ *  anything unmentioned counts as unconfirmed — so the lazy path rejects instead
+ *  of approving. That inversion is the point; a checklist that is cheap to sign
+ *  is a checklist that gets signed. */
+function buildReviewBrief(plan: ChainPlan, idx: number, criteria: ReviewCriterion[], outDir: string): string {
+  const step = plan.chain[idx];
+  const brief = fs.readFileSync(plan.brief_file, "utf8");
+  const list = criteria.length
+    ? criteria.map(c => `- \`${c.id}\`${c.blocking ? " **(blocking)**" : ""} — ${c.description}`).join("\n")
+    : "- (this seat declared no acceptance criteria; judge against the brief and say so in `notes`)";
+
+  return [
+    `# Review — ${step.reviewer} reviewing ${step.employee}`,
+    "",
+    "You are this seat's immediate superior. You did not do the work; you answer for it.",
+    "",
+    "## What the client asked the company for",
+    brief,
+    "",
+    `## What ${step.employee} was asked to do`,
+    step.task,
+    "",
+    `## Where its work is`,
+    `\`${outDir}\` — read the files before judging. A verdict on work you did not open is worthless.`,
+    "",
+    `## The criteria ${step.employee} declared for itself`,
+    list,
+    "",
+    "## Your answer: ONE JSON object, nothing else",
+    "```json",
+    '{"confirmed":[{"id":"<criterion id, verbatim>","evidence":"<file:line, or a quote — what PROVES it>"}],',
+    ' "unconfirmed":[{"id":"<criterion id>","why":"<what is missing, concretely>"}],',
+    ' "notes":"<one line, optional>"}',
+    "```",
+    "",
+    "Rules, and they are enforced by the engine that reads this:",
+    "- An `id` that is not in the list above is DROPPED. Do not invent criteria.",
+    "- A criterion goes under `confirmed` only with real evidence — a path, a line, a quote. Evidence like \"looks good\" moves it to `unconfirmed`.",
+    "- **Anything you do not mention counts as unconfirmed.** Silence is not approval.",
+    "- Do not write the verdict or the score: the engine computes both from what you confirmed. Your job is observation, not arithmetic.",
+    "- Judging your subordinate generously does not help them. An approval that does not survive the next reader costs the company more than a rejection that names the gap.",
+  ].join("\n");
+}
+
+function cmdReview(argv: string[]): void {
+  const planFile = arg(argv, "--plan");
+  const indexRaw = arg(argv, "--index");
+  if (!planFile || indexRaw === undefined) die("review needs --plan and --index.", EXIT_ARGS);
+  const plan: ChainPlan = JSON.parse(fs.readFileSync(planFile!, "utf8"));
+  const idx = Number(indexRaw);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= plan.chain.length) {
+    die(`--index ${indexRaw} is out of range: this plan has ${plan.chain.length} step(s).`, EXIT_ARGS);
+  }
+  const step = plan.chain[idx];
+  if (!step.reviewer) {
+    die(`${step.employee} is the root of the org chart — it signs for the delivery, it is not reviewed. `
+      + "There is nobody above it to ask.", EXIT_ARGS);
+  }
+
+  const bizDir = plan.businesses_root
+    ? path.join(plan.businesses_root, plan.business)
+    : resolveEntityDir("businesses", plan.business, plan.project_dir);
+  const isLast = idx === plan.chain.length - 1;
+  const workDir = isLast ? plan.outputs_root : path.join(plan.outputs_root, "_team", step.employee);
+  const criteria = criteriaFor(bizDir, step.employee);
+
+  // The reviewer runs as itself — its own persona and its own mind-clone, ranked
+  // against the review task. A generic judge is what this replaces.
+  const reviewDir = path.join(plan.outputs_root, "_review", step.employee);
+  fs.mkdirSync(reviewDir, { recursive: true });
+  const briefFile = path.join(reviewDir, ".review-brief.md");
+  fs.writeFileSync(briefFile, buildReviewBrief(plan, idx, criteria, workDir));
+
+  const ep = spawnSync("bun", [
+    path.join(SKILLS, "businesses/lib/employee-prompt.ts"),
+    plan.business, step.reviewer, plan.project_dir, briefFile, reviewDir,
+  ], {
+    encoding: "utf8", maxBuffer: 32 * 1024 * 1024,
+    env: { ...process.env, BUSINESSES_DIR: path.dirname(bizDir) },
+  });
+  if (ep.status !== 0) die(`could not build the prompt for ${step.reviewer}: ${ep.stderr?.slice(0, 300) || `exit ${ep.status}`}`);
+
+  emitAudit({
+    event: "x_review_requested", trace_id: plan.project_id, project_id: plan.project_id,
+    business_slug: plan.business, employee: step.employee, reviewer: step.reviewer,
+    step: idx + 1, total: plan.chain.length, criteria: criteria.length,
+  }, plan.project_root);
+
+  process.stdout.write(ep.stdout);
+  console.error(`[review] ${step.reviewer} reviewing ${step.employee} · ${criteria.length} criteria · work in ${workDir}`);
+  console.error(`[review] write the verdict JSON, then: nrv team verdict --plan ${planFile} --index ${idx} --verdict <file.json>`);
+}
+
+/** Read the reviewer's answer, and decide — here, not there.
+ *
+ *  The reviewer reports observations; the engine does the arithmetic. That split
+ *  exists because a reviewer that grades itself grades generously, and because a
+ *  score computed from confirmed criteria is checkable by anyone who reads the
+ *  same two files afterwards.
+ *
+ *  Exit code IS the loop: 0 approved, 3 rejected, so the caller branches on it
+ *  without parsing anything. */
+function cmdVerdict(argv: string[]): void {
+  const planFile = arg(argv, "--plan");
+  const indexRaw = arg(argv, "--index");
+  const verdictFile = arg(argv, "--verdict");
+  if (!planFile || indexRaw === undefined || !verdictFile) die("verdict needs --plan, --index and --verdict.", EXIT_ARGS);
+  if (!fs.existsSync(verdictFile!)) die(`verdict file not found: ${verdictFile}`, EXIT_ARGS);
+
+  const plan: ChainPlan = JSON.parse(fs.readFileSync(planFile!, "utf8"));
+  const idx = Number(indexRaw);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= plan.chain.length) {
+    die(`--index ${indexRaw} is out of range: this plan has ${plan.chain.length} step(s).`, EXIT_ARGS);
+  }
+  const step = plan.chain[idx];
+
+  let raw: any;
+  try {
+    const text = fs.readFileSync(verdictFile!, "utf8");
+    // The reviewer is an LLM; a fenced block or a sentence around the object is
+    // ordinary, and failing the whole review over punctuation would teach the
+    // wrong lesson. The object itself is what must be well formed.
+    raw = JSON.parse(text.match(/\{[\s\S]*\}/)?.[0] ?? text);
+  } catch (e: any) { die(`the verdict is not JSON: ${e.message}`); }
+
+  const bizDir = plan.businesses_root
+    ? path.join(plan.businesses_root, plan.business)
+    : resolveEntityDir("businesses", plan.business, plan.project_dir);
+  const criteria = criteriaFor(bizDir, step.employee);
+  const known = new Map(criteria.map(c => [c.id, c]));
+
+  // Confirmed means: a real id, and evidence that is not a shrug. Everything
+  // else — including everything the reviewer simply did not mention — is
+  // unconfirmed. That asymmetry is the design: silence rejects.
+  const invented: string[] = [];
+  const confirmed = new Set<string>();
+  for (const c of Array.isArray(raw?.confirmed) ? raw.confirmed : []) {
+    const id = typeof c?.id === "string" ? c.id : "";
+    if (!known.has(id)) { if (id) invented.push(id); continue; }
+    const ev = String(c?.evidence ?? "").trim();
+    if (ev.length >= 12) confirmed.add(id);
+  }
+
+  const total = criteria.length;
+  const score = total === 0 ? 1 : confirmed.size / total;
+  const blockingMissed = criteria.filter(c => c.blocking && !confirmed.has(c.id)).map(c => c.id);
+  const floor = REVIEW_SCORE_FLOOR;
+  const approved = score >= floor && blockingMissed.length === 0;
+
+  const gaps = criteria.filter(c => !confirmed.has(c.id)).map(c => {
+    const said = (Array.isArray(raw?.unconfirmed) ? raw.unconfirmed : []).find((u: any) => u?.id === c.id);
+    return { id: c.id, blocking: c.blocking, why: String(said?.why ?? "not mentioned by the reviewer").slice(0, 300) };
+  });
+
+  emitAudit({
+    event: approved ? "x_review_approved" : "x_review_rejected",
+    trace_id: plan.project_id, project_id: plan.project_id, business_slug: plan.business,
+    employee: step.employee, reviewer: step.reviewer, step: idx + 1, total: plan.chain.length,
+    score: Number(score.toFixed(3)), floor, confirmed: [...confirmed],
+    ...(gaps.length ? { gaps } : {}), ...(blockingMissed.length ? { blocking_missed: blockingMissed } : {}),
+    ...(invented.length ? { invented_ids: invented } : {}),
+  }, plan.project_root);
+
+  console.log(JSON.stringify({
+    employee: step.employee, reviewer: step.reviewer,
+    verdict: approved ? "approved" : "rejected",
+    score: Number(score.toFixed(3)), floor, confirmed: [...confirmed], gaps,
+    ...(blockingMissed.length ? { blocking_missed: blockingMissed } : {}),
+    ...(invented.length ? { invented_ids: invented } : {}),
+  }, null, 2));
+
+  if (invented.length) {
+    console.error(`[verdict] ${invented.length} id(s) not in ${step.employee}'s acceptance were dropped: ${invented.join(", ")}`);
+  }
+  if (!approved) {
+    console.error(`[verdict] REJECTED — score ${score.toFixed(2)} < ${floor}${blockingMissed.length ? `; blocking unconfirmed: ${blockingMissed.join(", ")}` : ""}`);
+    console.error(`[verdict] send it back to ${step.employee} IN THE SAME SESSION with the gaps above named.`);
+    process.exit(3);
+  }
+  console.error(`[verdict] approved — score ${score.toFixed(2)} ≥ ${floor}`);
+}
+
 const argv = process.argv.slice(2);
 const sub = argv[0];
 if (!sub || sub === "-h" || sub === "--help") {
@@ -257,12 +493,31 @@ if (!sub || sub === "-h" || sub === "--help") {
       map, the colleagues' output paths and the scope guard. Run it in your own
       subagent, verbatim. Emits dispatch_business for that seat.
 
+  nrv team review --plan <plan.json> --index <n>
+
+      Prints the prompt for that seat's IMMEDIATE SUPERIOR: the client brief,
+      what the seat was asked, where its work is, and the criteria the seat
+      declared for itself. The reviewer answers with a JSON object listing only
+      what it CONFIRMED, with evidence.
+
+  nrv team verdict --plan <plan.json> --index <n> --verdict <file.json>
+
+      Judges that answer. Anything unmentioned counts as unconfirmed, evidence
+      that is a shrug does not count, and an id the seat never declared is
+      dropped. The engine computes the score, not the reviewer.
+      Exit 0 approved · exit 3 rejected — send it back in the SAME session.
+
   Loop:
       nrv team plan … --save .nirvana/chain.json
-      for i in 0 1 2: nrv team step --plan .nirvana/chain.json --index $i
-                      → run each prompt in a subagent, in order.`);
+      for each step i:
+        nrv team step   --plan .nirvana/chain.json --index $i   → run it
+        nrv team review --plan .nirvana/chain.json --index $i   → run it
+        nrv team verdict --plan .nirvana/chain.json --index $i --verdict v.json
+        exit 3 → hand the gaps back to step $i in its own session, then re-review`);
   process.exit(EXIT_OK);
 }
 if (sub === "plan") cmdPlan(argv.slice(1));
 else if (sub === "step") cmdStep(argv.slice(1));
-else die(`unknown subcommand '${sub}'. Try: plan, step.`, EXIT_ARGS);
+else if (sub === "review") cmdReview(argv.slice(1));
+else if (sub === "verdict") cmdVerdict(argv.slice(1));
+else die(`unknown subcommand '${sub}'. Try: plan, step, review, verdict.`, EXIT_ARGS);

--- a/skills/harness/tests/chain-review.test.ts
+++ b/skills/harness/tests/chain-review.test.ts
@@ -214,3 +214,52 @@ describe("the audit can answer who reviewed what, and why it failed", () => {
     expect(e?.confirmed).toEqual(["has_three_items", "names_a_source"]);
   }, spawnBudgetMs(2));
 });
+
+describe("nrv team receipt — computed, never narrated", () => {
+  // The failure this whole line of work started from was a deliverable crediting
+  // six seats with one dispatch event behind them. A receipt assembled from the
+  // audit cannot make that mistake: there is nothing to read for a seat that
+  // never ran. So the head does not write the receipt — the engine does.
+  test("a plan whose seats never ran is refused, and names who is missing", () => {
+    const p = plan();
+    const r = run(["receipt", "--plan", p]);
+    expect(r.code).toBe(3);
+    const out = JSON.parse(r.out);
+    expect(out.complete).toBe(false);
+    expect(out.never_dispatched).toEqual(["worker", "boss"]);
+    expect(r.err).toMatch(/do NOT report this business as delivered/);
+  }, spawnBudgetMs(2));
+
+  test("dispatched and approved seats sign off; the root needs no superior", () => {
+    const p = plan();
+    // The two events a real run would leave behind, written straight into the
+    // audit the receipt reads — no agent needs to run to test the arithmetic.
+    run(["step", "--plan", p, "--index", "0"]);
+    run(["step", "--plan", p, "--index", "1"]);
+    verdict(p, 0, { confirmed: [
+      { id: "has_three_items", evidence: "01-worker.md:3-5 — three full lines" },
+      { id: "names_a_source", evidence: "01-worker.md:3 — citations inline" },
+    ] });
+
+    const r = run(["receipt", "--plan", p]);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.out);
+    expect(out.complete).toBe(true);
+    expect(out.seats.find((x: any) => x.seat === "worker").review).toBe("approved");
+    // The head of the house signs; nobody reviews it, and that is not a gap.
+    expect(out.seats.find((x: any) => x.seat === "boss").review).toBe("signs (no superior)");
+    expect(audit().some(e => e.event === "x_business_signed_off")).toBe(true);
+  }, spawnBudgetMs(4));
+
+  test("a seat that ran but was rejected keeps the business unsigned", () => {
+    const p = plan();
+    run(["step", "--plan", p, "--index", "0"]);
+    run(["step", "--plan", p, "--index", "1"]);
+    verdict(p, 0, { confirmed: [] });
+
+    const r = run(["receipt", "--plan", p]);
+    expect(r.code).toBe(3);
+    expect(JSON.parse(r.out).review_unresolved).toEqual(["worker"]);
+    expect(audit().some(e => e.event === "x_business_incomplete")).toBe(true);
+  }, spawnBudgetMs(4));
+});

--- a/skills/harness/tests/chain-review.test.ts
+++ b/skills/harness/tests/chain-review.test.ts
@@ -1,0 +1,216 @@
+// chain-review.test.ts — the immediate superior as reviewer, and the one
+// property the whole design rests on: silence rejects.
+//
+// A reviewer asked "is your subordinate's work good?" says yes — same model,
+// same run, no incentive to object. So approval is not asked for. The reviewer
+// reports what it CONFIRMED, with evidence, and the engine does the arithmetic:
+// anything unmentioned is unconfirmed, and unconfirmed does not score. The lazy
+// path therefore rejects instead of approving, which is the inversion that makes
+// a checklist worth having.
+//
+// Zero-token: the verdict is a file, so no reviewer needs to run to test how a
+// verdict is judged. Runs with: bun test skills/harness/tests
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+
+const CLI = path.resolve(import.meta.dir, "..", "scripts", "chain.ts");
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-review-"));
+  fs.mkdirSync(path.join(tmp, ".nirvana"), { recursive: true });
+});
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function manifest(slug: string): string {
+  return [
+    `name: ${slug}`, "author: nirvana-os", "version: 1.0.0", "protocol: '2.0'",
+    `description: A fixture business used by the ${slug} review tests.`,
+    "domains:", "  - testing",
+    "runtime_requirements:", "  minimum:", "    - runtime: claude-code", "",
+  ].join("\n");
+}
+
+/** Two seats: a worker with two declared criteria, and the boss above it. */
+function business(): string {
+  const dir = path.join(tmp, "businesses", "acme");
+  fs.mkdirSync(path.join(dir, "employees"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "business.yaml"), manifest("acme"), "utf8");
+  fs.writeFileSync(path.join(dir, "org-chart.yaml"),
+    "chart:\n- employee: boss\n  reports: []\n  direct_reports:\n  - worker\n- employee: worker\n  reports:\n  - boss\n  direct_reports: []\n", "utf8");
+  fs.writeFileSync(path.join(dir, "employees", "worker.md"),
+    "---\nname: worker\nrole: worker specialist\ndescription: The worker seat of this fixture business.\n"
+    + "acceptance:\n"
+    + "  - id: has_three_items\n    description: \"The file lists exactly three items, each one a full line\"\n    blocking: true\n    minimum_score: 0.9\n"
+    + "  - id: names_a_source\n    description: \"Each item names where it came from\"\n    blocking: false\n    minimum_score: 0.9\n"
+    + "---\n\n# worker\n\nMethod of worker.\n", "utf8");
+  fs.writeFileSync(path.join(dir, "employees", "boss.md"),
+    "---\nname: boss\nrole: boss specialist\ndescription: The boss seat of this fixture business.\nis_brief_intake: true\n"
+    + "acceptance:\n  - id: signs_the_delivery\n    description: \"The delivery is assembled and signed by the head of the house\"\n    blocking: true\n    minimum_score: 0.9\n"
+    + "---\n\n# boss\n\nMethod of boss.\n", "utf8");
+  return dir;
+}
+
+/** A plan written by hand — `plan` needs a director; judging a verdict does not. */
+function plan(): string {
+  business();
+  const p = path.join(tmp, "plan.json");
+  fs.writeFileSync(p, JSON.stringify({
+    business: "acme", project_id: "proj-review-1", project_dir: tmp, project_root: tmp,
+    outputs_root: path.join(tmp, "out"), brief_file: brief(),
+    businesses_root: path.join(tmp, "businesses"), intake: "boss", reason: "fixture",
+    chain: [
+      { employee: "worker", task: "List three items.", reviewer: "boss" },
+      { employee: "boss", task: "Assemble and sign." },
+    ],
+  }, null, 2));
+  return p;
+}
+
+function brief(): string {
+  const f = path.join(tmp, "brief.md");
+  fs.writeFileSync(f, "Liste três itens sobre o assunto.", "utf8");
+  return f;
+}
+
+function run(args: string[]): { code: number; out: string; err: string } {
+  const r = spawnSync("bun", [CLI, ...args], {
+    encoding: "utf8", cwd: tmp,
+    env: { ...process.env, HARNESS_LOGS_DIR: path.join(tmp, ".nirvana", "logs", "harness") },
+  });
+  return { code: r.status ?? 1, out: r.stdout ?? "", err: r.stderr ?? "" };
+}
+
+function verdict(p: string, idx: number, body: unknown): { code: number; out: string; err: string } {
+  const f = path.join(tmp, `v-${idx}-${Math.random().toString(36).slice(2)}.json`);
+  fs.writeFileSync(f, typeof body === "string" ? body : JSON.stringify(body));
+  return run(["verdict", "--plan", p, "--index", String(idx), "--verdict", f]);
+}
+
+function audit(): any[] {
+  const day = new Date().toISOString().slice(0, 10);
+  const f = path.join(tmp, ".nirvana", "logs", "harness", day, "audit.jsonl");
+  if (!fs.existsSync(f)) return [];
+  return fs.readFileSync(f, "utf8").split("\n").filter(Boolean).map(l => JSON.parse(l));
+}
+
+describe("nrv team review", () => {
+  test("the reviewer gets its own persona, the brief, and the subordinate's criteria", () => {
+    const p = plan();
+    const r = run(["review", "--plan", p, "--index", "0"]);
+    expect(r.code).toBe(0);
+    // Its own seat, not a generic judge — that is the whole reason to ask a boss.
+    expect(r.out).toContain("Method of boss");
+    // What the client asked, so the review can compare delivery against request.
+    expect(r.out).toContain("Liste três itens sobre o assunto.");
+    // And the criteria the SUBORDINATE declared, verbatim, blocking marked.
+    expect(r.out).toContain("`has_three_items`");
+    expect(r.out).toContain("(blocking)");
+    expect(r.out).toContain("`names_a_source`");
+    expect(r.err).toContain("boss reviewing worker");
+  }, spawnBudgetMs(3));
+
+  test("the root of the chart has nobody above it, and the refusal says so", () => {
+    const p = plan();
+    const r = run(["review", "--plan", p, "--index", "1"]);
+    expect(r.code).toBe(4);
+    expect(r.err).toMatch(/root of the org chart|signs for the delivery/);
+  }, spawnBudgetMs(2));
+});
+
+describe("nrv team verdict — silence rejects", () => {
+  test("a reviewer that confirms nothing FAILS, rather than waving it through", () => {
+    const p = plan();
+    const r = verdict(p, 0, { confirmed: [], notes: "looks fine to me" });
+    expect(r.code).toBe(3);
+    const out = JSON.parse(r.out);
+    expect(out.verdict).toBe("rejected");
+    expect(out.score).toBe(0);
+    // The gap says the reviewer never mentioned it — not that the work is bad.
+    expect(out.gaps.find((g: any) => g.id === "has_three_items").why).toMatch(/not mentioned/);
+  }, spawnBudgetMs(2));
+
+  test("real evidence on every criterion approves", () => {
+    const p = plan();
+    const r = verdict(p, 0, { confirmed: [
+      { id: "has_three_items", evidence: "01-worker.md:3-5 — three full lines" },
+      { id: "names_a_source", evidence: "01-worker.md:3 — each line ends with a citation" },
+    ] });
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.out).verdict).toBe("approved");
+    expect(JSON.parse(r.out).score).toBe(1);
+  }, spawnBudgetMs(2));
+
+  test("a blocking criterion left unconfirmed sinks the review whatever the score", () => {
+    const p = plan();
+    // Half the criteria confirmed: 0.5, under the floor anyway — so confirm the
+    // NON-blocking one and leave the blocking one out, which is the case the
+    // floor alone would not catch if there were ten criteria.
+    const r = verdict(p, 0, { confirmed: [{ id: "names_a_source", evidence: "01-worker.md:3 — sources cited inline" }] });
+    expect(r.code).toBe(3);
+    expect(JSON.parse(r.out).blocking_missed).toEqual(["has_three_items"]);
+  }, spawnBudgetMs(2));
+
+  test("evidence that is a shrug does not count as evidence", () => {
+    const p = plan();
+    const r = verdict(p, 0, { confirmed: [
+      { id: "has_three_items", evidence: "ok" },
+      { id: "names_a_source", evidence: "" },
+    ] });
+    expect(r.code).toBe(3);
+    expect(JSON.parse(r.out).confirmed).toEqual([]);
+  }, spawnBudgetMs(2));
+
+  test("a criterion the seat never declared is dropped and named", () => {
+    const p = plan();
+    const r = verdict(p, 0, { confirmed: [{ id: "invented_rule", evidence: "I checked it thoroughly and it holds" }] });
+    expect(r.code).toBe(3);
+    expect(JSON.parse(r.out).invented_ids).toEqual(["invented_rule"]);
+    expect(r.err).toMatch(/not in worker's acceptance were dropped/);
+  }, spawnBudgetMs(2));
+
+  test("a fenced or chatty answer still parses — punctuation is not the contract", () => {
+    const p = plan();
+    const r = verdict(p, 0, "Here is my review:\n```json\n"
+      + JSON.stringify({ confirmed: [
+        { id: "has_three_items", evidence: "01-worker.md:3-5 — three full lines" },
+        { id: "names_a_source", evidence: "01-worker.md:3 — citations inline" },
+      ] }) + "\n```\nHope that helps.");
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.out).verdict).toBe("approved");
+  }, spawnBudgetMs(2));
+});
+
+describe("the audit can answer who reviewed what, and why it failed", () => {
+  test("every verdict carries the trace, the pair, the score and the gaps", () => {
+    const p = plan();
+    verdict(p, 0, { confirmed: [] });
+    const e = audit().find(x => x.event === "x_review_rejected");
+    // Finding 16 of the observability notes: gate verdicts carry no trace, so
+    // "did this run pass" cannot be answered by a join. These do.
+    expect(e?.trace_id).toBe("proj-review-1");
+    expect(e?.project_id).toBe("proj-review-1");
+    expect(e?.business_slug).toBe("acme");
+    expect(e?.employee).toBe("worker");
+    expect(e?.reviewer).toBe("boss");
+    expect(e?.score).toBe(0);
+    expect(e?.floor).toBe(0.9);
+    expect(e?.blocking_missed).toEqual(["has_three_items"]);
+  }, spawnBudgetMs(2));
+
+  test("an approval is logged as its own event, not as the absence of a rejection", () => {
+    const p = plan();
+    verdict(p, 0, { confirmed: [
+      { id: "has_three_items", evidence: "01-worker.md:3-5 — three full lines" },
+      { id: "names_a_source", evidence: "01-worker.md:3 — citations inline" },
+    ] });
+    const e = audit().find(x => x.event === "x_review_approved");
+    expect(e?.employee).toBe("worker");
+    expect(e?.score).toBe(1);
+    expect(e?.confirmed).toEqual(["has_three_items", "names_a_source"]);
+  }, spawnBudgetMs(2));
+});

--- a/skills/harness/tests/preflight-index.test.ts
+++ b/skills/harness/tests/preflight-index.test.ts
@@ -15,6 +15,9 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { TEARDOWN_BUDGET_MS } from "./helpers/test-budgets.ts";
 
+/** Seeding three registries with the real indexers, on the slowest runner. */
+const SEED_BUDGET_MS = 300_000;
+
 const REPO_SKILLS = path.join(import.meta.dir, "..", "..");
 const INDEX_TS = path.join(import.meta.dir, "..", "scripts", "index.ts");
 const PREFLIGHT_TS = path.join(import.meta.dir, "..", "lib", "preflight-index.ts");
@@ -89,9 +92,19 @@ beforeAll(() => {
   ].join("\n"));
 
   // Seed all three registries once with the real indexers.
+  // Three real indexers over a seeded library. 120 s was enough until a slow
+  // windows-latest runner took longer and the failure read as "index failed"
+  // with an empty stderr — `spawnSync` returns status null when it kills the
+  // child, and nothing here said so. Both halves are fixed: a budget sized like
+  // every other one in this suite, and an error that distinguishes a timeout
+  // from an exit code, because the two need opposite responses.
   const seed = spawnSync(process.execPath, [INDEX_TS, "--quiet"], {
-    encoding: "utf8", env: fixtureEnv(), cwd: work, timeout: 120_000,
+    encoding: "utf8", env: fixtureEnv(), cwd: work, timeout: SEED_BUDGET_MS,
   });
+  if (seed.status === null) {
+    throw new Error(`fixture seed index TIMED OUT after ${SEED_BUDGET_MS} ms `
+      + `(the runner was slower than the budget, not a broken index): ${seed.stderr || "(no stderr)"}`);
+  }
   if (seed.status !== 0) {
     throw new Error(`fixture seed index failed (exit ${seed.status}): ${seed.stderr}`);
   }


### PR DESCRIPTION
Step 2 of `docs/architecture/hierarchical-review.md`, which shipped in #210.

## What it does

A business declares who reports to whom, and nothing read it. Now the seat above reviews the seat below, against the criteria the subordinate declared for itself.

```
nrv team review  --plan <p> --index <n>              → the superior's prompt
nrv team verdict --plan <p> --index <n> --verdict f  → exit 0 approved · 3 rejected
```

`plan` now carries `reviewer` per step, read from `org-chart.yaml` — never invented. A step whose seat is the root has no reviewer: the head signs for the delivery rather than being signed off.

The review prompt is built by the same `employee-prompt.ts` every seat gets, so the reviewer arrives **as itself** — its own persona and its own mind-clone, ranked against the review task. That is the point of asking a boss instead of a rubric.

## The design problem, and the inversion that solves it

A reviewer asked *"is your subordinate's work good?"* says yes. Same model, same run, no incentive to object.

So approval is never asked for. The reviewer lists only what it **confirmed**, each with evidence, and four rules do the rest:

| rule | effect |
|---|---|
| anything unmentioned counts as unconfirmed | `{"confirmed":[]}` scores 0 and fails — **the lazy path rejects** |
| evidence under 12 chars is a shrug | `"evidence":"ok"` leaves the criterion unconfirmed |
| an id the seat never declared is dropped | and named in the log; a review of invented criteria is not a review |
| the engine computes the score | a reviewer that grades itself grades generously |

Floor **0.90**, not 1.0 — one unconfirmable micro-check should not sink a good delivery. `blocking: true` is the author's absolute: unconfirmed sinks it whatever the score says. (`readAcceptance` already defaulted to a 0.92 floor; this is the same idea, one notch more forgiving.)

Verified on all four paths, by exit code: lazy → 3 · real evidence → 0 · shrug evidence → 3 · invented id → 3.

## Audit that can actually be joined

`x_review_approved` / `x_review_rejected` carry the trace, the reviewer/reviewed pair, the score, the floor, the confirmed ids and every gap with its reason.

This is deliberate, not decoration: today's `gate_passed` events carry **no `trace_id` at all** — measured, 10 of 12 on a live run — so "did this run pass?" cannot be answered by a join. I was not going to add another floor on top of an audit that cannot attribute.

## What is untouched

The engine's gate, and on purpose. The superior answers *is this good work, and does it match what was asked*. The pipeline answers *is there a deliverable, is it a stub, does it match the manifest* — deterministically, fail-closed, for free. A model asked "is this a stub?" fails **open**; `isDeliverable` fails **closed**. More eyes, not fewer.

## Measured before building

```
businesses with a usable review route ....... 65 / 65
seats declaring acceptance[] ................ 611 / 611
```

**No business needed changing.** The route and the contract already existed everywhere; only the engine was missing.

## Verification

- `bun run test:fast` — 2103 pass, 0 fail.
- `bun test skills/harness/tests skills/businesses/tests` — 1810 pass; the 4 remaining failures are pre-existing, order-dependent, live-library reads.
- `bun run check:quick` — exit 0. CLI parity — 62 commands in sync.
- 10 new tests, all zero-token: the verdict is a file, so judging a verdict needs no reviewer to run.

## Not done, and stated rather than hidden

Step 3 — countersignature rising to the head and its short receipt to the orchestrator — is next and smaller than this.

The falsification test written into the design doc **has not run yet**: give a real superior a deliberately weak artifact and see whether it rejects *citing a criterion*. What is proven here is that the parser cannot be fooled by a lazy or dishonest verdict. What is not yet proven is that a real reviewer writes an honest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk