### PR TITLE
fix(activate): a pack's shell lines run in a POSIX shell on Windows too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### A pack's shell lines run in a POSIX shell on Windows too
+
+A squad's `post_install` hooks, its `check:` commands and the bare presence probe (`command -v <tool>`) are written in POSIX: `~`, `|`, `||`, `head`, `>/dev/null`. On macOS and Linux they go to `/bin/sh`; on Windows `execSync` handed them to `cmd.exe`, which speaks none of it, so every string dependency read as "missing" and every POSIX hook failed — silently, because a failed hook matched no branch of the failure collector. Measured on the published packs: 9 of the 47 Genesis squads and 22 of 23 in the other packs carry such hooks.
+
+The engine already requires Git for Windows there (the `nrv.cmd` launcher delegates to Git Bash). The POSIX-authored steps now run in that same bash on Windows, so the language mismatch is gone without touching a pack or the hook contract; what a pack wrote for Windows (`install.win32`) keeps running in `cmd.exe`. A failed hook is now a warning on the activation result, which is what the agent driving the activation reads and acts on; it never blocks the squad. The proof is a test that runs the pack-shaped lines through the activator on all three CI systems.
+
 ## 0.13.3 — 2026-09-05
 
 ### An older Codex drops a flag instead of the whole run

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,14 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### As linhas de shell de um pack rodam numa shell POSIX também no Windows
+
+Os hooks de `post_install` de um squad, seus comandos `check:` e a sonda de presença (`command -v <ferramenta>`) são escritos em POSIX: `~`, `|`, `||`, `head`, `>/dev/null`. No macOS e no Linux vão para o `/bin/sh`; no Windows o `execSync` os entregava ao `cmd.exe`, que não fala nada disso, então toda dependência em string aparecia como "faltando" e todo hook POSIX falhava — em silêncio, porque hook falhado não casava com ramo nenhum do coletor de falhas. Medido nos packs publicados: 9 dos 47 squads do Genesis e 22 de 23 dos outros packs carregam hooks assim.
+
+O engine já exige o Git for Windows lá (o `nrv.cmd` delega ao Git Bash). Os passos escritos em POSIX agora rodam nesse mesmo bash no Windows, então a diferença de língua some sem tocar em pack nem no contrato de hooks; o que um pack escreveu para o Windows (`install.win32`) continua rodando no `cmd.exe`. Um hook que falha agora é aviso no resultado da ativação, que é o que o agente que conduz a ativação lê e trata; nunca bloqueia o squad. A prova é um teste que roda as linhas com a forma dos packs pelo activator nos três sistemas do CI.
+
 ## 0.13.3 — 2026-09-05
 
 ### Um Codex mais antigo perde uma flag, não a execução inteira

--- a/skills/squads/lib/activator.js
+++ b/skills/squads/lib/activator.js
@@ -65,13 +65,69 @@ function readYaml(filePath) {
   catch (e) { return null; }
 }
 
-function checkCmd(cmd, opts = {}) {
+// ── Which shell runs a pack's shell lines ─────────────────────────────
+//
+// A squad's `post_install`, its `check:` commands and the bare presence probe
+// (`command -v <tool>`) are written in POSIX: `~`, `|`, `||`, `head`,
+// `>/dev/null`. On macOS and Linux `execSync` hands them to /bin/sh and they
+// work. On Windows `execSync` hands them to cmd.exe, which speaks none of that:
+// `~` stays a tilde, `head` does not exist, `command -v` is not a builtin — so
+// every string dependency read as "missing" and every POSIX hook failed, both
+// silently. Measured on the published packs (2026-09-06): 9 of the 47 Genesis
+// squads and 22 of 23 in the other packs carry such hooks.
+//
+// The engine already requires Git for Windows there (the `nrv.cmd` launcher
+// delegates to Git Bash and refuses to run without it). So the POSIX-authored
+// steps run in that same bash on Windows, and the language mismatch is gone
+// without touching a single pack or changing the hook contract. What a pack
+// wrote FOR Windows — `install.win32` — keeps running in cmd.exe, because that
+// is the shell it was written for. No Git Bash found: the old behaviour, so a
+// machine that somehow runs the activator without it is no worse off.
+let POSIX_SHELL_CACHE;
+function posixShell() {
+  if (POSIX_SHELL_CACHE !== undefined) return POSIX_SHELL_CACHE;
+  const override = process.env.NIRVANA_POSIX_SHELL;
+  if (override) { POSIX_SHELL_CACHE = fs.existsSync(override) ? override : null; return POSIX_SHELL_CACHE; }
+  if (PLATFORM !== 'win32') { POSIX_SHELL_CACHE = null; return null; } // execSync already uses /bin/sh
+  const candidates = [
+    process.env.ProgramFiles && path.join(process.env.ProgramFiles, 'Git', 'bin', 'bash.exe'),
+    process.env['ProgramFiles(x86)'] && path.join(process.env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'),
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'),
+  ].filter(Boolean);
   try {
-    execSync(cmd, { stdio: 'pipe', timeout: opts.timeoutMs || 30000 });
-    return { ok: true };
+    const w = spawnSync('where.exe', ['git'], { encoding: 'utf8', windowsHide: true });
+    for (const line of String(w.stdout || '').split(/\r?\n/)) {
+      const g = line.trim();
+      if (g) candidates.push(path.resolve(path.dirname(g), '..', 'bin', 'bash.exe'));
+    }
+  } catch { /* no git on PATH */ }
+  POSIX_SHELL_CACHE = candidates.find((c) => { try { return fs.statSync(c).isFile(); } catch { return false; } }) || null;
+  return POSIX_SHELL_CACHE;
+}
+
+// Runs one shell line and returns the execSync shape, through the POSIX shell
+// when `posix` is asked for and one exists, through the platform default
+// otherwise. Never throws.
+function shellExec(cmd, { posix = false, stdio = 'pipe', timeoutMs, cwd, env } = {}) {
+  const shell = posix ? posixShell() : null;
+  try {
+    if (shell) {
+      const r = spawnSync(shell, ['-c', cmd], { stdio, timeout: timeoutMs, cwd: cwd || undefined, env, encoding: 'utf8', windowsHide: true });
+      if (r.error) return { ok: false, error: r.error.message, code: r.status, stderr: r.stderr || null };
+      if ((r.status ?? 1) !== 0) return { ok: false, error: `Command failed (exit ${r.status}): ${cmd}`, code: r.status, stderr: r.stderr || null };
+      return { ok: true, output: r.stdout || '' };
+    }
+    const out = execSync(cmd, { stdio, timeout: timeoutMs, cwd: cwd || undefined, env });
+    return { ok: true, output: out ? out.toString() : '' };
   } catch (e) {
-    return { ok: false, error: e.message };
+    return { ok: false, error: e.message, code: e.status, stderr: e.stderr ? e.stderr.toString() : null };
   }
+}
+
+// Presence and `check:` commands are POSIX-authored in every pack.
+function checkCmd(cmd, opts = {}) {
+  const r = shellExec(cmd, { posix: true, stdio: 'pipe', timeoutMs: opts.timeoutMs || 30000, env: DEPS.depsEnv(process.env) });
+  return r.ok ? { ok: true } : { ok: false, error: r.error };
 }
 
 function runCmd(cmd, opts = {}) {
@@ -79,21 +135,17 @@ function runCmd(cmd, opts = {}) {
   // an automation agent can see brew/git/pip progress in real time.
   const verbose = process.env.MAESTRO_ACTIVATOR_VERBOSE === '1';
   const stdio = verbose ? 'inherit' : (opts.silent ? 'pipe' : 'pipe');
-  try {
-    const out = execSync(cmd, {
-      stdio,
-      timeout: opts.timeoutMs || 600000,
-      cwd: opts.cwd || undefined,
-      // depsEnv FIRST, then the caller's overrides: a shell line from
-      // `system[].install` or `post_install` inherits the pinned caches, so a
-      // `npx puppeteer browsers install chrome` buried in a squad's hook lands
-      // in ~/.nirvana/cache/puppeteer like everything else.
-      env: { ...DEPS.depsEnv(process.env), ...(opts.env || {}) },
-    });
-    return { ok: true, output: out ? out.toString() : '' };
-  } catch (e) {
-    return { ok: false, error: e.message, code: e.status, stderr: e.stderr ? e.stderr.toString() : null };
-  }
+  return shellExec(cmd, {
+    posix: opts.posix === true,
+    stdio,
+    timeoutMs: opts.timeoutMs || 600000,
+    cwd: opts.cwd || undefined,
+    // depsEnv FIRST, then the caller's overrides: a shell line from
+    // `system[].install` or `post_install` inherits the pinned caches, so a
+    // `npx puppeteer browsers install chrome` buried in a squad's hook lands
+    // in ~/.nirvana/cache/puppeteer like everything else.
+    env: { ...DEPS.depsEnv(process.env), ...(opts.env || {}) },
+  });
 }
 
 // A package list is DATA. `runCmd` builds a shell string, which is right for
@@ -706,7 +758,8 @@ function runPostInstall(commands, dryRun) {
   const results = [];
   for (const cmd of commands) {
     if (dryRun) { results.push({ cmd, status: 'would_run' }); continue; }
-    const r = runCmd(cmd, { timeoutMs: 120000 });
+    // POSIX-authored by every pack that has one: through Git Bash on Windows.
+    const r = runCmd(cmd, { timeoutMs: 120000, posix: true });
     results.push({ cmd, status: r.ok ? 'ok' : 'failed', error: r.ok ? null : r.error });
   }
   return { status: 'done', kind: 'post_install', items: results };
@@ -916,6 +969,11 @@ function activate(slug, opts = {}) {
       // installs its code deps and runs in degraded mode until the user supplies
       // them. Surfaced as warnings so the caller can prompt the user.
       else if (item.status === 'missing_required' || item.status === 'missing_system_tool') warnings.push({ step: stepName, ...item });
+      // A post_install hook that failed. Hooks are cosmetic (reindex, print a
+      // version) and the agent driving the activation is who reads this: a
+      // warning it can act on, never a failure that hides the squad. Until now
+      // this status matched no branch at all and the failure was invisible.
+      else if (item.status === 'failed') warnings.push({ step: stepName, ...item });
     }
   }
 
@@ -957,7 +1015,7 @@ function deactivate(slug) {
 
 // windowsCmdMetachar is exported for its own test: it is the whole Windows
 // decision, and the spawn it guards cannot be exercised from a POSIX runner.
-module.exports = { activate, status, deactivate, _windowsShellPlan: windowsShellPlan, _fetchAndExecute: fetchAndExecute };
+module.exports = { activate, status, deactivate, _windowsShellPlan: windowsShellPlan, _fetchAndExecute: fetchAndExecute, _posixShell: posixShell };
 
 // CLI — exit codes follow the contract documented in scripts/activate-squad.sh:
 //   0 = ok / activated

--- a/skills/squads/tests/activator-posix-shell.test.ts
+++ b/skills/squads/tests/activator-posix-shell.test.ts
@@ -1,0 +1,93 @@
+// activator-posix-shell.test.ts — a pack's shell lines are POSIX; the activator
+// runs them in a POSIX shell on every platform, Windows included (Git Bash,
+// which the nrv launcher already requires there). The lines below are the
+// shapes the published packs actually use. A failing hook is a warning the
+// driving agent can read, never a failure that hides the squad.
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const ACTIVATOR = join(REPO, "skills", "squads", "lib", "activator.js");
+const roots: string[] = [];
+afterEach(() => { while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+function fixture(dependencies: string) {
+  const root = mkdtempSync(join(tmpdir(), "activator-posix-")); roots.push(root);
+  const squadDir = join(root, "squads", "fixture-squad");
+  mkdirSync(squadDir, { recursive: true });
+  writeFileSync(join(squadDir, "squad.yaml"), 'name: fixture-squad\nversion: "1.0.0"\nprotocol: "5.0"\ndescription: test\n');
+  writeFileSync(join(squadDir, "dependencies.yaml"), dependencies);
+  return { root, squadDir, stateFile: join(root, "state", "fixture-squad", "activated.json") };
+}
+function activate(f: { root: string; squadDir: string }) {
+  const r = spawnSync(process.execPath, [ACTIVATOR, "activate", "fixture-squad"], {
+    encoding: "utf8",
+    env: { ...process.env, NIRVANA_SKILLS_DIR: join(REPO, "skills"), NIRVANA_RESOLVED_SQUAD_PATH: f.squadDir, NIRVANA_STATE_DIR: join(f.root, "state"), NIRVANA_HOME: f.root },
+  });
+  return { status: r.status, json: JSON.parse(r.stdout), stderr: r.stderr ?? "" };
+}
+
+describe("the POSIX shell the activator uses", () => {
+  test("on Windows, Git Bash is found (the launcher requires it); elsewhere /bin/sh is already POSIX", () => {
+    const { _posixShell } = require(ACTIVATOR);
+    const shell = _posixShell();
+    if (process.platform === "win32") {
+      expect(shell, "Git for Windows must be found on a Windows machine that runs nrv").toBeTruthy();
+      expect(shell!.toLowerCase()).toContain("bash.exe");
+    } else {
+      expect(shell).toBeNull();
+    }
+  });
+});
+
+describe("post_install lines shaped like the published packs", () => {
+  test("pipes, ||-fallbacks, ~ expansion and head all run, on this platform, through the POSIX shell", () => {
+    const f = fixture([
+      "post_install:",
+      '  - "echo posix-pipe | head -1"',
+      '  - "nirvana-tool-that-does-not-exist --version || echo fallback-taken"',
+      '  - "test -d ~ && echo home-expands"',
+      "  - \"printf '%s\\\\n' a b c | head -1 >/dev/null 2>&1\"",
+      '  - "bun --version | head -1"',
+      "",
+    ].join("\n"));
+    const r = activate(f);
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.json.steps.post_install.items.map((i: any) => i.status)).toEqual(["ok", "ok", "ok", "ok", "ok"]);
+    expect(r.json.warnings).toHaveLength(0);
+  }, 60_000);
+
+  test("a failing hook is a warning the agent can read; the squad still activates and its state is written", () => {
+    const f = fixture('post_install:\n  - "exit 7"\n  - "echo still-runs"\n');
+    const r = activate(f);
+    expect(r.status).toBe(0);
+    expect(r.json.ok).toBe(true);
+    expect(r.json.failures).toHaveLength(0);
+    expect(r.json.steps.post_install.items.map((i: any) => i.status)).toEqual(["failed", "ok"]);
+    expect(r.json.warnings).toHaveLength(1);
+    expect(r.json.warnings[0]).toMatchObject({ step: "post_install", status: "failed", cmd: "exit 7" });
+    expect(existsSync(f.stateFile)).toBe(true);
+  }, 60_000);
+});
+
+describe("system tool presence through the same shell", () => {
+  test("a tool that exists on every CI machine is already_present; an absent one is a missing_system_tool warning", () => {
+    const f = fixture("system:\n  - git\n  - nirvana-certainly-absent-tool\n");
+    const r = activate(f);
+    expect(r.status).toBe(0);
+    const byName = Object.fromEntries(r.json.steps.system.map((i: any) => [i.name, i.status]));
+    expect(byName.git).toBe("already_present");
+    expect(byName["nirvana-certainly-absent-tool"]).toBe("missing_system_tool");
+    expect(r.json.warnings.map((w: any) => w.name)).toEqual(["nirvana-certainly-absent-tool"]);
+  }, 60_000);
+
+  test("an object dependency's check: runs in the POSIX shell too", () => {
+    const f = fixture('system:\n  - name: git-via-check\n    check: "git --version | head -1"\n');
+    const r = activate(f);
+    expect(r.status).toBe(0);
+    expect(r.json.steps.system[0].status).toBe("already_present");
+  }, 60_000);
+});


### PR DESCRIPTION
## Why

A squad's `post_install` hooks, `check:` commands and the bare presence probe (`command -v <tool>`) are POSIX-authored (`~`, `|`, `||`, `head`, `>/dev/null`). On Windows `execSync` handed them to `cmd.exe`: every string dependency read as "missing" and every POSIX hook failed — silently, because status `failed` matched no branch of the failure collector. Measured on the published packs: 9/47 Genesis squads and 22/23 in the other packs carry such hooks.

This is the problem #228 tried to address by changing the hook contract (a failing hook → activation failure). That direction breaks the packs on Windows instead of fixing the engine; this PR fixes the engine.

## What

- `posixShell()`: on Windows, Git Bash (`%ProgramFiles%\Git\bin\bash.exe`, `%ProgramFiles(x86)%`, `%LOCALAPPDATA%\Programs\Git`, or derived from `where git`); `NIRVANA_POSIX_SHELL` overrides; elsewhere `/bin/sh` via `execSync` as before. The `nrv.cmd` launcher already requires Git for Windows, so this adds no prerequisite.
- `post_install`, `check:` and the presence probe run through it (`shellExec(..., { posix: true })`); `install.win32` keeps running in `cmd.exe` — written for Windows, runs in Windows.
- A `post_install` item with status `failed` is now a **warning** on the result (it was invisible); it never blocks activation and the state is still written. No new hook shape, no `optional` field: the contract is unchanged.
- No Git Bash: previous behaviour.

## Verification

`activator-posix-shell.test.ts` (5), run on all three CI systems — Windows is the proof: pack-shaped lines (`echo x | head -1`, `missing || echo fallback`, `test -d ~ && …`, `printf … | head -1 >/dev/null 2>&1`, `bun --version | head -1`) all `ok`; a failing hook is a warning and the squad activates; `git` is `already_present` and an absent tool is a `missing_system_tool` warning; an object `check:` with a pipe passes. Squads area 104/104; `check:quick`, changelog parity, english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk