### PR TITLE
fix(verify): the completeness check reads a squad run's manifest too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The completeness check learned that squads have manifests too
+
+`verify-deliverable.ts` looked for a run's `deliverables.json` under `businesses/<slug>/` and at the run root. A squad run files its manifest under `squads/<slug>/`, mirroring the business convention, and the check had never looked there. On 2026-09-04 a live run had two such manifests on disk, every promised file present and above the size floor, and the check answered FAIL_INDETERMINATE "no deliverables.json" — a verdict about where the tool looked, not about the work. The maestro of that run diagnosed it correctly before anyone here did.
+
+It reads all three locations now, the indeterminate reason names the paths it tried, and the CLI hint stops telling a squad to run `brief-business.ts`. The protocol's verify step says `<slug>` instead of `<business_slug>`, because it always applied to both.
+
 ## 0.13.0 — 2026-09-04
 
 ### `nrv audit where` and `nrv audit tail`

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,14 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### A checagem de completude aprendeu que squads também têm manifesto
+
+O `verify-deliverable.ts` procurava o `deliverables.json` de uma execução em `businesses/<slug>/` e na raiz da execução. Uma execução de squad grava o manifesto em `squads/<slug>/`, espelhando a convenção das empresas, e a checagem nunca tinha olhado ali. Em 04/09/2026 uma execução real tinha dois manifestos desses em disco, todo arquivo prometido presente e acima do piso de tamanho, e a checagem respondeu FAIL_INDETERMINATE "no deliverables.json" — um veredito sobre onde a ferramenta olhou, não sobre o trabalho. O maestro daquela execução diagnosticou certo antes de qualquer um aqui.
+
+Agora lê os três lugares, o motivo do indeterminado nomeia os caminhos que tentou, e a dica do CLI para de mandar um squad rodar `brief-business.ts`. O passo de verificação do protocolo diz `<slug>` em vez de `<business_slug>`, porque sempre valeu para os dois.
+
 ## 0.13.0 — 2026-09-04
 
 ### `nrv audit where` e `nrv audit tail`

--- a/skills/businesses/scripts/verify-deliverable.ts
+++ b/skills/businesses/scripts/verify-deliverable.ts
@@ -103,12 +103,17 @@ export function verifyDeliverableOnDisk(
   // --manifest). It's authoritative; brief.md regex is best-effort fallback.
   let expectedPathsRaw: string[] = [];
   let manifestSource = "brief-regex";
-  const deliverablesPath = path.join(projectDir, "businesses", businessSlug, "deliverables.json");
-  const deliverablesPathAlt = path.join(projectDir, "deliverables.json"); // project-level fallback
-
-  let manifestFile: string | null = null;
-  if (fs.existsSync(deliverablesPath)) manifestFile = deliverablesPath;
-  else if (fs.existsSync(deliverablesPathAlt)) manifestFile = deliverablesPathAlt;
+  // A run files its manifest under the target that produced it: `businesses/<slug>/`
+  // for a business, `squads/<slug>/` for a squad, or at the run root. This check
+  // knew the first and the last. On 2026-09-04 a squad run had two manifests under
+  // `squads/`, every promised file on disk, and got FAIL_INDETERMINATE "no
+  // deliverables.json" — a verdict about where the tool looked, not about the work.
+  const manifestCandidates = [
+    path.join(projectDir, "businesses", businessSlug, "deliverables.json"),
+    path.join(projectDir, "squads", businessSlug, "deliverables.json"),
+    path.join(projectDir, "deliverables.json"), // run-level fallback
+  ];
+  const manifestFile: string | null = manifestCandidates.find(p => fs.existsSync(p)) ?? null;
 
   if (manifestFile) {
     try {
@@ -156,7 +161,7 @@ export function verifyDeliverableOnDisk(
   if (expectedPathsRaw.length === 0) {
     return base("FAIL_INDETERMINATE", {
       manifest_source: manifestSource,
-      reason: "no deliverables.json, no acceptance[] entry with a path, and brief.md has no /path markers",
+      reason: `no deliverables.json (looked in ${manifestCandidates.map(p => path.relative(projectDir, p)).join(", ")}), no acceptance[] entry with a path, and brief.md has no /path markers`,
     });
   }
 
@@ -215,7 +220,7 @@ if (import.meta.main) {
   if (r.status === "FAIL_INDETERMINATE") {
     console.error(`WARN: ${r.reason || "indeterminate"}`);
     if (r.reason && r.reason.startsWith("no deliverables.json")) {
-      console.error("To fix: register the project with `brief-business.ts --manifest <paths.json>` next time.");
+      console.error("To fix: write the run's manifest next time — `brief-business.ts --manifest <paths.json>` for a business, or `squads/<slug>/deliverables.json` beside a squad's outputs.");
     }
   }
 

--- a/skills/businesses/tests/acceptance.test.ts
+++ b/skills/businesses/tests/acceptance.test.ts
@@ -135,7 +135,7 @@ describe("verify-deliverable reads the acceptance promise", () => {
       process.chdir(cwd);
       const r = verifyDeliverableOnDisk("prj_1", "brandcraft", { businessDir: null, minBytes: 10 });
       expect(r).toMatchObject({ status: "PASS", expected: 1, found: 1 });
-      expect(r.manifest_source).toContain("squads/brandcraft/deliverables.json");
+      expect(r.manifest_source).toMatch(/squads[\\/]brandcraft[\\/]deliverables\.json$/); // Windows reports backslashes
     } finally { process.chdir(saved); }
   });
 

--- a/skills/businesses/tests/acceptance.test.ts
+++ b/skills/businesses/tests/acceptance.test.ts
@@ -119,6 +119,26 @@ describe("verify-deliverable reads the acceptance promise", () => {
     } finally { process.chdir(saved); }
   });
 
+  // A squad run writes its manifest under `squads/<slug>/`, mirroring the
+  // `businesses/<slug>/` convention. On 2026-09-04 a live run had two of those
+  // on disk, every promised file present, and this check answered
+  // FAIL_INDETERMINATE "no deliverables.json" — it had never looked there.
+  test("a squad run's manifest under squads/<slug>/ is found and verified", () => {
+    const { cwd } = project({});
+    const squadOut = path.join(cwd, "outputs", "prj_1", "squads", "brandcraft", "outputs");
+    fs.mkdirSync(squadOut, { recursive: true });
+    const report = path.join(squadOut, "01-veredicto.md");
+    fs.writeFileSync(report, "Um veredicto com corpo suficiente para não ser stub.\n", "utf8");
+    fs.writeFileSync(path.join(cwd, "outputs", "prj_1", "squads", "brandcraft", "deliverables.json"), JSON.stringify({ deliverables: [report] }), "utf8");
+    const saved = process.cwd();
+    try {
+      process.chdir(cwd);
+      const r = verifyDeliverableOnDisk("prj_1", "brandcraft", { businessDir: null, minBytes: 10 });
+      expect(r).toMatchObject({ status: "PASS", expected: 1, found: 1 });
+      expect(r.manifest_source).toContain("squads/brandcraft/deliverables.json");
+    } finally { process.chdir(saved); }
+  });
+
   test("a business that promises nothing keeps the brief-regex behavior", () => {
     const bizDir = business({ "brief-intake": "acceptance:\n  - id: quality\n    description: Sem path\n" });
     const { cwd, outputsRoot } = project({ "report.md": "conteúdo" });

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -428,9 +428,9 @@ Run TWO checks in order:
 
 **1. Deliverable verification** — disk-truth:
 ```bash
-bun ~/.nirvana/skills/businesses/scripts/verify-deliverable.ts <project_id> <business_slug>
+bun ~/.nirvana/skills/businesses/scripts/verify-deliverable.ts <project_id> <slug>
 ```
-Returns `{expected, found, missing, empty_or_stub, status}`, exit 0 (PASS) / 1 (FAIL). If FAIL, re-dispatch a revision agent before proceeding. **Without verify=PASS, no `gate_passed` is legitimate.**
+`<slug>` is the target that produced the work — a business or a squad; the manifest is read from `businesses/<slug>/` or `squads/<slug>/` under the run. Returns `{expected, found, missing, empty_or_stub, status}`, exit 0 (PASS) / 1 (FAIL) / 2 (indeterminate: no manifest found — a tool gap, not a verdict on the work). If FAIL, re-dispatch a revision agent before proceeding. **Without verify=PASS, no `gate_passed` is legitimate.**
 
 **2. Rubric quality gate:**
 ```bash


### PR DESCRIPTION
`verify-deliverable.ts` looked for a run's `deliverables.json` under `businesses/<slug>/` and at the run root. A squad run files its manifest under `squads/<slug>/`, mirroring the business convention, and the check had never looked there.

On a live run with two squad manifests on disk, every promised file present and above the size floor, the check answered `FAIL_INDETERMINATE "no deliverables.json"` — a verdict about where the tool looked, not about the work. The run's maestro diagnosed it as a tool mismatch before anyone here did.

## Change

- `verifyDeliverableOnDisk` reads `businesses/<slug>/`, `squads/<slug>/`, then the run root; first hit wins.
- The indeterminate reason names the three paths it tried.
- The CLI hint no longer tells a squad to run `brief-business.ts`.
- `SKILL.md` verify step: `<slug>` instead of `<business_slug>`, with exit 2 documented as a tool gap rather than a verdict.

## Verification

- New test in `businesses/tests/acceptance.test.ts`: a `squads/<slug>/deliverables.json` fixture was FAIL_INDETERMINATE before the change and PASSes after (11/11 in the file, 101/101 in the area).
- Re-ran the check on the live run that produced the report: both squads now `PASS` (4/4 and 2/2), `manifest_source` pointing at `squads/<slug>/deliverables.json`.
- `delivery-pipeline.test.ts` green (it stubs the script and is unaffected). `check:quick`, changelog parity, english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk