### PR TITLE
fix(businesses): seat audit is JSONL again, and the verify verdict reaches the audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 (`nirvana-os-engine`); each release ships the full engine tarball that
 `npx @nirvana-os/cli` and pack installs consume.
 
+## Unreleased
+
+### The seat audit is JSONL again, and the verify verdict reaches the audit
+
+Two regressions from 2026-09-04, both in the businesses package and both invisible to the caller. The seat prompt's audit emitter wrote the two characters `\` `n` between events instead of a newline once it was wrapped with the provenance stamp, so every `mind_clone_injected` since then landed on one line that no line reader could parse: the event that proves a clone was injected was the one that vanished. And `verify-deliverable` recomputed the run root when filing its verdict, shadowed its own variable while doing it, printed "audit emit failed non-fatal" and exited with the verdict's code, so the gate looked healthy while the audit never received a `verify_passed` or `verify_failed`. The check now reports the run directory it resolved (`project_dir` on the report) and the CLI files the verdict beside it. Both paths are read back by tests now.
+
 ## 0.13.4 — 2026-09-06
 
 ### `nrv glance --idle-min 0` means no idle shutdown, and the hook messages name `nrv setup`

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -6,6 +6,12 @@ Todas as mudanças relevantes do engine Nirvana-OS. As versões correspondem às
 releases no GitHub (`nirvana-os-engine`); cada release publica o tarball completo
 do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
+## Não lançado
+
+### O audit do cargo volta a ser JSONL, e o veredito do verify chega ao audit
+
+Duas regressões de 04/09/2026, as duas no pacote de empresas e as duas invisíveis para quem chama. O emissor de audit do prompt do cargo passou a escrever os dois caracteres `\` `n` entre eventos em vez de uma quebra de linha quando ganhou o carimbo de proveniência, então todo `mind_clone_injected` desde então caiu numa linha só que nenhum leitor de linhas consegue ler: o evento que prova que um clone foi injetado era o que sumia. E o `verify-deliverable` recalculava a raiz do run ao arquivar o veredito, sombreava a própria variável nisso, imprimia "audit emit failed non-fatal" e saía com o código do veredito, então o portão parecia saudável enquanto o audit nunca recebia um `verify_passed` ou `verify_failed`. A checagem agora informa o diretório do run que resolveu (`project_dir` no relatório) e o CLI arquiva o veredito ao lado dele. Os dois caminhos agora são relidos por testes.
+
 ## 0.13.4 — 2026-09-06
 
 ### `nrv glance --idle-min 0` significa sem desligamento por ociosidade, e as mensagens de hooks nomeiam `nrv setup`

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -95,7 +95,7 @@ function appendAuditEvent(project_dir: string, event: Record<string, unknown>): 
     fs.mkdirSync(dir, { recursive: true });
     fs.appendFileSync(
       path.join(dir, "audit.jsonl"),
-      JSON.stringify(stamp({ ts: new Date().toISOString(), ...event })) + "\\n"
+      JSON.stringify(stamp({ ts: new Date().toISOString(), ...event })) + "\n"
     );
   } catch {
     // non-fatal

--- a/skills/businesses/scripts/verify-deliverable.ts
+++ b/skills/businesses/scripts/verify-deliverable.ts
@@ -41,6 +41,10 @@ export type DeliverableReport = {
   empty_or_stub: string[];
   delta_pct: number;
   min_bytes_threshold: number;
+  /** The run directory the check resolved (nested `outputs/<project_id>/` or the
+   *  flat chain root). The CLI files the verdict beside the run; recomputing the
+   *  root there is how a verdict once went nowhere. Absent when indeterminate. */
+  project_dir?: string;
   reason?: string;
 };
 
@@ -54,6 +58,7 @@ export function verifyDeliverableOnDisk(
 ): DeliverableReport {
   const minBytes = opts.minBytes ?? 200;
   const outputsRoot = opts.outputsRoot;
+  let resolvedProjectDir: string | undefined;
 
   const base = (
     status: DeliverableReport["status"],
@@ -69,6 +74,7 @@ export function verifyDeliverableOnDisk(
     empty_or_stub: [],
     delta_pct: 100,
     min_bytes_threshold: minBytes,
+    ...(resolvedProjectDir ? { project_dir: resolvedProjectDir } : {}),
     ...extra,
   });
 
@@ -92,6 +98,7 @@ export function verifyDeliverableOnDisk(
     return base("FAIL_INDETERMINATE", { reason: `project not found in ${projectRootCandidates.join(" or ")} (neither nested nor flat layout)` });
   }
   const projectDir = projectsRoot ? path.join(projectsRoot, projectId) : flatRoot!;
+  resolvedProjectDir = projectDir;
 
   const briefPath = path.join(projectDir, "brief.md");
   if (!fs.existsSync(briefPath)) {
@@ -191,6 +198,7 @@ export function verifyDeliverableOnDisk(
     empty_or_stub: empty,
     delta_pct: deltaPct,
     min_bytes_threshold: minBytes,
+    project_dir: projectDir,
   };
 }
 
@@ -245,13 +253,13 @@ if (import.meta.main) {
   // silent in the audit (matches the original, which exited before emit).
   if (r.status === "PASS" || r.status === "FAIL") {
     try {
-      const projectsRoot = [
-        path.join(process.cwd(), "outputs"),
-        path.join(process.cwd(), ".nirvana/outputs"),
-        path.join(os.homedir(), ".nirvana/outputs"),
-      ].find(p => fs.existsSync(path.join(p, projectId)))!;
-      const projectDir = path.join(projectDir, "businesses", businessSlug);
-      fs.mkdirSync(projectDir, { recursive: true });
+      // The check already resolved the run directory (nested or flat); the
+      // verdict is filed beside that run. This block once recomputed the root
+      // and shadowed its own variable, and the verdict never reached the audit.
+      if (!r.project_dir) throw new Error("verdict without a resolved run directory");
+      const projectDir = r.project_dir;
+      const businessOutDir = path.join(projectDir, "businesses", businessSlug);
+      fs.mkdirSync(businessOutDir, { recursive: true });
       const auditEntry = JSON.stringify({
         ts: report.timestamp,
         event: r.status === "PASS" ? "verify_passed" : "verify_failed",
@@ -264,7 +272,7 @@ if (import.meta.main) {
         stub_count: r.empty_or_stub.length,
         delta_pct: r.delta_pct,
       });
-      fs.appendFileSync(path.join(projectDir, "audit.jsonl"), auditEntry + "\n");
+      fs.appendFileSync(path.join(businessOutDir, "audit.jsonl"), auditEntry + "\n");
 
       // Also emit to harness daily audit (per-project when inside a project, else $HOME)
       const { harnessLogsDir } = require(path.join(SKILLS_ROOT, "_shared/lib/log-paths.ts"));

--- a/skills/businesses/tests/employee-prompt-audit-line.test.ts
+++ b/skills/businesses/tests/employee-prompt-audit-line.test.ts
@@ -1,0 +1,75 @@
+// employee-prompt-audit-line.test.ts — the seat's audit file is JSONL: one
+// event per physical line.
+//
+// On 2026-09-04 the emitter was wrapped with the provenance stamp and the
+// separator became the two characters `\` `n`. Every `mind_clone_injected`
+// since then landed on ONE line, which no line reader can parse — the event
+// that proves a clone was injected was the one that vanished. No test read the
+// file back, so nothing noticed. This one does.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
+
+describe("the seat audit is one event per line", () => {
+  const R = mkdtempSync(join(tmpdir(), "audit-line-"));
+  afterAll(() => rmSync(R, { recursive: true, force: true }));
+
+  writeFileSync(join(R, ".env"), "NIRVANA_SCOPE=project\n", "utf8");
+  const biz = join(R, ".nirvana", "businesses", "audit-co");
+  mkdirSync(join(biz, "employees"), { recursive: true });
+  writeFileSync(join(biz, "business.yaml"), "name: audit-co\ndescription: a fixture business\n", "utf8");
+  writeFileSync(join(biz, "employees", "writer.md"), [
+    "---",
+    "assigned_mind_clones:",
+    "  - fixture-voice",
+    "---",
+    "# Writer",
+    "",
+    "Writes the thing.",
+    "",
+  ].join("\n"), "utf8");
+
+  const agentDir = join(R, "dna", "fixture-voice", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "AGENT.md"), "# fixture-voice\n\nMethod of the fixture voice.\n", "utf8");
+  writeFileSync(join(R, ".nirvana", ".mind-clones-registry.json"), JSON.stringify({
+    mind_clones: {
+      "fixture-voice": {
+        slug: "fixture-voice", display_name: "Fixture Voice", tags: [], dir: join(R, "dna", "fixture-voice"),
+        persona_files: { agent: join(agentDir, "AGENT.md") },
+        match: { one_liner: "the fixture voice", domains: [], serves: "fixture", when_to_use: null, not_for: null, delegates_to: [], refuses: [] },
+      },
+    },
+  }), "utf8");
+
+  const briefFile = join(R, "brief.txt");
+  writeFileSync(briefFile, "escreva o texto de abertura, na voz do fixture-voice", "utf8");
+
+  // Pinned, not inherited: another test file setting HARNESS_LOGS_DIR would
+  // send this audit somewhere the assertions are not looking.
+  const logsRoot = join(R, ".nirvana", "logs", "harness");
+  const r = spawnSync(process.execPath, [
+    join(import.meta.dir, "..", "lib", "employee-prompt.ts"),
+    "audit-co", "writer", R, briefFile,
+  ], { cwd: R, encoding: "utf8", env: { ...process.env, HARNESS_LOGS_DIR: logsRoot } });
+
+  test("the clone was injected, so there is something to audit", () => {
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}`).toContain("--- MIND-CLONE: fixture-voice");
+  }, spawnBudgetMs(1));
+
+  test("every event sits on its own line and parses", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const file = join(logsRoot, today, "audit.jsonl");
+    const raw = readFileSync(file, "utf8");
+    const lines = raw.split("\n").filter(Boolean);
+    const events = lines.map(l => JSON.parse(l));
+    // As many physical lines as events: the literal `\n` separator glued them.
+    expect(lines.length).toBe((raw.match(/"event":/g) ?? []).length);
+    expect(events.some(e => e.event === "mind_clone_injected")).toBe(true);
+    expect(raw).not.toContain("}\\n{");
+  });
+});

--- a/skills/businesses/tests/verify-deliverable-audit.test.ts
+++ b/skills/businesses/tests/verify-deliverable-audit.test.ts
@@ -1,0 +1,88 @@
+// verify-deliverable-audit.test.ts — a verdict that is printed is also filed.
+//
+// The CLI recomputed the run root when writing the audit and, since 2026-09-04,
+// shadowed its own variable while doing it (`const projectDir = path.join(projectDir, …)`).
+// The `catch` printed "non-fatal" and the process exited with the verdict's
+// code, so the gate looked healthy while the audit never received a single
+// `verify_passed` or `verify_failed`. Anyone checking the chain from the audit
+// concluded the verification never ran. The check now reports the run
+// directory it resolved and the CLI files the verdict beside it; this test
+// reads the audit back for both verdicts.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
+
+const SCRIPT = join(import.meta.dir, "..", "scripts", "verify-deliverable.ts");
+const today = () => new Date().toISOString().slice(0, 10);
+
+function run(W: string, projectId: string, biz: string) {
+  const logsRoot = join(W, ".nirvana", "logs", "harness");
+  const r = spawnSync(process.execPath, [SCRIPT, projectId, biz], {
+    cwd: W, encoding: "utf8", env: { ...process.env, HARNESS_LOGS_DIR: logsRoot },
+  });
+  const report = JSON.parse(`${r.stdout}`.trim().replace(/^[^{]*/, ""));
+  const runAudit = join(W, "outputs", projectId, "businesses", biz, "audit.jsonl");
+  const dayAudit = join(logsRoot, today(), "audit.jsonl");
+  const lines = (f: string) => existsSync(f) ? readFileSync(f, "utf8").split("\n").filter(Boolean).map(l => JSON.parse(l)) : [];
+  return { code: r.status, stderr: `${r.stderr}`, report, runEvents: lines(runAudit), dayEvents: lines(dayAudit) };
+}
+
+/** A nested-layout run: `outputs/<project_id>/` with a brief and a manifest. */
+function scaffold(W: string, projectId: string, biz: string, deliverable: { name: string; write: boolean }): void {
+  mkdirSync(join(W, ".nirvana"), { recursive: true });
+  const run = join(W, "outputs", projectId);
+  mkdirSync(join(run, "businesses", biz), { recursive: true });
+  writeFileSync(join(run, "brief.md"), "# Brief\n\nDeliver the report.\n", "utf8");
+  const target = join(run, "businesses", biz, deliverable.name);
+  writeFileSync(join(run, "businesses", biz, "deliverables.json"), JSON.stringify([target]), "utf8");
+  if (deliverable.write) writeFileSync(target, "# Report\n\n" + "A paragraph of real content. ".repeat(20) + "\n", "utf8");
+}
+
+describe("verify-deliverable files its verdict", () => {
+  const roots: string[] = [];
+  afterAll(() => { for (const d of roots) rmSync(d, { recursive: true, force: true }); });
+
+  test("PASS is written beside the run and in the day's audit", () => {
+    const W = mkdtempSync(join(tmpdir(), "verify-pass-")); roots.push(W);
+    scaffold(W, "proj-pass", "acme", { name: "report.md", write: true });
+    const out = run(W, "proj-pass", "acme");
+    expect(out.report.status).toBe("PASS");
+    expect(out.code).toBe(0);
+    expect(out.stderr).not.toContain("audit emit failed");
+    expect(out.runEvents.map(e => e.event)).toEqual(["verify_passed"]);
+    expect(out.dayEvents.some(e => e.event === "verify_passed" && e.project_id === "proj-pass" && e.business_slug === "acme")).toBe(true);
+  }, spawnBudgetMs(1));
+
+  test("FAIL is filed too, with the counts the verdict was made from", () => {
+    const W = mkdtempSync(join(tmpdir(), "verify-fail-")); roots.push(W);
+    scaffold(W, "proj-fail", "acme", { name: "report.md", write: false });
+    const out = run(W, "proj-fail", "acme");
+    expect(out.report.status).toBe("FAIL");
+    expect(out.code).toBe(1);
+    expect(out.stderr).not.toContain("audit emit failed");
+    const ev = out.runEvents.find(e => e.event === "verify_failed");
+    expect(ev).toBeDefined();
+    expect(ev.expected).toBe(1);
+    expect(ev.found).toBe(0);
+    expect(out.dayEvents.some(e => e.event === "verify_failed")).toBe(true);
+  }, spawnBudgetMs(1));
+
+  test("the pure check reports the run directory it resolved", async () => {
+    const W = mkdtempSync(join(tmpdir(), "verify-dir-")); roots.push(W);
+    scaffold(W, "proj-dir", "acme", { name: "report.md", write: true });
+    const mod = await import("../scripts/verify-deliverable.ts");
+    const prev = process.cwd();
+    process.chdir(W);
+    try {
+      const r = mod.verifyDeliverableOnDisk("proj-dir", "acme");
+      // process.cwd() comes back resolved after chdir into a symlinked tmpdir (macOS).
+      expect(realpathSync(r.project_dir!)).toBe(realpathSync(join(W, "outputs", "proj-dir")));
+      const gone = mod.verifyDeliverableOnDisk("no-such-project", "acme");
+      expect(gone.status).toBe("FAIL_INDETERMINATE");
+      expect(gone.project_dir).toBeUndefined();
+    } finally { process.chdir(prev); }
+  });
+});


### PR DESCRIPTION
One behaviour: two audit writes that silently went nowhere since 2026-09-04 now land, and are read back by tests.

- `employee-prompt.ts` `appendAuditEvent` wrote the literal two characters `\` `n` between events (introduced when the line was wrapped with `stamp()`), so every `mind_clone_injected` since then sat on one physical line that no JSONL reader can parse. Now `"\n"`.
- `verify-deliverable.ts` recomputed the run root when filing its verdict and shadowed its own variable (`const projectDir = path.join(projectDir, …)`, a TDZ read), caught the error as "non-fatal" and exited with the verdict's code. The pure check now returns the run directory it resolved (`project_dir` on `DeliverableReport`, absent when indeterminate) and the CLI files `verify_passed|verify_failed` beside that run and in the day's audit.

Impact on published packs: none (engine scripts only). Tests: `employee-prompt-audit-line.test.ts` (one event per line, `mind_clone_injected` present) and `verify-deliverable-audit.test.ts` (PASS and FAIL both filed; `project_dir` reported; indeterminate has none). Both fail against the previous code (4 of 5 assertions), pass now; businesses suite 106/106; `check:quick`, changelog parity and english-source green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk