### PR TITLE
fix(validate): self_retrieval_miss reports every missed brief, not the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### `self_retrieval_miss` reports every missed brief
+
+The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.
+
 ### The seat audit is JSONL again, and the verify verdict reaches the audit
 
 Two regressions from 2026-09-04, both in the businesses package and both invisible to the caller. The seat prompt's audit emitter wrote the two characters `\` `n` between events instead of a newline once it was wrapped with the provenance stamp, so every `mind_clone_injected` since then landed on one line that no line reader could parse: the event that proves a clone was injected was the one that vanished. And `verify-deliverable` recomputed the run root when filing its verdict, shadowed its own variable while doing it, printed "audit emit failed non-fatal" and exited with the verdict's code, so the gate looked healthy while the audit never received a `verify_passed` or `verify_failed`. The check now reports the run directory it resolved (`project_dir` on the report) and the CLI files the verdict beside it. Both paths are read back by tests now.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### `self_retrieval_miss` reporta todos os briefs que erram
+
+O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.
+
 ### O audit do cargo volta a ser JSONL, e o veredito do verify chega ao audit
 
 Duas regressões de 04/09/2026, as duas no pacote de empresas e as duas invisíveis para quem chama. O emissor de audit do prompt do cargo passou a escrever os dois caracteres `\` `n` entre eventos em vez de uma quebra de linha quando ganhou o carimbo de proveniência, então todo `mind_clone_injected` desde então caiu numa linha só que nenhum leitor de linhas consegue ler: o evento que prova que um clone foi injetado era o que sumia. E o `verify-deliverable` recalculava a raiz do run ao arquivar o veredito, sombreava a própria variável nisso, imprimia "audit emit failed non-fatal" e saía com o código do veredito, então o portão parecia saudável enquanto o audit nunca recebia um `verify_passed` ou `verify_failed`. A checagem agora informa o diretório do run que resolveu (`project_dir` no relatório) e o CLI arquiva o veredito ao lado dele. Os dois caminhos agora são relidos por testes.

--- a/skills/_shared/lib/verify/kinds/business.ts
+++ b/skills/_shared/lib/verify/kinds/business.ts
@@ -648,6 +648,10 @@ async function selfRetrieval(ctx: CheckContext): Promise<Finding[]> {
   let prepared = MATCH_INDEX.get(registries as object);
   if (!prepared) { prepared = router.prepareMatchIndex(registries); MATCH_INDEX.set(registries as object, prepared); }
 
+  // Every miss is reported, not only the first. The `return` used to sit inside
+  // this loop, so an author fixing briefs one at a time learned about the next
+  // miss only after fixing this one, and "1 warning" could mean fourteen.
+  const misses: ReturnType<typeof mk>[] = [];
   for (const brief of briefs) {
     const result = await router.route(brief, { registries, amplify: false, preparedMatchIndex: prepared });
     const s3 = result?.stage3 ?? {};
@@ -659,9 +663,9 @@ async function selfRetrieval(ctx: CheckContext): Promise<Finding[]> {
     });
     if (hit === 0) continue;
     const top = ranked.slice(0, 3).map((c: any) => `${c?.meta?.slug ?? c?.id ?? "?"} (${typeof c?.normalized === "number" ? c.normalized.toFixed(2) : "-"})`).join(", ") || "no candidates";
-    return [mk("self_retrieval_miss", `example_brief ${JSON.stringify(brief.slice(0, 48))} does not return this business first (rank ${hit === -1 ? "-" : hit + 1})`, `top: ${top}`)];
+    misses.push(mk("self_retrieval_miss", `example_brief ${JSON.stringify(brief.slice(0, 48))} does not return this business first (rank ${hit === -1 ? "-" : hit + 1})`, `top: ${top}`));
   }
-  return [];
+  return misses;
 }
 
 export async function check(ctx: CheckContext): Promise<Finding[]> {

--- a/skills/_shared/tests/verify-business.test.ts
+++ b/skills/_shared/tests/verify-business.test.ts
@@ -490,9 +490,13 @@ describe("the self-retrieval axis", () => {
       warnings: [],
     };
     const report = await verifyEntity("business", dir, { stateDir: null, emit: null, baselinePath: null, registries });
-    const hit = report.findings.find((f) => f.id === "self_retrieval_miss");
-    expect(hit).toBeDefined();
-    expect(hit!.baselined).toBe(false);
+    // Every miss is reported, not only the first: the three briefs all route to
+    // the brand studio, and the author must see all three.
+    const misses = report.findings.filter((f) => f.id === "self_retrieval_miss");
+    expect(misses.length).toBe(3);
+    expect(new Set(misses.map((f) => f.message)).size).toBe(3);
+    const hit = misses[0];
+    expect(hit.baselined).toBe(false);
     expect(report.summary.warnings).toBeGreaterThan(0);
     expect(report.verdict).toBe("ADMITTED");            // a warning never rejects on its own
   });


### PR DESCRIPTION
One behaviour: the `self_retrieval_miss` check in `verify/kinds/business.ts` accumulates a finding per missed `example_brief` instead of returning on the first. An author fixing briefs one at a time used to learn about the next miss only after fixing this one; "1 warning" could mean fourteen (measured on an installed library: one business missed 14 of 30 briefs and the validator reported one).

Impact on published packs: none (validator output only; verdicts unchanged, a warning never rejects). Test: the existing three-brief fixture now asserts three distinct findings. `verify-business` suite 48/48, `check:quick` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk