### PR TITLE
fix(driver): an older Codex drops a flag instead of the whole run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### An older Codex drops a flag instead of the whole run
+
+The adapter is audited against Codex 0.153.4, and the flags it gained on 2026-09-05 are younger than many installed CLIs: `--approve-for-me` arrived in 0.147 (2026-08-07), `--ephemeral` in 0.134, `--output-schema` in 0.132. clap answers an unknown flag with exit 2 and `unexpected argument '<flag>' found` before anything runs, so on such a machine every dispatch would have died at argv. Now the adapter drops the flag Codex names, records a warning on the result (`codex: this version does not know --add-dir; retried without it (extra directories were not granted)`), and runs with what that version has; `--approve-for-me` falls back to `-s workspace-write`, the pre-0.147 restricted path. A flag that is not optional (`--json`) is not retried. Found by asking whether clients were ready to update, and answering by installing the published tarball into a clean home before saying yes.
+
 ## 0.13.2 — 2026-09-05
 
 ### A pack update no longer costs you your edits

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,12 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### Um Codex mais antigo perde uma flag, não a execução inteira
+
+O adapter foi auditado contra o Codex 0.153.4, e as flags que ele ganhou em 05/09/2026 são mais novas que muitos CLIs instalados: `--approve-for-me` chegou na 0.147 (07/08/2026), `--ephemeral` na 0.134, `--output-schema` na 0.132. O clap responde a uma flag desconhecida com exit 2 e `unexpected argument '<flag>' found` antes de qualquer coisa rodar, então numa máquina dessas todo despacho morreria no argv. Agora o adapter descarta a flag que o Codex nomeia, registra um aviso no resultado (`codex: this version does not know --add-dir; retried without it (extra directories were not granted)`) e roda com o que aquela versão tem; `--approve-for-me` cai para `-s workspace-write`, o caminho restrito anterior à 0.147. Uma flag que não é opcional (`--json`) não é repetida. Achado ao perguntar se os clientes estavam prontos para atualizar, e ao responder instalando o tarball publicado num home limpo antes de dizer sim.
+
 ## 0.13.2 — 2026-09-05
 
 ### Atualizar um pack não custa mais as suas edições

--- a/docs/architecture/project-directory-and-runtimes.md
+++ b/docs/architecture/project-directory-and-runtimes.md
@@ -110,6 +110,17 @@ the probe above exercised) and from `nrv watch-fs <project>` as filesystem
 evidence. Wiring a plugin hook is a future cut, gated on a run where the hook is
 observed firing.
 
+## 4a. Which Codex
+
+The adapter is audited against Codex 0.153. The flags it uses arrived over the
+summer of 2026 (`--output-schema` 0.132, `--ephemeral` 0.134, `--approve-for-me`
+0.147 on 2026-08-07; hooks from 0.129). A client on an older Codex is not left
+with a dead dispatch: when Codex answers `unexpected argument '<flag>'`, the
+adapter drops that flag, records a warning on the result, and runs with what
+that version has — `--approve-for-me` falls back to `-s workspace-write`, which
+is the pre-0.147 restricted path and stalls on the first approval. Codex 0.147
+or newer gets the full set; `codex update` is the fix.
+
 ## 4b. Codex hooks are installed already trusted
 
 Codex runs a hook only after the user reviews it, and an unreviewed hook is

--- a/skills/_shared/lib/host-agent-driver.ts
+++ b/skills/_shared/lib/host-agent-driver.ts
@@ -1595,13 +1595,39 @@ function runCodex(opts: RunHeadlessOpts): RunHeadlessResult {
   if (opts.yolo === false) args.push("--approve-for-me");
   else args.push("--dangerously-bypass-approvals-and-sandbox");
 
-  const r = driverSpawnSync("codex", args, {
+  const spawnOpts = {
     cwd: opts.cwd,
     input: withPreamble(opts),
-    encoding: "utf8",
+    encoding: "utf8" as const,
     ...(typeof opts.timeoutMs === "number" ? { timeout: opts.timeoutMs } : {}),
     maxBuffer: 64 * 1024 * 1024,
-  });
+  };
+  const warnings: string[] = [];
+  // Flags audited on 0.153.4 are not all on the Codex a client runs:
+  // --approve-for-me arrived in 0.147 (2026-08-07), --add-dir and --ephemeral
+  // later than the adapter's previous audit. clap answers an unknown flag with
+  // exit 2 and "error: unexpected argument '<flag>' found" before anything
+  // runs. Rather than turning every dispatch on an older Codex into that
+  // error, the optional flags are dropped one at a time as Codex names them,
+  // each drop recorded as a warning, and the run proceeds with what that
+  // version has. --approve-for-me falls back to the pre-0.147 restricted path.
+  const takesValue = new Set(["--add-dir", "-c", "--output-schema", "-i", "--model"]);
+  const droppable = new Set(["--add-dir", "--approve-for-me", "--ephemeral", "--output-schema", "-i", "-c", "--model"]);
+  let r = driverSpawnSync("codex", args, spawnOpts);
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const m = (r.status ?? 1) !== 0 ? (r.stderr || "").match(/unexpected argument '([^']+)'/) : null;
+    const flag = m?.[1];
+    if (!flag || !droppable.has(flag) || !args.includes(flag)) break;
+    const next: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === flag) { if (takesValue.has(flag)) i++; continue; }
+      next.push(args[i]);
+    }
+    if (flag === "--approve-for-me") next.push("-s", "workspace-write");
+    warnings.push(`codex: this version does not know ${flag}; retried without it${flag === "--approve-for-me" ? " (restricted path is -s workspace-write, which stalls on the first approval)" : flag === "--add-dir" ? " (extra directories were not granted)" : ""}`);
+    args.length = 0; args.push(...next);
+    r = driverSpawnSync("codex", args, spawnOpts);
+  }
 
   const durationMs = Date.now() - started;
   const exitCode = r.status ?? (r.signal ? 124 : 1);
@@ -1610,7 +1636,6 @@ function runCodex(opts: RunHeadlessOpts): RunHeadlessResult {
   let sessionId: string | null = opts.sessionId ?? null;
   let streamError: string | null = null;
   let usage: RunHeadlessResult["usage"];
-  const warnings: string[] = [];
   for (const line of (r.stdout || "").split("\n")) {
     const t = line.trim();
     if (!t.startsWith("{")) continue;

--- a/skills/harness/tests/driver-adapters.test.ts
+++ b/skills/harness/tests/driver-adapters.test.ts
@@ -11,7 +11,7 @@
 //      (the pi exit-0-on-provider-failure pattern, generalized).
 // Plus light-layer checks (callHostAgent stdin delivery, legacy __testRuntime
 // shape, persona-truncation warning).
-import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -71,6 +71,9 @@ beforeAll(() => {
 
   // codex — STDIN delivery; JSONL events; error on exit 0; no USD.
   fake("codex", `
+    // An older Codex: clap rejects a flag it does not know, exit 2, before anything runs.
+    const rejects = (process.env.FAKE_CODEX_REJECT || "").split(",").filter(Boolean);
+    for (const f of rejects) if (argv.includes(f)) { process.stderr.write("error: unexpected argument '" + f + "' found\\n"); process.exit(2); }
     const len = await stdinLen();
     const oi = argv.indexOf("-o");
     const out = oi >= 0 ? argv[oi + 1] : "";
@@ -577,4 +580,38 @@ describe("codex — flags audited against 0.153.4, usage and notices", () => {
     expect(r.usage).toEqual({ inputTokens: 10, cachedInputTokens: 4, cacheWriteInputTokens: 0, outputTokens: 5, reasoningOutputTokens: 2 });
     expect(r.warnings).toEqual(["Skill descriptions were shortened to fit the skills context budget."]);
   }, spawnBudgetMs(2));
+});
+
+describe("codex — an older CLI that rejects a flag", () => {
+  afterEach(() => { delete process.env.FAKE_CODEX_REJECT; });
+
+  test("--add-dir unknown: retried without it, the run succeeds, the result says the grant did not happen", () => {
+    process.env.FAKE_CODEX_REJECT = "--add-dir";
+    const r = runWith("codex", { addDirs: [path.join(TMP, "a"), path.join(TMP, "b")] });
+    expect(r.ok).toBe(true);
+    expect(capturedArgs("codex")).not.toContain("--add-dir");
+    expect(r.warnings!.some((w) => w.includes("--add-dir"))).toBe(true);
+  }, spawnBudgetMs(3));
+
+  test("--approve-for-me unknown (pre-0.147): falls back to -s workspace-write and says so", () => {
+    process.env.FAKE_CODEX_REJECT = "--approve-for-me";
+    const r = runWith("codex", { yolo: false });
+    expect(r.ok).toBe(true);
+    const args = capturedArgs("codex");
+    expect(args).not.toContain("--approve-for-me");
+    expect(args[args.indexOf("-s") + 1]).toBe("workspace-write");
+    expect(r.warnings!.some((w) => w.includes("--approve-for-me"))).toBe(true);
+  }, spawnBudgetMs(3));
+
+  test("two unknown flags are dropped one after the other; a real failure is not retried forever", () => {
+    process.env.FAKE_CODEX_REJECT = "--ephemeral,--add-dir";
+    const r = runWith("codex", { ephemeral: true, addDirs: [path.join(TMP, "a")] });
+    expect(r.ok).toBe(true);
+    // Two drops; the fake's own skills-budget notice rides along and is not counted.
+    expect(r.warnings!.filter((w) => w.includes("does not know")).length).toBe(2);
+    process.env.FAKE_CODEX_REJECT = "--json"; // not droppable: the error stands
+    const bad = runWith("codex", {});
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toContain("--json");
+  }, spawnBudgetMs(5));
 });


### PR DESCRIPTION
## Why

Asked whether clients were ready to update, I installed the published 0.13.2 tarball into a clean home (Claude + Codex present): skills, deps link, Codex hooks with trust, Claude hooks, `nrv --version` — all fine. The gap is the Codex CLI *version*: the adapter's new flags are younger than many installed CLIs (`--approve-for-me` 0.147 / 2026-08-07, `--ephemeral` 0.134, `--output-schema` 0.132; per the openai/codex release notes), and clap rejects an unknown flag with exit 2 before anything runs — every dispatch on such a machine would have died at argv.

## What

`runCodex` retries when Codex answers `unexpected argument '<flag>' found`: the named flag (one of `--add-dir`, `--approve-for-me`, `--ephemeral`, `--output-schema`, `-i`, `-c`, `--model`, with its value) is dropped, a warning is recorded on the result (`codex: this version does not know --add-dir; retried without it (extra directories were not granted)`), and the run proceeds; `--approve-for-me` falls back to `-s workspace-write`, the pre-0.147 restricted path. A flag that is not optional (`--json`) is not retried. At most four drops.

Docs: `project-directory-and-runtimes.md` §4a names the version floor (0.147 for the full set) and the fallback.

## Verification

Driver tests (+3): `--add-dir` rejected → retried, ok, warning; `--approve-for-me` rejected → `-s workspace-write`, warning; two rejections in sequence → two drops; `--json` rejected → real failure surfaced. Full file 45/45, autonomy pins green, `check:quick`, changelog parity, english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk