### PR TITLE
feat(routing): the digest token budget is a config key, and the ladder says where it stands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The `return` sat inside the loop over `example_briefs`, so the validator named o
 The clone closure (`entity-graph`, which `list-clone-refs` and the pack build use) and the seat prompt read their frontmatter lists with a regex that accepted only the `- item` block form. `squads_authorized: [brandcraft]` parsed as empty while the "declared" test saw the key, so the seat was told the opposite of what its author wrote: "WITHOUT dispatching squads". Both readers now parse the frontmatter as YAML, block or inline, and keep the line reader only for frontmatter that is not YAML. A closed set the scope's catalog cannot serve stays a closed set, with the missing squads named, instead of collapsing into "declared EMPTY".
 
 `pinned_mind_clones`, the field Business Protocol v2 §7.7 created for the seat whose identity is the clone, was read by the validator and by nothing else: the pinned clone never entered a pack's closure, and the prompt never channeled it unless the author repeated the slug under `assigned_mind_clones`. The closure reads it now, and the prompt channels a pinned clone before any request or search, with the decision line saying so.
+### The routing digest budget is a config key, and the ladder says where it stands
+
+`routing.digest_token_budget` (default 50000; 0 = no budget) replaces the constant that sized the routing digest. A library that outgrew the constant degraded to the last rung in silence, dropping every `domains` list the agentic router reads, and the one way to keep the digest whole was to edit the installed file, which the next `nrv update` reverted. `nrv index` now says which level the digest settled on and what level 4 drops, and the over-budget message names the real last rung and the knob. The default is unchanged: a library that fit before still fits.
 
 ### The seat audit is JSONL again, and the verify verdict reaches the audit
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -16,6 +16,9 @@ O `return` ficava dentro do laço sobre `example_briefs`, então o validador nom
 O fecho de clones (`entity-graph`, que o `list-clone-refs` e o build de pack usam) e o prompt do cargo liam as listas do frontmatter com um regex que só aceitava a forma em bloco `- item`. `squads_authorized: [brandcraft]` virava lista vazia enquanto o teste de "declarado" via a chave, e o cargo recebia o oposto do que o autor escreveu: "SEM despachar squads". Os dois leitores agora interpretam o frontmatter como YAML, em bloco ou inline, e só mantêm o leitor de linhas para frontmatter que não é YAML. Um conjunto fechado que o catálogo do escopo não tem continua fechado, com os squads ausentes nomeados, em vez de virar "declarado VAZIO".
 
 `pinned_mind_clones`, o campo que o Business Protocol v2 §7.7 criou para o cargo cuja identidade é o clone, era lido pelo validador e por mais nada: o clone fixado nunca entrava no fecho de um pack, e o prompt nunca o canalizava a menos que o autor repetisse o slug em `assigned_mind_clones`. O fecho agora o lê, e o prompt canaliza o clone fixado antes de qualquer pedido ou busca, com a linha de decisão dizendo isso.
+### O orçamento do digest de roteamento é chave de config, e a escada diz onde está
+
+`routing.digest_token_budget` (padrão 50000; 0 = sem teto) substitui a constante que dimensionava o digest de roteamento. Uma biblioteca que crescia além da constante degradava até o último degrau em silêncio, descartando toda lista de `domains` que o roteador agêntico lê, e o único jeito de manter o digest inteiro era editar o arquivo instalado, que o `nrv update` seguinte revertia. O `nrv index` agora diz em que nível o digest ficou e o que o nível 4 descarta, e a mensagem de estouro nomeia o último degrau real e a chave. O padrão não mudou: uma biblioteca que cabia antes continua cabendo.
 
 ### O audit do cargo volta a ser JSONL, e o veredito do verify chega ao audit
 

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -64,6 +64,7 @@ Gerada a partir do schema. `nrv config explain <chave>` mostra a descrição de 
 | `routing.mode` | `NIRVANA_ROUTING_MODE` | `agentic` | global, projeto | agentic / fast |
 | `routing.dense` | `NIRVANA_ROUTER_DENSE` (`1` = fallback, `0` = off) | `off` | global, projeto | off / fallback |
 | `routing.on_router_failure` | nenhuma | `agent-x-only` | global, projeto | cascade / agent-x-only / fail |
+| `routing.digest_token_budget` | nenhuma | `50000` | global, projeto | inteiro >= 0 (tokens); 0 = sem teto |
 | `supervisor.progress_ping_sec` | `NIRVANA_PROGRESS_PING_SEC` | `1800` | global, projeto | inteiro >= 0 (segundos) |
 | `supervisor.stall_threshold_ms` | `NIRVANA_STALL_THRESHOLD_MS` | `300000` | global, projeto | inteiro > 0 (milissegundos) |
 | `supervisor.touch_events_max` | `NIRVANA_TOUCH_EVENTS_MAX` | `500` | global, projeto | inteiro >= 0 (eventos); 0 = não relata arquivos |

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -252,6 +252,9 @@ export const SETTINGS = {
   "routing.on_router_failure": enumSetting("routing.on_router_failure",
     "Quando o roteador agêntico falha no transporte (após 1 retry): agent-x-only = pula direto pro agent-x, BM25 nunca dispara sem --fast explícito (padrão); cascade = tenta BM25 antes do agent-x; fail = encerra sem despachar nada.",
     ["cascade", "agent-x-only", "fail"], { default: "agent-x-only" }),
+  "routing.digest_token_budget": numberSetting("routing.digest_token_budget",
+    "Orçamento em tokens do digest de roteamento (chars/4); acima dele o digest degrada por níveis. 0 = sem teto.",
+    { default: 50000, type: nonNegativeInt, expects: "inteiro >= 0 (tokens)" }),
 
   "supervisor.progress_ping_sec": numberSetting("supervisor.progress_ping_sec",
     "Intervalo em segundos do aviso de progresso de um run longo; 0 silencia.",

--- a/skills/harness/scripts/build-routing-digest.ts
+++ b/skills/harness/scripts/build-routing-digest.ts
@@ -7,7 +7,8 @@
  * them into ONE pipe-delimited English file (`.routing-digest.md`, written next
  * to the registries, scope-aware via ROUTING_DIGEST_PATH) that a router LLM can
  * read whole: every business, squad, capability collision and mind-clone, one
- * line each, under a hard <50k-token budget (chars/4 heuristic).
+ * line each, under the configured token budget (`routing.digest_token_budget`,
+ * default 50k, chars/4 heuristic).
  *
  * Budget degradation ladder (entries are NEVER dropped):
  *   L0  full format (2 example briefs, capability one-liners, 160c descriptions)
@@ -45,6 +46,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { paths as nrvPaths, parseArgs, EXIT } from "../../_shared/lib/bun-helpers.ts";
 import { resolveScope } from "../../_shared/lib/scope.ts";
+import { resolveSetting } from "../../_shared/lib/settings.ts";
 
 // ─────────────────────────────────────────────────────────────────────
 // Paths — where the registries and the digest live (scope-aware)
@@ -112,6 +114,8 @@ export interface DigestResult {
   tokens: number;
   degradationLevel: 0 | 1 | 2 | 3 | 4;
   overBudget: boolean;
+  /** The budget the ladder was walked against (0 = none). */
+  budget: number;
   counts: {
     businesses: number;
     squads: number;
@@ -124,6 +128,18 @@ export interface DigestResult {
 }
 
 export const TOKEN_BUDGET = 50_000;
+
+/** The budget in force: `routing.digest_token_budget` from config, falling back
+ *  to the constant. It used to be the constant alone, with no knob, and a
+ *  library that outgrew it degraded to the last rung in silence; the one way to
+ *  keep the digest whole was to edit the installed file, which the next
+ *  `nrv update` reverted. 0 means no budget: level 0, never over budget. */
+export function configuredTokenBudget(): number {
+  try {
+    const v = Number(resolveSetting("routing.digest_token_budget").value);
+    return Number.isFinite(v) && v >= 0 ? v : TOKEN_BUDGET;
+  } catch { return TOKEN_BUDGET; }
+}
 
 /** chars/4 heuristic — the budget currency of the digest. */
 export const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
@@ -302,7 +318,7 @@ function renderAt(input: DigestInput, level: 0 | 1 | 2 | 3 | 4, generatedAt: str
  * into exit 1).
  */
 export function buildDigest(input: DigestInput, opts: { budgetTokens?: number; generatedAt?: string } = {}): DigestResult {
-  const budget = opts.budgetTokens ?? TOKEN_BUDGET;
+  const budget = opts.budgetTokens ?? configuredTokenBudget();
   const generatedAt = opts.generatedAt ?? new Date().toISOString();
   let text = "";
   let tokens = 0;
@@ -311,14 +327,15 @@ export function buildDigest(input: DigestInput, opts: { budgetTokens?: number; g
     level = l;
     text = renderAt(input, l, generatedAt);
     tokens = estimateTokens(text);
-    if (tokens < budget) break;
+    if (budget === 0 || tokens < budget) break;
   }
   const capIds = Object.keys(input.capabilities);
   return {
     text,
     tokens,
     degradationLevel: level,
-    overBudget: tokens >= budget,
+    overBudget: budget > 0 && tokens >= budget,
+    budget,
     counts: {
       businesses: Object.keys(input.businesses).length,
       squads: Object.keys(input.squads).length,
@@ -549,7 +566,7 @@ if (import.meta.main) {
       digest_path: checkBudget ? null : digestPath,
       aliases_path: checkBudget ? null : aliasesPath,
       tokens: digest.tokens,
-      budget: TOKEN_BUDGET,
+      budget: digest.budget,
       degradation_level: digest.degradationLevel,
       over_budget: digest.overBudget,
       counts: digest.counts,
@@ -557,14 +574,15 @@ if (import.meta.main) {
     }, null, 2));
   } else if (!quiet) {
     const c = digest.counts;
-    console.error(`[build-routing-digest] ~${digest.tokens} tokens (budget ${TOKEN_BUDGET}, chars/4) · degradation level ${digest.degradationLevel}`);
+    console.error(`[build-routing-digest] ~${digest.tokens} tokens (budget ${digest.budget || "none"}, chars/4) · degradation level ${digest.degradationLevel}`);
     console.error(`[build-routing-digest] businesses=${c.businesses} squads=${c.squads} capability_ids=${c.capabilityIds} providers=${c.capabilityProviders} collisions=${c.capabilityCollisions} clones=${c.mindClones} (${c.mindClonesEnriched} enriched)`);
     console.error(`[build-routing-digest] alias groups: ${aliases.length}`);
     if (!checkBudget) {
       console.error(`[build-routing-digest] digest → ${digestPath}`);
       console.error(`[build-routing-digest] aliases → ${aliasesPath}`);
     }
-    if (digest.overBudget) console.error(`[build-routing-digest] OVER BUDGET even at level 3 — trim registry descriptions/briefs.`);
+    if (digest.overBudget) console.error(`[build-routing-digest] OVER BUDGET even at level ${digest.degradationLevel}, the last rung — raise it with \`nrv config set routing.digest_token_budget <tokens>\` (0 = no budget) or trim registry descriptions/briefs.`);
+    else if (digest.degradationLevel > 0) console.error(`[build-routing-digest] degraded to level ${digest.degradationLevel} to fit the budget — level 4 drops every domains list; raise routing.digest_token_budget to keep them.`);
   }
 
   if (checkBudget && digest.overBudget) process.exit(EXIT.FAILURES);

--- a/skills/harness/tests/routing-digest.test.ts
+++ b/skills/harness/tests/routing-digest.test.ts
@@ -15,7 +15,7 @@ import { spawnSync } from "node:child_process";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
 import {
   buildDigest, buildKeywordAliases, splitKeywordGroups, foldKey, detectLang,
-  estimateTokens, trunc, TOKEN_BUDGET, loadDigestInput,
+  estimateTokens, trunc, TOKEN_BUDGET, loadDigestInput, configuredTokenBudget,
   type DigestInput,
 } from "../scripts/build-routing-digest.ts";
 
@@ -113,6 +113,27 @@ function sectionLines(text: string, section: string): string[] {
   }
   return out;
 }
+
+describe("routing digest — the budget is a knob, and 0 means none", () => {
+  // The budget used to be a constant with no knob. A library that outgrew it
+  // degraded to the last rung in silence, and the only way to keep the digest
+  // whole was to edit the installed file, which the next update reverted.
+  test("an explicit budget is walked and echoed on the result", () => {
+    const tight = buildDigest(fixtureInput(), { budgetTokens: 1, generatedAt: "2026-01-01T00:00:00.000Z" });
+    expect(tight.budget).toBe(1);
+    expect(tight.degradationLevel).toBe(4);
+    expect(tight.overBudget).toBe(true);
+  });
+  test("budget 0 never degrades and is never over budget", () => {
+    const open = buildDigest(fixtureInput(), { budgetTokens: 0, generatedAt: "2026-01-01T00:00:00.000Z" });
+    expect(open.budget).toBe(0);
+    expect(open.degradationLevel).toBe(0);
+    expect(open.overBudget).toBe(false);
+  });
+  test("the configured budget comes from settings, default 50000", () => {
+    expect(configuredTokenBudget()).toBe(50_000);
+  });
+});
 
 describe("routing digest — format grammar", () => {
   const r = buildDigest(fixtureInput(), { generatedAt: "2026-01-01T00:00:00.000Z" });


### PR DESCRIPTION
One behaviour: the routing digest budget becomes `routing.digest_token_budget` (settings schema, `nrv config`, docs row), default 50000, 0 = no budget. `buildDigest` walks the ladder against the configured value and echoes `budget` on the result; the JSON and stderr output print the effective budget; the over-budget message names the real last rung (level 4, not 3) and the knob, and a degraded build says which level it settled on and that level 4 drops every `domains` list.

Why: the constant had no knob. An installed library that outgrew it degraded to level 4 in silence, and the only way to keep the digest whole was to hand-edit the installed script, which the next `nrv update` reverts.

Impact on published packs: none; default unchanged. Tests: explicit budget walked and echoed; budget 0 never degrades; configured default is 50000. `routing-digest` 37/37, settings 93/93, `check:quick` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk