### PR TITLE
chore: neutral placeholder paths in shipped docs, comments and test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -599,7 +599,7 @@ Adds a project switcher to the topnav: an always-visible label showing the
 currently bound project (previously nothing), a dropdown of other Nirvana
 projects discovered on the machine, and a free-text path field for anything
 not discovered. Discovery decodes Claude Code's own transcript-directory
-naming convention (`~/.claude/projects/-Users-guto-nirvana-os`, path
+naming convention (`~/.claude/projects/-Users-alice-nirvana-os`, path
 separators encoded as `-`) by walking the real filesystem and preferring
 the longest real match at each step — a blind `-` → `/` replace misreads a
 hyphenated name like `nirvana-os` as `nirvana/os`; this doesn't, because it

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -616,7 +616,7 @@ o projeto vinculado agora (antes não existia nada), um dropdown com outros
 projetos Nirvana descobertos na máquina, e um campo de texto livre para
 qualquer um não descoberto. A descoberta decodifica a convenção de
 nomenclatura de diretório de transcrição do próprio Claude Code
-(`~/.claude/projects/-Users-guto-nirvana-os`, separadores de caminho
+(`~/.claude/projects/-Users-alice-nirvana-os`, separadores de caminho
 codificados como "-") caminhando pelo sistema de arquivos real e preferindo
 o maior trecho real a cada passo — uma substituição cega de "-" por "/" lê
 errado um nome com hífen como `nirvana-os` como `nirvana/os`; isso não

--- a/skills/_shared/README.md
+++ b/skills/_shared/README.md
@@ -179,7 +179,7 @@ from validators import (
 )
 
 biz = BusinessManifest.model_validate(manifest_dict)   # raises pydantic.ValidationError on fail
-ok = validate_dna_file('/Volumes/guto1/mindclones/02-negocios/naval-ravikant.md')
+ok = validate_dna_file('/Volumes/external/mindclones/02-negocios/naval-ravikant.md')
 ```
 
 Test: `cd ~/.nirvana/skills/_shared/validators && python3 -m pytest validators.py` (36 passed).

--- a/skills/_shared/scripts/import-claude-transcripts.ts
+++ b/skills/_shared/scripts/import-claude-transcripts.ts
@@ -46,7 +46,7 @@ const PROJECTS_ROOT = path.join(os.homedir(), ".claude", "projects");
 
 function encodeProjectPath(absPath: string): string {
   // Claude Code encodes the absolute path by replacing slashes with hyphens
-  // and prefixing with a single dash. e.g. ~/foo → -Users-guto-foo.
+  // and prefixing with a single dash. e.g. ~/foo → -Users-alice-foo.
   return absPath.replace(/\//g, "-");
 }
 

--- a/skills/businesses/BUSINESS_PROTOCOL_V1.md
+++ b/skills/businesses/BUSINESS_PROTOCOL_V1.md
@@ -606,7 +606,7 @@ Inherits Squad Protocol v4 §6.5 (Identity, Guidelines DO/DO NOT, Process, Outpu
 
 ### 7.5 Mind-clone employees (special case)
 
-When `type: mind_clone`, the employee references a canonical DNA in `${DNA_LIBRARY}/` (consolidated from `/Volumes/guto1/mindclones/`, `~/.claude/agents/`, `${SQUADS_DIR}/sales-funnel-masters/specialists/`).
+When `type: mind_clone`, the employee references a canonical DNA in `${DNA_LIBRARY}/` (consolidated from `/Volumes/external/mindclones/`, `~/.claude/agents/`, `${SQUADS_DIR}/sales-funnel-masters/specialists/`).
 
 ```yaml
 type: mind_clone

--- a/skills/harness/lib/glance/views/glance.js
+++ b/skills/harness/lib/glance/views/glance.js
@@ -1078,8 +1078,8 @@ function glance() {
       if (item.cwd && (item.cwd === root || item.cwd.startsWith(root + '/'))) return true;
 
       // 2. Fallback for project_id. Claude Code stores transcripts under
-      //    ~/.claude/projects/-Users-guto-foo-bar/, and our importer turns that
-      //    back into "Users/guto/foo/bar" — every "-" becomes "/" indiscriminately,
+      //    ~/.claude/projects/-Users-alice-foo-bar/, and our importer turns that
+      //    back into "Users/alice/foo/bar" — every "-" becomes "/" indiscriminately,
       //    so a real "nirvana-os" path is encoded as "nirvana/os". We can't reverse
       //    that perfectly, but for matching we normalise BOTH sides by treating
       //    "/" and "-" as the same separator and lowercasing.

--- a/skills/harness/tests/glance-project-switcher.test.ts
+++ b/skills/harness/tests/glance-project-switcher.test.ts
@@ -206,10 +206,10 @@ describe("decodeClaudeProjectDirName", () => {
   test("recovers a hyphenated leaf directory name (the case a blind replace(/-/g,'/') gets wrong)", () => {
     const root = makeTempRoot("nrv-decode-");
     roots.push(root);
-    fs.mkdirSync(path.join(root, "Users", "guto", "nirvana-os"), { recursive: true });
-    // Claude Code encoding of "<root>/Users/guto/nirvana-os": every "/" -> "-".
-    const encoded = "-Users-guto-nirvana-os";
-    expect(decodeClaudeProjectDirName(encoded, root)).toBe(path.join(root, "Users", "guto", "nirvana-os"));
+    fs.mkdirSync(path.join(root, "Users", "alice", "nirvana-os"), { recursive: true });
+    // Claude Code encoding of "<root>/Users/alice/nirvana-os": every "/" -> "-".
+    const encoded = "-Users-alice-nirvana-os";
+    expect(decodeClaudeProjectDirName(encoded, root)).toBe(path.join(root, "Users", "alice", "nirvana-os"));
   });
 
   test("prefers the longest real match, so a hyphenated name beats the wrong shorter split even when both exist", () => {
@@ -237,18 +237,18 @@ describe("discoverKnownProjects / validateProjectPath", () => {
     fs.mkdirSync(claudeProjects, { recursive: true });
 
     // A real Nirvana project — should be listed.
-    fs.mkdirSync(path.join(root, "Users", "guto", "nirvana-os", ".nirvana"), { recursive: true });
-    fs.mkdirSync(path.join(claudeProjects, "-Users-guto-nirvana-os"), { recursive: true });
+    fs.mkdirSync(path.join(root, "Users", "alice", "nirvana-os", ".nirvana"), { recursive: true });
+    fs.mkdirSync(path.join(claudeProjects, "-Users-alice-nirvana-os"), { recursive: true });
 
     // A real directory, but no .nirvana/ marker — must NOT be listed.
-    fs.mkdirSync(path.join(root, "Users", "guto", "not-a-project"), { recursive: true });
-    fs.mkdirSync(path.join(claudeProjects, "-Users-guto-not-a-project"), { recursive: true });
+    fs.mkdirSync(path.join(root, "Users", "alice", "not-a-project"), { recursive: true });
+    fs.mkdirSync(path.join(claudeProjects, "-Users-alice-not-a-project"), { recursive: true });
 
     // An encoded name that doesn't decode to anything real — dropped, not an error.
     fs.mkdirSync(path.join(claudeProjects, "-nothing-here-at-all"), { recursive: true });
 
     const found = discoverKnownProjects(claudeProjects, root);
-    expect(found).toEqual([{ path: path.join(root, "Users", "guto", "nirvana-os"), name: "nirvana-os" }]);
+    expect(found).toEqual([{ path: path.join(root, "Users", "alice", "nirvana-os"), name: "nirvana-os" }]);
   });
 
   test("validateProjectPath accepts a real .nirvana/-marked directory and rejects everything else", () => {

--- a/skills/squads/SQUAD_PROTOCOL_V5.md
+++ b/skills/squads/SQUAD_PROTOCOL_V5.md
@@ -308,7 +308,7 @@ The registry is **cache, not source-of-truth**. Source of truth remains the `squ
   "schema_version": "1.0.0",
   "generated_at": "2026-05-02T15:00:00Z",
   "host_protocol_version": "5.0",
-  "squads_root_dirs": ["${SQUADS_DIR}", "/Volumes/guto1/squads"],
+  "squads_root_dirs": ["${SQUADS_DIR}", "/Volumes/external/squads"],
   "squads": {
     "instagram-intelligence-nirvana": {
       "version": "5.4.0",


### PR DESCRIPTION
Six files inside `skills/` (shipped in the tarball) used a real home directory or volume name as the example path: two code comments (`glance.js`, `import-claude-transcripts.ts`), three protocol/README snippets (`SQUAD_PROTOCOL_V5.md`, `BUSINESS_PROTOCOL_V1.md`, `_shared/README.md`) and the fixture directories of `glance-project-switcher.test.ts`. All now use neutral placeholders (`alice`, `/Volumes/external/`). Two old changelog lines got the same treatment. No behaviour changes; the switcher test still passes (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk