### PR TITLE
fix(squads): make Windows activation checks and hooks honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## 0.13.3 — 2026-09-05
 
+### Squad activation reports Windows tools and hook failures honestly
+
+System dependency names are now checked without placing the manifest value in
+a shell command. Windows uses `where.exe`, POSIX keeps `command -v` with the
+name passed as data, and object entries without a custom `check` fall back to a
+validated executable name. A missing tool with no Windows recipe is reported
+as missing instead of implying that the program itself does not support
+Windows.
+
+Post-install hooks accept both legacy strings and objects with `command`,
+`name`, and `optional`. Invalid or failed required hooks now fail activation,
+produce exit code 1, and prevent a new success state from replacing the prior
+state. Optional failures remain warnings. This does not translate POSIX shell
+hooks for Windows; pack authors still need to provide portable commands where
+their hooks use shell-specific syntax.
+
 ### An older Codex drops a flag instead of the whole run
 
 The adapter is audited against Codex 0.153.4, and the flags it gained on 2026-09-05 are younger than many installed CLIs: `--approve-for-me` arrived in 0.147 (2026-08-07), `--ephemeral` in 0.134, `--output-schema` in 0.132. clap answers an unknown flag with exit 2 and `unexpected argument '<flag>' found` before anything runs, so on such a machine every dispatch would have died at argv. Now the adapter drops the flag Codex names, records a warning on the result (`codex: this version does not know --add-dir; retried without it (extra directories were not granted)`), and runs with what that version has; `--approve-for-me` falls back to `-s workspace-write`, the pre-0.147 restricted path. A flag that is not optional (`--json`) is not retried. Found by asking whether clients were ready to update, and answering by installing the published tarball into a clean home before saying yes.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,22 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## 0.13.3 — 2026-09-05
 
+### A ativação de squads reporta ferramentas do Windows e falhas de hooks com honestidade
+
+Os nomes de dependências de sistema agora são verificados sem colocar o valor
+do manifesto em um comando de shell. O Windows usa `where.exe`, o POSIX mantém
+`command -v` com o nome passado como dado, e entradas em objeto sem um `check`
+próprio usam um nome de executável validado. Uma ferramenta ausente sem receita
+para Windows é reportada como ausente, sem sugerir que o programa inteiro é
+incompatível com a plataforma.
+
+Hooks pós-instalação aceitam strings legadas e objetos com `command`, `name` e
+`optional`. Hooks obrigatórios inválidos ou que falham agora derrubam a
+ativação, produzem código de saída 1 e impedem que um novo estado de sucesso
+substitua o estado anterior. Falhas opcionais continuam como avisos. A mudança
+não traduz hooks de shell POSIX para Windows; autores de packs ainda precisam
+fornecer comandos portáveis quando os hooks usam sintaxe específica de shell.
+
 ### Um Codex mais antigo perde uma flag, não a execução inteira
 
 O adapter foi auditado contra o Codex 0.153.4, e as flags que ele ganhou em 05/09/2026 são mais novas que muitos CLIs instalados: `--approve-for-me` chegou na 0.147 (07/08/2026), `--ephemeral` na 0.134, `--output-schema` na 0.132. O clap responde a uma flag desconhecida com exit 2 e `unexpected argument '<flag>' found` antes de qualquer coisa rodar, então numa máquina dessas todo despacho morreria no argv. Agora o adapter descarta a flag que o Codex nomeia, registra um aviso no resultado (`codex: this version does not know --add-dir; retried without it (extra directories were not granted)`) e roda com o que aquela versão tem; `--approve-for-me` cai para `-s workspace-write`, o caminho restrito anterior à 0.147. Uma flag que não é opcional (`--json`) não é repetida. Achado ao perguntar se os clientes estavam prontos para atualizar, e ao responder instalando o tarball publicado num home limpo antes de dizer sim.

--- a/skills/squads/lib/activator.js
+++ b/skills/squads/lib/activator.js
@@ -81,9 +81,19 @@ function checkExecutable(tool) {
     return { ok: false, invalid: true, error: 'Executable name must be a single safe token.' };
   }
   const probe = PLATFORM === 'win32'
-    ? spawnSync('where.exe', [tool], { stdio: 'pipe', windowsHide: true })
+    ? spawnSync('where.exe', [tool], { stdio: 'pipe', windowsHide: true, encoding: 'utf8' })
     : spawnSync('/bin/sh', ['-c', 'command -v "$1" >/dev/null 2>&1', 'sh', tool], { stdio: 'pipe' });
-  return probe.status === 0
+  const found = PLATFORM !== 'win32' || String(probe.stdout || '')
+    .split(/\r?\n/)
+    .map(candidate => candidate.trim())
+    .filter(Boolean)
+    .some(candidate => {
+      const allowed = new Set(String(process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+        .split(';').map(ext => ext.toLowerCase()).filter(Boolean));
+      try { return allowed.has(path.extname(candidate).toLowerCase()) && fs.statSync(candidate).isFile(); }
+      catch { return false; }
+    });
+  return probe.status === 0 && found
     ? { ok: true }
     : { ok: false, error: probe.error ? probe.error.message : `Executable '${tool}' was not found on PATH.` };
 }

--- a/skills/squads/lib/activator.js
+++ b/skills/squads/lib/activator.js
@@ -74,6 +74,20 @@ function checkCmd(cmd, opts = {}) {
   }
 }
 
+const EXECUTABLE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+
+function checkExecutable(tool) {
+  if (typeof tool !== 'string' || !EXECUTABLE_TOKEN.test(tool)) {
+    return { ok: false, invalid: true, error: 'Executable name must be a single safe token.' };
+  }
+  const probe = PLATFORM === 'win32'
+    ? spawnSync('where.exe', [tool], { stdio: 'pipe', windowsHide: true })
+    : spawnSync('/bin/sh', ['-c', 'command -v "$1" >/dev/null 2>&1', 'sh', tool], { stdio: 'pipe' });
+  return probe.status === 0
+    ? { ok: true }
+    : { ok: false, error: probe.error ? probe.error.message : `Executable '${tool}' was not found on PATH.` };
+}
+
 function runCmd(cmd, opts = {}) {
   // Verbose mode (set by CLI via env) overrides silent: stream output live so
   // an automation agent can see brew/git/pip progress in real time.
@@ -352,19 +366,29 @@ function installSystem(dep, dryRun, confirmHeavy) {
   if (typeof dep === 'string') {
     const tool = dep.trim().split(/[\s<>=!~]/)[0];
     if (!tool) return { name: dep, status: 'skipped', kind: 'system' };
-    const present = checkCmd(`command -v ${tool}`).ok;
-    return present
+    const presence = checkExecutable(tool);
+    if (presence.invalid) {
+      return { name: tool, status: 'invalid_system_tool', kind: 'system', spec: dep, error: presence.error };
+    }
+    return presence.ok
       ? { name: tool, status: 'already_present', kind: 'system' }
       : { name: tool, status: 'missing_system_tool', kind: 'system', spec: dep,
           note: `Prereq '${tool}' not found on PATH. Install it (brew/apt/winget) and re-activate.` };
   }
-  const checkResult = checkCmd(dep.check);
+  const hasCheck = typeof dep.check === 'string' && dep.check.trim().length > 0;
+  const checkResult = hasCheck ? checkCmd(dep.check) : checkExecutable(dep.name);
+  if (!hasCheck && checkResult.invalid) {
+    return { name: dep.name, status: 'invalid_system_tool', kind: 'system', error: checkResult.error };
+  }
   if (checkResult.ok) {
     return { name: dep.name, status: 'already_present', kind: 'system' };
   }
   const installCmd = (dep.install || {})[PLATFORM];
   if (!installCmd) {
-    return { name: dep.name, status: 'install_unsupported_platform', kind: 'system', platform: PLATFORM };
+    return hasCheck
+      ? { name: dep.name, status: 'install_unsupported_platform', kind: 'system', platform: PLATFORM }
+      : { name: dep.name, status: 'missing_system_tool', kind: 'system', platform: PLATFORM,
+          note: `Prereq '${dep.name}' not found on PATH and no ${PLATFORM} install recipe is declared.` };
   }
   if (dryRun) {
     return { name: dep.name, status: 'would_install', kind: 'system', cmd: installCmd };
@@ -416,7 +440,7 @@ function installSystem(dep, dryRun, confirmHeavy) {
   if (!installResult.ok) {
     return { name: dep.name, status: 'install_failed', kind: 'system', error: installResult.error };
   }
-  const recheck = checkCmd(dep.check);
+  const recheck = hasCheck ? checkCmd(dep.check) : checkExecutable(dep.name);
   return {
     name: dep.name,
     status: recheck.ok ? 'installed' : 'install_completed_but_check_failed',
@@ -704,10 +728,19 @@ function checkEnvVars(vars) {
 function runPostInstall(commands, dryRun) {
   if (!Array.isArray(commands) || commands.length === 0) return { status: 'no_post_install' };
   const results = [];
-  for (const cmd of commands) {
-    if (dryRun) { results.push({ cmd, status: 'would_run' }); continue; }
+  for (const hook of commands) {
+    const objectHook = hook && typeof hook === 'object' && !Array.isArray(hook);
+    const cmd = typeof hook === 'string' ? hook : (objectHook ? hook.command : null);
+    const name = objectHook && typeof hook.name === 'string' ? hook.name : undefined;
+    const optional = objectHook && hook.optional === true;
+    const details = { ...(name ? { name } : {}), cmd, ...(optional ? { optional: true } : {}) };
+    if (typeof cmd !== 'string' || cmd.trim().length === 0) {
+      results.push({ ...details, status: 'failed', error: 'Post-install hook command must be a non-empty string.' });
+      continue;
+    }
+    if (dryRun) { results.push({ ...details, status: 'would_run' }); continue; }
     const r = runCmd(cmd, { timeoutMs: 120000 });
-    results.push({ cmd, status: r.ok ? 'ok' : 'failed', error: r.ok ? null : r.error });
+    results.push({ ...details, status: r.ok ? 'ok' : 'failed', error: r.ok ? null : r.error });
   }
   return { status: 'done', kind: 'post_install', items: results };
 }
@@ -910,12 +943,15 @@ function activate(slug, opts = {}) {
     const items = Array.isArray(step) ? step : (step.items || [step]);
     for (const item of items) {
       if (!item || !item.status) continue;
-      if (/_failed$/.test(item.status)) failures.push({ step: stepName, ...item });
+      if (item.status === 'failed' || /_failed$/.test(item.status)) {
+        if (item.optional === true) warnings.push({ step: stepName, ...item });
+        else failures.push({ step: stepName, ...item });
+      }
       else if (item.status === 'confirmation_required') confirmations.push({ step: stepName, ...item });
       // Missing API keys / system prereqs do NOT block activation — the squad
       // installs its code deps and runs in degraded mode until the user supplies
       // them. Surfaced as warnings so the caller can prompt the user.
-      else if (item.status === 'missing_required' || item.status === 'missing_system_tool') warnings.push({ step: stepName, ...item });
+      else if (item.status === 'missing_required' || item.status === 'missing_system_tool' || item.status === 'invalid_system_tool') warnings.push({ step: stepName, ...item });
     }
   }
 
@@ -961,7 +997,7 @@ module.exports = { activate, status, deactivate, _windowsShellPlan: windowsShell
 
 // CLI — exit codes follow the contract documented in scripts/activate-squad.sh:
 //   0 = ok / activated
-//   1 = failures present (one or more steps reported _failed)
+//   1 = failures present (one or more steps reported failed / *_failed)
 //   2 = confirmations required (heavy downloads / sudo)
 //   4 = invalid args / squad not found
 if (require.main === module) {

--- a/skills/squads/tests/activator-system-and-hooks.test.ts
+++ b/skills/squads/tests/activator-system-and-hooks.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const ACTIVATOR = join(REPO, "skills", "squads", "lib", "activator.js");
+
+interface Fixture {
+  root: string;
+  squadDir: string;
+  stateFile: string;
+  binDir: string;
+}
+
+function fixture(dependencies: string): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "activator-system-hooks-"));
+  const squadDir = join(root, "squads", "fixture-squad");
+  const stateFile = join(root, "state", "fixture-squad", "activated.json");
+  const binDir = join(root, "bin");
+  mkdirSync(squadDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(squadDir, "squad.yaml"), 'name: fixture-squad\nversion: "1.0.0"\nprotocol: "5.0"\ndescription: test\n');
+  writeFileSync(join(squadDir, "dependencies.yaml"), dependencies);
+  return { root, squadDir, stateFile, binDir };
+}
+
+function fakeExecutable(f: Fixture, name: string): void {
+  if (process.platform === "win32") {
+    writeFileSync(join(f.binDir, `${name}.cmd`), "@exit /b 0\r\n");
+  } else {
+    writeFileSync(join(f.binDir, name), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  }
+}
+
+function activate(f: Fixture): { status: number | null; json: any; stderr: string } {
+  const result = spawnSync(process.execPath, [ACTIVATOR, "activate", "fixture-squad"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NIRVANA_SKILLS_DIR: join(REPO, "skills"),
+      NIRVANA_RESOLVED_SQUAD_PATH: f.squadDir,
+      NIRVANA_STATE_DIR: join(f.root, "state"),
+      NIRVANA_HOME: f.root,
+      PATH: `${f.binDir}${delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+  return { status: result.status, json: JSON.parse(result.stdout), stderr: result.stderr ?? "" };
+}
+
+describe("system executable presence", () => {
+  test("a string dependency uses a platform-safe argv probe", () => {
+    const f = fixture("system:\n  - nirvana-presence-fixture\n");
+    fakeExecutable(f, "nirvana-presence-fixture");
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.steps.system[0].status).toBe("already_present");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("a manifest name cannot become shell syntax", () => {
+    const f = fixture('system:\n  - "fixture-tool&echo"\n');
+    try {
+      const result = activate(f);
+      expect(result.json.steps.system[0].status).toBe("invalid_system_tool");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("an object without check falls back to its present executable name", () => {
+    const f = fixture("system:\n  - name: nirvana-object-fixture\n");
+    fakeExecutable(f, "nirvana-object-fixture");
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.steps.system[0].status).toBe("already_present");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("an absent object without check reports the missing tool instead of platform incompatibility", () => {
+    const f = fixture("system:\n  - name: nirvana-certainly-absent-tool\n");
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.steps.system[0].status).toBe("missing_system_tool");
+      expect(result.json.warnings).toHaveLength(1);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("post-install hook contracts", () => {
+  test("legacy string and object hooks both succeed", () => {
+    const f = fixture([
+      "post_install:",
+      '  - "exit 0"',
+      "  - name: object hook",
+      '    command: "exit 0"',
+      "",
+    ].join("\n"));
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.steps.post_install.items.map((item: any) => item.status)).toEqual(["ok", "ok"]);
+      expect(result.json.steps.post_install.items[1].name).toBe("object hook");
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("an optional failing hook is a warning and does not block activation", () => {
+    const f = fixture("post_install:\n  - name: optional hook\n    command: \"exit 7\"\n    optional: true\n");
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.ok).toBe(true);
+      expect(result.json.failures).toHaveLength(0);
+      expect(result.json.warnings[0]).toMatchObject({ step: "post_install", name: "optional hook", status: "failed", optional: true });
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("a required failing hook exits 1 and preserves existing activation state", () => {
+    const f = fixture('post_install:\n  - name: required hook\n    command: "exit 7"\n');
+    const previous = '{"marker":"previous-state"}\n';
+    mkdirSync(join(f.root, "state", "fixture-squad"), { recursive: true });
+    writeFileSync(f.stateFile, previous);
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(1);
+      expect(result.json.ok).toBe(false);
+      expect(result.json.failures[0]).toMatchObject({ step: "post_install", name: "required hook", status: "failed" });
+      expect(readFileSync(f.stateFile, "utf8")).toBe(previous);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
+
+  test("an invalid required hook fails honestly while an invalid optional hook warns", () => {
+    const required = fixture("post_install:\n  - name: malformed required hook\n");
+    const optional = fixture("post_install:\n  - name: malformed optional hook\n    optional: true\n");
+    try {
+      const requiredResult = activate(required);
+      expect(requiredResult.status).toBe(1);
+      expect(requiredResult.json.failures[0]).toMatchObject({ status: "failed", name: "malformed required hook" });
+
+      const optionalResult = activate(optional);
+      expect(optionalResult.status).toBe(0);
+      expect(optionalResult.json.ok).toBe(true);
+      expect(optionalResult.json.warnings[0]).toMatchObject({ status: "failed", optional: true });
+      expect(existsSync(optional.stateFile)).toBe(true);
+    } finally {
+      rmSync(required.root, { recursive: true, force: true });
+      rmSync(optional.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/skills/squads/tests/activator-system-and-hooks.test.ts
+++ b/skills/squads/tests/activator-system-and-hooks.test.ts
@@ -44,6 +44,9 @@ function activate(f: Fixture): { status: number | null; json: any; stderr: strin
       NIRVANA_STATE_DIR: join(f.root, "state"),
       NIRVANA_HOME: f.root,
       PATH: `${f.binDir}${delimiter}${process.env.PATH ?? ""}`,
+      ...(process.platform === "win32"
+        ? { PATHEXT: [process.env.PATHEXT, ".COM;.EXE;.BAT;.CMD"].filter(Boolean).join(";") }
+        : {}),
     },
   });
   return { status: result.status, json: JSON.parse(result.stdout), stderr: result.stderr ?? "" };

--- a/skills/squads/tests/activator-system-and-hooks.test.ts
+++ b/skills/squads/tests/activator-system-and-hooks.test.ts
@@ -95,6 +95,19 @@ describe("system executable presence", () => {
       rmSync(f.root, { recursive: true, force: true });
     }
   });
+
+  test.skipIf(process.platform !== "win32")("a plain LICENSE file found by where.exe is not an executable", () => {
+    const f = fixture("system:\n  - LICENSE\n");
+    writeFileSync(join(f.binDir, "LICENSE"), "not executable\n");
+    try {
+      const result = activate(f);
+      expect(result.status).toBe(0);
+      expect(result.json.steps.system[0].status).toBe("missing_system_tool");
+      expect(result.json.warnings).toHaveLength(1);
+    } finally {
+      rmSync(f.root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("post-install hook contracts", () => {


### PR DESCRIPTION
## What this changes

This patch makes squad activation on Windows report system tools and post-install hook outcomes honestly. It checks executable names without shell interpolation, validates `where.exe` results against real files and `PATHEXT`, falls back to a safe `name` probe for system dependency objects without `check`, and supports both legacy string hooks and `{ name?, command, optional? }` hooks.

Required hook failures now produce a failed activation and exit code 1 without replacing prior success state. Optional failures remain warnings. The patch does not translate POSIX commercial pack hooks for Windows; hooks using `~`, `|| true`, `head`, or similar shell-specific syntax still need a pack-level correction or a future contract decision.

## How it was tested

- Focused activator suites: 24 passed, 4 platform-conditional skips, 0 failed.
- The new Windows regression file passed three consecutive isolated runs after its fixture was stabilized.
- `bun run check:quick`: passed.
- Independent review: READY after the `where.exe` false-positive follow-up.
- Official CI passed the gates and full smoke suite on Ubuntu, macOS, and Windows with frozen dependencies.
- Full `bun test` at the earlier review point: 2,594 passed, 45 skipped, 21 failed. Nineteen failures were known environment or baseline failures. Two were new fixture failures caused by shared `PATHEXT` interference and were subsequently fixed in `d5cc686`; a clean full-suite rerun is not claimed here.
- `bun run check:all` stops on pre-existing Zod 4.5.4 schema drift from the shared dependency store.

## Checklist

- [ ] `bun test skills/harness/tests` passes
- [x] No hardcoded model names (the engine never prescribes a model — it inherits the runtime's)
- [x] No paid pack content, secrets, or `.env` values added to the engine
- [ ] **I have read and agree to the Nirvana-OS CLA v1.0** ([CLA.md](../CLA.md))

<!-- CLA agreement is required. PRs without it may be closed unmerged. You can also agree by signing off commits: git commit -s -->
