### PR TITLE
chore: source comments name the measurement, not the machine

### DIFF
--- a/skills/harness/lib/glance/project-discovery.ts
+++ b/skills/harness/lib/glance/project-discovery.ts
@@ -4,11 +4,11 @@
  * `POST /api/actions/switch-project`).
  *
  * Source: Claude Code's own transcript-storage convention. A session run
- * from `/Users/guto/nirvana-os` gets its transcripts stored under
- * `~/.claude/projects/-Users-guto-nirvana-os/` — every path separator
+ * from `/home/dev/nirvana-os` gets its transcripts stored under
+ * `~/.claude/projects/-home-dev-nirvana-os/` — every path separator
  * turned into "-", with a leading "-" for the leading "/". That encoding is
  * LOSSY: a real directory name can itself contain "-" (`nirvana-os`,
- * `systems-atelier`), so it is not reversible by a blind
+ * `mini-apps`), so it is not reversible by a blind
  * `replace(/-/g, "/")` — that would misread `nirvana-os` as `nirvana/os`.
  *
  * `decodeClaudeProjectDirName()` recovers the real path by walking the

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -10,10 +10,9 @@
  * the org chart at all, and the maestro did the only thing it could: hand the
  * whole business to a single subagent.
  *
- * Measured on a live run, 2026-09-04: `nexus-council` (9 seats) and
- * `systems-atelier` (14 seats) each emitted ONE `dispatch_business` and zero
- * per-employee events — while the deliverables named six of those seats as
- * contributors. Work attributed to seats that never ran as audited agents is the
+ * Measured on a live run, 2026-09-04: two businesses with 23 seats between them
+ * emitted ONE `dispatch_business` each and zero per-employee events — while the
+ * deliverables named six of those seats as contributors. Work attributed to seats that never ran as audited agents is the
  * exact fiction the audit protocol exists to prevent, and it was not a bug in
  * anyone's code: no procedure existed.
  *


### PR DESCRIPTION
Two comments in shipped source carried identifiers from a development machine:

- `glance/project-discovery.ts` — a home path in the transcript-encoding example
- `harness/scripts/chain.ts` — two installed business slugs in the measurement that motivated the chain runner

Both are illustrations and illustrate exactly as well without the names. The measurement stays: 23 seats across two businesses, one `dispatch_business` each, zero per-employee events.

Found while verifying the published 0.13.0 tarball as a client. `check:quick` green; `glance-project-switcher.test.ts` 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk