### PR TITLE
feat(packs): --keep-clones, and a backup before the overlay writes over an edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### A pack update no longer costs you your edits
+
+`nrv update <pack>` overlays the new pack over the installed one, and it said so plainly: the pack is the source of truth, and there is no backup. A buyer who had tuned a mind-clone lost the tuning on the next update, with a warning at best.
+
+Two things now. Any component you changed since the pack installed it (the manifest remembers what it installed, so a change is measurable) is copied to `~/.nirvana/backups/packs/<pack>/<stamp>/<kind>/<slug>/` before the overlay writes over it, and the run says which ones and where; a user-created component that collides with a pack slug is backed up the same way. And `--keep-clones` (also `--keep-squads`, `--keep-businesses`) leaves every component of that kind already on disk exactly as it is — new ones still arrive, nothing is removed — while the manifest keeps recording what the pack last installed, so a later plain update treats them as updates again rather than as current. `--dry` names what it would back up.
+
 ### Codex hooks, installed already trusted
 
 Codex runs a hook only after the user reviews it in the TUI, and an unreviewed hook is skipped in silence — `codex exec` prints nothing and the hook never fires (measured: zero payloads without trust, five with it). So an installer that only wrote hooks.json would install nothing a headless run could use, which is why Codex had no audit hooks while Claude, Gemini and Antigravity had them for months.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,12 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### Atualizar um pack não custa mais as suas edições
+
+`nrv update <pack>` sobrepõe o pack novo ao instalado, e dizia isso sem rodeios: o pack é a fonte de verdade, e não há backup. Quem tinha ajustado um clone perdia o ajuste na atualização seguinte, no máximo com um aviso.
+
+Duas coisas agora. Qualquer componente que você mudou desde que o pack o instalou (o manifesto lembra o que instalou, então a mudança é mensurável) é copiado para `~/.nirvana/backups/packs/<pack>/<carimbo>/<tipo>/<slug>/` antes de o overlay escrever por cima, e a execução diz quais e onde; um componente criado por você que colide com um slug do pack é copiado do mesmo jeito. E `--keep-clones` (também `--keep-squads`, `--keep-businesses`) deixa todo componente daquele tipo que já está em disco exatamente como está — os novos ainda chegam, nada é removido — enquanto o manifesto continua registrando o que o pack instalou por último, para que uma atualização seguinte sem a flag os trate de novo como atualização, não como atuais. `--dry` nomeia o que faria backup.
+
 ### Hooks do Codex, instalados já confiáveis
 
 O Codex só roda um hook depois que o usuário o revisa na TUI, e um hook não revisado é pulado em silêncio — o `codex exec` não imprime nada e o hook nunca dispara (medido: zero payloads sem confiança, cinco com ela). Então um instalador que só escrevesse o hooks.json não instalaria nada que uma execução headless pudesse usar, e é por isso que o Codex não tinha hooks de auditoria enquanto Claude, Gemini e Antigravity tinham há meses.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The paid layer is **content, not capability**: curated, ready-to-run collections
 | `nrv multi-target plan\|run\|status <plan.json>` | Compile, execute, or inspect a multi-target plan over the Run Kernel (`NIRVANA_MULTI_TARGET_KILL_SWITCH=1` turns `run` off) |
 | `nrv validate <squad\|business\|clone> <slug> [--fix]` | Admission gate for one entity, or `--all` for every installed one; `--fix` repairs what can be repaired without inventing anything |
 | `nrv migrate <slug> --to 6 [--apply]` | Convert a squad to Squad Protocol 6.0; dry run by default, `--apply` writes with a backup |
-| `nrv update <pack>` | Update an installed pack |
+| `nrv update <pack> [--keep-clones]` | Update an installed pack; your edited components are backed up first, or kept in place with `--keep-<kind>` |
 | `nrv doctor` | Check the installation; on Windows, `nrv install --repair-path` cleans the user PATH entries it warns about |
 
 Everything else, your agent runs. Full reference: [docs/CLI.md](./docs/CLI.md).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,6 +97,7 @@ A project is where a run's audit, briefs and deliverables live, for every runtim
 | `nrv baseline [--days=N] [--save]` | Snapshot system KPIs from the audit log. |
 | `nrv improver run [--days=N]` | Meta-Nirvana: mine the audit log and propose improvements. |
 | `nrv update [--check\|--force]` | Self-update: pull + re-run installer + re-index. |
+| `nrv update <pack> [--keep-clones\|--keep-squads\|--keep-businesses] [--check]` | Update an installed pack. A component you changed since the pack installed it is backed up under `~/.nirvana/backups/packs/<pack>/<stamp>/` before the overlay replaces it; `--keep-<kind>` leaves what is on disk as it is (new components still arrive). |
 
 > `nrv validate` exits `0` admitted · `1` an error the debt baseline does not cover · `2` only warnings, under `--strict` · `64` usage error or unknown entity. The system doctor moved to `nrv doctor`; `nrv validate` with no arguments still runs it, with a deprecation notice, for one release. Kind aliases: `biz`, `clone`, `mc`. Full contract: [docs/architecture/validate-gate.md](architecture/validate-gate.md).
 >

--- a/skills/_shared/scripts/install-content.ts
+++ b/skills/_shared/scripts/install-content.ts
@@ -47,6 +47,15 @@ function packsDir(): string { return join(nirvanaHome(), ".nirvana", "packs"); }
 const argv = process.argv.slice(2);
 const DRY = argv.includes("--dry");
 const SKIP_VALIDATE = argv.includes("--skip-validate");
+const NO_INDEX = argv.includes("--no-index");
+// --keep-clones (also --keep-squads / --keep-businesses): components of that
+// kind already on disk are neither replaced nor removed by this overlay; new
+// ones still arrive. For a buyer who edited a clone, this is how an update
+// stops being a choice between "new pack" and "my work".
+const KEEP = new Set<string>();
+if (argv.includes("--keep-clones") || argv.includes("--keep-mind-clones")) KEEP.add("mind-clones");
+if (argv.includes("--keep-squads")) KEEP.add("squads");
+if (argv.includes("--keep-businesses")) KEEP.add("businesses");
 const slugIdx = argv.indexOf("--slug");
 const SLUG = slugIdx >= 0 ? (argv[slugIdx + 1] ?? "") : "";
 const verIdx = argv.indexOf("--version");
@@ -193,31 +202,58 @@ const man: Manifest = (() => { try { return JSON.parse(readFileSync(manifestPath
 const availableIn = (dir: string, marker: string): string[] =>
   existsSync(dir) ? readdirSync(dir).filter((e) => !e.startsWith(".") && e !== "README.md" && existsSync(join(dir, e, marker))) : [];
 
-interface SyncRes { added: string[]; updated: string[]; unchanged: string[]; removed: string[]; overwritten: string[]; hashes: Record<string, string>; breaking: BreakingChange[]; }
+interface SyncRes { added: string[]; updated: string[]; unchanged: string[]; removed: string[]; overwritten: string[]; kept: string[]; backedUp: string[]; hashes: Record<string, string>; breaking: BreakingChange[]; }
+
+// Where a component goes before the overlay writes over it. One directory per
+// overlay run, created on first use so a run that backs nothing up leaves
+// nothing behind. Restoring is a copy back.
+const BACKUP_STAMP = new Date().toISOString().replace(/[:.]/g, "-");
+function backupRoot(): string { return join(nirvanaHome(), ".nirvana", "backups", "packs", SLUG, BACKUP_STAMP); }
+function backupComponent(kind: string, slug: string, dst: string, ex: string[]): void {
+  if (DRY) return;
+  const dest = join(backupRoot(), kind, slug);
+  mkdirSync(dest, { recursive: true });
+  cpSync(dst, dest, { recursive: true, force: true, filter: (p) => { const rel = relative(dst, p).split(sep).join("/"); return rel === "" || !isExcluded(rel, ex); } });
+}
+
 function syncKind(kind: string, srcRoot: string, dstRoot: string, available: string[], old: Record<string, string>, precomputed?: Record<string, string>): SyncRes {
   const ex = RUNSTATE_EXCLUDES[kind] ?? [];
-  const res: SyncRes = { added: [], updated: [], unchanged: [], removed: [], overwritten: [], hashes: {}, breaking: [] };
+  const keep = KEEP.has(kind);
+  const res: SyncRes = { added: [], updated: [], unchanged: [], removed: [], overwritten: [], kept: [], backedUp: [], hashes: {}, breaking: [] };
   if (available.length) mkdirSync(dstRoot, { recursive: true });
   for (const slug of available) {
     const src = join(srcRoot, slug), dst = join(dstRoot, slug);
     const h = precomputed?.[slug] ?? hashDir(src, ex); res.hashes[slug] = h;
-    if (!existsSync(dst)) { res.added.push(slug); if (!DRY) mirror(src, dst, ex); }
+    if (!existsSync(dst)) { res.added.push(slug); if (!DRY) mirror(src, dst, ex); continue; }
+    // --keep-<kind>: what is on disk stays, whatever the pack carries. The
+    // manifest keeps saying what the pack last INSTALLED here (the previous
+    // hash), so the next overlay without the flag treats it as an update again
+    // rather than as already current. A component the pack never owned stays
+    // outside the manifest.
+    if (keep) { res.kept.push(slug); if (slug in old) res.hashes[slug] = old[slug]; else delete res.hashes[slug]; continue; }
     // Collision: it exists on disk but the pack never owned it (outside the
     // manifest) — a user creation with the same slug. The pack wins (it is the
-    // source of truth) and there is no backup; warning only makes the loss
-    // visible, it does not prevent it.
-    else if (!(slug in old)) { res.overwritten.push(slug); if (!DRY) mirror(src, dst, ex); }
-    else {
-      const prev = old[slug] ?? hashDir(dst, ex);
-      if (prev !== h) {
-        res.updated.push(slug);
-        // BEFORE the mirror: the only window when installed and incoming coexist.
-        res.breaking.push(...contractBreaks(dst, src, `${kind}/${slug}`));
-        if (!DRY) mirror(src, dst, ex);
-      } else res.unchanged.push(slug);
-    }
+    // source of truth), and the user's version is backed up first.
+    if (!(slug in old)) { res.overwritten.push(slug); res.backedUp.push(slug); backupComponent(kind, slug, dst, ex); if (!DRY) mirror(src, dst, ex); continue; }
+    const prev = old[slug];
+    if (prev !== h) {
+      res.updated.push(slug);
+      // BEFORE the mirror: the only window when installed and incoming coexist.
+      res.breaking.push(...contractBreaks(dst, src, `${kind}/${slug}`));
+      // Changed on disk since the pack installed it — the buyer's edits. Backed
+      // up before the overlay replaces them; an untouched component is not,
+      // because the pack can always reproduce it.
+      if (hashDir(dst, ex) !== prev) { res.backedUp.push(slug); backupComponent(kind, slug, dst, ex); }
+      if (!DRY) mirror(src, dst, ex);
+    } else res.unchanged.push(slug);
   }
-  for (const slug of Object.keys(old)) { if (available.includes(slug)) continue; const dst = join(dstRoot, slug); if (existsSync(dst)) { res.removed.push(slug); if (!DRY) rmSync(dst, { recursive: true, force: true }); } }
+  for (const slug of Object.keys(old)) {
+    if (available.includes(slug)) continue;
+    const dst = join(dstRoot, slug);
+    if (!existsSync(dst)) continue;
+    if (keep) { res.kept.push(slug); res.hashes[slug] = old[slug]; continue; }
+    res.removed.push(slug); if (!DRY) rmSync(dst, { recursive: true, force: true });
+  }
   return res;
 }
 
@@ -321,7 +357,7 @@ const sq = runs["squads"], bz = runs["businesses"], cl = runs["mind-clones"];
   }
 }
 
-const line = (l: string, r: SyncRes) => console.log(`  ${l}: ${r.added.length} new · ${r.updated.length} updated · ${r.unchanged.length} unchanged · ${r.removed.length} removed${r.overwritten.length ? ` · ${r.overwritten.length} overwritten` : ""}`);
+const line = (l: string, r: SyncRes) => console.log(`  ${l}: ${r.added.length} new · ${r.updated.length} updated · ${r.unchanged.length} unchanged · ${r.removed.length} removed${r.kept.length ? ` · ${r.kept.length} kept (local)` : ""}${r.overwritten.length ? ` · ${r.overwritten.length} OVERWRITTEN` : ""}`);
 console.log(`${DRY ? "[DRY] " : ""}install-content '${SLUG}' ← ${CONTENT}`);
 line("squads", sq); line("businesses", bz); line("mind-clones", cl);
 
@@ -338,9 +374,21 @@ if (collisions.length > 0) {
   console.log();
   console.log(`  ${DRY ? "WOULD OVERWRITE" : "OVERWRITTEN"}: ${collisions.length} component(s) you created share a slug with a pack component.`);
   for (const c of collisions) console.log(`    ! ${c}`);
-  console.log("    The pack is the source of truth for its own components, so it wins — and there is no backup.");
-  console.log("    To keep your version, give it a different slug (your own components are never touched).");
+  console.log("    The pack is the source of truth for its own components, so it wins; your version was backed up first (below).");
+  console.log("    To keep your version in place, give it a different slug, or pass --keep-clones / --keep-squads / --keep-businesses.");
   console.log("    Your run-state (projects/, outputs/, memory/projects) was preserved.");
+}
+// What the overlay wrote over that the buyer had changed: named, and where it
+// went. The one loss this script can cause is edits made after install; a line
+// that says "backed up" and a directory that holds them is the difference
+// between an update and an accident.
+const backedUp = ([["squads", sq], ["businesses", bz], ["mind-clones", cl]] as const)
+  .flatMap(([l, r]) => r.backedUp.map((s) => `${l}/${s}`));
+if (backedUp.length > 0) {
+  console.log();
+  console.log(`  ${DRY ? "WOULD BACK UP" : "BACKED UP"}: ${backedUp.length} component(s) changed on this machine since the pack installed them${DRY ? "" : ` → ${backupRoot()}`}`);
+  for (const c of backedUp) console.log(`    ~ ${c}`);
+  console.log(`    Restore one by copying it back over the installed directory; keep it out of future updates with --keep-<kind>.`);
 }
 
 if (!DRY) {
@@ -355,6 +403,7 @@ if (!DRY) {
   // lived elsewhere. Now it falls back to the engine's own indexer, which is
   // where it always is: whoever gets here already has the engine, because this
   // script lives inside it.
+  if (NO_INDEX) { console.log("  (--no-index) registries not rebuilt — run 'nrv index' before routing to the new content."); process.exit(0); }
   console.log("  re-indexing registries...");
   const nrvBin = join(homedir(), ".local", "bin", "nrv");
   const indexer = join(import.meta.dir, "..", "..", "harness", "scripts", "index.ts");

--- a/skills/_shared/scripts/update-pack.ts
+++ b/skills/_shared/scripts/update-pack.ts
@@ -3,8 +3,14 @@
  * update-pack.ts — updates an already-installed paid pack, authenticated by the
  * PROVENANCE's license_key (no login). It is what `nrv update <slug>` calls.
  *
- *   nrv update <slug>            downloads the current version and re-applies (overlay)
- *   nrv update <slug> --check    only compares the installed version with the server's
+ *   nrv update <slug>                 downloads the current version and re-applies (overlay)
+ *   nrv update <slug> --keep-clones   …but leaves every mind-clone already on disk as it is
+ *                                     (--keep-squads / --keep-businesses likewise)
+ *   nrv update <slug> --check         only compares the installed version with the server's
+ *
+ * Components the buyer changed since the pack installed them are backed up
+ * under ~/.nirvana/backups/packs/<slug>/<stamp>/ before the overlay writes
+ * over them (install-content.ts); --keep-<kind> leaves them in place instead.
  *
  * Flow: PROVENANCE (license_key + version) → POST /pack-update (signed URL) →
  * download the stamped .zip → unzip → find the content folder → install-content.
@@ -186,6 +192,8 @@ async function main(): Promise<number> {
   const ic = spawnSync(process.execPath, [
     join(SKILLS, "_shared", "scripts", "install-content.ts"),
     content, "--slug", slug, ...(version ? ["--version", version] : []),
+    // Pass-through: --keep-clones / --keep-squads / --keep-businesses / --no-index.
+    ...args.filter((a) => a.startsWith("--keep") || a === "--no-index"),
   ], { stdio: "inherit" });
 
   // Refresh the license from the artifact that was just downloaded.

--- a/skills/harness/tests/install-content-keep.test.ts
+++ b/skills/harness/tests/install-content-keep.test.ts
@@ -1,0 +1,115 @@
+// install-content-keep.test.ts — a pack update against a buyer's edits.
+//
+// --keep-clones leaves every mind-clone already on disk as it is (new ones
+// still arrive); without it, a component changed since the pack installed it
+// is backed up before the overlay writes over it, and a user-created component
+// that collides with a pack slug is backed up too. The real script, a real
+// temp home; the only thing skipped is validation and re-indexing.
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+
+const SCRIPT = path.join(import.meta.dir, "..", "..", "_shared", "scripts", "install-content.ts");
+const roots: string[] = [];
+afterEach(() => { while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+function home(): string {
+  const h = fs.mkdtempSync(path.join(os.tmpdir(), "nrv-keep-clones-")); roots.push(h);
+  return h;
+}
+function content(h: string, name: string, clones: Record<string, string>): string {
+  const c = path.join(h, "content", name);
+  for (const k of ["squads", "businesses", "mind-clones"]) fs.mkdirSync(path.join(c, k), { recursive: true });
+  for (const [slug, dna] of Object.entries(clones)) {
+    fs.mkdirSync(path.join(c, "mind-clones", slug, "dna"), { recursive: true });
+    fs.writeFileSync(path.join(c, "mind-clones", slug, "MANIFEST.yaml"), `name: ${slug}\n`);
+    fs.writeFileSync(path.join(c, "mind-clones", slug, "dna", "DNA.md"), dna);
+  }
+  return c;
+}
+function run(h: string, c: string, args: string[]) {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v === undefined || /^(NIRVANA_HOME|SQUADS_DIR|BUSINESSES_DIR|DNA_LIBRARY)$/.test(k)) continue;
+    env[k] = v;
+  }
+  Object.assign(env, { HOME: h, USERPROFILE: h, NIRVANA_HOME: h });
+  const r = spawnSync(process.execPath, [SCRIPT, c, "--slug", "test-pack", "--skip-validate", "--no-index", ...args], { encoding: "utf8", env, cwd: h });
+  return { code: r.status ?? -1, out: `${r.stdout}\n${r.stderr}` };
+}
+const dna = (h: string, slug: string) => path.join(h, "businesses", "_library", "dna", slug, "dna", "DNA.md");
+const manifest = (h: string) => JSON.parse(fs.readFileSync(path.join(h, ".nirvana", "packs", "test-pack.json"), "utf8"));
+const backups = (h: string) => path.join(h, ".nirvana", "backups", "packs", "test-pack");
+
+describe("pack overlay vs the buyer's edits", () => {
+  test("--keep-clones: an edited clone stays, a new clone arrives, the manifest still records what the pack last installed", () => {
+    const h = home();
+    const v1 = content(h, "v1", { "expert-x": "v1\n" });
+    expect(run(h, v1, ["--version", "1"]).code).toBe(0);
+    expect(fs.readFileSync(dna(h, "expert-x"), "utf8")).toBe("v1\n");
+    const recorded = manifest(h)["mind-clones"]["expert-x"];
+    fs.writeFileSync(dna(h, "expert-x"), "mine\n");                       // the buyer's edit
+
+    const v2 = content(h, "v2", { "expert-x": "v2\n", "expert-y": "y\n" });
+    const r = run(h, v2, ["--version", "2", "--keep-clones"]);
+    expect(r.code, r.out).toBe(0);
+    expect(fs.readFileSync(dna(h, "expert-x"), "utf8")).toBe("mine\n");   // kept
+    expect(fs.readFileSync(dna(h, "expert-y"), "utf8")).toBe("y\n");      // new one still arrives
+    expect(r.out).toContain("1 kept (local)");
+    expect(manifest(h)["mind-clones"]["expert-x"]).toBe(recorded);        // not "current" — a later plain update replaces it
+    expect(manifest(h)["mind-clones"]["expert-y"]).toBeTruthy();
+    expect(fs.existsSync(backups(h))).toBe(false);                         // nothing was overwritten, nothing backed up
+  }, spawnBudgetMs(2));
+
+  test("without the flag: the edited clone is backed up, then replaced; an untouched clone is replaced without a backup", () => {
+    const h = home();
+    const v1 = content(h, "v1", { "expert-x": "v1\n", "expert-z": "z1\n" });
+    expect(run(h, v1, ["--version", "1"]).code).toBe(0);
+    fs.writeFileSync(dna(h, "expert-x"), "mine\n");
+    const v2 = content(h, "v2", { "expert-x": "v2\n", "expert-z": "z2\n" });
+    const r = run(h, v2, ["--version", "2"]);
+    expect(r.code, r.out).toBe(0);
+    expect(fs.readFileSync(dna(h, "expert-x"), "utf8")).toBe("v2\n");
+    expect(fs.readFileSync(dna(h, "expert-z"), "utf8")).toBe("z2\n");
+    expect(r.out).toContain("BACKED UP: 1 component(s)");
+    expect(r.out).toContain("~ mind-clones/expert-x");
+    expect(r.out).not.toContain("~ mind-clones/expert-z");
+    const stamps = fs.readdirSync(backups(h));
+    expect(stamps.length).toBe(1);
+    expect(fs.readFileSync(path.join(backups(h), stamps[0], "mind-clones", "expert-x", "dna", "DNA.md"), "utf8")).toBe("mine\n");
+    expect(fs.existsSync(path.join(backups(h), stamps[0], "mind-clones", "expert-z"))).toBe(false);
+  }, spawnBudgetMs(2));
+
+  test("a user-created clone that collides with a pack slug is backed up before the pack wins", () => {
+    const h = home();
+    const v1 = content(h, "v1", {});
+    expect(run(h, v1, ["--version", "1"]).code).toBe(0);
+    fs.mkdirSync(path.dirname(dna(h, "mine-clone")), { recursive: true });
+    fs.writeFileSync(path.join(h, "businesses", "_library", "dna", "mine-clone", "MANIFEST.yaml"), "name: mine-clone\n");
+    fs.writeFileSync(dna(h, "mine-clone"), "hand-made\n");
+    const v2 = content(h, "v2", { "mine-clone": "pack\n" });
+    const r = run(h, v2, ["--version", "2"]);
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("OVERWRITTEN: 1 component(s)");
+    expect(r.out).toContain("~ mind-clones/mine-clone");
+    expect(fs.readFileSync(dna(h, "mine-clone"), "utf8")).toBe("pack\n");
+    const stamps = fs.readdirSync(backups(h));
+    expect(fs.readFileSync(path.join(backups(h), stamps[0], "mind-clones", "mine-clone", "dna", "DNA.md"), "utf8")).toBe("hand-made\n");
+  }, spawnBudgetMs(2));
+
+  test("--dry names what it would back up and touches nothing", () => {
+    const h = home();
+    const v1 = content(h, "v1", { "expert-x": "v1\n" });
+    expect(run(h, v1, ["--version", "1"]).code).toBe(0);
+    fs.writeFileSync(dna(h, "expert-x"), "mine\n");
+    const v2 = content(h, "v2", { "expert-x": "v2\n" });
+    const r = run(h, v2, ["--version", "2", "--dry"]);
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("WOULD BACK UP: 1 component(s)");
+    expect(fs.readFileSync(dna(h, "expert-x"), "utf8")).toBe("mine\n");
+    expect(fs.existsSync(backups(h))).toBe(false);
+  }, spawnBudgetMs(2));
+});


### PR DESCRIPTION
## Why

`nrv update <pack>` overlays the new pack over the installed one and said so plainly: the pack is the source of truth, and there is no backup. A buyer who had tuned a mind-clone lost the tuning on the next update, with a warning at best.

## What

- **Backup before overwrite (default).** A component changed since the pack installed it — measurable, because the manifest records the hash the pack installed — is copied to `~/.nirvana/backups/packs/<pack>/<stamp>/<kind>/<slug>/` (run-state excluded) before the overlay replaces it. A user-created component that collides with a pack slug is backed up the same way. The run prints `BACKED UP: n component(s) … → <dir>` with the list; `--dry` prints `WOULD BACK UP`. An untouched component is not backed up: the pack can reproduce it.
- **`--keep-clones`** (also `--keep-squads`, `--keep-businesses`): every component of that kind already on disk stays exactly as it is; new ones still arrive; nothing is removed. The manifest keeps the hash the pack last installed for kept components, so a later update without the flag treats them as updates again rather than as current.
- `--no-index` (automation/tests). `nrv update <pack>` forwards `--keep-*` and `--no-index` to the overlay.
- Docs: `docs/CLI.md` row, README row, `update-pack.ts` usage.

## Verification

`install-content-keep.test.ts` (4), real script against a temp home with `--skip-validate --no-index`: keep leaves the edit and installs the new clone, manifest hash stays the installed one, no backup dir; plain update backs up the edited clone (and not the untouched one) then replaces both; a colliding user clone is backed up before the pack wins; `--dry` names it and touches nothing. `install-order.test.ts` still green; `check:quick`, changelog parity, english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk