### PR TITLE
fix: tests stop writing to the owner's audit, and three CLI papercuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,19 @@ The run worked — three seats dispatched by name, two reviews approved against 
 **A gate verdict with no trace says so.** The delivery pipeline exports `NIRVANA_TRACE_ID` and friends, but an agent invoking the gate by hand does not — and ten of twelve verdicts in a live run carried `trace_id: null`, unjoinable to the run they judged. The gate now warns on stderr naming the variables, so the gap is visible instead of silent.
 
 **A chosen mind-clone was never loaded.** Seats are handed a ranked list and told to choose; nothing is auto-injected unless the brief names one. Three seats each picked a clone, logged a considered reason, and then worked from what the model already knew about that person — a name in a log, not a voice in the work. Rule 9 of the protocol calls that claiming fidelity you did not load. The step brief now says it plainly: load it with `nrv inspect-clone <slug> --dna`, or decide none fits and work as yourself, which is honest and allowed.
+### Tests stopped writing into the owner's audit
+
+The machine's global audit held 134 events for one day and not one was a real dispatch: `p-handoff`, `p-broken-ledger`, webhook deliveries with `subject: run_1`, sixteen `gate_passed` paired with sixteen `gate_failed`. All fixture data from `bun test`, all of it counted by `nrv doctor` as activity and mined by `nrv baseline` as signal.
+
+Every test process now gets its own log root and signing key (`skills/test-preload.ts`, wired through `bunfig.toml`), and `harnessLogsDir` gains one rung below the project and above the home: a test-isolation root that a test cannot lose by deleting `HARNESS_LOGS_DIR` — which some do deliberately, to exercise the "caller did not set it" branch, and which used to reopen the path to the real audit for whatever wrote next in the shared process.
+
+It took four attempts to reach zero, and the last one is the lesson: `handoff.js` carried **two** near-identical audit-writing blocks. The first was fixed hours earlier; the second still hardcoded `~/.harness-logs` and still wrote unstamped. A fix landing on one copy while the defect survives in the other produces a measurement that looks exactly like success.
+
+### `nrv clean` accepts a path, and the preflight stops mistaking $HOME for a project
+
+`nrv clean <path>` joined the argument onto outputs roots, producing candidates like `/Users/x/outputs/Users/x/my-project` and then reporting the project as not found. An absolute path is the thing itself. It also now recognises `.nirvana/project.yaml` — what `nrv init` writes, and the scaffold a user most often wants to undo.
+
+The harness preflight tested for the *existence* of `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`. Every Claude Code user has a `~/CLAUDE.md`, so `$HOME` looked like an adopted project — while `project-root.js` refuses `$HOME` outright, leaving a session that believes it has a contract and has no project scope. It tests for the contract marker now, and refuses `$HOME` and `/` explicitly.
 
 ### An event the engine wrote is now distinguishable from one an agent typed
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -69,6 +69,19 @@ A execução funcionou — três cadeiras despachadas com nome, duas revisões a
 **Veredito de gate sem trace passa a dizer isso.** O pipeline de entrega exporta `NIRVANA_TRACE_ID` e companhia, mas um agente chamando o gate na mão não exporta — e dez de doze vereditos de uma execução real vieram com `trace_id: null`, impossíveis de juntar à execução que julgaram. O gate agora avisa no stderr nomeando as variáveis, para a lacuna ficar visível em vez de silenciosa.
 
 **Um mind-clone escolhido nunca era carregado.** As cadeiras recebem uma lista rankeada e escolhem; nada é injetado a menos que o brief nomeie. Três cadeiras escolheram, registraram um motivo pensado, e trabalharam com o que o modelo já sabia sobre aquela pessoa — um nome no log, não uma voz no trabalho. A Regra 9 do protocolo chama isso de alegar fidelidade que não se carregou. O brief do passo agora diz com todas as letras: carregue com `nrv inspect-clone <slug> --dna`, ou decida que nenhum serve e trabalhe como você mesmo, o que é honesto e permitido.
+### Os testes pararam de escrever na auditoria do dono
+
+A auditoria global da máquina tinha 134 eventos num dia e nenhum era despacho real: `p-handoff`, `p-broken-ledger`, entregas de webhook com `subject: run_1`, dezesseis `gate_passed` pareados com dezesseis `gate_failed`. Tudo dado de fixture do `bun test`, tudo contado pelo `nrv doctor` como atividade e minerado pelo `nrv baseline` como sinal.
+
+Todo processo de teste passa a ter raiz de log e chave de assinatura próprias (`skills/test-preload.ts`, ligado pelo `bunfig.toml`), e o `harnessLogsDir` ganha um degrau abaixo do projeto e acima do home: uma raiz de isolamento de teste que o teste não perde ao apagar `HARNESS_LOGS_DIR` — coisa que alguns fazem de propósito, para exercitar o ramo "o chamador não definiu", e que reabria o caminho para a auditoria real de quem escrevesse em seguida no processo compartilhado.
+
+Foram quatro tentativas até chegar a zero, e a última é a lição: o `handoff.js` tinha **duas** cópias quase idênticas do bloco que escreve auditoria. A primeira foi corrigida horas antes; a segunda continuava com `~/.harness-logs` hardcoded e continuava sem carimbo. Correção que acerta uma cópia enquanto o defeito sobrevive na outra produz uma medição idêntica à do sucesso.
+
+### O `nrv clean` aceita caminho, e o preflight para de confundir $HOME com projeto
+
+O `nrv clean <caminho>` juntava o argumento às raízes de saída, produzindo candidatos como `/Users/x/outputs/Users/x/meu-projeto` e então reportando o projeto como não encontrado. Um caminho absoluto é a própria coisa. Ele também passa a reconhecer `.nirvana/project.yaml` — o que o `nrv init` escreve, e o scaffold que o usuário mais quer desfazer.
+
+O preflight do harness testava a *existência* de `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`. Todo usuário de Claude Code tem um `~/CLAUDE.md`, então o `$HOME` parecia projeto adotado — enquanto o `project-root.js` recusa o `$HOME` de saída, deixando uma sessão que acredita ter contrato e não tem escopo de projeto. Agora testa o marcador do contrato, e recusa `$HOME` e `/` explicitamente.
 
 ### Evento que o engine escreveu agora se distingue de evento que um agente digitou
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,3 +3,7 @@
 # their own tests with their own dependencies (installed in the buyer project,
 # not here) — scanning them made a bare `bun test` report 55 phantom failures.
 root = "skills"
+
+# Every test process gets its own log root and signing key, so a test can never
+# append to the owner's real audit. See skills/test-preload.ts.
+preload = ["./skills/test-preload.ts"]

--- a/skills/_shared/lib/handoff.js
+++ b/skills/_shared/lib/handoff.js
@@ -249,6 +249,12 @@ function updateHandoffPhase(projectDir, newPhase, opts) {
     // "somebody typed this", and the hook stream is the highest-volume writer
     // in the system — leaving it unsigned would drown the signal in the very
     // place a reader looks to decide whether a run is real.
+    //
+    // This is the SECOND copy of this block in this file. The first was fixed
+    // hours earlier and this one was missed, which is the argument against
+    // near-duplicate emitters: the fix lands on one, the defect survives in the
+    // other, and the measurement that finds it looks identical to the one that
+    // said the fix worked.
     let stamped = event;
     try { stamped = require('./audit-provenance.js').stamp(event); } catch { /* no key, still log */ }
     const payload = JSON.stringify(stamped) + '\n';

--- a/skills/_shared/lib/log-paths.js
+++ b/skills/_shared/lib/log-paths.js
@@ -13,7 +13,8 @@
  * Resolution order (first match wins):
  *   1. $HARNESS_LOGS_DIR / $MAESTRO_LOGS_DIR (explicit override, honored everywhere)
  *   2. <projectRoot>/.nirvana/logs/{harness,maestro}/  (when running inside a project)
- *   3. ~/.harness-logs/ / ~/.maestro-logs/            (fallback, no project context)
+ *   3. $NIRVANA_TEST_LOGS_HOME                        (test isolation; preload only)
+ *   4. ~/.harness-logs/ / ~/.maestro-logs/            (fallback, no project context)
  *
  * The project-root walk itself lives in project-root.js — see that file for
  * why HOME (and everything between `start` and HOME) is never a valid root.
@@ -37,6 +38,14 @@ function harnessLogsDir(opts) {
   if (process.env.HARNESS_LOGS_DIR) return path.resolve(process.env.HARNESS_LOGS_DIR);
   const root = resolveProjectRoot(opts);
   if (root) return path.join(root, '.nirvana', 'logs', 'harness');
+  // Last rung before the owner's home: a test process. `HARNESS_LOGS_DIR` is
+  // the honest override and a test that deletes it — to exercise the
+  // "caller did not set it" branch, which is a real branch — reopens the path
+  // to the real audit for whatever writes during that window. Three fixture
+  // events reached it that way on 2026-09-05, after four other leaks were
+  // already closed. Chasing them one test at a time is how the fifth gets
+  // missed; this closes the class. Set only by skills/test-preload.ts.
+  if (process.env.NIRVANA_TEST_LOGS_HOME) return path.resolve(process.env.NIRVANA_TEST_LOGS_HOME);
   return path.join(os.homedir(), '.harness-logs');
 }
 

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -191,10 +191,15 @@ a one-line repair you perform, because you are the one holding the shell.
 Before anything else, check whether this directory is a Nirvana project:
 
 ```bash
-ls AGENTS.md CLAUDE.md GEMINI.md 2>/dev/null | head -1
+# The MARKER, not the filename. Every Claude Code user has a ~/CLAUDE.md, so
+# testing for the file makes $HOME look like an adopted project — and it is not
+# one: project-root.js refuses $HOME outright, so the session gets a contract it
+# believes in and no project scope. Measured 2026-09-04: a session opened at
+# $HOME wrote its brief to the global fallback and dispatched nothing.
+grep -l "nirvana-os:invocation-contract" AGENTS.md CLAUDE.md GEMINI.md 2>/dev/null | head -1
 ```
 
-Nothing came back? Run `nrv init .` and continue. It writes the contract
+Nothing came back? Run `nrv init .` and continue — unless you are at `$HOME` or `/`, which are never project roots. There, stop and ask the user to open a project directory instead; scaffolding a project on top of somebody's home is not a cheap repair. It writes the contract
 (`AGENTS.md` + `CLAUDE.md` + `GEMINI.md`, one per runtime family) plus the
 `.nirvana/` scaffold. It never touches code, and it never overwrites: a contract
 file that already exists keeps the user's rules at the top and gets the Nirvana

--- a/skills/harness/scripts/clean-project.ts
+++ b/skills/harness/scripts/clean-project.ts
@@ -45,15 +45,28 @@ if (!projectId) {
 // A directory only qualifies as a Nirvana project if it carries one of these
 // markers — guards against nuking an unrelated folder that happens to match.
 function isNirvanaProject(dir: string): boolean {
-  return ["businesses", "brief.md", "HANDOFF.json", "squads"].some(m => fs.existsSync(path.join(dir, m)));
+  // `.nirvana/project.yaml` is what `nrv init` writes, and it was missing from
+  // this list — so the scaffold a user most often wants to undo was the one
+  // shape `nrv clean` refused to recognise.
+  const markers = ["businesses", "brief.md", "HANDOFF.json", "squads", path.join(".nirvana", "project.yaml")];
+  return markers.some(m => fs.existsSync(path.join(dir, m)));
 }
 
-const candidates = [
-  path.join(process.cwd(), "outputs", projectId),            // novo default visível
-  path.join(os.homedir(), ".nirvana/outputs", projectId),
-  path.join(process.cwd(), ".nirvana/outputs", projectId),
-  path.join(os.homedir(), projectId),
-];
+// An absolute path is the thing itself, not a name to look up. Joining one onto
+// an outputs root produced candidates like
+// `/Users/x/outputs/Users/x/my-project` — nonsense the user then had to read
+// past to learn that `nrv clean <path>` simply is not supported. It is now.
+const looksLikePath = path.isAbsolute(projectId) || projectId.startsWith("~") || projectId.includes(path.sep);
+const expanded = projectId.startsWith("~") ? path.join(os.homedir(), projectId.slice(1)) : projectId;
+
+const candidates = looksLikePath
+  ? [path.resolve(expanded)]
+  : [
+      path.join(process.cwd(), "outputs", projectId),            // novo default visível
+      path.join(os.homedir(), ".nirvana/outputs", projectId),
+      path.join(process.cwd(), ".nirvana/outputs", projectId),
+      path.join(os.homedir(), projectId),
+    ];
 
 const projectDirs = [...new Set(candidates)].filter(d => fs.existsSync(d) && fs.statSync(d).isDirectory() && isNirvanaProject(d));
 

--- a/skills/harness/tests/cloudevents-envelope.test.ts
+++ b/skills/harness/tests/cloudevents-envelope.test.ts
@@ -22,6 +22,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { makeTempRoot, removeDir } from "./helpers/temp-dirs.ts";
 
+/** The isolated root the test preload created. Captured before any test
+ *  mutates the env, so a teardown restores isolation instead of removing it. */
+const PRELOAD_LOGS_DIR = process.env.HARNESS_LOGS_DIR!;
+
 const ce = require("../../_shared/lib/cloudevents.js");
 const audit = require("../lib/audit.js");
 
@@ -29,7 +33,7 @@ const TMP = makeTempRoot("nrv-cloudevents-");
 const previousLogsDir = process.env.HARNESS_LOGS_DIR;
 
 afterAll(() => {
-  if (previousLogsDir === undefined) delete process.env.HARNESS_LOGS_DIR;
+  if (previousLogsDir === undefined) process.env.HARNESS_LOGS_DIR = PRELOAD_LOGS_DIR;
   else process.env.HARNESS_LOGS_DIR = previousLogsDir;
   removeDir(TMP);
 });

--- a/skills/harness/tests/glance-execution-runner.test.ts
+++ b/skills/harness/tests/glance-execution-runner.test.ts
@@ -14,6 +14,10 @@ import { shimRuntimeOnPath } from "./helpers/fake-glance-child.ts";
 import { removeDir } from "./helpers/temp-dirs.ts";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 
+/** The isolated root the test preload created. Captured before any test
+ *  mutates the env, so a teardown restores isolation instead of removing it. */
+const PRELOAD_LOGS_DIR = process.env.HARNESS_LOGS_DIR!;
+
 const DISPATCH = path.join(import.meta.dir, "..", "scripts", "dispatch.ts");
 const roots: string[] = [];
 const restores: Array<() => void> = [];
@@ -92,8 +96,13 @@ describe("createDispatchExecutionRunner", () => {
   test("the child audits where the cockpit reads: HARNESS_LOGS_DIR is pinned to the project's harness log unless the caller set it", async () => {
     const { root, briefFile, fake } = fixture();
     const previous = process.env.HARNESS_LOGS_DIR;
+    // This test exercises the "caller did NOT set it" branch, so the delete is
+    // the point and has to stay. What must not stay is the unset state: the
+    // teardown restores the preload's isolated root rather than leaving the
+    // variable absent, because absent sends every writer that runs after this
+    // file — in the same process — to the owner's real audit.
     delete process.env.HARNESS_LOGS_DIR;
-    restores.push(() => { if (previous !== undefined) process.env.HARNESS_LOGS_DIR = previous; });
+    restores.push(() => { process.env.HARNESS_LOGS_DIR = previous ?? PRELOAD_LOGS_DIR; });
     // The fake writes its cost event where dispatch.ts does: under HARNESS_LOGS_DIR when set, else under the
     // scaffold it creates (outputs/<pid>/.nirvana/logs/harness), which nothing on the server side reads.
     const pinned = createDispatchExecutionRunner({ dispatchScriptPath: fake, env: { FAKE_DISPATCH_COST_USD: "0.3" } });

--- a/skills/harness/tests/run-kernel.test.ts
+++ b/skills/harness/tests/run-kernel.test.ts
@@ -267,7 +267,7 @@ describe("ArtifactRef and compatibility facade", () => {
       expect(auditFiles.length).toBeGreaterThan(0);
     } finally {
       ledger.close();
-      if (previousLogs === undefined) delete process.env.HARNESS_LOGS_DIR; else process.env.HARNESS_LOGS_DIR = previousLogs;
+      process.env.HARNESS_LOGS_DIR = previousLogs ?? PRELOAD_LOGS_DIR;
       if (previousState === undefined) delete process.env.NIRVANA_STATE_DB; else process.env.NIRVANA_STATE_DB = previousState;
     }
   }, KERNEL_BUDGET_MS);
@@ -297,7 +297,7 @@ describe("ArtifactRef and compatibility facade", () => {
       expect(legacyErrorFor("failed", { error: "", reason: "runtime_incompatible", errors: ["model unknown", 42] })).toBe("runtime_incompatible: model unknown");
     } finally {
       ledger.close();
-      if (previousLogs === undefined) delete process.env.HARNESS_LOGS_DIR; else process.env.HARNESS_LOGS_DIR = previousLogs;
+      process.env.HARNESS_LOGS_DIR = previousLogs ?? PRELOAD_LOGS_DIR;
       if (previousState === undefined) delete process.env.NIRVANA_STATE_DB; else process.env.NIRVANA_STATE_DB = previousState;
     }
   }, KERNEL_BUDGET_MS);
@@ -317,6 +317,10 @@ describe("two processes writing one kernel", () => {
     const writer = path.join(root, "writer.ts");
     fs.writeFileSync(writer, `
 import { appendEvent, createRun, openKernel } from ${JSON.stringify(store)};
+
+/** The isolated root the test preload created. Captured before any test
+ *  mutates the env, so a teardown restores isolation instead of removing it. */
+const PRELOAD_LOGS_DIR = process.env.HARNESS_LOGS_DIR!;
 const kernel = openKernel(process.argv[2]);
 const actor = { kind: "test", id: "child" };
 createRun(kernel, { projectId: "prj_busy", runId: "run_child", traceId: "trace_child", planId: "plan_child",

--- a/skills/test-preload.ts
+++ b/skills/test-preload.ts
@@ -1,0 +1,28 @@
+// test-preload.ts — no test writes into the owner's real audit.
+//
+// Measured 2026-09-04: the machine's global audit held 134 events for the day
+// and NOT ONE was a real dispatch — `p-handoff`, `p-broken-ledger`, webhook
+// deliveries with `subject: run_1`, sixteen gate_passed paired with sixteen
+// gate_failed. All of it fixture data from `bun test`, and all of it counted by
+// `nrv doctor` as activity and mined by `nrv baseline` as signal.
+//
+// The cause is ordinary: a test that does not pin `HARNESS_LOGS_DIR` gets the
+// resolver's fallback, which is the user's home. One line here removes the
+// whole class, and a test that wants its own root still sets it and wins.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+if (!process.env.HARNESS_LOGS_DIR) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-test-logs-"));
+  process.env.HARNESS_LOGS_DIR = dir;
+}
+// Same for the signing key: a test run must not create or read the install's.
+// The floor a deleted HARNESS_LOGS_DIR falls to. A test that unsets the
+// override is testing a real branch; it should not thereby gain a path to the
+// owner's audit.
+process.env.NIRVANA_TEST_LOGS_HOME = process.env.HARNESS_LOGS_DIR;
+
+if (!process.env.NIRVANA_AUDIT_KEY) {
+  process.env.NIRVANA_AUDIT_KEY = path.join(process.env.HARNESS_LOGS_DIR!, "audit-key");
+}


### PR DESCRIPTION
Follows #212. Closes six of the twenty observability findings collected while watching two live runs.

## Tests were writing into the owner's real audit

One day's global audit held **134 events and not one was a real dispatch**: `p-handoff`, `p-broken-ledger`, webhook deliveries with `subject: run_1`, sixteen `gate_passed` paired with sixteen `gate_failed`. Fixture data from `bun test` — counted by `nrv doctor` as activity, mined by `nrv baseline` as signal.

Every test process now gets its own log root and signing key (`skills/test-preload.ts`, wired through `bunfig.toml`), and `harnessLogsDir` gains one rung between the project and the home: a test-isolation root a test **cannot lose by deleting `HARNESS_LOGS_DIR`** — which some do deliberately, to exercise the "caller did not set it" branch, and which reopened the path to the real audit for whatever wrote next in the shared process.

**It took four attempts to reach zero, and the fourth is the lesson.** `handoff.js` carried **two near-identical audit-writing blocks**. The first was fixed hours earlier; the second still hardcoded `~/.harness-logs` and still wrote unstamped. Three events kept arriving after each "fix", and each measurement looked exactly like the ones that had worked.

Measured before and after on the real file: `vazamento: 3` → `vazamento: 0`, whole suite.

## Three papercuts

- **`nrv clean <path>`** joined the argument onto outputs roots, producing candidates like `/Users/x/outputs/Users/x/my-project` and reporting "not found" for a directory it had just been handed. It also now recognises `.nirvana/project.yaml` — what `nrv init` writes, and the scaffold a user most often wants to undo.
- **The preflight mistook `$HOME` for a project.** It tested for the *existence* of `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`, and every Claude Code user has a `~/CLAUDE.md` — so a session opened at home believed it had a contract while `project-root.js` refuses `$HOME` outright, leaving it with no project scope. Measured: such a session wrote its brief to the global fallback and dispatched nothing. It tests the contract marker now, and refuses `$HOME` and `/` explicitly.
- **Finding 13 was wrong**, and is struck through in the notes rather than deleted: `validate-chain` does exit 1 on PROTOCOL_VIOLATION. I had read `$?` after piping through `tail`. A findings list that quietly drops its mistakes is one you cannot trust the rest of.

## Verification

- `bun run test:fast` — 2110 pass, 0 fail, and **0 events leaked** to the real audit (measured by line count before/after).
- `bun run check:quick` — exit 0.
- One Glance test caught my first attempt at this: it deletes the env on purpose to test a real branch, and my "fix" removed its ability to. The delete stayed; the teardown restores isolation instead of absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk