### PR TITLE
feat(claws): a project is where an OpenClaw agent lives too, and the engine says how

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A project is where a claw lives too
+
+Claude, Codex, Gemini and Hermes work in the directory they were started in, so "open it inside the project" was the whole recipe and every `nrv` call logged under `<project>/.nirvana/logs/harness/`. OpenClaw does not: an agent works in its **workspace**, reads `AGENTS.md` from there, and ignores where the person typed. Nothing in the engine said so, and the installer note called OpenClaw a runtime that reads no contract at all.
+
+The binding is one command — `openclaw agents add <name> --workspace <project> --non-interactive` — and it makes the `AGENTS.md` that `nrv init` wrote the agent's operating instructions. Measured on a fresh project: the agent summarised the contract, `pwd` was the project, and `nrv audit emit` landed signed in the project's log with nothing in the global one. `nrv init` prints the command when `openclaw` is on PATH (and the Hermes recipe when `hermes` is), `nrv doctor` lists the agents bound this way, the project skeleton git-ignores the `memory/` OpenClaw writes into its workspace, and the installer note says what is true now. `docs/architecture/project-directory-and-runtimes.md` holds the rule and the recipe per runtime; OpenClaw's tool hooks are documented as not wired, with the upstream issues that say why.
+
+Found by the same probe: the 0.13.0 notes promised `nrv audit where` and `nrv audit tail`; the CLI only knew `audit-where` and `audit-tail`, and `nrv audit where` answered "No events found for project 'where'". Both spellings reach the same scripts now.
+
 ### Codex runs with the flags Codex has now, and every runtime gets its directories
 
 The Codex adapter was audited on 2026-08-26 and used three flags. Against 0.153.4 it now passes the directory grants (`--add-dir` for the project dir, the outputs root and the business or squad dir — the same grants Claude already received, which Codex never did, so under a sandbox a seat could not reach its playbooks), a real restricted path (`--approve-for-me`, which by itself means the workspace-write sandbox — 0.153 rejects it combined with `-s`: the sandbox stays and approvals go to Codex's reviewer agent instead of stalling a run nobody is watching — `-s workspace-write` alone inherited the user's `approval_policy` and blocked at the first escalation), and the provider as `-c model_provider=…`, because `--provider` was removed from `codex exec` and every dispatch with a provider hint was failing before it ran. Three opt-in flags for callers that want them: `--ephemeral` (never when a session will be resumed), `--output-schema`, `-i` images, and `web_search` per run.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,14 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O projeto também é onde um claw mora
+
+Claude, Codex, Gemini e Hermes trabalham no diretório em que foram abertos, então "abra dentro do projeto" era a receita inteira e toda chamada `nrv` logava em `<projeto>/.nirvana/logs/harness/`. O OpenClaw não: um agente trabalha no seu **workspace**, lê o `AGENTS.md` de lá e ignora onde a pessoa digitou. Nada no engine dizia isso, e a nota do instalador chamava o OpenClaw de runtime que não lê contrato nenhum.
+
+O vínculo é um comando — `openclaw agents add <nome> --workspace <projeto> --non-interactive` — e ele faz do `AGENTS.md` que o `nrv init` escreveu a instrução operacional do agente. Medido num projeto recém-criado: o agente resumiu o contrato, o `pwd` era o projeto, e o `nrv audit emit` caiu assinado no log do projeto sem nada no global. O `nrv init` imprime o comando quando `openclaw` está no PATH (e a receita do Hermes quando `hermes` está), o `nrv doctor` lista os agentes vinculados assim, o esqueleto do projeto ignora no git o `memory/` que o OpenClaw escreve no workspace, e a nota do instalador diz o que é verdade agora. `docs/architecture/project-directory-and-runtimes.md` guarda a regra e a receita por runtime; os hooks de ferramenta do OpenClaw ficam documentados como não ligados, com as issues upstream que dizem por quê.
+
+Achado pela mesma sondagem: as notas da 0.13.0 prometiam `nrv audit where` e `nrv audit tail`; o CLI só conhecia `audit-where` e `audit-tail`, e `nrv audit where` respondia "No events found for project 'where'". As duas grafias chegam agora aos mesmos scripts.
+
 ### O Codex roda com as flags que o Codex tem agora, e todo runtime recebe seus diretórios
 
 O adapter do Codex tinha sido auditado em 26/08/2026 e usava três flags. Contra a 0.153.4 ele agora passa as concessões de diretório (`--add-dir` para o diretório do projeto, a raiz de saídas e o diretório da empresa ou do squad — as mesmas que o Claude já recebia e o Codex nunca recebeu, então sob sandbox um seat não alcançava seus playbooks), um caminho restrito de verdade (`--approve-for-me`, que sozinho já significa o sandbox workspace-write — a 0.153 rejeita a combinação com `-s`: o sandbox fica e as aprovações vão ao agente revisor do Codex em vez de travar uma execução que ninguém está olhando — `-s workspace-write` sozinho herdava o `approval_policy` do usuário e bloqueava na primeira escalada), e o provedor como `-c model_provider=…`, porque `--provider` foi removida do `codex exec` e todo despacho com dica de provedor falhava antes de rodar. Três flags opcionais para quem quiser: `--ephemeral` (nunca quando a sessão vai ser retomada), `--output-schema`, `-i` para imagens, e `web_search` por execução.

--- a/bin/nrv
+++ b/bin/nrv
@@ -267,6 +267,12 @@ case "$cmd" in
     if [ "${1:-}" = "emit" ]; then
       shift; exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-emit.ts" "$@"
     fi
+    if [ "${1:-}" = "where" ]; then
+      shift; exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-where.ts" "$@"
+    fi
+    if [ "${1:-}" = "tail" ]; then
+      shift; exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-tail.ts" "$@"
+    fi
     exec "$BUN_BIN" "$SKILLS/harness/scripts/audit-view.ts" "$@" ;;
   search)
     exec "$BUN_BIN" "$SKILLS/harness/scripts/search.ts" "$@" ;;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,6 +72,8 @@ Useful flags on `run` / `auto`: `--single` / `--team` (how many seats of the bus
 | `nrv export <project> [--format=zip\|tgz]` | Bundle a project's outputs to share. |
 | `nrv clean <project> [--hard]` | Remove a project scaffold (trash by default). |
 
+A project is where a run's audit, briefs and deliverables live, for every runtime — including OpenClaw, whose agent must have the project as its workspace. How each one enters it: [docs/architecture/project-directory-and-runtimes.md](architecture/project-directory-and-runtimes.md).
+
 ## Libraries & distribution
 
 | Command | What it does |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -45,6 +45,7 @@ Este diretório é a fonte canônica para a evolução integrada do Run Kernel, 
 25. [Sessões do maestro](maestro-sessions.md)
 
 26. [Portão de admissão `nrv validate`](validate-gate.md)
+27. [O diretório do projeto e como cada runtime entra nele](project-directory-and-runtimes.md)
 
 ## ADRs
 

--- a/docs/architecture/project-directory-and-runtimes.md
+++ b/docs/architecture/project-directory-and-runtimes.md
@@ -1,0 +1,134 @@
+# The project directory, and how each runtime enters it
+
+**Status:** current · **Date:** 2026-09-05 · **Language:** English (engine documentation)
+
+A Nirvana project is a directory `nrv init` wrote. Everything a run produces
+lives under it, and every agent runtime reaches it the same way: by working
+**inside** it. This page states the rule once, then the recipe per runtime,
+including the two whose home is not the current directory.
+
+## 1. The rule
+
+`log-paths.js` resolves where audit goes, in this order:
+
+1. `HARNESS_LOGS_DIR` (explicit override, honoured everywhere)
+2. `<project>/.nirvana/logs/harness/` when the process runs inside a project
+3. `NIRVANA_TEST_LOGS_HOME` (test isolation only)
+4. `~/.harness-logs/` when nothing above applies
+
+"Inside a project" is decided by `project-root.js`: walk up from the process
+**cwd** until a directory carries `.nirvana/`, stopping at `$HOME` (a stray
+`~/.nirvana` is the engine's install, never a project). `NIRVANA_PROJECT_ROOT`
+names the root explicitly when cwd cannot.
+
+So the invariant a runtime has to satisfy is small: its shell and file tools run
+with cwd inside the project, or the variable is set. Then `nrv` commands the
+agent issues log under `.nirvana/logs/harness/`, deliverables land under
+`outputs/`, briefs under `.nirvana/briefs/`, and `HANDOFF.json` sits at the
+root. `nrv audit where` prints the resolved root and the reason.
+
+## 2. What `nrv init` writes
+
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — one contract in three filenames, so
+every runtime finds the one it reads — plus `.nirvana/` (briefs, businesses,
+squads, mind-clones, `project.yaml`), `.env`, `.env.example`, `.gitignore`,
+`README.md`. Per-project skills are opt-in (`--with-skills`); by default the
+project relies on the machine's `~/.nirvana/skills`.
+
+## 3. Per runtime
+
+| Runtime | Enter the project | Contract read from | Extra roots | Audit source |
+|---|---|---|---|---|
+| Claude Code | `cd <project> && claude` | `CLAUDE.md` in cwd | `--add-dir` | hooks (`PreToolUse`/`PostToolUse`) + `nrv audit emit` |
+| Codex | `cd <project> && codex`, or `codex exec -C <project>` | `AGENTS.md` in cwd (native) | `--add-dir` | `nrv audit emit` (hooks: pending) |
+| Gemini CLI | `cd <project> && gemini` | `GEMINI.md` in cwd | `--include-directories` | hooks + `nrv audit emit` |
+| Antigravity | `cd <project> && agy` | `AGENTS.md` in cwd | `--add-dir` | hooks + `nrv audit emit` |
+| Hermes | `nrv-hermes`, or `hermes chat --in <project>` | `AGENTS.md` injected from cwd | n/a (works in cwd) | shell hooks (`pre/post_tool_call`) + fs-watch |
+| OpenClaw | the project **is** the agent's workspace (below) | `AGENTS.md` in the workspace | n/a (workspace is the root) | `nrv audit emit` + fs-watch (tool hooks: see §4.3) |
+
+The scripted path (`nrv dispatch --exec`, `nrv team step`) passes the project
+dir, the outputs root and the business or squad dir to the child runtime through
+the flag in the third column (`RUNTIME_DIR_GRANT_FLAG` in the driver). Runtimes
+without a flag (grok, pi, kimi, opencode) get a warning on the result.
+
+## 4. OpenClaw: the project is the agent's home
+
+OpenClaw inverts the model. An agent works in its **workspace**: `AGENTS.md`,
+`SOUL.md` and `IDENTITY.md` are read from there at every session start (and
+scaffolded if missing), relative paths resolve there, and skills are found under
+`<workspace>/skills`, `<workspace>/.agents/skills`, then the personal
+`~/.agents/skills` (where the installer links the engine), then managed and
+bundled ones. The current directory of the person typing plays no part.
+
+### 4.1 The recommended binding
+
+```
+nrv init my-project
+openclaw agents add my-project --workspace ~/my-project --non-interactive
+```
+
+One dedicated agent per project. Its operating instructions are the `AGENTS.md`
+`nrv init` wrote, its tools run with cwd in the project, and every `nrv` call it
+makes logs in the project. `nrv init` prints this command when `openclaw` is on
+PATH; `nrv doctor` lists the agents bound this way.
+
+Measured on 2026-09-05, gateway mode, a fresh `nrv init` project: the agent
+summarised the contract correctly ("invoke the harness skill, dispatch through
+Business → Squad → agent-x, pass the gate and the audit trail"), `pwd` returned
+the project, and `nrv audit emit x_openclaw_probe` landed in
+`<project>/.nirvana/logs/harness/<date>/audit.jsonl` with provenance `engine`;
+the global log received nothing. The run used OpenClaw's Codex harness for an
+OpenAI model (`agentHarnessId: codex`), which is how OpenClaw executes OpenAI
+agents.
+
+What OpenClaw adds to the project root on first run: `SOUL.md`, `IDENTITY.md`,
+`USER.md`, `BOOTSTRAP.md` (removed after onboarding) and `memory/` with one file
+per day. `memory/` is git-ignored by the skeleton; the persona files are
+versionable and yours to edit.
+
+Running it: `openclaw agent --agent my-project -m "…"` through the Gateway, or
+`--local` when no Gateway holds the state directory (`--local` needs exclusive
+ownership of it, and refuses while the service runs). The JSON envelope carries
+`result.payloads[].text`, `result.meta.agentMeta.usage` and `costUsd`.
+
+### 4.2 The other binding, and why it is second
+
+`agents.entries.<id>.cwd` points tool execution at a directory other than the
+workspace. Logs would land in the project, but the project's `AGENTS.md` would
+not be the agent's instructions (bootstrap files come from the workspace), and
+the docs state that sandboxed runs reject an alternate cwd. Use it only when the
+agent must keep a shared persona across many projects.
+
+### 4.3 Audit inside OpenClaw
+
+OpenClaw's plugin SDK declares `before_tool_call` / `after_tool_call` hooks and
+its docs say embedded and CLI runners dispatch them. Its own issue tracker
+records them registering and not firing across several releases (#5513, #5943,
+#7297, #60209). The engine therefore does not wire an OpenClaw tool hook yet;
+audit inside an OpenClaw agent comes from the contract (`nrv audit emit`, which
+the probe above exercised) and from `nrv watch-fs <project>` as filesystem
+evidence. Wiring a plugin hook is a future cut, gated on a run where the hook is
+observed firing.
+
+## 5. Hermes
+
+Hermes works in cwd and injects `AGENTS.md` from it (what `--ignore-rules`
+switches off). `nrv-hermes`, installed with the engine, finds the project root by
+walking up, exports `NIRVANA_PROJECT_SKILLS` for the `${NIRVANA_PROJECT_SKILLS}`
+entry the installer added to `~/.hermes/config.yaml:skills.external_dirs`, and
+runs `nrv watch-fs` beside the session. The `pre_tool_call` / `post_tool_call`
+shell hooks the installer wires carry `cwd` in their payload, so their events
+resolve to the project's log. Hermes reads no project-local `.hermes/`; only
+`~/.hermes/`. `hermes project create` + `add-folder` groups sessions in the
+desktop app and gives kanban tasks a worktree; it does not move the logs.
+Unseen hooks ask for consent once (`--accept-hooks`, `HERMES_ACCEPT_HOOKS=1` or
+`hooks_auto_accept: true` for headless use).
+
+## 6. Sources
+
+OpenClaw: [agent workspace](https://docs.openclaw.ai/concepts/agent-workspace) ·
+[config — agents](https://docs.openclaw.ai/gateway/config-agents) ·
+[`openclaw agent`](https://docs.openclaw.ai/cli/agent) ·
+[plugin hooks](https://docs.openclaw.ai/plugins/hooks). Hermes:
+[event hooks](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks).
+Codex: [non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode).

--- a/skills/_shared/lib/openclaw.ts
+++ b/skills/_shared/lib/openclaw.ts
@@ -1,0 +1,100 @@
+// openclaw.ts — OpenClaw's agent roster, read for one question: which agents
+// have a Nirvana project as their home.
+//
+// OpenClaw inverts the model every other runtime here follows. Claude, Codex,
+// Gemini and Hermes work in the directory they were started in, so "run it
+// inside the project" is the whole recipe. An OpenClaw agent works in its
+// WORKSPACE: that is where AGENTS.md/SOUL.md/IDENTITY.md are read from at every
+// session start, where relative paths resolve, and where skills under
+// `<workspace>/skills` and `<workspace>/.agents/skills` are found
+// (docs.openclaw.ai/concepts/agent-workspace, 2026.8). The way a project meets
+// an OpenClaw agent is therefore to make the project the agent's workspace:
+//
+//   openclaw agents add <name> --workspace <project> --non-interactive
+//
+// Measured 2026-09-05 with a project written by `nrv init`: the agent read the
+// project's AGENTS.md, `pwd` was the project, and `nrv audit emit` landed
+// signed in `<project>/.nirvana/logs/harness/`, nothing in the global log.
+//
+// `agents.entries.<id>.cwd` exists too ("working directory for tool execution,
+// separate from workspace") and would put the logs in the project while the
+// agent's files stay elsewhere — but then the project's AGENTS.md is not the
+// agent's instructions, and the docs say sandboxed runs reject an alternate
+// cwd. It is documented, not recommended.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface OpenClawAgent {
+  id: string;
+  workspace: string | null;
+  cwd: string | null;
+}
+
+/** OPENCLAW_CONFIG_PATH, else <state dir>/openclaw.json, the state dir being OPENCLAW_STATE_DIR or ~/.openclaw. */
+export function openclawConfigPath(): string {
+  if (process.env.OPENCLAW_CONFIG_PATH) return process.env.OPENCLAW_CONFIG_PATH;
+  const state = process.env.OPENCLAW_STATE_DIR || path.join(os.homedir(), ".openclaw");
+  return path.join(state, "openclaw.json");
+}
+
+function expandHome(p: string): string {
+  return p === "~" ? os.homedir() : p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
+}
+
+/**
+ * The roster as the config declares it. Both shapes OpenClaw has used are read:
+ * `agents.entries` (an object keyed by id) and the older `agents.list` (an
+ * array with `id`). A workspace an agent does not set falls back to
+ * `<agents.defaults.workspace>/<id>` for non-main agents, per the docs; the
+ * main agent uses the default itself. An unreadable config is an empty roster,
+ * never an error — this feeds a doctor line and an init hint.
+ */
+export function readOpenClawAgents(configPath = openclawConfigPath()): OpenClawAgent[] {
+  let raw: string;
+  try { raw = fs.readFileSync(configPath, "utf8"); } catch { return []; }
+  let cfg: any;
+  try { cfg = JSON.parse(raw); } catch { return []; }
+  const agents = cfg?.agents ?? {};
+  const defaultWs = typeof agents?.defaults?.workspace === "string"
+    ? expandHome(agents.defaults.workspace)
+    : path.join(process.env.OPENCLAW_STATE_DIR || path.join(os.homedir(), ".openclaw"), "workspace");
+  const out: OpenClawAgent[] = [];
+  const push = (id: string, entry: any) => {
+    const ws = typeof entry?.workspace === "string" ? expandHome(entry.workspace)
+      : id === "main" ? defaultWs : path.join(defaultWs, id);
+    out.push({ id, workspace: ws, cwd: typeof entry?.cwd === "string" ? expandHome(entry.cwd) : null });
+  };
+  if (agents.entries && typeof agents.entries === "object" && !Array.isArray(agents.entries)) {
+    for (const [id, entry] of Object.entries(agents.entries)) push(id, entry);
+  } else if (Array.isArray(agents.list)) {
+    for (const entry of agents.list) if (entry && typeof entry.id === "string") push(entry.id, entry);
+  }
+  return out;
+}
+
+/** A directory is a Nirvana project when it carries the `.nirvana/` scaffold `nrv init` writes. */
+export function isNirvanaProject(dir: string): boolean {
+  try { return fs.statSync(path.join(dir, ".nirvana")).isDirectory(); } catch { return false; }
+}
+
+/** Agents whose workspace is a Nirvana project — the recommended binding. */
+export function openclawAgentsOnProjects(configPath?: string): OpenClawAgent[] {
+  return readOpenClawAgents(configPath).filter((a) => a.workspace !== null && isNirvanaProject(a.workspace));
+}
+
+function realOrSelf(p: string): string {
+  try { return fs.realpathSync(p); } catch { return path.resolve(p); }
+}
+
+/** The agent whose workspace IS this project, if one is bound. */
+export function openclawAgentFor(projectDir: string, configPath?: string): OpenClawAgent | null {
+  const want = realOrSelf(projectDir);
+  return readOpenClawAgents(configPath).find((a) => a.workspace !== null && realOrSelf(a.workspace) === want) ?? null;
+}
+
+/** The one command that binds a project to a new dedicated agent. */
+export function openclawBindCommand(projectDir: string, name: string): string {
+  const safe = name.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "nirvana";
+  return `openclaw agents add ${safe} --workspace ${projectDir} --non-interactive`;
+}

--- a/skills/_shared/lib/runtime-dirs.ts
+++ b/skills/_shared/lib/runtime-dirs.ts
@@ -59,7 +59,7 @@ export const RUNTIME_TARGETS: RuntimeTarget[] = [
     name: "openclaw",
     bin: "openclaw",
     skillsDir: join(homedir(), ".agents/skills"),
-    note: "OpenClaw reads no project contract (AGENTS.md/CLAUDE.md have no effect there); invoke skills explicitly: /harness <brief>. Dispatch is the scripted path (nrv dispatch --exec).",
+    note: "OpenClaw works in an agent's WORKSPACE, not in cwd: a project meets it when the project IS the workspace — `openclaw agents add <name> --workspace <project> --non-interactive` — and then AGENTS.md is the agent's operating instructions and every nrv call logs in the project. Dispatch is the scripted path (nrv dispatch --exec).",
   },
 ];
 

--- a/skills/_shared/scripts/init-project.ts
+++ b/skills/_shared/scripts/init-project.ts
@@ -35,6 +35,7 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { parseArgs, EXIT, log, paths } from "../lib/bun-helpers.ts";
 import { ProjectService } from "../../harness/lib/control-plane/project-service.ts";
+import { openclawAgentFor, openclawBindCommand } from "../lib/openclaw.ts";
 
 const SKILLS_ROOT = process.env.NIRVANA_SKILLS_DIR
   || (fs.existsSync(path.join(os.homedir(), ".nirvana", "skills")) ? path.join(os.homedir(), ".nirvana", "skills") : path.join(os.homedir(), ".claude", "skills"));
@@ -577,7 +578,32 @@ async function main() {
       log.ok(`Audit hooks active across installed agents — runs auto-track in 'nrv glance'.`);
     }
   } catch { /* check is best-effort */ }
+  // The claws. Claude, Codex, Gemini and Hermes work where they are started, so
+  // "open it here" is the whole recipe. OpenClaw works in an agent's workspace,
+  // and the way this directory becomes that agent's home is one command — said
+  // here, once, because nothing in OpenClaw will ever say it.
+  try {
+    if (binOnPath("openclaw")) {
+      const bound = openclawAgentFor(target);
+      if (bound) {
+        log.ok(`OpenClaw: agent '${bound.id}' already has this project as its workspace.`);
+      } else {
+        log.info(`OpenClaw: to make this project an agent's workspace (AGENTS.md becomes its instructions; every nrv call logs here):`);
+        log.info(`  ${openclawBindCommand(target, path.basename(target))}`);
+        log.info(`  OpenClaw then scaffolds SOUL.md, IDENTITY.md, USER.md and memory/ in the project; memory/ is git-ignored.`);
+      }
+    }
+    if (binOnPath("hermes")) {
+      log.info(`Hermes: nrv-hermes from this directory (or hermes chat --in ${target}) — AGENTS.md is injected from cwd and the audit hooks already log here.`);
+    }
+  } catch { /* hints are best-effort */ }
   process.exit(EXIT.OK);
+}
+
+/** `where` on Windows, `which` elsewhere: is the CLI on PATH? */
+function binOnPath(bin: string): boolean {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try { return require("node:child_process").spawnSync(probe, [bin], { stdio: "ignore" }).status === 0; } catch { return false; }
 }
 
 await main();

--- a/skills/_shared/templates/project-skeleton/.gitignore
+++ b/skills/_shared/templates/project-skeleton/.gitignore
@@ -32,3 +32,7 @@ outputs/
 # OS noise
 .DS_Store
 Thumbs.db
+
+# OpenClaw agent state, when this project is an agent's workspace
+# (`openclaw agents add <name> --workspace <this dir>`): daily memory logs.
+memory/

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -28,6 +28,7 @@ import { paths as nrvPaths } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope, enumerate } from "../../_shared/lib/scope.ts";
 import { RUNTIME_TARGETS, RUNTIME_SKILL_DIRS, PROJECT_CONTRACT_FILES, SKILLS as SKILL_NAMES } from "../../_shared/lib/runtime-dirs.ts";
 import { listRuntimes, whichSync } from "../../_shared/lib/host-agent-driver.ts";
+import { openclawAgentsOnProjects } from "../../_shared/lib/openclaw.ts";
 import { expandEnv, findTempNrvEntries, readUserPath, tempRoots } from "../../_shared/lib/windows-user-path.ts";
 import { parseAuditLine } from "../../_shared/lib/cloudevents.js";
 import {
@@ -134,6 +135,18 @@ add(
     ? `${runtimesOnPath}/${listRuntimes().length} agent runtime(s) on PATH`
     : `no agent runtime on PATH — dispatch cannot run; install one (claude, codex, gemini, …)${headlessCI ? " (CI environment: reported as warning)" : ""}`,
 );
+
+// SECTION 1a-ter: CLAWS ON PROJECTS — OpenClaw works in an agent's workspace,
+// not in cwd, so the only way a Nirvana project meets an OpenClaw agent is to
+// BE that agent's workspace. This line says which agents are bound that way.
+// Informational: a machine with no binding is not degraded.
+if (which("openclaw")) {
+  const bound = openclawAgentsOnProjects();
+  add("openclaw: agents on projects", "PASS",
+    bound.length
+      ? bound.map((a) => `${a.id} → ${a.workspace!.replace(HOME, "~")}`).join(", ")
+      : "none bound — `openclaw agents add <name> --workspace <project> --non-interactive` makes a project the agent's home");
+}
 
 // SECTION 1a-bis-judge: GAUNTLET EVALUATOR — which evaluator a Gauntlet started
 // today would get, by the same selection the three canaries use

--- a/skills/harness/scripts/nrv.ts
+++ b/skills/harness/scripts/nrv.ts
@@ -119,6 +119,10 @@ switch (cmd) {
   case "pack": runScript(join(H, "pack.ts"), rest);
   case "audit-view": case "audit": {
     if (rest[0] === "emit") runScript(join(H, "audit-emit.ts"), rest.slice(1));
+    // The 0.13.0 notes said `nrv audit where` / `nrv audit tail`; the CLI only
+    // knew the hyphenated names. Both spellings now reach the same script.
+    if (rest[0] === "where") runScript(join(H, "audit-where.ts"), rest.slice(1));
+    if (rest[0] === "tail") runScript(join(H, "audit-tail.ts"), rest.slice(1));
     runScript(join(H, "audit-view.ts"), rest);
   }
   case "search": runScript(join(H, "search.ts"), rest);

--- a/skills/harness/tests/openclaw.test.ts
+++ b/skills/harness/tests/openclaw.test.ts
@@ -1,0 +1,62 @@
+// openclaw.test.ts — reading OpenClaw's roster and answering "which agents have
+// a Nirvana project as their workspace". Pure: a config file and directories in
+// a temp dir, no OpenClaw binary.
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { isNirvanaProject, openclawAgentFor, openclawAgentsOnProjects, openclawBindCommand, readOpenClawAgents } from "../../_shared/lib/openclaw.ts";
+
+const roots: string[] = [];
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+// Directories first, then the config that names them.
+function fixture(config: (p: { project: string; plain: string }) => unknown) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-openclaw-")); roots.push(root);
+  const project = path.join(root, "my-project");
+  fs.mkdirSync(path.join(project, ".nirvana"), { recursive: true });
+  const plain = path.join(root, "plain-dir");
+  fs.mkdirSync(plain, { recursive: true });
+  const cfg = path.join(root, "openclaw.json");
+  fs.writeFileSync(cfg, JSON.stringify(config({ project, plain })));
+  return { root, project, plain, cfg };
+}
+
+describe("OpenClaw roster → projects", () => {
+  test("entries shape: the agent whose workspace is a project is found; the others are not", () => {
+    const { project, plain, cfg } = fixture((p) => ({ agents: { defaults: { workspace: "/tmp/ws" }, entries: {
+      main: {}, docs: { workspace: p.plain }, proj: { workspace: p.project, cwd: "/elsewhere" },
+    } } }));
+    const all = readOpenClawAgents(cfg);
+    expect(all.map((a) => a.id).sort()).toEqual(["docs", "main", "proj"]);
+    expect(all.find((a) => a.id === "main")!.workspace).toBe("/tmp/ws");            // main uses the default itself
+    expect(all.find((a) => a.id === "proj")!.cwd).toBe("/elsewhere");
+    expect(openclawAgentsOnProjects(cfg).map((a) => a.id)).toEqual(["proj"]);
+    expect(openclawAgentFor(project, cfg)!.id).toBe("proj");
+    expect(openclawAgentFor(plain, cfg)!.id).toBe("docs");           // bound, just not to a project
+    expect(openclawAgentFor(path.join(plain, "..", "unbound"), cfg)).toBeNull();
+  });
+
+  test("list shape (older configs) is read the same way; unset workspaces fall back to <default>/<id>", () => {
+    const { cfg } = fixture((p) => ({ agents: { defaults: { workspace: "~/ws" }, list: [
+      { id: "main" }, { id: "side" }, { id: "proj", workspace: p.project },
+    ] } }));
+    const all = readOpenClawAgents(cfg);
+    expect(all.find((a) => a.id === "side")!.workspace).toBe(path.join(os.homedir(), "ws", "side"));
+    expect(openclawAgentsOnProjects(cfg).map((a) => a.id)).toEqual(["proj"]);
+  });
+
+  test("a missing or unreadable config is an empty roster, never a throw", () => {
+    const { root } = fixture(() => ({}));
+    expect(readOpenClawAgents(path.join(root, "nope.json"))).toEqual([]);
+    const bad = path.join(root, "bad.json"); fs.writeFileSync(bad, "{ not json");
+    expect(readOpenClawAgents(bad)).toEqual([]);
+  });
+
+  test("isNirvanaProject needs the .nirvana directory, and the bind command is safe to paste", () => {
+    const { project, plain } = fixture(() => ({}));
+    expect(isNirvanaProject(project)).toBe(true);
+    expect(isNirvanaProject(plain)).toBe(false);
+    expect(openclawBindCommand("/x/y/my project", "my project!")).toBe("openclaw agents add my-project --workspace /x/y/my project --non-interactive");
+  });
+});


### PR DESCRIPTION
## Why

Claude, Codex, Gemini and Hermes work in the directory they were started in, so "open it inside the project" was the whole recipe and every `nrv` call logged under `<project>/.nirvana/logs/harness/`. OpenClaw does not: an agent works in its **workspace**, reads `AGENTS.md` from there and ignores where the person typed. Nothing in the engine said so; the installer note called OpenClaw a runtime that reads no contract at all.

## What

- **The binding**: `openclaw agents add <name> --workspace <project> --non-interactive`. Measured on a fresh `nrv init` project through the Gateway: the agent summarised the contract correctly, `pwd` was the project, `nrv audit emit` landed in `<project>/.nirvana/logs/harness/<date>/audit.jsonl` with provenance `engine`, the global log received nothing.
- `_shared/lib/openclaw.ts`: reads the roster (`agents.entries` and the older `agents.list`), answers which agents have a Nirvana project as workspace.
- `nrv init`: prints the bind command when `openclaw` is on PATH, and the Hermes recipe when `hermes` is; says so when the project is already bound.
- `nrv doctor`: `OPENCLAW → agents on projects` lists the bound agents.
- Project skeleton `.gitignore`: `memory/` (OpenClaw's daily logs in its workspace).
- Installer note for OpenClaw rewritten to what is true.
- `docs/architecture/project-directory-and-runtimes.md`: the log-resolution rule, what `nrv init` writes, a per-runtime table, the OpenClaw recipe and its alternative (`cwd`) with the documented caveat, Hermes, and the tool-hook status with upstream issues.
- `nrv audit where` / `nrv audit tail`: both spellings now reach the scripts the 0.13.0 notes promised (`nrv audit where` used to answer "No events found for project 'where'").

## Verification

- `openclaw.test.ts` (4): both config shapes, default-workspace fallback, unreadable config → empty roster, bind command sanitised.
- Installed from this branch on the maintainer's machine: doctor line present, `nrv audit where` resolves, `nrv init` prints the hints, new project `.gitignore` carries `memory/`.
- `check:quick`, cli parity, changelog parity, english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk