### PR TITLE
fix: everything the two live org-chart runs exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The validators learned the chain layout
+
+A run dispatched through `nrv team` writes a FLAT outputs root — `outputs/` with `outputs/_team/<seat>/` beside the finals — while the scripted path nests everything under `outputs/<project_id>/`. Both are legitimate; the validators knew one. So `validate-chain --verify-disk` read no per-target audits for a chain run and `verify-deliverable` answered "project not found" for work sitting on disk in front of it.
+
+The run's own maestro reported this before anyone here noticed, with the right diagnosis — a path-convention defect, not missing work — in an `x_validator_layout_mismatch` event it emitted after delivering.
+
+Both validators read both layouts now, and `validate-chain` also reads the project's own `audit.jsonl`, which `handoff.js` writes and nothing read: six handoff events could sit in a project while the validator reported zero and called the chain a violation. On a real chain run it now sees the whole thing — three per-seat dispatches, two approved reviews, the delivery — and the one gap it reports (`verify_passed` absent) is true.
+
+Rather than teach every future checker a second convention, `nrv team plan` now writes `brief.md` at the outputs root, which is the file the existing convention asks for. One line, and a chain run becomes legible to tools that do not know it is one.
+
 ### The cockpit reads every audit a run wrote, and says who wrote each line
 
 Glance read one audit file. A run writes to up to four — the orchestrator's daily log, the project's own log, one per dispatched target under its outputs tree, and the global fallback — so the cockpit showed runs with no dispatches while their files sat on disk. Measured on this machine after the change: nine runs whose dispatches were invisible, and seats (`ds-creative-director`, `t360-ceo`, `al-publisher`) that had never appeared at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The canonical emitter was the one that did not stamp
+
+`nrv audit emit` — the path the protocol tells agents to use — writes through `harness/lib/audit.js`, and that was the one emitter left unstamped. So the internal emitters were signed and the one agents actually call was not, which meant a legitimate agent-emitted event was indistinguishable from a line somebody typed: the exact confusion the stamp exists to end, preserved at the only place it mattered. It stamps the envelope now.
+
+The implementation moved to a CJS sibling (`audit-provenance.js`, with the `.ts` as its typed face) because `audit.js` is CommonJS and a `.js` requiring a `.ts` is the ESM boundary Windows enforces as a hard error. The repo's own gate caught that within a minute of the mistake.
+
+### A persona loaded by hand now leaves a trace
+
+Seats are handed a ranked list of mind-clones and told to choose; nothing is auto-injected. A seat that loads one by hand was doing the right thing invisibly — three seats embodied someone in a live run with zero `mind_clone_injected` in the audit. `nrv inspect-clone` now emits `x_clone_loaded` when it runs inside a trace, and stays silent otherwise: a person looking is not a run loading.
+
+The instruction that sends a seat there was also wrong. It said `nrv inspect-clone <slug> --dna`, and that flag prints layer COUNTS, not the DNA. It now points at the default output, which prints `Path:` and the artifacts, and names the three files to read.
+
 ### Five things the first real org-chart run exposed
 
 The run worked — three seats dispatched by name, two reviews approved against declared criteria, a computed receipt that closed. Watching it closely turned up five defects, four of them introduced the same day.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The cockpit reads every audit a run wrote, and says who wrote each line
+
+Glance read one audit file. A run writes to up to four — the orchestrator's daily log, the project's own log, one per dispatched target under its outputs tree, and the global fallback — so the cockpit showed runs with no dispatches while their files sat on disk. Measured on this machine after the change: nine runs whose dispatches were invisible, and seats (`ds-creative-director`, `t360-ceo`, `al-publisher`) that had never appeared at all.
+
+Every event Glance serves now carries `_provenance`: `engine` when the engine signed it, `unsigned` when nothing did, `tampered` when the signature no longer matches its content. The cockpit is where somebody decides whether a run happened, and until now a line an agent typed rendered identically to one the engine emitted.
+
+`unsigned` on an old event means "written before stamping existed", not "forged". The distinction only runs forward.
+
+Two guards, both added because the tests caught their absence: a pinned `HARNESS_LOGS_DIR` means read that root and not the world (a fixture had started wandering through the machine's real projects), and an absent root stays **undetermined** rather than becoming a measured zero — a distinction this cockpit already had a test for.
+
+### The handoff stream wrote to a hardcoded path
+
+`handoff.js` appended to `~/.harness-logs/` directly instead of resolving the log root, which is the exact split brain `log-paths.js` warns about in its own header: writes go per-project, reads still hit `$HOME`, the chain breaks. It did — a live run left six handoff events in the project's audit and zero in the daily log `validate-chain` reads, and the run's own validator reported the gap before anyone here noticed it. It resolves the root now, and its events are stamped like every other engine write.
+
 ### The canonical emitter was the one that did not stamp
 
 `nrv audit emit` — the path the protocol tells agents to use — writes through `harness/lib/audit.js`, and that was the one emitter left unstamped. So the internal emitters were signed and the one agents actually call was not, which meant a legitimate agent-emitted event was indistinguishable from a line somebody typed: the exact confusion the stamp exists to end, preserved at the only place it mattered. It stamps the envelope now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### Five things the first real org-chart run exposed
+
+The run worked — three seats dispatched by name, two reviews approved against declared criteria, a computed receipt that closed. Watching it closely turned up five defects, four of them introduced the same day.
+
+**The provenance stamp covered 2 emitters out of 23.** Shipping it that way produced a signal worse than none: within minutes, three legitimate engine events read as unsigned, and a reader following the label would have concluded the orchestrator was fabricating them. Every emitter now stamps, and `_shared/lib/audit-emit.ts` exists so the next one does not have to remember — the eighteen private copies of that four-line function are why this was 2 of 23 rather than a one-line change.
+
+**`dispatch_business` counted prompts, not dispatches.** It fired when the seat's prompt was built, so a caller that asked for the same prompt twice logged two dispatches for one seat's work. A repeat now emits `x_seat_prompt_reissued`: the repetition is information, not a second dispatch.
+
+**Consulting a receipt changed the log it read.** `nrv team receipt` emitted its sign-off event every time, so looking at a run altered it. Signing is now `--sign`; without it the receipt only reports.
+
+**A gate verdict with no trace says so.** The delivery pipeline exports `NIRVANA_TRACE_ID` and friends, but an agent invoking the gate by hand does not — and ten of twelve verdicts in a live run carried `trace_id: null`, unjoinable to the run they judged. The gate now warns on stderr naming the variables, so the gap is visible instead of silent.
+
+**A chosen mind-clone was never loaded.** Seats are handed a ranked list and told to choose; nothing is auto-injected unless the brief names one. Three seats each picked a clone, logged a considered reason, and then worked from what the model already knew about that person — a name in a log, not a voice in the work. Rule 9 of the protocol calls that claiming fidelity you did not load. The step brief now says it plainly: load it with `nrv inspect-clone <slug> --dna`, or decide none fits and work as yourself, which is honest and allowed.
+
 ### An event the engine wrote is now distinguishable from one an agent typed
 
 The audit is the engine's evidence and it is a text file any agent with Write can append to. On 2026-09-04 one did: a maestro wrote `dispatch_business`, `gate_passed` and an event name the engine has never emitted (`business_completed`) into a run's audit, with timestamps rounded to the minute. The real pipeline ran too, minutes later — so the file held a self-issued verdict and a real one, and **nothing in their shape told them apart**.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,20 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O cockpit lê toda auditoria que a execução escreveu, e diz quem escreveu cada linha
+
+O Glance lia um arquivo de auditoria. Uma execução escreve em até quatro — o log diário do orquestrador, o log do próprio projeto, um por alvo despachado dentro da árvore de saída, e o fallback global — então o cockpit mostrava execuções sem despacho nenhum enquanto os arquivos estavam em disco. Medido nesta máquina depois da mudança: nove execuções cujos despachos eram invisíveis, e cadeiras (`ds-creative-director`, `t360-ceo`, `al-publisher`) que nunca tinham aparecido.
+
+Todo evento que o Glance serve passa a carregar `_provenance`: `engine` quando o engine assinou, `unsigned` quando ninguém assinou, `tampered` quando a assinatura não bate mais com o conteúdo. O cockpit é onde alguém decide se uma execução aconteceu, e até agora uma linha digitada por um agente aparecia igual a uma emitida pelo engine.
+
+`unsigned` num evento antigo significa "escrito antes de o carimbo existir", não "forjado". A distinção só vale para frente.
+
+Duas guardas, ambas acrescentadas porque os testes pegaram a falta delas: um `HARNESS_LOGS_DIR` fixado significa ler aquela raiz e não o mundo (um fixture tinha começado a vagar pelos projetos reais da máquina), e raiz ausente continua **indeterminada** em vez de virar zero medido — distinção que este cockpit já tinha teste.
+
+### O fluxo de handoff escrevia num caminho hardcoded
+
+O `handoff.js` acrescentava direto em `~/.harness-logs/` em vez de resolver a raiz do log, que é exatamente o split brain que o `log-paths.js` avisa no próprio cabeçalho: escritas vão por projeto, leituras continuam no `$HOME`, a cadeia quebra. E quebrou — uma execução real deixou seis eventos de handoff na auditoria do projeto e zero no log diário que o `validate-chain` lê, e o validador da própria execução reportou a lacuna antes de qualquer um aqui notar. Agora ele resolve a raiz, e seus eventos são carimbados como toda escrita do engine.
+
 ### O emissor canônico era justamente o que não carimbava
 
 O `nrv audit emit` — o caminho que o protocolo manda os agentes usarem — escreve pelo `harness/lib/audit.js`, e era o único emissor que faltava carimbar. Ou seja: os emissores internos assinados e o que os agentes de fato chamam, não. Um evento legítimo emitido por agente ficava indistinguível de uma linha digitada — exatamente a confusão que o carimbo existe para acabar, preservada no único lugar que importava. Agora ele carimba o envelope.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,18 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O emissor canônico era justamente o que não carimbava
+
+O `nrv audit emit` — o caminho que o protocolo manda os agentes usarem — escreve pelo `harness/lib/audit.js`, e era o único emissor que faltava carimbar. Ou seja: os emissores internos assinados e o que os agentes de fato chamam, não. Um evento legítimo emitido por agente ficava indistinguível de uma linha digitada — exatamente a confusão que o carimbo existe para acabar, preservada no único lugar que importava. Agora ele carimba o envelope.
+
+A implementação foi para um irmão CJS (`audit-provenance.js`, com o `.ts` como face tipada) porque o `audit.js` é CommonJS e um `.js` fazendo require de `.ts` é a fronteira ESM que o Windows trata como erro duro. O gate do próprio repo pegou isso um minuto depois do erro.
+
+### Persona carregada na mão agora deixa rastro
+
+As cadeiras recebem uma lista rankeada de mind-clones e escolhem; nada é injetado automaticamente. Uma cadeira que carrega na mão estava fazendo a coisa certa de forma invisível — três cadeiras encarnaram alguém numa execução real com zero `mind_clone_injected` no log. O `nrv inspect-clone` passa a emitir `x_clone_loaded` quando roda dentro de um trace, e fica calado fora dele: pessoa olhando não é execução carregando.
+
+A instrução que manda a cadeira até lá também estava errada. Dizia `nrv inspect-clone <slug> --dna`, e essa flag imprime CONTAGEM de camadas, não o DNA. Agora aponta a saída padrão, que imprime `Path:` e os artefatos, e nomeia os três arquivos a ler.
+
 ### Cinco coisas que a primeira execução real do organograma expôs
 
 A execução funcionou — três cadeiras despachadas com nome, duas revisões aprovadas contra critério declarado, um recibo calculado que fechou. Observá-la de perto revelou cinco defeitos, quatro deles introduzidos no mesmo dia.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,16 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Os validadores aprenderam o layout de cadeia
+
+Uma execução despachada pelo `nrv team` escreve numa raiz de saída PLANA — `outputs/` com `outputs/_team/<cadeira>/` ao lado dos finais — enquanto o caminho scriptado aninha tudo sob `outputs/<project_id>/`. Os dois são legítimos; os validadores conheciam um. Então o `validate-chain --verify-disk` não lia auditoria por-alvo nenhuma numa execução de cadeia, e o `verify-deliverable` respondia "project not found" para trabalho que estava em disco na frente dele.
+
+O maestro da própria execução reportou isso antes de qualquer um aqui notar, com o diagnóstico certo — defeito de convenção de caminho, não trabalho faltando — num evento `x_validator_layout_mismatch` que ele emitiu depois de entregar.
+
+Os dois validadores leem os dois layouts agora, e o `validate-chain` também lê o `audit.jsonl` do próprio projeto, que o `handoff.js` escreve e nada lia: seis eventos de handoff podiam estar num projeto enquanto o validador reportava zero e chamava a cadeia de violação. Numa execução de cadeia real ele agora enxerga tudo — três despachos por cadeira, duas revisões aprovadas, a entrega — e a única lacuna que reporta (`verify_passed` ausente) é verdadeira.
+
+Em vez de ensinar uma segunda convenção a todo verificador futuro, o `nrv team plan` passa a escrever `brief.md` na raiz de saída, que é o arquivo que a convenção existente pede. Uma linha, e uma execução de cadeia fica legível para ferramentas que não sabem que ela é uma.
+
 ### O cockpit lê toda auditoria que a execução escreveu, e diz quem escreveu cada linha
 
 O Glance lia um arquivo de auditoria. Uma execução escreve em até quatro — o log diário do orquestrador, o log do próprio projeto, um por alvo despachado dentro da árvore de saída, e o fallback global — então o cockpit mostrava execuções sem despacho nenhum enquanto os arquivos estavam em disco. Medido nesta máquina depois da mudança: nove execuções cujos despachos eram invisíveis, e cadeiras (`ds-creative-director`, `t360-ceo`, `al-publisher`) que nunca tinham aparecido.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,20 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Cinco coisas que a primeira execução real do organograma expôs
+
+A execução funcionou — três cadeiras despachadas com nome, duas revisões aprovadas contra critério declarado, um recibo calculado que fechou. Observá-la de perto revelou cinco defeitos, quatro deles introduzidos no mesmo dia.
+
+**O carimbo de procedência cobria 2 emissores de 23.** Publicar assim produziu um sinal pior que nenhum: em minutos, três eventos legítimos do engine apareceram como não assinados, e quem seguisse o rótulo concluiria que o orquestrador estava fabricando eventos. Agora todo emissor carimba, e o `_shared/lib/audit-emit.ts` existe para o próximo não precisar lembrar — as dezoito cópias privadas daquela função de quatro linhas são a razão de isto ter sido 2 de 23 em vez de uma linha.
+
+**O `dispatch_business` contava prompt, não despacho.** Ele disparava quando o prompt da cadeira era montado, então quem pedisse o mesmo prompt duas vezes registrava dois despachos para o trabalho de uma cadeira. A repetição agora emite `x_seat_prompt_reissued`: repetir é informação, não um segundo despacho.
+
+**Consultar um recibo alterava o log que ele lia.** O `nrv team receipt` emitia o evento de assinatura toda vez, então olhar uma execução a modificava. Assinar virou `--sign`; sem isso, o recibo só relata.
+
+**Veredito de gate sem trace passa a dizer isso.** O pipeline de entrega exporta `NIRVANA_TRACE_ID` e companhia, mas um agente chamando o gate na mão não exporta — e dez de doze vereditos de uma execução real vieram com `trace_id: null`, impossíveis de juntar à execução que julgaram. O gate agora avisa no stderr nomeando as variáveis, para a lacuna ficar visível em vez de silenciosa.
+
+**Um mind-clone escolhido nunca era carregado.** As cadeiras recebem uma lista rankeada e escolhem; nada é injetado a menos que o brief nomeie. Três cadeiras escolheram, registraram um motivo pensado, e trabalharam com o que o modelo já sabia sobre aquela pessoa — um nome no log, não uma voz no trabalho. A Regra 9 do protocolo chama isso de alegar fidelidade que não se carregou. O brief do passo agora diz com todas as letras: carregue com `nrv inspect-clone <slug> --dna`, ou decida que nenhum serve e trabalhe como você mesmo, o que é honesto e permitido.
+
 ### Evento que o engine escreveu agora se distingue de evento que um agente digitou
 
 A auditoria é a evidência do engine e é um arquivo de texto em que qualquer agente com Write acrescenta linha. Em 04/09/2026 um acrescentou: um maestro escreveu `dispatch_business`, `gate_passed` e um nome de evento que o engine nunca emitiu (`business_completed`) dentro da auditoria de uma execução, com horários cravados no minuto. O pipeline real também rodou, minutos depois — então o arquivo ficou com um veredito auto-emitido e um real, e **nada no formato deles os distinguia**.

--- a/skills/_shared/lib/audit-emit.ts
+++ b/skills/_shared/lib/audit-emit.ts
@@ -1,0 +1,44 @@
+// audit-emit.ts — the one function that appends to an audit log.
+//
+// There were eighteen private copies of this, each four lines long and each
+// slightly its own. They were harmless while an audit line was just a line. They
+// stopped being harmless the moment events started carrying a provenance stamp:
+// stamping two of the eighteen produced a signal that was WORSE than no signal,
+// because three legitimate engine events read as unsigned within minutes of
+// shipping and a reader following the label would have concluded the maestro was
+// fabricating them. I did conclude that, twice, about my own engine.
+//
+// So the copies are the defect, not the missing stamps. One owner, every caller
+// through it, and a gate that fails when a new copy appears.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { harnessLogsDir } from "./log-paths.ts";
+import { stamp } from "./audit-provenance.ts";
+
+export interface EmitOptions {
+  /** Where the project root is, for resolving which log to write. */
+  cwd?: string;
+  /** Write here instead of the resolved log — the per-target logs under an
+   *  outputs tree, which belong to one dispatch rather than to the project. */
+  file?: string;
+}
+
+/**
+ * Append one event, stamped, to the audit.
+ *
+ * Never throws: an engine that cannot write its log must still finish its work.
+ * A caller that needs to know whether the write landed gets the boolean.
+ */
+export function emitAudit(payload: Record<string, any>, opts: EmitOptions = {}): boolean {
+  try {
+    const target = opts.file ?? path.join(
+      harnessLogsDir({ cwd: opts.cwd }),
+      new Date().toISOString().slice(0, 10),
+      "audit.jsonl",
+    );
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.appendFileSync(target, JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
+    return true;
+  } catch { return false; }
+}

--- a/skills/_shared/lib/audit-provenance.js
+++ b/skills/_shared/lib/audit-provenance.js
@@ -1,0 +1,84 @@
+// audit-provenance.js — the implementation, in CJS so a `.js` caller can
+// require() it directly.
+//
+// `harness/lib/audit.js` is the canonical emitter and it is CommonJS. A `.js`
+// requiring a `.ts` is the ESM boundary Windows enforces as a hard error, and
+// this repo already carries the fix as a pattern: the logic lives in the CJS
+// sibling, the `.ts` is the typed face. Same shape as log-paths.ts/.js.
+//
+// Why any of this exists: an audit line an agent typed used to be
+// indistinguishable from one the engine emitted. See the .ts for the full
+// account, including what this does not buy.
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const STAMP_FIELD = "sig";
+
+function auditKeyPath() {
+  if (process.env.NIRVANA_AUDIT_KEY) return process.env.NIRVANA_AUDIT_KEY;
+  const home = process.env.NIRVANA_HOME || os.homedir();
+  return path.join(home, ".nirvana", "audit-key");
+}
+
+let cached = null;
+let cachedFrom = "";
+
+function auditKey() {
+  const p = auditKeyPath();
+  if (cached && cachedFrom === p) return cached;
+  try {
+    if (fs.existsSync(p)) {
+      const raw = fs.readFileSync(p, "utf8").trim();
+      if (raw.length >= 32) { cached = Buffer.from(raw, "hex"); cachedFrom = p; return cached; }
+    }
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const key = crypto.randomBytes(32);
+    fs.writeFileSync(p, key.toString("hex"), { mode: 0o600 });
+    cached = key; cachedFrom = p;
+    return cached;
+  } catch { return null; }
+}
+
+function resetAuditKeyCache() { cached = null; cachedFrom = ""; }
+
+/** Keys sorted: two emitters building the same event in a different order must
+ *  not produce different MACs for identical content. */
+function canonical(event) {
+  const rest = { ...event };
+  delete rest[STAMP_FIELD];
+  return JSON.stringify(rest, Object.keys(rest).sort());
+}
+
+function stamp(event) {
+  const key = auditKey();
+  if (!key) return event;
+  const sig = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
+  return { ...event, [STAMP_FIELD]: sig };
+}
+
+function provenanceOf(event) {
+  const sig = event && event[STAMP_FIELD];
+  if (typeof sig !== "string" || !sig) return "unsigned";
+  const key = auditKey();
+  if (!key) return "unsigned";
+  const expect = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
+  const a = Buffer.from(sig), b = Buffer.from(expect);
+  return a.length === b.length && crypto.timingSafeEqual(a, b) ? "engine" : "tampered";
+}
+
+function auditProvenanceSummary(file) {
+  const out = { engine: 0, unsigned: 0, tampered: 0, total: 0 };
+  let lines;
+  try { lines = fs.readFileSync(file, "utf8").split("\n").filter(Boolean); } catch { return out; }
+  for (const l of lines) {
+    let e;
+    try { e = JSON.parse(l); } catch { continue; }
+    out.total++;
+    out[provenanceOf(e)]++;
+  }
+  return out;
+}
+
+module.exports = { STAMP_FIELD, auditKeyPath, auditKey, resetAuditKeyCache, stamp, provenanceOf, auditProvenanceSummary };

--- a/skills/_shared/lib/audit-provenance.ts
+++ b/skills/_shared/lib/audit-provenance.ts
@@ -34,107 +34,17 @@
 // on one machine. Losing it invalidates old stamps, which reads as "unverified",
 // which is the honest answer after a key rotation.
 
-import * as crypto from "node:crypto";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { paths } from "./bun-helpers.ts";
-
-/** The field the stamp lives in. Short, so it does not dominate a log line. */
-export const STAMP_FIELD = "sig";
-
-/** Where the per-install key lives. Never inside a project, never in a pack.
- *
- *  `NIRVANA_AUDIT_KEY` overrides it, and is read on every call rather than once:
- *  `paths` memoizes, so a test that redirected `NIRVANA_HOME` would only win if
- *  it were the first thing in the process to touch it — and a test that has to
- *  win a race writes a key into the owner's real home when it loses. */
-export function auditKeyPath(): string {
-  return process.env.NIRVANA_AUDIT_KEY || path.join(paths.NIRVANA_HOME, ".nirvana", "audit-key");
-}
-
-let cached: Buffer | null = null;
-let cachedFrom = "";
-
-/**
- * The install's signing key, created on first use.
- *
- * Unreadable or uncreatable (a read-only home, a sandbox) returns null rather
- * than throwing: an engine that cannot sign must still run and still log. The
- * events come out unstamped, a reader reports them as unverified, and nothing
- * pretends otherwise.
- */
-export function auditKey(): Buffer | null {
-  const p = auditKeyPath();
-  if (cached && cachedFrom === p) return cached;
-  try {
-    if (fs.existsSync(p)) {
-      const raw = fs.readFileSync(p, "utf8").trim();
-      if (raw.length >= 32) { cached = Buffer.from(raw, "hex"); cachedFrom = p; return cached; }
-    }
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    const key = crypto.randomBytes(32);
-    fs.writeFileSync(p, key.toString("hex"), { mode: 0o600 });
-    cached = key; cachedFrom = p;
-    return cached;
-  } catch { return null; }
-}
-
-/** Test seam: forget the cached key so a fixture can point at its own home. */
-export function resetAuditKeyCache(): void { cached = null; cachedFrom = ""; }
-
-/**
- * The bytes that get signed: the event minus its own stamp, with keys sorted.
- *
- * Sorted because `JSON.stringify` preserves insertion order, and an emitter that
- * builds the same event with its keys in a different order would produce a
- * different MAC for identical content — a false "tampered" on honest data.
- */
-function canonical(event: Record<string, any>): string {
-  const { [STAMP_FIELD]: _drop, ...rest } = event;
-  return JSON.stringify(rest, Object.keys(rest).sort());
-}
-
-/** Add the stamp. Returns the event unchanged when there is no key to sign with. */
-export function stamp<T extends Record<string, any>>(event: T): T {
-  const key = auditKey();
-  if (!key) return event;
-  const sig = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
-  return { ...event, [STAMP_FIELD]: sig };
-}
+// The implementation lives in the CJS sibling so `harness/lib/audit.js` — the
+// canonical emitter, and CommonJS — can require() it without crossing the ESM
+// boundary Windows enforces as a hard error. Mirrors log-paths.ts/.js.
+import * as impl from "./audit-provenance.js";
 
 export type Provenance = "engine" | "unsigned" | "tampered";
 
-/**
- * Who wrote this event.
- *
- *  - `engine`    — signed, and the signature matches its own content.
- *  - `unsigned`  — no stamp. Either a narrator, or an engine that could not
- *                  reach its key, or a line written before this existed. All
- *                  three mean the same thing to a reader: not evidence.
- *  - `tampered`  — stamped, but the content does not match the stamp. Someone
- *                  edited a real event, which is worse than writing a fake one.
- */
-export function provenanceOf(event: Record<string, any>): Provenance {
-  const sig = event?.[STAMP_FIELD];
-  if (typeof sig !== "string" || !sig) return "unsigned";
-  const key = auditKey();
-  if (!key) return "unsigned";
-  const expect = crypto.createHmac("sha256", key).update(canonical(event)).digest("hex").slice(0, 32);
-  // Length-safe compare; a mismatch here is a finding, not an error.
-  const a = Buffer.from(sig), b = Buffer.from(expect);
-  return a.length === b.length && crypto.timingSafeEqual(a, b) ? "engine" : "tampered";
-}
-
-/** Count a file's events by provenance — what a reader needs before trusting it. */
-export function auditProvenanceSummary(file: string): { engine: number; unsigned: number; tampered: number; total: number } {
-  const out = { engine: 0, unsigned: 0, tampered: 0, total: 0 };
-  let lines: string[];
-  try { lines = fs.readFileSync(file, "utf8").split("\n").filter(Boolean); } catch { return out; }
-  for (const l of lines) {
-    let e: any;
-    try { e = JSON.parse(l); } catch { continue; }
-    out.total++;
-    out[provenanceOf(e)]++;
-  }
-  return out;
-}
+export const STAMP_FIELD: string = impl.STAMP_FIELD;
+export const auditKeyPath: () => string = impl.auditKeyPath;
+export const auditKey: () => Buffer | null = impl.auditKey;
+export const resetAuditKeyCache: () => void = impl.resetAuditKeyCache;
+export const stamp: <T extends Record<string, any>>(event: T) => T = impl.stamp;
+export const provenanceOf: (event: Record<string, any>) => Provenance = impl.provenanceOf;
+export const auditProvenanceSummary: (file: string) => { engine: number; unsigned: number; tampered: number; total: number } = impl.auditProvenanceSummary;

--- a/skills/_shared/lib/handoff.js
+++ b/skills/_shared/lib/handoff.js
@@ -245,13 +245,24 @@ function updateHandoffPhase(projectDir, newPhase, opts) {
       last_task_completed: merged.last_task_completed || null,
       next_task_id: merged.next_task_id || null,
     };
-    const payload = JSON.stringify(event) + '\n';
+    // Stamped like every other engine write: an unstamped event reads as
+    // "somebody typed this", and the hook stream is the highest-volume writer
+    // in the system — leaving it unsigned would drown the signal in the very
+    // place a reader looks to decide whether a run is real.
+    let stamped = event;
+    try { stamped = require('./audit-provenance.js').stamp(event); } catch { /* no key, still log */ }
+    const payload = JSON.stringify(stamped) + '\n';
     // Local project audit
     const localAuditPath = path.join(projectDir, merged.audit_log_path || 'audit.jsonl');
     fs.appendFileSync(localAuditPath, payload);
-    // Global daily audit (so nrv glance and cross-trace tools can see it)
+    // The DAILY log — resolved, never hardcoded. log-paths.js says it in its own
+    // header: a hardcoded ~/.harness-logs creates split brain, because writes go
+    // per-project while reads still hit $HOME and the chain breaks. It did:
+    // 2026-09-04, a run left six handoff events in the project-root audit and
+    // ZERO in the daily log `validate-chain` reads, and the run's own validator
+    // reported the gap before anyone here noticed it.
     const today = new Date().toISOString().slice(0, 10);
-    const globalDir = path.join(require('os').homedir(), '.harness-logs', today);
+    const globalDir = path.join(require('./log-paths.js').harnessLogsDir({ cwd: projectDir }), today);
     fs.mkdirSync(globalDir, { recursive: true });
     fs.appendFileSync(path.join(globalDir, 'audit.jsonl'), payload);
   } catch (e) {

--- a/skills/_shared/scripts/inspect-clone.ts
+++ b/skills/_shared/scripts/inspect-clone.ts
@@ -271,6 +271,27 @@ if (commands.length > 0) {
 }
 console.log("");
 console.log(`Path: ${cloneDir}`);
+
+// A seat that loads a persona by hand leaves no trace, and on 2026-09-04 that
+// produced a run where three seats each embodied someone with zero
+// `mind_clone_injected` in the audit — functionally right, unaccountable. This
+// is the one place that knows a persona was handed over, so it says so. Silent
+// when there is no project context: a bare `nrv inspect-clone` from a terminal
+// is a person looking, not a run loading.
+try {
+  if (process.env.NIRVANA_TRACE_ID || process.env.NIRVANA_PROJECT_ID) {
+    const { emitAudit } = require(join(import.meta.dir, "..", "lib", "audit-emit.ts"));
+    emitAudit({
+      event: "x_clone_loaded",
+      trace_id: process.env.NIRVANA_TRACE_ID || null,
+      project_id: process.env.NIRVANA_PROJECT_ID || null,
+      business_slug: process.env.NIRVANA_BUSINESS_SLUG || null,
+      mind_clone: slug,
+      mind_clone_path: cloneDir,
+      via: "inspect-clone",
+    });
+  }
+} catch { /* never break an inspection over its own bookkeeping */ }
 console.log("");
 console.log(`Tip: bun inspect-clone.ts ${slug} --commands  # see all commands`);
 console.log(`Tip: bun inspect-clone.ts ${slug} --format=json  # full machine-readable output`);

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -39,6 +39,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { createRequire } from "node:module";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 const requireCjs = createRequire(import.meta.url);
 import { resolveScope, enumerate } from "../../_shared/lib/scope.ts";
 
@@ -94,7 +95,7 @@ function appendAuditEvent(project_dir: string, event: Record<string, unknown>): 
     fs.mkdirSync(dir, { recursive: true });
     fs.appendFileSync(
       path.join(dir, "audit.jsonl"),
-      JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n"
+      JSON.stringify(stamp({ ts: new Date().toISOString(), ...event })) + "\\n"
     );
   } catch {
     // non-fatal

--- a/skills/businesses/scripts/verify-deliverable.ts
+++ b/skills/businesses/scripts/verify-deliverable.ts
@@ -78,12 +78,22 @@ export function verifyDeliverableOnDisk(
     path.join(process.cwd(), ".nirvana/outputs"),   // compat: runs antigos
     path.join(os.homedir(), ".nirvana/outputs"),
   ];
+  // Two layouts, both legitimate. The scripted path nests a run under
+  // `outputs/<project_id>/`; `nrv team` writes a chain into a FLAT outputs root
+  // with `_team/<seat>/` beside the finals. This checker knew only the first, so
+  // it answered FAIL_INDETERMINATE for a chain run whose files were on disk —
+  // "project not found" for work that was right there. `projectDir` is whichever
+  // one actually holds the run.
   const projectsRoot = projectRootCandidates.find(p => fs.existsSync(path.join(p, projectId)));
-  if (!projectsRoot) {
-    return base("FAIL_INDETERMINATE", { reason: `project not found in ${projectRootCandidates.join(" or ")}` });
+  const flatRoot = !projectsRoot
+    ? projectRootCandidates.find(p => fs.existsSync(path.join(p, "brief.md")) || fs.existsSync(path.join(p, "_team")))
+    : null;
+  if (!projectsRoot && !flatRoot) {
+    return base("FAIL_INDETERMINATE", { reason: `project not found in ${projectRootCandidates.join(" or ")} (neither nested nor flat layout)` });
   }
+  const projectDir = projectsRoot ? path.join(projectsRoot, projectId) : flatRoot!;
 
-  const briefPath = path.join(projectsRoot, projectId, "brief.md");
+  const briefPath = path.join(projectDir, "brief.md");
   if (!fs.existsSync(briefPath)) {
     return base("FAIL_INDETERMINATE", { reason: `brief not found: ${briefPath}` });
   }
@@ -93,8 +103,8 @@ export function verifyDeliverableOnDisk(
   // --manifest). It's authoritative; brief.md regex is best-effort fallback.
   let expectedPathsRaw: string[] = [];
   let manifestSource = "brief-regex";
-  const deliverablesPath = path.join(projectsRoot, projectId, "businesses", businessSlug, "deliverables.json");
-  const deliverablesPathAlt = path.join(projectsRoot, projectId, "deliverables.json"); // project-level fallback
+  const deliverablesPath = path.join(projectDir, "businesses", businessSlug, "deliverables.json");
+  const deliverablesPathAlt = path.join(projectDir, "deliverables.json"); // project-level fallback
 
   let manifestFile: string | null = null;
   if (fs.existsSync(deliverablesPath)) manifestFile = deliverablesPath;
@@ -121,7 +131,7 @@ export function verifyDeliverableOnDisk(
     const bizDir = opts.businessDir ?? businessDirFor(businessSlug);
     const promised = bizDir ? readAcceptance(bizDir).paths : [];
     if (promised.length > 0) {
-      const base = outputsRoot ?? path.join(projectsRoot, projectId);
+      const base = outputsRoot ?? projectDir;
       expectedPathsRaw = promised.map(entry => path.isAbsolute(entry.path) ? entry.path : path.resolve(base, entry.path));
       acceptanceMinBytes = new Map(promised.map((entry, index) => [expectedPathsRaw[index], entry.minBytes ?? minBytes]));
       manifestSource = "acceptance";
@@ -235,7 +245,7 @@ if (import.meta.main) {
         path.join(process.cwd(), ".nirvana/outputs"),
         path.join(os.homedir(), ".nirvana/outputs"),
       ].find(p => fs.existsSync(path.join(p, projectId)))!;
-      const projectDir = path.join(projectsRoot, projectId, "businesses", businessSlug);
+      const projectDir = path.join(projectDir, "businesses", businessSlug);
       fs.mkdirSync(projectDir, { recursive: true });
       const auditEntry = JSON.stringify({
         ts: report.timestamp,

--- a/skills/harness/lib/agentic-router.ts
+++ b/skills/harness/lib/agentic-router.ts
@@ -33,6 +33,7 @@ import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import { BUN_BIN } from "../../_shared/lib/bun-helpers.ts";
 import { resolveRoutingArtifactPaths } from "../scripts/build-routing-digest.ts";
 import { formatRulesForRouterPrompt, type RuntimeRule } from "./runtime-rules.ts";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 
 const EXEC_RUNTIMES: ReadonlyArray<string> = ["claude-code", "codex", "gemini-cli", "antigravity-cli", "kimi-cli", "grok-cli", "pi"];
 
@@ -71,7 +72,7 @@ function emitAudit(payload: Record<string, any>, cwd?: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 

--- a/skills/harness/lib/audit.js
+++ b/skills/harness/lib/audit.js
@@ -1,3 +1,9 @@
+/** Stamp an envelope, tolerating an engine that cannot reach its key. */
+function stampEvent(envelope) {
+  try { return require('../../_shared/lib/audit-provenance.js').stamp(envelope); }
+  catch { return envelope; }
+}
+
 /**
  * Audit logger (JSONL append-only) for the Harness Protocol v1.
  *
@@ -233,7 +239,17 @@ function emit(event, payload, ctx) {
   // reader accepts both forms (cloudevents.js `toLegacyEvent`). The SQLite
   // side above keeps the flat shape on purpose: its own columns already give
   // the filter-without-parsing property the envelope buys for the file.
-  fs.appendFileSync(file, JSON.stringify(ce.toEnvelope(ev, ctx)) + '\n', 'utf8');
+  //
+  // The stamp goes on the ENVELOPE, not the inner event, because that is what
+  // lands on disk and what a reader parses. This is the path `nrv audit emit`
+  // takes — the one the protocol tells agents to use — and leaving it unstamped
+  // was the hole that made the whole signal useless on 2026-09-04: the internal
+  // emitters were stamped and the canonical one was not, so a legitimate
+  // agent-emitted event was indistinguishable from a line somebody typed. The
+  // distinction being drawn is "went through engine code" versus "raw append",
+  // and an agent calling `nrv audit emit` is on the right side of it.
+  const envelope = stampEvent(ce.toEnvelope(ev, ctx));
+  fs.appendFileSync(file, JSON.stringify(envelope) + '\n', 'utf8');
   return { path: file, event: ev };
 }
 

--- a/skills/harness/lib/cascade-runner.ts
+++ b/skills/harness/lib/cascade-runner.ts
@@ -19,6 +19,7 @@ import { buildHandoffPrompt } from "./handoff-prompt.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import { estimateCostUsd } from "./cost-estimator.ts";
 import { addSpend, isBudgetExhausted, getSpend } from "./spend-tracker.ts";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 
 /**
  * Cooldown applied to a runtime that failed to authenticate. Short on purpose:
@@ -32,7 +33,7 @@ function emitAudit(payload: Record<string, any>, projectRoot: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 

--- a/skills/harness/lib/glance/data-loader.ts
+++ b/skills/harness/lib/glance/data-loader.ts
@@ -18,6 +18,7 @@ import { readFrontmatter } from "../../../_shared/lib/frontmatter-edit.ts";
 import * as orgChartEditor from "./org-chart-editor.ts";
 import * as employeeFrontmatterEditor from "./employee-frontmatter-editor.ts";
 import { parseAuditLine } from "../../../_shared/lib/cloudevents.js";
+import { provenanceOf } from "../../../_shared/lib/audit-provenance.js";
 
 // Neutral skills-tree root. Resolves to ~/.nirvana/skills when present so the
 // tree survives ~/.claude removal; falls back to the legacy ~/.claude/skills.
@@ -509,8 +510,54 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
 
   const runs = new Map<string, Run>();
 
-  for (const d of dirs) {
-    const f = path.join(HARNESS_LOGS_ROOT, d, "audit.jsonl");
+  // One run writes its audit to up to FOUR files: the orchestrator's daily log,
+  // one per dispatched target under its outputs tree, and the global fallback.
+  // Reading a subset is how a reader concludes a healthy run never dispatched —
+  // measured 2026-09-04, when a viewer looking only here saw gate_passed with no
+  // dispatch anywhere and was one sentence from reporting fraud. `validate-chain`
+  // disagreed, and the disagreement is what saved it. The cockpit reads them all.
+  // Two guards, both learned from breaking the tests that caught them:
+  //
+  //  - A caller that PINNED a log root (HARNESS_LOGS_DIR) means "read this, not
+  //    the world". Without this, a fixture with its own root went wandering
+  //    through the machine's real projects and reported the owner's runs.
+  //  - An absent root is UNDETERMINED, not zero, and that distinction has its
+  //    own test. Widening the search would have answered "zero runs" for a
+  //    question whose honest answer is "I cannot tell".
+  const perTargetLogs: string[] = [];
+  const rootIsPinned = !!process.env.HARNESS_LOGS_DIR;
+  try {
+    for (const projRoot of (rootIsPinned || !fs.existsSync(HARNESS_LOGS_ROOT) ? [] : listProjectRootsForAudit())) {
+      // The project's own daily log: where the orchestrator's phases land when
+      // the run happened inside a project. Missing it is why a chain run showed
+      // no seats here while its files sat on disk.
+      const projLogRoot = path.join(projRoot, ".nirvana", "logs", "harness");
+      try {
+        for (const d of fs.readdirSync(projLogRoot)) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
+          const f = path.join(projLogRoot, d, "audit.jsonl");
+          if (fs.existsSync(f)) perTargetLogs.push(f);
+        }
+      } catch { /* no project log yet */ }
+
+      const outs = path.join(projRoot, "outputs");
+      if (!fs.existsSync(outs)) continue;
+      const stack = [outs];
+      while (stack.length) {
+        const dir = stack.pop()!;
+        let entries: fs.Dirent[];
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+        for (const e of entries) {
+          const full = path.join(dir, e.name);
+          if (e.isDirectory()) { if (stack.length < 512) stack.push(full); }
+          else if (e.name === "audit.jsonl") perTargetLogs.push(full);
+        }
+      }
+    }
+  } catch { /* a project tree we cannot walk contributes nothing, not an error */ }
+
+  for (const d of [...dirs, ...perTargetLogs]) {
+    const f = perTargetLogs.includes(d) ? d : path.join(HARNESS_LOGS_ROOT, d, "audit.jsonl");
     if (!fs.existsSync(f)) continue;
     const lines = fs.readFileSync(f, "utf8").split("\n").filter(Boolean);
     for (const line of lines) {
@@ -518,6 +565,9 @@ export function buildRuns(opts: { since?: string; limit?: number; days?: number 
       // Both forms: a CloudEvents envelope comes back flat, a legacy line
       // comes back by identity. See _shared/lib/cloudevents.js.
       try { ev = parseAuditLine(line); } catch { continue; }
+      // Who wrote it, on the run view as on the tail. Without this the cockpit
+      // shows a typed dispatch and an emitted one identically.
+      try { ev._provenance = provenanceOf(JSON.parse(line)); } catch { ev._provenance = "unsigned"; }
       const tid = ev.trace_id || "no-trace";
       if (opts.since && ev.ts < opts.since) continue;
 
@@ -697,6 +747,18 @@ export function getProjectDag(id: string) {
  * Returns events in newest-first order with synthetic numeric `id` so
  * the SSE delta logic upstream can de-duplicate.
  */
+/** Project roots whose outputs trees may hold per-target audit logs. Derived
+ *  from the projects Glance already knows about, so this walks what the cockpit
+ *  already lists and nothing else. */
+function listProjectRootsForAudit(): string[] {
+  // `discoverKnownProjects` — the name matters, and a silent catch is why it
+  // took a manual check to notice the first attempt called something that does
+  // not exist. A helper that swallows its own wiring error reports zero and
+  // looks healthy.
+  const { discoverKnownProjects } = require(path.join(SKILLS_ROOT, "harness", "lib", "glance", "project-discovery.ts"));
+  return (discoverKnownProjects() || []).map((p: any) => p.path).filter(Boolean).slice(0, 60);
+}
+
 export function tailJsonlEvents(limit = 50): Array<any> {
   const baseDir = paths.HARNESS_LOGS_DIR;
   if (!fs.existsSync(baseDir)) return [];
@@ -714,8 +776,15 @@ export function tailJsonlEvents(limit = 50): Array<any> {
     // the actual append order (Pre fires before Post, etc.).
     for (let i = lines.length - 1; i >= 0 && out.length < limit; i--) {
       try {
+        // Provenance travels with the event, because the cockpit is where
+        // somebody decides whether a run happened. An event an agent typed
+        // renders identically to one the engine emitted unless the reader is
+        // told — measured 2026-09-04, when a maestro wrote its own
+        // dispatch_business and gate_passed into a live run's audit and
+        // nothing in their shape distinguished them.
+        const raw = JSON.parse(lines[i]);
         const ev = parseAuditLine(lines[i]);
-        out.push({ ...ev, id: new Date(ev.ts).getTime(), _ord: i });
+        out.push({ ...ev, id: new Date(ev.ts).getTime(), _ord: i, _provenance: provenanceOf(raw) });
       } catch {}
     }
     if (out.length >= limit) break;
@@ -741,7 +810,7 @@ export function tailLogs(opts: { type: "harness" | "maestro"; date?: string; lim
   for (const f of files) {
     const lines = fs.readFileSync(path.join(dayDir, f), "utf8").split("\n").filter(Boolean);
     for (const line of lines) {
-      try { events.push({ ...parseAuditLine(line), _file: f }); } catch {}
+      try { events.push({ ...parseAuditLine(line), _file: f, _provenance: provenanceOf(JSON.parse(line)) }); } catch {}
     }
   }
   return {

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -1586,6 +1586,29 @@ export async function startServer(opts: ServerOptions) {
         return new Response(readView(p.slice(1)), { headers: { "content-type": STATIC_ASSETS[p], "cache-control": "no-store" } });
       }
 
+      // ─── Prototype sandbox (owner request, 2026-09-01) ───
+      // Preact + Signals + htm, via an import map, no build step — testing
+      // whether that stack organizes better than the monolithic glance.js
+      // while staying zero-build. Purely additive: never linked from the
+      // real index.html, not part of any shipped release. Same-origin, so
+      // its fetch()/EventSource calls hit the real /api/* routes below with
+      // no CORS setup — this doubles as the answer to "would Bun work fine
+      // as a pure API for a different frontend": yes, unchanged.
+      if (p === "/prototype" || p === "/prototype/" || p === "/prototype/index.html") {
+        const html = readView("prototype/index.html").replaceAll("__ASSET_VER__", assetVersion());
+        return new Response(html, { headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } });
+      }
+      const PROTOTYPE_ASSETS: Record<string, string> = {
+        "/prototype/app.js": "application/javascript",
+        "/prototype/panel.js": "application/javascript",
+        "/prototype/businesses-panel.js": "application/javascript",
+        "/prototype/agents-panel.js": "application/javascript",
+        "/prototype/debug-hud.js": "application/javascript",
+      };
+      if (PROTOTYPE_ASSETS[p]) {
+        return new Response(readView(p.slice(1)), { headers: { "content-type": PROTOTYPE_ASSETS[p], "cache-control": "no-store" } });
+      }
+
       // ─── API ───
       if (p === "/api/health") {
         return json({

--- a/skills/harness/lib/glance/views/prototype/agents-panel.js
+++ b/skills/harness/lib/glance/views/prototype/agents-panel.js
@@ -1,0 +1,45 @@
+// agents-panel.js — the REAL live SSE stream (/api/agents/live) that the
+// shipped Agents tab also consumes (glance.js's `this.agentsES`). Module-level
+// signals (not component-local) so the EventSource opens exactly once no
+// matter how many times Preact re-renders this component — the same
+// "subscribe once, read reactively everywhere" property Alpine's
+// EventSource-in-a-method pattern has to manage by hand today.
+import { html } from "htm/preact";
+import { signal, useSignalEffect } from "@preact/signals";
+import { Panel } from "./panel.js";
+
+const agents = signal([]);
+const summary = signal(null);
+const pulses = signal(0);
+let streamOpened = false;
+
+function ensureStream() {
+  if (streamOpened) return;
+  streamOpened = true;
+  const es = new EventSource("/api/agents/live");
+  const apply = (raw) => {
+    const d = JSON.parse(raw);
+    agents.value = d.agents || [];
+    summary.value = d.summary || null;
+  };
+  es.addEventListener("snapshot", (e) => apply(e.data));
+  es.addEventListener("pulse", (e) => { apply(e.data); pulses.value++; });
+}
+
+export function AgentsPanel() {
+  useSignalEffect(() => { ensureStream(); });
+  return html`
+    <${Panel} title="Agentes ao vivo" hint="SSE real de /api/agents/live">
+      <p class="text-[10px] text-[var(--text-tertiary)] mb-2">pulsos recebidos nesta sessão: ${pulses.value}</p>
+      ${agents.value.length === 0 && html`<p class="text-sm text-[var(--text-tertiary)]">nenhum agente ativo agora</p>`}
+      <ul class="flex flex-col gap-1 max-h-64 overflow-auto">
+        ${agents.value.map(a => html`
+          <li key=${a.trace_id} class="text-sm px-2 py-1.5 rounded-[var(--radius-sm)] bg-[var(--surface-2)]">
+            <b>${a.label}</b> — <span class="text-[var(--text-tertiary)]">${a.status}</span>
+            ${a.current_tool && html` · <span class="text-[var(--accent)]">${a.current_tool}</span>`}
+          </li>
+        `)}
+      </ul>
+    </${Panel}>
+  `;
+}

--- a/skills/harness/lib/glance/views/prototype/app.js
+++ b/skills/harness/lib/glance/views/prototype/app.js
@@ -1,0 +1,31 @@
+// app.js — bootstrap only. Every real piece of UI is its own file
+// (panel.js, businesses-panel.js, agents-panel.js, debug-hud.js); this file
+// just composes them. That split IS the thing being tested: can a
+// contributor open one small file for one feature, instead of one shared
+// multi-thousand-line glance.js for all of them.
+import { render } from "preact";
+import { html } from "htm/preact";
+import { BusinessesPanel } from "./businesses-panel.js";
+import { AgentsPanel } from "./agents-panel.js";
+import { DebugHud } from "./debug-hud.js";
+
+function App() {
+  return html`
+    <div class="flex flex-col gap-4">
+      <header class="flex items-baseline justify-between">
+        <h1 class="text-lg font-semibold">Glance — prototype</h1>
+        <span class="text-[10px] text-[var(--text-tertiary)]">
+          Preact + Signals + htm, via import map · Tailwind (browser CDN) lendo tokens.css · zero build ·
+          servido pelo mesmo Bun em /prototype · não faz parte de nenhuma release
+        </span>
+      </header>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <${BusinessesPanel} />
+        <${AgentsPanel} />
+      </div>
+      <${DebugHud} />
+    </div>
+  `;
+}
+
+render(html`<${App} />`, document.getElementById("root"));

--- a/skills/harness/lib/glance/views/prototype/businesses-panel.js
+++ b/skills/harness/lib/glance/views/prototype/businesses-panel.js
@@ -1,0 +1,58 @@
+// businesses-panel.js — real data from the REAL running Glance API
+// (GET /api/businesses, the same route the shipped Businesses tab calls).
+// Demonstrates: a signal holding server data, a derived filter with no
+// manual re-render wiring, and a real fetch-timing measurement (not a
+// marketing claim — an actual number read off this machine's own registry).
+import { html } from "htm/preact";
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { Panel } from "./panel.js";
+
+let renderCount = 0;
+
+export function BusinessesPanel() {
+  renderCount++;
+  const businesses = useSignal([]);
+  const filter = useSignal("");
+  const loading = useSignal(true);
+  const error = useSignal(null);
+  const fetchMs = useSignal(0);
+
+  useSignalEffect(() => {
+    const t0 = performance.now();
+    fetch("/api/businesses")
+      .then(r => r.json())
+      .then(data => {
+        businesses.value = data.businesses || [];
+        fetchMs.value = Math.round(performance.now() - t0);
+        loading.value = false;
+      })
+      .catch(e => { error.value = String(e); loading.value = false; });
+  });
+
+  const q = filter.value.trim().toLowerCase();
+  const filtered = q ? businesses.value.filter(b => b.slug.toLowerCase().includes(q)) : businesses.value;
+
+  return html`
+    <${Panel} title="Businesses" hint="dado real de GET /api/businesses">
+      <input
+        class="w-full mb-3 px-2 py-1.5 text-sm bg-[var(--surface-2)] border border-[var(--border-default)] rounded-[var(--radius-sm)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+        placeholder="filtrar por slug..."
+        value=${filter.value}
+        onInput=${e => { filter.value = e.target.value; }}
+      />
+      ${loading.value && html`<p class="text-sm text-[var(--text-tertiary)]">carregando...</p>`}
+      ${error.value && html`<p class="text-sm text-[var(--status-danger-fg)]">${error.value}</p>`}
+      <ul class="flex flex-col gap-1 max-h-64 overflow-auto">
+        ${filtered.map(b => html`
+          <li key=${b.slug} class="text-sm px-2 py-1.5 rounded-[var(--radius-sm)] hover:bg-[var(--surface-2)]">
+            <b>${b.slug}</b>
+            <span class="text-[var(--text-tertiary)]"> · ${(b.domains || []).slice(0, 3).join(", ")}</span>
+          </li>
+        `)}
+      </ul>
+      <p class="text-[10px] text-[var(--text-tertiary)] mt-2">
+        ${filtered.length} de ${businesses.value.length} · fetch em ${fetchMs.value}ms · este componente renderizou ${renderCount}x
+      </p>
+    </${Panel}>
+  `;
+}

--- a/skills/harness/lib/glance/views/prototype/debug-hud.js
+++ b/skills/harness/lib/glance/views/prototype/debug-hud.js
@@ -1,0 +1,55 @@
+// debug-hud.js — "mensurável" made literal: real Content-Length bytes read
+// off this same running server for every prototype file versus the real
+// glance.js, via HEAD requests. No estimate, no marketing number — whatever
+// this panel shows is what the server actually served just now.
+import { html } from "htm/preact";
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { Panel } from "./panel.js";
+
+const FILES = [
+  { path: "/prototype/app.js", label: "app.js (bootstrap)" },
+  { path: "/prototype/panel.js", label: "panel.js (componente reusável)" },
+  { path: "/prototype/businesses-panel.js", label: "businesses-panel.js" },
+  { path: "/prototype/agents-panel.js", label: "agents-panel.js" },
+  { path: "/prototype/debug-hud.js", label: "debug-hud.js (este arquivo)" },
+];
+const BASELINE = { path: "/glance.js", label: "glance.js — Glance real, um arquivo com todo o estado do app" };
+
+export function DebugHud() {
+  const sizes = useSignal({});
+  useSignalEffect(() => {
+    Promise.all([...FILES, BASELINE].map(f =>
+      fetch(f.path, { method: "HEAD" }).then(r => [f.path, Number(r.headers.get("content-length") || 0)])
+    )).then(entries => { sizes.value = Object.fromEntries(entries); });
+  });
+
+  const kb = (bytes) => (bytes / 1024).toFixed(1);
+  const prototypeTotal = FILES.reduce((sum, f) => sum + (sizes.value[f.path] || 0), 0);
+  const baselineSize = sizes.value[BASELINE.path] || 0;
+
+  return html`
+    <${Panel} title="Debug HUD" hint="Content-Length real via HEAD, não estimativa">
+      <ul class="text-xs flex flex-col gap-1">
+        ${FILES.map(f => html`
+          <li key=${f.path} class="flex justify-between">
+            <span class="text-[var(--text-secondary)]">${f.label}</span>
+            <span class="text-[var(--text-tertiary)]">${kb(sizes.value[f.path] || 0)} KB</span>
+          </li>
+        `)}
+        <li class="flex justify-between border-t border-[var(--border-subtle)] pt-1 mt-1">
+          <span class="text-[var(--text-primary)] font-medium">total do prototype (5 arquivos)</span>
+          <span class="text-[var(--text-primary)] font-medium">${kb(prototypeTotal)} KB</span>
+        </li>
+        <li class="flex justify-between">
+          <span class="text-[var(--text-secondary)]">${BASELINE.label}</span>
+          <span class="text-[var(--text-tertiary)]">${kb(baselineSize)} KB</span>
+        </li>
+      </ul>
+      <p class="text-[10px] text-[var(--text-tertiary)] mt-3 leading-relaxed">
+        O ponto não é qual número é menor — é que aqui cada arquivo tem UMA responsabilidade e pode ser aberto,
+        entendido e testado sozinho. No glance.js real, mexer em uma aba exige carregar o arquivo inteiro na
+        cabeça pra achar onde encaixar um campo novo (foi assim que o editor de organograma foi adicionado).
+      </p>
+    </${Panel}>
+  `;
+}

--- a/skills/harness/lib/glance/views/prototype/index.html
+++ b/skills/harness/lib/glance/views/prototype/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="apple-dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Glance prototype — Preact + Tailwind, zero-build</title>
+<!--
+  ISOLATED SANDBOX (owner request, 2026-09-01) — never linked from the real
+  index.html/glance.js, never shipped in a release. Same Bun server, new
+  route (/prototype), so /api/* calls below are real, same-origin, no CORS
+  setup needed — this IS the "Bun as API + a different frontend" question
+  answered by running code instead of a diagram.
+
+  Tailwind's browser build (JIT-compiles in the browser, official CDN,
+  "not for production" per Tailwind's own docs because of the compile-time
+  cost at public-web scale — irrelevant for a single-user localhost cockpit)
+  reads tokens.css's own custom properties via arbitrary-value classes
+  (bg-[var(--surface-1)], etc.) instead of a separate palette, so this
+  prototype LOOKS like Glance rather than inventing a new design language.
+-->
+<link rel="stylesheet" href="/tokens.css?v=__ASSET_VER__">
+<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+<script type="importmap">
+{
+  "imports": {
+    "preact": "https://esm.sh/preact@10",
+    "preact/": "https://esm.sh/preact@10/",
+    "@preact/signals": "https://esm.sh/@preact/signals@1?external=preact",
+    "htm/preact": "https://esm.sh/htm@3/preact?external=preact"
+  }
+}
+</script>
+<style>
+  body { background: var(--surface-0); color: var(--text-primary); font-family: var(--font-sans); }
+</style>
+</head>
+<body>
+  <div id="root" class="p-6 max-w-5xl mx-auto flex flex-col gap-4"></div>
+  <script type="module" src="/prototype/app.js?v=__ASSET_VER__"></script>
+</body>
+</html>

--- a/skills/harness/lib/glance/views/prototype/panel.js
+++ b/skills/harness/lib/glance/views/prototype/panel.js
@@ -1,0 +1,19 @@
+// panel.js — the ONE reusable floating-panel component this whole prototype
+// leans on. In the real Glance today the same visual pattern (header +
+// scrollable body + footer with Salvar/Cancelar) is hand-duplicated three
+// times with near-identical markup and CSS: .memory-add-modal, .graph-settings
+// and .org-edit-panel (index.html/glance.css). Here it is written once.
+import { html } from "htm/preact";
+
+export function Panel({ title, hint, children, footer }) {
+  return html`
+    <section class="bg-[var(--surface-1)] border border-[var(--border-default)] rounded-[var(--radius-lg)] shadow-[var(--shadow-2)] overflow-hidden flex flex-col">
+      <header class="flex items-center justify-between gap-3 px-4 py-3 border-b border-[var(--border-default)] bg-[var(--surface-0)]">
+        <span class="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">${title}</span>
+        ${hint && html`<span class="text-[10px] text-[var(--text-tertiary)]">${hint}</span>`}
+      </header>
+      <div class="p-4 flex-1 overflow-auto">${children}</div>
+      ${footer && html`<footer class="flex gap-2 px-4 py-3 border-t border-[var(--border-default)]">${footer}</footer>`}
+    </section>
+  `;
+}

--- a/skills/harness/lib/squad-exec.ts
+++ b/skills/harness/lib/squad-exec.ts
@@ -22,6 +22,7 @@ import { LEGACY_CAPABILITY_ID } from "./capability-resolver.ts";
 import {
   normalizeWorkflow, readWorkflow, referencedComponents, resolveWorkflowRef, type CanonicalStep,
 } from "../../squads/lib/workflow-reader.ts";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 import { LIMITS } from "../../_shared/validators/limits.ts";
 import { runWithCascade } from "./cascade-runner.ts";
 import { sessionKey, getSession, putSession, dropSession } from "./session-store.ts";
@@ -90,7 +91,7 @@ function appendAudit(payload: Record<string, any>, projectRoot?: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -299,6 +299,14 @@ export function buildStepBrief(step: ChainStep, idx: number, total: number, args
     // delivery — the language of the instruction leaking into the work.
     "## Language\nThese instructions are in English. What you DELIVER follows the language of the client brief above.",
     "",
+    // A seat is handed a RANKED LIST of mind-clones and told to choose; nothing
+    // is auto-injected unless the brief named one. On 2026-09-04 three seats
+    // each picked a clone, logged a good reason, and then worked without ever
+    // loading it — so the persona was a name in a log, not a voice in the work,
+    // and the run read as if it had clone fidelity it never had. Rule 9 of the
+    // protocol names that exact failure: never claim fidelity you did not load.
+    "## If you pick a mind-clone, LOAD IT\nYour prompt lists candidates; nothing was injected for you. Choosing one and working from what you already know about that person is NOT embodying them — it is the failure the protocol calls claiming fidelity you did not load. If you pick one, run `nrv inspect-clone <slug> --dna` and work from what it says. If you decide none fits, say so in your output and work as yourself; that is honest and allowed.",
+    "",
     priorBlock + gapBlock + outputInstr,
     scopeGuard("en"),
   ].join("\n");

--- a/skills/harness/lib/team-orchestrator.ts
+++ b/skills/harness/lib/team-orchestrator.ts
@@ -305,7 +305,7 @@ export function buildStepBrief(step: ChainStep, idx: number, total: number, args
     // loading it — so the persona was a name in a log, not a voice in the work,
     // and the run read as if it had clone fidelity it never had. Rule 9 of the
     // protocol names that exact failure: never claim fidelity you did not load.
-    "## If you pick a mind-clone, LOAD IT\nYour prompt lists candidates; nothing was injected for you. Choosing one and working from what you already know about that person is NOT embodying them — it is the failure the protocol calls claiming fidelity you did not load. If you pick one, run `nrv inspect-clone <slug> --dna` and work from what it says. If you decide none fits, say so in your output and work as yourself; that is honest and allowed.",
+    "## If you pick a mind-clone, LOAD IT\nYour prompt lists candidates; nothing was injected for you. Choosing one and working from what you already know about that person is NOT embodying them — it is the failure the protocol calls claiming fidelity you did not load. If you pick one, run `nrv inspect-clone <slug>` — it prints `Path:` and the artifacts it holds — then READ `agent/AGENT.md`, `agent/SOUL.md` and `dna/dna-schema.md` under that path, and work from what they say. (Not `--dna`: that flag prints layer COUNTS, not the DNA.) If you decide none fits, say so in your output and work as yourself; that is honest and allowed.",
     "",
     priorBlock + gapBlock + outputInstr,
     scopeGuard("en"),

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -277,11 +277,20 @@ function cmdStep(argv: string[]): void {
   // The proof. Emitted HERE rather than by the caller, because a caller that
   // must remember to audit is a caller that will eventually forget — which is
   // how two businesses and 23 seats produced one dispatch event between them.
+  // Asking for the prompt twice is not dispatching twice. Measured on the first
+  // real org-chart run (2026-09-04): the caller ran `team step --index 0` twice
+  // and the audit showed two dispatches for one seat's work, because the event
+  // fired when the PROMPT WAS BUILT. The repeat is still information — the
+  // caller asked again for a reason — so it is recorded as a repeat.
+  const marker = path.join(outDir, ".dispatched");
+  const reissue = fs.existsSync(marker);
   emitAudit({
-    event: "dispatch_business", trace_id: plan.project_id, project_id: plan.project_id,
+    event: reissue ? "x_seat_prompt_reissued" : "dispatch_business",
+    trace_id: plan.project_id, project_id: plan.project_id,
     business_slug: plan.business, employee: step.employee,
     mode: "chain-step", step: idx + 1, total,
   }, plan.project_root);
+  try { fs.writeFileSync(marker, new Date().toISOString()); } catch { /* best effort */ }
 
   process.stdout.write(ep.stdout);
   // Where to write, on stderr so it never contaminates the prompt on stdout.
@@ -489,6 +498,7 @@ function cmdReceipt(argv: string[]): void {
   const planFile = arg(argv, "--plan");
   if (!planFile) die("receipt needs --plan.", EXIT_ARGS);
   if (!fs.existsSync(planFile!)) die(`plan file not found: ${planFile}`, EXIT_ARGS);
+  const sign = argv.includes("--sign");
   const plan: ChainPlan = JSON.parse(fs.readFileSync(planFile!, "utf8"));
 
   // Read the run's own events. Same resolution the writers use, so a reader can
@@ -549,7 +559,11 @@ function cmdReceipt(argv: string[]): void {
     ...(narrated.length ? { not_counted: narrated } : {}),
   }, null, 2));
 
-  emitAudit({
+  // Consulting a receipt must not change the log it reads. Running `team
+  // receipt` to LOOK emitted a second x_business_signed_off into a real run on
+  // 2026-09-04 — mine, next to the maestro's — so an inspector was altering the
+  // evidence it inspected. `--sign` is the act; without it this only reports.
+  if (sign) emitAudit({
     event: complete ? "x_business_signed_off" : "x_business_incomplete",
     trace_id: plan.project_id, project_id: plan.project_id, business_slug: plan.business,
     seats: rows.length, dispatched: rows.filter(r => r.dispatched).length,

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -213,6 +213,17 @@ function cmdPlan(argv: string[]): void {
     intake, reason, chain: chainWithReviewers,
   };
 
+  // The convention every verifier already expects: `brief.md` at the outputs
+  // root. Teaching each checker a second layout is how a convention becomes two
+  // conventions; writing the file the existing one asks for costs a line and
+  // makes `verify-deliverable` and the completeness ceiling work on a chain run
+  // without knowing it is one.
+  try {
+    fs.mkdirSync(outputsRoot, { recursive: true });
+    const dest = path.join(outputsRoot, "brief.md");
+    if (!fs.existsSync(dest)) fs.writeFileSync(dest, brief);
+  } catch { /* an unwritable outputs root fails later, louder, on the first step */ }
+
   const save = arg(argv, "--save");
   if (save) {
     fs.mkdirSync(path.dirname(save), { recursive: true });

--- a/skills/harness/scripts/quality-gate.ts
+++ b/skills/harness/scripts/quality-gate.ts
@@ -202,7 +202,8 @@ async function runWithRevisions(artifact: string, content: string, args: string[
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(require(path.join(SKILLS_ROOT, "_shared/lib/log-paths.ts")).harnessLogsDir({ cwd: path.dirname(path.resolve(artifact)) }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({
+    const _stamp = require(path.join(SKILLS_ROOT, "_shared/lib/audit-provenance.ts")).stamp;
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(_stamp({
       ts: out.timestamp,
       event: result.verdict === "pass" ? "gate_passed" : "gate_failed",
       mode: "with-revisions",
@@ -211,7 +212,7 @@ async function runWithRevisions(artifact: string, content: string, args: string[
       business_slug: process.env.NIRVANA_BUSINESS_SLUG || null,
       artifact, rubric: rubric.name, score: out.total_score,
       judge_runtime: out.judge_runtime,
-    }) + "\n");
+    })) + "\n");
   } catch { /* non-fatal */ }
 
   return result.verdict === "pass" ? 0 : 1;
@@ -300,7 +301,16 @@ async function main() {
       score_avg: verdict.score,
       failed_rubrics: results.filter(r => !r.passed && !r.skipped).map(r => r.name),
     };
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(event) + "\n");
+    const _stamp = require(path.join(SKILLS_ROOT, "_shared/lib/audit-provenance.ts")).stamp;
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(_stamp(event)) + "\n");
+    // A verdict nobody can join to a run is a verdict nobody can act on. The
+    // delivery pipeline exports these; an agent invoking the gate by hand does
+    // not, and on 2026-09-04 ten of twelve gate verdicts in a live run carried
+    // trace_id: null. Silence made that invisible, so it says so now.
+    if (!event.trace_id) {
+      console.error("[gate] WARNING: no trace_id — this verdict cannot be joined to a run. "
+        + "Export NIRVANA_TRACE_ID, NIRVANA_PROJECT_ID and NIRVANA_BUSINESS_SLUG before calling the gate.");
+    }
   } catch {
     // non-fatal
   }

--- a/skills/harness/scripts/revise.ts
+++ b/skills/harness/scripts/revise.ts
@@ -30,6 +30,7 @@ import { runDelivery, deliverAfterRuntimeError, type DeliveryResult } from "../l
 import { loadHarnessConfig } from "../lib/harness-config.ts";
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
 import { scopeGuard } from "../../_shared/lib/scope-guard.ts";
+import { stamp } from "../../_shared/lib/audit-provenance.ts";
 
 const ANSI = { reset: "\x1b[0m", bold: "\x1b[1m", dim: "\x1b[2m", green: "\x1b[32m", red: "\x1b[31m", yellow: "\x1b[33m", cyan: "\x1b[36m", lime: "\x1b[38;5;154m" };
 const noColor = process.argv.includes("--no-color") || !process.stdout.isTTY;
@@ -73,7 +74,7 @@ function appendAudit(payload: Record<string, any>, projectRoot?: string): void {
     const today = new Date().toISOString().slice(0, 10);
     const dir = path.join(harnessLogsDir({ cwd: projectRoot }), today);
     fs.mkdirSync(dir, { recursive: true });
-    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify({ ts: new Date().toISOString(), ...payload }) + "\n");
+    fs.appendFileSync(path.join(dir, "audit.jsonl"), JSON.stringify(stamp({ ts: new Date().toISOString(), ...payload })) + "\n");
   } catch { /* non-fatal */ }
 }
 

--- a/skills/harness/scripts/validate-chain.ts
+++ b/skills/harness/scripts/validate-chain.ts
@@ -52,10 +52,19 @@ function loadEvents(projectId: string): { events: AuditEvent[]; sources: string[
   };
 
   // 1. Project-local audits
+  //
+  // `nrv team` writes a chain run into a FLAT outputs root — `outputs/` with
+  // `outputs/_team/<seat>/` beside it — rather than `outputs/<project_id>/`.
+  // Both layouts are legitimate and this validator only knew one, so a chain
+  // run's per-target audits were invisible to it and the chain read as absent.
+  // The run's own maestro reported that gap (`x_validator_layout_mismatch`,
+  // 2026-09-04) with the right diagnosis: a path convention defect, not missing
+  // work. Both layouts are read now.
   const candidateRoots = [
     path.join(process.cwd(), "outputs", projectId),            // novo default visível
     path.join(process.cwd(), ".nirvana/outputs", projectId),
     path.join(os.homedir(), ".nirvana/outputs", projectId),
+    path.join(process.cwd(), "outputs"),                       // chain layout: flat root
   ];
   for (const root of candidateRoots) {
     if (!fs.existsSync(root)) continue;
@@ -74,6 +83,23 @@ function loadEvents(projectId: string): { events: AuditEvent[]; sources: string[
         }
       }
     }
+  }
+
+  // 1b. The project's own audit.jsonl — where `handoff.js` writes its local
+  // copy. Nothing read it, so six handoff events could sit in a project while
+  // this validator reported zero and called the chain a PROTOCOL_VIOLATION.
+  for (const local of [path.join(process.cwd(), "audit.jsonl")]) {
+    if (!fs.existsSync(local)) continue;
+    const lines = fs.readFileSync(local, "utf8").split("\n").filter(l => l.trim());
+    let bad = 0;
+    for (const l of lines) {
+      try {
+        const e = parseAuditLine(l);
+        if (!e.project_id || !e.trace_id || e.project_id === projectId || e.trace_id === projectId) addEvent(e);
+      } catch { bad++; }
+    }
+    if (bad) unreadable.push({ file: local, count: bad });
+    sources.push(local);
   }
 
   // 2. Global daily audits — filter by project_id or trace_id

--- a/skills/harness/tests/chain-review.test.ts
+++ b/skills/harness/tests/chain-review.test.ts
@@ -241,7 +241,7 @@ describe("nrv team receipt — computed, never narrated", () => {
       { id: "names_a_source", evidence: "01-worker.md:3 — citations inline" },
     ] });
 
-    const r = run(["receipt", "--plan", p]);
+    const r = run(["receipt", "--plan", p, "--sign"]);
     expect(r.code).toBe(0);
     const out = JSON.parse(r.out);
     expect(out.complete).toBe(true);
@@ -257,9 +257,39 @@ describe("nrv team receipt — computed, never narrated", () => {
     run(["step", "--plan", p, "--index", "1"]);
     verdict(p, 0, { confirmed: [] });
 
-    const r = run(["receipt", "--plan", p]);
+    const r = run(["receipt", "--plan", p, "--sign"]);
     expect(r.code).toBe(3);
     expect(JSON.parse(r.out).review_unresolved).toEqual(["worker"]);
     expect(audit().some(e => e.event === "x_business_incomplete")).toBe(true);
+  }, spawnBudgetMs(4));
+});
+
+describe("consulting a receipt does not change the log it reads", () => {
+  // Found by using it: running `team receipt` to LOOK at a real run emitted a
+  // second x_business_signed_off next to the maestro's. An inspector that alters
+  // the evidence is not an inspector.
+  test("without --sign it reports and writes nothing", () => {
+    const p = plan();
+    run(["step", "--plan", p, "--index", "0"]);
+    run(["step", "--plan", p, "--index", "1"]);
+    verdict(p, 0, { confirmed: [
+      { id: "has_three_items", evidence: "01-worker.md:3-5 — three full lines" },
+      { id: "names_a_source", evidence: "01-worker.md:3 — citations inline" },
+    ] });
+    const before = audit().length;
+    const r = run(["receipt", "--plan", p]);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.out).complete).toBe(true);
+    expect(audit().length).toBe(before);
+    expect(audit().some(e => e.event === "x_business_signed_off")).toBe(false);
+  }, spawnBudgetMs(4));
+
+  test("asking for the same prompt twice logs a reissue, not a second dispatch", () => {
+    const p = plan();
+    run(["step", "--plan", p, "--index", "0"]);
+    run(["step", "--plan", p, "--index", "0"]);
+    const ev = audit();
+    expect(ev.filter(e => e.event === "dispatch_business" && e.employee === "worker")).toHaveLength(1);
+    expect(ev.filter(e => e.event === "x_seat_prompt_reissued" && e.employee === "worker")).toHaveLength(1);
   }, spawnBudgetMs(4));
 });


### PR DESCRIPTION
Everything found by watching two real org-chart runs end to end. Ten defects; **nine of them were introduced the same day**, and none was caught by the test suite — 2112 tests were green throughout.

## Where they came from

| how it was found | count |
|---|---|
| by **using** what had just been built | 5 |
| by **verifying a claim I had made** | 4 |
| reported by the **run's own maestro** | 1 |
| by an automated test | 0 |

## Audit provenance

The audit is a text file any agent can append to, and on a live run one did: a maestro wrote its own `dispatch_business`, its own `gate_passed`, and an event name the engine has never emitted, minutes before the real pipeline emitted the same names. Nothing in their shape told them apart.

Engine writes are now HMAC-stamped, keyed per install (`~/.nirvana/audit-key`, `NIRVANA_AUDIT_KEY` to override, never in a pack). A reader gets `engine` / `unsigned` / `tampered`.

**Stated plainly in the module and the changelog:** this defeats casual narration, which is the failure that happened. It does **not** defeat a determined forger, who can read the key. Claiming otherwise would be the same species of dishonesty this closes.

Shipping it at 2 emitters of 23 made the signal *worse than none* — three legitimate engine events read as unsigned within minutes and I twice concluded my own engine was fabricating them. All emitters stamp now, including `harness/lib/audit.js`, the canonical path `nrv audit emit` takes and the one agents actually call. The implementation lives in a CJS sibling because that file is CommonJS and a `.js` requiring a `.ts` is the ESM boundary Windows treats as a hard error — the repo's own gate caught that a minute after I wrote it.

## The rest

- **`dispatch_business` counted prompts, not dispatches.** Asking for the same prompt twice logged two dispatches for one seat's work. A repeat is now `x_seat_prompt_reissued`.
- **Consulting a receipt changed the log it read.** `team receipt` emitted its sign-off every time. Signing is `--sign`; otherwise it only reports.
- **A gate verdict with no trace says so.** Ten of twelve verdicts in a live run carried `trace_id: null`, unjoinable to the run they judged. The gate warns on stderr and names the variables.
- **A chosen mind-clone was never loaded.** Three seats each picked one, logged a considered reason, and worked from general knowledge — fidelity claimed, not loaded. The step brief now says: load it, or say none fits and work as yourself. In the next run all three loaded, one declaring "AGENT+SOUL+DNA, 34 items", and the reviewer *declined* a clone with a reason. `nrv inspect-clone` emits `x_clone_loaded` inside a trace.
- **`handoff.js` wrote to a hardcoded `~/.harness-logs`** — the exact split brain `log-paths.js` warns about in its own header. A run left six handoff events in the project audit and zero in the daily log `validate-chain` reads.
- **Glance read one audit file of four.** Nine runs' dispatches were invisible in the cockpit; seats that had never appeared now do. Every event carries `_provenance`.
- **The validators knew one layout.** `validate-chain --verify-disk` and `verify-deliverable` expected `outputs/<project_id>/` and could not see a chain run's flat root. `team plan` now also writes `brief.md` where the existing convention asks, so a chain run is legible to tools that do not know it is one.

## Verification

- `bun run test:fast` — 2112 pass, 0 fail. `bun test skills/harness/tests skills/businesses/tests` — 1815 pass; the 4 remaining are pre-existing, order-dependent, live-library reads.
- `bun run check:quick` — exit 0. CLI parity in sync.
- Glance: 162 pass. Two of its own tests caught my first attempt walking the machine's real projects from inside a fixture, and turning "undetermined" into a measured zero. Both guards are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk