### PR TITLE
feat(audit): nrv audit where / tail, and cost events that name a real path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### `nrv audit where` and `nrv audit tail`
+
+Following a run meant knowing `harnessLogsDir`'s three-rung precedence by heart, remembering that a run writes to up to four files, and hand-writing a `jq` filter that handles both event envelopes. I built that filter three times in one day and got it wrong all three: once missing every CloudEvents line, once with an invalid escape that made the whole expression fail silently, once reading a single file and nearly reporting a healthy run as fraud.
+
+`nrv audit where` prints the resolved log root **and the reason**, then every file holding events for a trace with a provenance count each. `nrv audit tail` follows a run across all four files, normalizes both envelopes, denies the hook stream by default (denying noise beats listing wanted events — a list goes blind the day the engine gains an `x_` event, which is the open namespace's whole point), and with `--follow` starts at the end like tail does, instead of replaying the day.
+
+### Cost events were filed under a path that does not exist
+
+`import-claude-transcripts.ts` recovered a project path from Claude Code's encoded directory name by replacing every `-` with `/`. That encoding replaces `/` with `-`, so undoing it that way destroys the hyphens belonging to the name: `projeto-mini-apps-agroautonomia` became `Users/guto/projeto/mini/apps/agroautonomia`, and every cost event for that project was filed under a path with no directory behind it.
+
+`decodeClaudeProjectDirName` already solved this — it walks the disk, preferring the longest run of tokens that names a real directory — and was one import away. When a path cannot be recovered the encoded name is kept verbatim: an honest opaque id beats a confident wrong one.
+
 ### The validators learned the chain layout
 
 A run dispatched through `nrv team` writes a FLAT outputs root — `outputs/` with `outputs/_team/<seat>/` beside the finals — while the scripted path nests everything under `outputs/<project_id>/`. Both are legitimate; the validators knew one. So `validate-chain --verify-disk` read no per-target audits for a chain run and `verify-deliverable` answered "project not found" for work sitting on disk in front of it.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,18 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### `nrv audit where` e `nrv audit tail`
+
+Acompanhar uma execução exigia saber de cor a precedência de três degraus do `harnessLogsDir`, lembrar que uma execução escreve em até quatro arquivos, e escrever à mão um filtro `jq` que trate os dois envelopes de evento. Eu montei esse filtro três vezes num dia e errei nas três: uma perdendo toda linha CloudEvents, uma com escape inválido que fazia a expressão inteira falhar em silêncio, uma lendo um arquivo só e quase reportando uma execução saudável como fraude.
+
+O `nrv audit where` imprime a raiz de log resolvida **e o motivo**, depois cada arquivo que guarda eventos de um trace, com contagem de procedência. O `nrv audit tail` acompanha a execução nos quatro arquivos, normaliza os dois envelopes, nega o fluxo de hooks por padrão (negar ruído é melhor que listar o que se quer — uma lista fica cega no dia em que o engine ganha um evento `x_`, que é justamente o ponto do namespace aberto) e, com `--follow`, começa no fim como o tail faz, em vez de repetir o dia.
+
+### Eventos de custo eram arquivados sob um caminho que não existe
+
+O `import-claude-transcripts.ts` recuperava o caminho do projeto a partir do nome de diretório codificado pelo Claude Code trocando todo `-` por `/`. Essa codificação troca `/` por `-`, então desfazer assim destrói os hífens que pertencem ao nome: `projeto-mini-apps-agroautonomia` virava `Users/guto/projeto/mini/apps/agroautonomia`, e todo evento de custo daquele projeto ia para um caminho sem diretório atrás.
+
+O `decodeClaudeProjectDirName` já resolvia isso — ele caminha o disco preferindo a maior sequência de tokens que nomeia um diretório real — e estava a um import de distância. Quando o caminho não é recuperável, o nome codificado fica como está: um id opaco honesto é melhor que um caminho errado com cara de certo.
+
 ### Os validadores aprenderam o layout de cadeia
 
 Uma execução despachada pelo `nrv team` escreve numa raiz de saída PLANA — `outputs/` com `outputs/_team/<cadeira>/` ao lado dos finais — enquanto o caminho scriptado aninha tudo sob `outputs/<project_id>/`. Os dois são legítimos; os validadores conheciam um. Então o `validate-chain --verify-disk` não lia auditoria por-alvo nenhuma numa execução de cadeia, e o `verify-deliverable` respondia "project not found" para trabalho que estava em disco na frente dele.

--- a/bin/nrv
+++ b/bin/nrv
@@ -234,6 +234,10 @@ case "$cmd" in
     exec "$BUN_BIN" "$SKILLS/harness/scripts/dispatch.ts" "$@" ;;
   team)
     exec "$BUN_BIN" "$SKILLS/harness/scripts/chain.ts" "$@" ;;
+  audit-where)
+    exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-where.ts" "$@" ;;
+  audit-tail)
+    exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-tail.ts" "$@" ;;
   run|autopilot)
     exec "$BUN_BIN" "$SKILLS/harness/scripts/dispatch.ts" "$@" --exec ;;
   auto)

--- a/skills/_shared/scripts/import-claude-transcripts.ts
+++ b/skills/_shared/scripts/import-claude-transcripts.ts
@@ -24,6 +24,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { decodeClaudeProjectDirName } from "../../harness/lib/glance/project-discovery.ts";
 import * as os from "node:os";
 import * as crypto from "node:crypto";
 import { parseArgs, EXIT } from "../lib/bun-helpers.ts";
@@ -103,7 +104,19 @@ const dirs = selectDirs();
 console.error(`[import] scanning ${dirs.length} project dir(s)…${dryRun ? " (dry-run)" : ""}`);
 
 for (const dir of dirs) {
-  const projectId = path.basename(dir).replace(/^-/, "").replace(/-/g, "/");
+  // Claude Code encodes a project path by replacing `/` with `-`. Undoing that
+  // by replacing every `-` with `/` destroys the hyphens that belong to the
+  // name: `projeto-mini-apps-agroautonomia` came out as
+  // `Users/guto/projeto/mini/apps/agroautonomia`, a path that does not exist,
+  // and every cost event for that project was filed under it.
+  //
+  // `decodeClaudeProjectDirName` recovers the real path by walking the disk —
+  // preferring the longest run of tokens that names a real directory — and it
+  // already existed, one import away. When it cannot recover a path (the
+  // directory is gone), the encoded name is kept verbatim: an honest opaque id
+  // beats a confident wrong one.
+  const encoded = path.basename(dir);
+  const projectId = decodeClaudeProjectDirName(encoded) ?? encoded;
   for (const file of listJsonl(dir)) {
     let raw: string;
     try { raw = fs.readFileSync(file, "utf8"); }

--- a/skills/harness/lib/commands.ts
+++ b/skills/harness/lib/commands.ts
@@ -70,6 +70,8 @@ export const COMMANDS: Command[] = [
   { name: "dispatch", target: "harness/scripts/dispatch.ts", category: "dispatch", args: '<business> "<brief>"', summary: "Scaffold a run (brief + DNA injection + audit; no exec)", visibility: "user" },
   { name: "run", aliases: ["autopilot"], custom: true, category: "dispatch", args: '<business> "<brief>" [--zip --pdf --html]', summary: "Autopilot: dispatch + execute + verify + gate", visibility: "user" },
   { name: "auto", custom: true, category: "dispatch", args: '"<brief>" [--zip --pdf --html]', summary: "Autopilot with auto-selected business (= run --auto)", visibility: "user" },
+  { name: "audit-where", target: "harness/scripts/audit-where.ts", category: "observability", args: "[--project <dir>] [--trace <id>]", summary: "Which audit files a run wrote, and why those", visibility: "user" },
+  { name: "audit-tail", target: "harness/scripts/audit-tail.ts", category: "observability", args: "[--follow] [--trace <id>] [--only orchestration|hooks|all]", summary: "Follow a run's audit, normalized, from now on", visibility: "user" },
   { name: "team", target: "harness/scripts/chain.ts", category: "dispatch", args: "plan|step|review|verdict ...", summary: "A business's org chart: plan the chain, get each seat's prompt, review it", visibility: "user" },
   { name: "revise", target: "harness/scripts/revise.ts", category: "dispatch", args: '<project> "<change>"', summary: "Apply a change keeping the same runtime session", visibility: "user" },
   { name: "ask", target: "harness/scripts/ask.ts", category: "dispatch", args: "<clone> [question]", summary: "Talk to a single mind-clone (DNA injected)", visibility: "user" },

--- a/skills/harness/scripts/audit-tail.ts
+++ b/skills/harness/scripts/audit-tail.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+/**
+ * audit-tail.ts — follow a run's audit, normalized, from now on.
+ *
+ * Three things every reader had to rebuild by hand, and get wrong:
+ *
+ *  1. TWO ENVELOPES. Some events are flat, some are CloudEvents with the name in
+ *     the last segment of `type` and the payload under `data`. A `jq` filter on
+ *     `.event` silently misses half of them — including `brief_received`, the
+ *     first event of a run. `parseAuditLine` has normalized both all along; it
+ *     is CJS, so nobody reading from a shell ever reached it.
+ *  2. FOUR FILES. A run writes to the project log, one per dispatched target,
+ *     and the global fallback. Following one is how a reader concludes a healthy
+ *     run never dispatched.
+ *  3. NO "FROM NOW ON". Every consumer replayed the whole file on first pass.
+ *     `--follow` starts at the end, like tail, unless asked otherwise.
+ *
+ * Usage:
+ *   nrv audit tail [--project <dir>] [--trace <id>] [--follow] [--all]
+ *                  [--only orchestration|hooks|all] [--json]
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { parseAuditLine } from "../../_shared/lib/cloudevents.js";
+import { provenanceOf } from "../../_shared/lib/audit-provenance.js";
+
+const argv = process.argv.slice(2);
+const arg = (n: string) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : undefined; };
+const follow = argv.includes("--follow");
+const fromStart = argv.includes("--all");
+const asJson = argv.includes("--json");
+const only = (arg("--only") ?? "orchestration") as "orchestration" | "hooks" | "all";
+const trace = arg("--trace");
+const projectDir = path.resolve(arg("--project") ?? process.cwd());
+
+/** The hook stream is the highest-volume writer and answers a different
+ *  question than orchestration. Denying it by name beats listing the events you
+ *  want: a list goes blind the day the engine gains an `x_` event, which is the
+ *  open namespace's whole point. */
+const HOOK_EVENTS = /^(tool_invoked|bash_completed|artifact_touched|x_webhook_delivery_attempted|x_ledger_progress_ping|x_ledger_state_changed)$/;
+
+function auditFiles(): string[] {
+  const roots = [harnessLogsDir({ cwd: projectDir }), path.join(projectDir, "outputs")];
+  const out: string[] = [];
+  for (const root of roots) {
+    const stack = [root];
+    while (stack.length) {
+      const dir = stack.pop()!;
+      let entries: fs.Dirent[];
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+      for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) { if (stack.length < 512) stack.push(full); }
+        else if (e.name === "audit.jsonl") out.push(full);
+      }
+    }
+  }
+  const local = path.join(projectDir, "audit.jsonl");
+  if (fs.existsSync(local)) out.push(local);
+  return [...new Set(out)];
+}
+
+function render(line: string, file: string): string | null {
+  let ev: any, raw: any;
+  try { raw = JSON.parse(line); ev = parseAuditLine(line); } catch { return null; }
+  const name = ev.event ?? "";
+  if (!name) return null;
+  const isHook = HOOK_EVENTS.test(name);
+  if (only === "orchestration" && isHook) return null;
+  if (only === "hooks" && !isHook) return null;
+  if (trace && ev.trace_id !== trace && ev.project_id !== trace) return null;
+  if (asJson) return JSON.stringify({ ...ev, _file: file, _provenance: provenanceOf(raw) });
+  const seat = ev.employee ? `  seat=${ev.employee}` : "";
+  const step = ev.step ? `  [${ev.step}/${ev.total}]` : "";
+  const prov = provenanceOf(raw) === "engine" ? "" : `  ·${provenanceOf(raw)}`;
+  const src = path.basename(path.dirname(file));
+  return `${String(ev.ts ?? "").slice(11, 19)} [${src}] ${name}${seat}${step}${prov}`;
+}
+
+const offsets = new Map<string, number>();
+function drain(initial: boolean): void {
+  for (const f of auditFiles()) {
+    let size = 0;
+    try { size = fs.statSync(f).size; } catch { continue; }
+    const prev = offsets.get(f);
+    if (prev === undefined) {
+      // `--follow` starts at the end; a one-shot read shows what is there.
+      offsets.set(f, initial && follow && !fromStart ? size : 0);
+      if (initial && follow && !fromStart) continue;
+    }
+    const from = offsets.get(f)!;
+    if (size <= from) { offsets.set(f, size); continue; }
+    let chunk = "";
+    try {
+      const fd = fs.openSync(f, "r");
+      const buf = Buffer.alloc(size - from);
+      fs.readSync(fd, buf, 0, buf.length, from);
+      fs.closeSync(fd);
+      chunk = buf.toString("utf8");
+    } catch { continue; }
+    offsets.set(f, size);
+    for (const line of chunk.split("\n")) {
+      if (!line.trim()) continue;
+      const out = render(line, f);
+      if (out) console.log(out);
+    }
+  }
+}
+
+drain(true);
+if (follow) {
+  setInterval(() => drain(false), 1000);
+} 

--- a/skills/harness/scripts/audit-where.ts
+++ b/skills/harness/scripts/audit-where.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * audit-where.ts — which audit files a run wrote, and why those.
+ *
+ * A run writes to up to four places: the project's daily log, one per dispatched
+ * target under its outputs tree, the global fallback, and — for handoff — the
+ * project's own `audit.jsonl`. Answering "where did this run write?" meant
+ * knowing `harnessLogsDir`'s three-rung precedence by heart and then guessing at
+ * the rest, and a reader who checked only one file concluded a healthy run had
+ * never dispatched. That happened, and it nearly got reported as fraud.
+ *
+ * This prints the resolution and the reason for it, plus every file that holds
+ * events for the trace, with a provenance count per file.
+ *
+ * Usage:
+ *   nrv audit where [--project <dir>] [--trace <id>] [--json]
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
+import { auditProvenanceSummary } from "../../_shared/lib/audit-provenance.js";
+
+const argv = process.argv.slice(2);
+const arg = (n: string) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : undefined; };
+const asJson = argv.includes("--json");
+const projectDir = path.resolve(arg("--project") ?? process.cwd());
+const trace = arg("--trace");
+
+/** Why the resolver landed where it did — the part nobody could see. */
+function why(): { root: string; reason: string } {
+  if (process.env.HARNESS_LOGS_DIR) {
+    return { root: path.resolve(process.env.HARNESS_LOGS_DIR), reason: "HARNESS_LOGS_DIR is set — an explicit override wins everywhere" };
+  }
+  const projectLog = path.join(projectDir, ".nirvana", "logs", "harness");
+  if (fs.existsSync(path.join(projectDir, ".nirvana"))) {
+    return { root: projectLog, reason: `inside a project (${projectDir} has .nirvana/) — the run logs with the project` };
+  }
+  return { root: path.join(os.homedir(), ".harness-logs"), reason: "no project context here — the global fallback" };
+}
+
+/** Every audit file under a root, however deep. Per-target logs live inside the
+ *  outputs tree, which is why a flat listing of the log root misses them. */
+function auditFilesUnder(root: string, cap = 400): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length && out.length < cap) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) { if (stack.length < 512) stack.push(full); }
+      else if (e.name === "audit.jsonl") out.push(full);
+    }
+  }
+  return out;
+}
+
+const resolution = why();
+const candidates = [
+  ...auditFilesUnder(resolution.root),
+  ...auditFilesUnder(path.join(projectDir, "outputs")),
+  path.join(projectDir, "audit.jsonl"),
+  ...auditFilesUnder(path.join(os.homedir(), ".harness-logs")),
+].filter((f, i, a) => fs.existsSync(f) && a.indexOf(f) === i);
+
+const files = candidates.map(f => {
+  const prov = auditProvenanceSummary(f);
+  let matched = prov.total;
+  if (trace) {
+    matched = 0;
+    try {
+      for (const l of fs.readFileSync(f, "utf8").split("\n")) {
+        if (l.includes(trace)) matched++;
+      }
+    } catch { matched = 0; }
+  }
+  return { file: f, events: prov.total, for_trace: matched, engine: prov.engine, unsigned: prov.unsigned, tampered: prov.tampered };
+}).filter(r => !trace || r.for_trace > 0);
+
+if (asJson) {
+  console.log(JSON.stringify({ resolved_root: resolution.root, reason: resolution.reason, project_dir: projectDir, trace: trace ?? null, files }, null, 2));
+} else {
+  console.log(`resolved root: ${resolution.root}`);
+  console.log(`  because:     ${resolution.reason}`);
+  console.log(`  project:     ${projectDir}`);
+  if (trace) console.log(`  trace:       ${trace}`);
+  console.log("");
+  if (!files.length) {
+    console.log(trace ? "No audit file holds events for that trace." : "No audit files found.");
+  } else {
+    console.log("files holding events" + (trace ? " for this trace" : "") + ":");
+    for (const f of files) {
+      const prov = `engine=${f.engine} unsigned=${f.unsigned}${f.tampered ? ` TAMPERED=${f.tampered}` : ""}`;
+      console.log(`  ${f.file}`);
+      console.log(`      ${trace ? `${f.for_trace} of ` : ""}${f.events} event(s) · ${prov}`);
+    }
+    console.log("");
+    console.log("`unsigned` on an old event means it predates stamping, not that it was forged.");
+  }
+}

--- a/skills/harness/scripts/nrv.ts
+++ b/skills/harness/scripts/nrv.ts
@@ -100,6 +100,8 @@ switch (cmd) {
     if (["--capability", "capability"].includes(sub)) runScript(join(S, "capability-doctor.ts"), rest.slice(1));
     runScript(join(H, "doctor-system.ts"), (sub === "--system" || sub === "system") ? rest.slice(1) : rest);
   }
+  case "audit-where": runScript(join(H, "audit-where.ts"), rest);
+  case "audit-tail": runScript(join(H, "audit-tail.ts"), rest);
   case "team": runScript(join(H, "chain.ts"), rest);
   case "dispatch": runScript(join(H, "dispatch.ts"), rest);
   case "run": case "autopilot": runScript(join(H, "dispatch.ts"), [...rest, "--exec"]);

--- a/skills/harness/tests/run-ledger.test.ts
+++ b/skills/harness/tests/run-ledger.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test, afterAll } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { KERNEL_BUDGET_MS } from "./helpers/test-budgets.ts";
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-run-ledger-test-"));
 // Snapshot BEFORE mutating: these are process-wide, and bun runs test FILES in
@@ -43,7 +44,7 @@ afterAll(() => {
 describe("run-ledger — schema and open", () => {
   test("resolveLedgerDbPath honors NIRVANA_RUN_LEDGER_DB", () => {
     expect(resolveLedgerDbPath()).toBe(path.join(TMP, "default-ledger.sqlite"));
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("openRun creates a dispatched row with defaults", () => {
     const h = freshLedger();
@@ -54,7 +55,7 @@ describe("run-ledger — schema and open", () => {
     expect(row.meta).toEqual({ a: 1 });
     expect(Date.parse(row.lease_expires_at!)).toBeGreaterThan(Date.now());
     expect(row.heartbeat_at).toBeTruthy();
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("run-ledger — state machine", () => {
@@ -69,7 +70,7 @@ describe("run-ledger — state machine", () => {
     expect(done.terminal_at).toBeTruthy();
     expect(done.child_pid).toBe(4242);
     expect(isTerminal(done.state)).toBe(true);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("withheld is terminal on the gate-fail path", () => {
     const h = freshLedger();
@@ -80,7 +81,7 @@ describe("run-ledger — state machine", () => {
     expect(w.state).toBe("withheld");
     expect(w.terminal_at).toBeTruthy();
     expect(w.last_error).toBe("gate fail");
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("illegal transitions throw", () => {
     const h = freshLedger();
@@ -91,7 +92,7 @@ describe("run-ledger — state machine", () => {
     expect(() => markState(h, run_id, "dispatched")).toThrow(/same-state/);
     // unknown state
     expect(() => markState(h, run_id, "flying" as any)).toThrow(/unknown state/);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("terminal states are final: no transition out, no lease renewal, no retries", () => {
     const h = freshLedger();
@@ -101,7 +102,7 @@ describe("run-ledger — state machine", () => {
     expect(() => markState(h, run_id, "failed")).toThrow(/terminal/);
     expect(renewLease(h, run_id, 60)).toBe(false);
     expect(() => incrementRetries(h, run_id)).toThrow(/terminal/);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("stalled and failed are recoverable", () => {
     const h = freshLedger();
@@ -114,7 +115,7 @@ describe("run-ledger — state machine", () => {
     const row = markState(h, run_id, "delivered");
     expect(row.state).toBe("delivered");
     expect(row.last_error).toBe("boom"); // COALESCE keeps the last real error
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("failed → verifying: the runtime-error salvage edge (artifacts on disk get judged)", () => {
     const h = freshLedger();
@@ -129,7 +130,7 @@ describe("run-ledger — state machine", () => {
     expect(row.last_error).toBe("runtime returned an error verdict");
     expect(row.meta.runtime_errored).toBe(true);
     expect(canTransition("failed", "verifying")).toBe(true);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("stalled → verifying: the supervisor salvage edge (an escalated run's artifacts get judged)", () => {
     const h = freshLedger();
@@ -142,7 +143,7 @@ describe("run-ledger — state machine", () => {
     expect(row.state).toBe("withheld");
     expect(row.last_error).toBe("supervisor: orphaned run; retries exhausted");
     expect(canTransition("stalled", "verifying")).toBe(true);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("patchMeta merges without a state transition", () => {
     const h = freshLedger();
@@ -153,13 +154,13 @@ describe("run-ledger — state machine", () => {
     expect(row.meta.outputs_root).toBe("/tmp/out");    // merged, not replaced
     expect(row.meta.salvaged).toBe(true);
     expect(patchMeta(h, "no-such-run", { salvaged: true })).toBeNull();
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("abandoned is unreachable via markState", () => {
     const h = freshLedger();
     const { run_id } = openRun(h, {});
     expect(() => markState(h, run_id, "abandoned")).toThrow(/abandon\(/);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("canTransition mirrors the table", () => {
     expect(canTransition("dispatched", "running")).toBe(true);
@@ -167,7 +168,7 @@ describe("run-ledger — state machine", () => {
     expect(canTransition("delivered", "running")).toBe(false);
     expect(canTransition("dispatched", "gated")).toBe(false);
     for (const t of TERMINAL_STATES) expect(canTransition(t as any, "running")).toBe(false);
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("run-ledger — leases and expiry queries", () => {
@@ -180,7 +181,7 @@ describe("run-ledger — leases and expiry queries", () => {
     expect(Date.parse(after.lease_expires_at!)).toBeGreaterThan(Date.parse(before));
     expect(Date.parse(after.lease_expires_at!)).toBeGreaterThan(Date.now() + 3000_000);
     expect(Date.parse(after.heartbeat_at!)).toBeGreaterThanOrEqual(Date.parse(row.heartbeat_at!));
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("findExpired returns only non-terminal runs with expired leases", () => {
     const h = freshLedger();
@@ -193,14 +194,14 @@ describe("run-ledger — leases and expiry queries", () => {
     expect(ids).toContain(expired.run_id);
     expect(ids).not.toContain(fresh.run_id);
     expect(ids).not.toContain(doneButExpired.run_id);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("findExpired honors an injected clock", () => {
     const h = freshLedger();
     const row = openRun(h, { initialLeaseSec: 900 });
     expect(findExpired(h).map(r => r.run_id)).not.toContain(row.run_id);
     expect(findExpired(h, Date.now() + 3600_000).map(r => r.run_id)).toContain(row.run_id);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("findNonTerminal / countNonTerminal exclude terminal rows", () => {
     const h = freshLedger();
@@ -212,7 +213,7 @@ describe("run-ledger — leases and expiry queries", () => {
     expect(ids).toContain(a.run_id);
     expect(ids).not.toContain(b.run_id);
     expect(countNonTerminal(h)).toBe(1);
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("run-ledger — abandon and resume info", () => {
@@ -226,7 +227,7 @@ describe("run-ledger — abandon and resume info", () => {
     expect(row.last_error).toBe("owner cancelled the brief");
     expect(row.terminal_at).toBeTruthy();
     expect(() => abandon(h, run_id, "again")).toThrow(/terminal/);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("resumeInfo exposes session, runtime, retries and meta", () => {
     const h = freshLedger();
@@ -243,7 +244,7 @@ describe("run-ledger — abandon and resume info", () => {
     expect(info.maxRetries).toBe(5);
     expect(info.meta.outputs_root).toBe("/tmp/x");
     expect(resumeInfo(h, "nope")).toBeNull();
-  });
+  }, KERNEL_BUDGET_MS);
 });
 
 describe("run-ledger — scanDir (what the heartbeat reports)", () => {
@@ -270,7 +271,7 @@ describe("run-ledger — scanDir (what the heartbeat reports)", () => {
     expect(scan.omitted).toBe(0);
     expect(scan.changed[0].sizeBytes).toBe("a/first.md".length);
     expect(scan.latestMs).toBeGreaterThanOrEqual(3_000_000);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("noise is never progress: .git, node_modules, .nirvana, dist and editor tempfiles are excluded", () => {
     const dir = tree({
@@ -283,7 +284,7 @@ describe("run-ledger — scanDir (what the heartbeat reports)", () => {
       ".DS_Store": 3_000_000,
     });
     expect(rel(dir, scanDir(dir, 1_000_000, { limit: 50 }))).toEqual(["report.md"]);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("noise still counts as liveness: latestMtimeMs sees what the report hides", () => {
     const dir = tree({ "node_modules/pkg/index.js": 4_000_000 });
@@ -291,14 +292,14 @@ describe("run-ledger — scanDir (what the heartbeat reports)", () => {
     // pruning the traversal would have silently changed that signal.
     expect(scanDir(dir, 1_000_000, { limit: 50 }).changed).toEqual([]);
     expect(latestMtimeMs(dir)).toBeGreaterThanOrEqual(4_000_000);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("the limit keeps the FIRST touches and names how many it dropped", () => {
     const dir = tree({ "s1.md": 2_000_000, "s2.md": 3_000_000, "s3.md": 4_000_000, "s4.md": 5_000_000 });
     const scan = scanDir(dir, 1_000_000, { limit: 2 });
     expect(rel(dir, scan)).toEqual(["s1.md", "s2.md"]);
     expect(scan.omitted).toBe(2);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("limit 0 reports nothing and still answers the liveness question", () => {
     const dir = tree({ "x.md": 2_000_000 });
@@ -306,11 +307,11 @@ describe("run-ledger — scanDir (what the heartbeat reports)", () => {
     expect(scan.changed).toEqual([]);
     expect(scan.omitted).toBe(0);
     expect(scan.latestMs).toBeGreaterThanOrEqual(2_000_000);
-  });
+  }, KERNEL_BUDGET_MS);
 
   test("a missing directory is empty, never a throw", () => {
     const scan = scanDir(path.join(TMP, "nope-not-here"), 0, { limit: 10 });
     expect(scan).toEqual({ latestMs: 0, changed: [], omitted: 0 });
     expect(latestMtimeMs(path.join(TMP, "nope-not-here"))).toBe(0);
-  });
+  }, KERNEL_BUDGET_MS);
 });


### PR DESCRIPTION
Closes findings 4, 10, 14 and 15 of the observability notes. Stacked conceptually on #213 (independent branches; both target main).

## Following a run required rebuilding three things by hand

I wrote that `jq` filter **three times in one day and got it wrong three times**: first missing every CloudEvents line (half a run, including `brief_received`), then with an invalid escape that made the whole expression fail *silently*, then reading a single audit file and coming one sentence from reporting a healthy run as fraud.

```
nrv audit where   # the resolved log root AND the reason, then every file
                  # holding events for a trace, with a provenance count each
nrv audit tail    # all four files, both envelopes normalized, hook stream
                  # denied by default, --follow starts at the END
```

Denying the hook stream by name beats listing the events you want: a list goes blind the day the engine gains an `x_` event, which is that namespace's whole point.

Sample, on a real chain run:

```
23:45:36 [2026-09-04] x_review_requested  seat=studio-researcher  [1/3]
23:46:49 [2026-09-04] x_review_approved   seat=studio-researcher  [1/3]
23:47:33 [2026-09-04] delivered  ·unsigned
```

## Cost events were filed under a path that does not exist

`import-claude-transcripts.ts` recovered a project path from Claude Code's encoded directory name with `.replace(/-/g, "/")`. That encoding replaces `/` with `-`, so undoing it that way **destroys the hyphens belonging to the name**:

```
-Users-guto-projeto-mini-apps-agroautonomia
  before → Users/guto/projeto/mini/apps/agroautonomia   (no such directory)
  after  → /Users/guto/projeto-mini-apps-agroautonomia
```

Every cost event for that project was filed under the broken path. `decodeClaudeProjectDirName` already solved this — it walks the disk, preferring the longest run of tokens that names a real directory — and was one import away. An unrecoverable name now stays verbatim: an honest opaque id beats a confident wrong one.

## Also

`run-ledger.test.ts` drives fsync-bound SQLite on Bun's 5 s default; a windows-latest runner took 6173 ms and the build went red on a timing threshold, not a defect. `KERNEL_BUDGET_MS` exists for exactly this and the file never imported it. **Third time today** this class cost a red build.

## Verification

- `bun run test:fast` — 2112 pass, 0 fail. `bun run check:quick` — exit 0.
- CLI parity — 64 commands in sync across the table, `bin/nrv` and `nrv.ts`.
- `decodeClaudeProjectDirName` checked against the three real encoded names on this machine; all three recover exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk