### PR TITLE
fix(glance): --idle-min 0 means no idle shutdown; hook messages say nrv setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### `nrv glance --idle-min 0` means no idle shutdown, and the hook messages name `nrv setup`
+
+`--idle-min 0` used to shut the cockpit down on the first watchdog tick: a truthy `"0"` became the number 0 and "idle longer than 0 ms" was true at once. Reported against the service-mode proposal (#89) as the reason a cockpit could not simply be left running. Zero now disarms the watchdog, `/api/health` reports `idle_timeout_ms: null`, and a cockpit meant to stay up all day is `nrv glance --idle-min 0 --no-open --port 3737`, registered with the operating system's own service manager when it must survive a reboot.
+
+The audit-hook installer is `nrv setup` (bare `nrv install` installs assets); #168 fixed the `nrv init` warning, and the doctor line and trust notes for the Codex hooks that had been written with the same wrong command now say `nrv setup` too.
+
 ### A pack's shell lines run in a POSIX shell on Windows too
 
 A squad's `post_install` hooks, its `check:` commands and the bare presence probe (`command -v <tool>`) are written in POSIX: `~`, `|`, `||`, `head`, `>/dev/null`. On macOS and Linux they go to `/bin/sh`; on Windows `execSync` handed them to `cmd.exe`, which speaks none of it, so every string dependency read as "missing" and every POSIX hook failed — silently, because a failed hook matched no branch of the failure collector. Measured on the published packs: 9 of the 47 Genesis squads and 22 of 23 in the other packs carry such hooks.
 
-The engine already requires Git for Windows there (the `nrv.cmd` launcher delegates to Git Bash). The POSIX-authored steps now run in that same bash on Windows, so the language mismatch is gone without touching a pack or the hook contract; what a pack wrote for Windows (`install.win32`) keeps running in `cmd.exe`. A failed hook is now a warning on the activation result, which is what the agent driving the activation reads and acts on; it never blocks the squad. The proof is a test that runs the pack-shaped lines through the activator on all three CI systems.
+The engine already requires Git for Windows there (the `nrv.cmd` launcher delegates to Git Bash). The POSIX-authored steps now run in that same bash on Windows, so the language mismatch is gone without touching a pack or the hook contract; what a pack wrote for Windows (`install.win32`) keeps running in `cmd.exe`. A failed hook is now a warning on the activation result, which is what the agent driving the activation reads and acts on; it never blocks the squad. The proof is a test that runs the pack-shaped lines through the activator on all three CI systems. The Windows symptom was reported in #228, which also carried the first attempt at a fix; this cut keeps that diagnosis and moves the correction into the engine, where it costs the packs nothing.
 
 ## 0.13.3 — 2026-09-05
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,11 +8,17 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### `nrv glance --idle-min 0` significa sem desligamento por ociosidade, e as mensagens de hooks nomeiam `nrv setup`
+
+`--idle-min 0` derrubava o cockpit no primeiro tique do watchdog: um `"0"` verdadeiro virava o número 0 e "ocioso há mais de 0 ms" era verdade na hora. Reportado contra a proposta de modo serviço (#89) como o motivo de um cockpit não poder simplesmente ficar rodando. Zero agora desarma o watchdog, `/api/health` reporta `idle_timeout_ms: null`, e um cockpit para ficar de pé o dia inteiro é `nrv glance --idle-min 0 --no-open --port 3737`, registrado no gerenciador de serviços do próprio sistema operacional quando precisa sobreviver a um reboot.
+
+O instalador de hooks de auditoria é `nrv setup` (`nrv install` sem argumento instala assets); o #168 corrigiu o aviso do `nrv init`, e a linha do doctor e as notas de confiança dos hooks do Codex, escritas com o mesmo comando errado, agora dizem `nrv setup` também.
+
 ### As linhas de shell de um pack rodam numa shell POSIX também no Windows
 
 Os hooks de `post_install` de um squad, seus comandos `check:` e a sonda de presença (`command -v <ferramenta>`) são escritos em POSIX: `~`, `|`, `||`, `head`, `>/dev/null`. No macOS e no Linux vão para o `/bin/sh`; no Windows o `execSync` os entregava ao `cmd.exe`, que não fala nada disso, então toda dependência em string aparecia como "faltando" e todo hook POSIX falhava — em silêncio, porque hook falhado não casava com ramo nenhum do coletor de falhas. Medido nos packs publicados: 9 dos 47 squads do Genesis e 22 de 23 dos outros packs carregam hooks assim.
 
-O engine já exige o Git for Windows lá (o `nrv.cmd` delega ao Git Bash). Os passos escritos em POSIX agora rodam nesse mesmo bash no Windows, então a diferença de língua some sem tocar em pack nem no contrato de hooks; o que um pack escreveu para o Windows (`install.win32`) continua rodando no `cmd.exe`. Um hook que falha agora é aviso no resultado da ativação, que é o que o agente que conduz a ativação lê e trata; nunca bloqueia o squad. A prova é um teste que roda as linhas com a forma dos packs pelo activator nos três sistemas do CI.
+O engine já exige o Git for Windows lá (o `nrv.cmd` delega ao Git Bash). Os passos escritos em POSIX agora rodam nesse mesmo bash no Windows, então a diferença de língua some sem tocar em pack nem no contrato de hooks; o que um pack escreveu para o Windows (`install.win32`) continua rodando no `cmd.exe`. Um hook que falha agora é aviso no resultado da ativação, que é o que o agente que conduz a ativação lê e trata; nunca bloqueia o squad. A prova é um teste que roda as linhas com a forma dos packs pelo activator nos três sistemas do CI. O sintoma no Windows foi reportado no #228, que também trouxe a primeira tentativa de correção; este corte mantém aquele diagnóstico e move a correção para o engine, onde ela não custa nada aos packs.
 
 ## 0.13.3 — 2026-09-05
 

--- a/docs/architecture/project-directory-and-runtimes.md
+++ b/docs/architecture/project-directory-and-runtimes.md
@@ -40,7 +40,7 @@ project relies on the machine's `~/.nirvana/skills`.
 | Runtime | Enter the project | Contract read from | Extra roots | Audit source |
 |---|---|---|---|---|
 | Claude Code | `cd <project> && claude` | `CLAUDE.md` in cwd | `--add-dir` | hooks (`PreToolUse`/`PostToolUse`) + `nrv audit emit` |
-| Codex | `cd <project> && codex`, or `codex exec -C <project>` | `AGENTS.md` in cwd (native) | `--add-dir` | hooks (`PreToolUse`/`PostToolUse` on `Bash\|apply_patch`, trusted by `nrv install`) + `nrv audit emit` |
+| Codex | `cd <project> && codex`, or `codex exec -C <project>` | `AGENTS.md` in cwd (native) | `--add-dir` | hooks (`PreToolUse`/`PostToolUse` on `Bash\|apply_patch`, trusted by `nrv setup`) + `nrv audit emit` |
 | Gemini CLI | `cd <project> && gemini` | `GEMINI.md` in cwd | `--include-directories` | hooks + `nrv audit emit` |
 | Antigravity | `cd <project> && agy` | `AGENTS.md` in cwd | `--add-dir` | hooks + `nrv audit emit` |
 | Hermes | `nrv-hermes`, or `hermes chat --in <project>` | `AGENTS.md` injected from cwd | n/a (works in cwd) | shell hooks (`pre/post_tool_call`) + fs-watch |
@@ -129,7 +129,7 @@ skipped in silence: `codex exec` prints nothing and the hook never fires
 hash of the normalized hook definition under `[hooks.state."<file>:<event>:<group>:<handler>"]`
 in `config.toml`, and it is reproducible — `_shared/lib/codex-hooks.ts`
 computes it the way `codex-rs` does (canonical JSON of the identity, SHA-256),
-verified against a hash Codex itself had recorded. `nrv install` therefore
+verified against a hash Codex itself had recorded. `nrv setup` therefore
 writes both the hooks and their trust, `--check` reports a hook that lost it,
 `--uninstall` removes both, and `nrv doctor` shows `codex: audit hooks`.
 

--- a/skills/_shared/scripts/install.ts
+++ b/skills/_shared/scripts/install.ts
@@ -557,7 +557,7 @@ function codexTrust(mode: "install" | "uninstall" | "check"): string[] {
   if (entries.length === 0) return notes;
   const untrusted = entries.filter((e) => !e.trusted);
   if (mode === "check") {
-    notes.push(untrusted.length ? `⚠ ${untrusted.length}/${entries.length} Codex hook(s) not trusted in ${configFile} — run: nrv install` : `✓ Codex hooks trusted (${entries.length})`);
+    notes.push(untrusted.length ? `⚠ ${untrusted.length}/${entries.length} Codex hook(s) not trusted in ${configFile} — run: nrv setup` : `✓ Codex hooks trusted (${entries.length})`);
     return notes;
   }
   if (untrusted.length === 0) return notes;

--- a/skills/harness/lib/glance/server.ts
+++ b/skills/harness/lib/glance/server.ts
@@ -1616,7 +1616,7 @@ export async function startServer(opts: ServerOptions) {
           version: "1.0.0",
           uptime_ms: Date.now() - STARTED_AT,
           idle_ms: Date.now() - lastActivity,
-          idle_timeout_ms: opts.idleMin * 60_000,
+          idle_timeout_ms: opts.idleMin > 0 ? opts.idleMin * 60_000 : null,
           allow_actions: opts.allowActions,
           scope: getScope(),
         });
@@ -2135,7 +2135,7 @@ export async function startServer(opts: ServerOptions) {
   });
 
   console.error(`[glance] up on ${url}  (scope=${getScope().mode}, allow_actions=${opts.allowActions}, theme=${opts.theme})`);
-  console.error(`[glance] auto-shutdown after ${opts.idleMin}min idle  ·  Ctrl+C to exit`);
+  console.error(opts.idleMin > 0 ? `[glance] auto-shutdown after ${opts.idleMin}min idle  ·  Ctrl+C to exit` : `[glance] no idle shutdown (--idle-min 0)  ·  Ctrl+C to exit`);
   if (!isLoopback) console.error(`[glance] served on ${host} — authentication required (Authorization: Bearer <token from \`nrv serve keygen --glance\`>); tenant = ${currentProjectRoot()}`);
   // A served instance is a VPS process with no display attached to it, most of the time; even
   // when one exists, opening a browser aimed at a bare non-TLS network address is not this
@@ -2148,13 +2148,14 @@ export async function startServer(opts: ServerOptions) {
   // The maestro turns have no recovery: a dying server signals them (Ctrl+C in a terminal session).
   const detach = () => { canaryQueue?.shutdown(); turnQueue?.shutdown(); };
 
-  // Idle watchdog (a running maestro turn keeps the server up; the tab may be closed meanwhile)
-  const watchdog = setInterval(() => {
+  // Idle watchdog (a running maestro turn keeps the server up; the tab may be closed meanwhile).
+  // Not armed at all when idleMin is 0: a cockpit meant to stay up all day.
+  const watchdog: ReturnType<typeof setInterval> | null = opts.idleMin > 0 ? setInterval(() => {
     if (Date.now() - lastActivity > opts.idleMin * 60_000 && !turnQueue?.hasActive()) {
       console.error(`[glance] idle ${opts.idleMin}min — shutting down`);
       shutdown(server, watchdog, detach);
     }
-  }, 30_000);
+  }, 30_000) : null;
 
   // SIGINT cleanup
   const onSignal = () => { console.error("\n[glance] SIGINT — shutting down"); shutdown(server, watchdog, detach); };
@@ -2510,9 +2511,9 @@ function streamJobSSE(req: Request, id: string): Response {
 
 /** Orderly stop: the execution queue detaches first, then the server, the pid file and the process.
  * `exit` and `pidFile` are seams for the unit test; production passes only the first three. */
-export function shutdown(server: { stop(closeActiveConnections?: boolean): void }, watchdog: ReturnType<typeof setInterval>,
+export function shutdown(server: { stop(closeActiveConnections?: boolean): void }, watchdog: ReturnType<typeof setInterval> | null,
   detach: () => void = () => {}, exit: (code: number) => void = code => process.exit(code), pidFile: string = PID_FILE): void {
-  clearInterval(watchdog);
+  if (watchdog) clearInterval(watchdog);
   try { detach(); } catch {}
   try { server.stop(true); } catch {}
   try { fs.unlinkSync(pidFile); } catch {}

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -151,12 +151,12 @@ if (which("openclaw")) {
 
 // SECTION 1a-quater: CODEX AUDIT HOOKS — present is not enough; Codex skips a
 // hook nobody trusted, silently, so `codex exec` would audit nothing while the
-// file looked wired. `nrv install` writes both; this line checks both.
+// file looked wired. `nrv setup` writes both; this line checks both.
 if (which("codex")) {
   const entries = codexHookTrustEntries(codexHooksPath(), codexConfigPath(), "audit-emit-from-hook.ts");
   const untrusted = entries.filter((e) => !e.trusted);
-  if (entries.length === 0) add("codex: audit hooks", "WARN", `not wired in ${codexHooksPath().replace(HOME, "~")} — run: nrv install`);
-  else if (untrusted.length) add("codex: audit hooks", "WARN", `${untrusted.length}/${entries.length} present but not trusted — a headless run skips them; run: nrv install`);
+  if (entries.length === 0) add("codex: audit hooks", "WARN", `not wired in ${codexHooksPath().replace(HOME, "~")} — run: nrv setup`);
+  else if (untrusted.length) add("codex: audit hooks", "WARN", `${untrusted.length}/${entries.length} present but not trusted — a headless run skips them; run: nrv setup`);
   else add("codex: audit hooks", "PASS", `${entries.length} hook(s) wired and trusted (PreToolUse/PostToolUse: Bash|apply_patch)`);
 }
 

--- a/skills/harness/scripts/glance.ts
+++ b/skills/harness/scripts/glance.ts
@@ -31,7 +31,7 @@ USAGE
   glance --read-only                  browse only; disable all write endpoints
   glance --port 4242                  fixed port instead of auto
   glance --no-open                    don't auto-open the browser
-  glance --idle-min 60                idle timeout in minutes (default 30)
+  glance --idle-min 60                idle timeout in minutes (default 30; 0 = never shut down on idle)
   glance --theme apple|apple-dark|awwwards    visual theme (default apple)
   glance --host 0.0.0.0               served instance — see SERVED below
   glance -h | --help                  this message
@@ -71,7 +71,12 @@ The cockpit auto-detects the project root from \$cwd (walks up looking for
 
 const port = flags.port ? Number(flags.port) : "auto";
 const open = !flags["no-open"];
-const idleMin = flags["idle-min"] ? Number(flags["idle-min"]) : 30;
+// `--idle-min 0` means NO idle shutdown. It used to mean "shut down on the first
+// watchdog tick": a truthy "0" string became the number 0, and `idle > 0` was
+// true immediately. Reported against the service-mode proposal (#89) — the
+// one-line reason a cockpit could not simply be left running.
+const idleMinRaw = flags["idle-min"] !== undefined ? Number(flags["idle-min"]) : 30;
+const idleMin = Number.isFinite(idleMinRaw) && idleMinRaw >= 0 ? idleMinRaw : 30;
 const host = (flags.host as string) || "127.0.0.1";
 if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") {
   const glanceKeys = listKeys().filter((k) => k.glance && !k.revoked).length;

--- a/skills/harness/tests/glance-idle-never.test.ts
+++ b/skills/harness/tests/glance-idle-never.test.ts
@@ -1,0 +1,28 @@
+// glance-idle-never.test.ts — `--idle-min 0` means the cockpit stays up: no
+// watchdog is armed and /api/health says so. It used to mean "shut down on the
+// first tick", the one-line reason a cockpit could not be left running.
+// One server per file, like every glance test: the module keeps boot-time state.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { startServer, shutdown } from "../lib/glance/server.ts";
+
+let instance: any;
+beforeAll(async () => {
+  instance = await startServer({ port: 0, open: false, idleMin: 0, allowActions: false, theme: "apple" } as any);
+});
+afterAll(() => { try { instance?.close(); } catch {} });
+
+describe("glance --idle-min 0", () => {
+  test("no idle timeout is advertised and the server keeps answering", async () => {
+    const health = await (await fetch(`http://127.0.0.1:${instance.port}/api/health`)).json();
+    expect(health.ok).toBe(true);
+    expect(health.idle_timeout_ms).toBeNull();
+    expect((await fetch(`http://127.0.0.1:${instance.port}/api/health`)).status).toBe(200);
+  }, 30_000);
+
+  test("shutdown tolerates a disarmed watchdog", () => {
+    let stopped = false; let code = -1;
+    shutdown({ stop() { stopped = true; } }, null, () => {}, (c) => { code = c; }, "/nonexistent/pid");
+    expect(stopped).toBe(true);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

- \`nrv glance --idle-min 0\` now means **no idle shutdown**. It used to shut the cockpit down on the first watchdog tick (a truthy \`"0"\` became the number 0, and \`idle > 0 ms\` was immediately true). The watchdog is not armed at all when \`idleMin\` is 0, \`shutdown()\` accepts a null watchdog, and \`/api/health\` reports \`idle_timeout_ms: null\`. Reported against the service-mode proposal (#89) as the reason a cockpit could not simply be left running.
- The Codex audit-hook texts written last week (doctor line, trust note in the installer, runtimes doc) said \`run: nrv install\`; the installer is \`nrv setup\` (#168 fixed the same wording in \`nrv init\`).
- CHANGELOG (EN/PT): credit #228 for the Windows POSIX-shell report and first fix attempt; entry for the idle fix.

## Tests

- \`skills/harness/tests/glance-idle-never.test.ts\`: server started with \`idleMin: 0\` advertises \`idle_timeout_ms: null\` and keeps answering; \`shutdown(server, null)\` still stops and exits 0.
- Ran with \`glance-control-plane\` and \`glance-auth-tenancy\` in one process; \`check:quick\`, changelog parity and english-source gates green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk