### PR TITLE
fix(businesses): frontmatter lists read as YAML, and a pinned clone is channeled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 ### `self_retrieval_miss` reports every missed brief
 
 The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.
+### Frontmatter lists read as YAML, and a pinned clone is channeled
+
+The clone closure (`entity-graph`, which `list-clone-refs` and the pack build use) and the seat prompt read their frontmatter lists with a regex that accepted only the `- item` block form. `squads_authorized: [brandcraft]` parsed as empty while the "declared" test saw the key, so the seat was told the opposite of what its author wrote: "WITHOUT dispatching squads". Both readers now parse the frontmatter as YAML, block or inline, and keep the line reader only for frontmatter that is not YAML. A closed set the scope's catalog cannot serve stays a closed set, with the missing squads named, instead of collapsing into "declared EMPTY".
+
+`pinned_mind_clones`, the field Business Protocol v2 §7.7 created for the seat whose identity is the clone, was read by the validator and by nothing else: the pinned clone never entered a pack's closure, and the prompt never channeled it unless the author repeated the slug under `assigned_mind_clones`. The closure reads it now, and the prompt channels a pinned clone before any request or search, with the decision line saying so.
 
 ### The seat audit is JSONL again, and the verify verdict reaches the audit
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -11,6 +11,11 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 ### `self_retrieval_miss` reporta todos os briefs que erram
 
 O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.
+### Listas do frontmatter lidas como YAML, e o clone fixado é canalizado
+
+O fecho de clones (`entity-graph`, que o `list-clone-refs` e o build de pack usam) e o prompt do cargo liam as listas do frontmatter com um regex que só aceitava a forma em bloco `- item`. `squads_authorized: [brandcraft]` virava lista vazia enquanto o teste de "declarado" via a chave, e o cargo recebia o oposto do que o autor escreveu: "SEM despachar squads". Os dois leitores agora interpretam o frontmatter como YAML, em bloco ou inline, e só mantêm o leitor de linhas para frontmatter que não é YAML. Um conjunto fechado que o catálogo do escopo não tem continua fechado, com os squads ausentes nomeados, em vez de virar "declarado VAZIO".
+
+`pinned_mind_clones`, o campo que o Business Protocol v2 §7.7 criou para o cargo cuja identidade é o clone, era lido pelo validador e por mais nada: o clone fixado nunca entrava no fecho de um pack, e o prompt nunca o canalizava a menos que o autor repetisse o slug em `assigned_mind_clones`. O fecho agora o lê, e o prompt canaliza o clone fixado antes de qualquer pedido ou busca, com a linha de decisão dizendo isso.
 
 ### O audit do cargo volta a ser JSONL, e o veredito do verify chega ao audit
 

--- a/skills/_shared/lib/entity-graph.js
+++ b/skills/_shared/lib/entity-graph.js
@@ -72,6 +72,32 @@ function declaredBy(employeeFile) {
   const text = readFileSync(employeeFile, "utf8");
   const fm = text.match(/^---[\s\S]*?^---/m)?.[0] ?? "";
   const out = [];
+  // The frontmatter is YAML, and a YAML list has two spellings: a `- item`
+  // block and an inline `[a, b]`. The line reader below accepted only the
+  // block form and answered "no clones" for the other, so a seat's clones
+  // never entered the pack closure. And `pinned_mind_clones` — the field the
+  // protocol created for the seat whose identity IS the clone — was not read
+  // at all: the one clone that most needed to travel was the one that did not.
+  let data = null;
+  try { data = parseYaml(fm.replace(/^---/, "").replace(/---\s*$/, "")); } catch { data = null; }
+  if (data && typeof data === "object") {
+    for (const key of ["assigned_mind_clones", "pinned_mind_clones"]) {
+      const v = data[key];
+      const items = Array.isArray(v) ? v : (typeof v === "string" && v.trim() ? [v] : []);
+      for (const item of items) {
+        const s = item == null ? "" : String(item).trim();
+        if (s) out.push(slugOf(s));
+      }
+    }
+    const refs = Array.isArray(data.dna_reference) ? data.dna_reference : (data.dna_reference != null ? [data.dna_reference] : []);
+    for (const r of refs) {
+      const slug = refToSlug(String(r));
+      if (slug) out.push(slug);
+    }
+    return out;
+  }
+  // Frontmatter that is not valid YAML: the old line reader, so a stray tab
+  // does not turn a declared clone into a missing one.
   const list = fm.match(/^assigned_mind_clones\s*:\s*\n((?:[ \t]*-\s.+\n?)+)/m);
   if (list) {
     for (const line of list[1].split("\n")) {

--- a/skills/_shared/tests/entity-graph.test.ts
+++ b/skills/_shared/tests/entity-graph.test.ts
@@ -64,6 +64,25 @@ describe("readCloneBindings", () => {
     expect(scan.availableClones.has("jane-friedman")).toBeTrue();
   });
 
+  test("an inline list and a pinned clone are bindings too", () => {
+    // Both spellings of a YAML list are the same data to the parser; the
+    // closure used to see only the block form. And `pinned_mind_clones` is the
+    // seat whose identity is the clone — the last field that may go unread.
+    const pack = packFixture();
+    clone(pack, "mark-cerny");
+    clone(pack, "jesse-schell");
+    clone(pack, "shigeru-miyamoto");
+    business(pack, "biz-inline", {
+      "designer": 'assigned_mind_clones: ["01-game/mark-cerny", "jesse-schell"]',
+      "director": "type: mind_clone\npinned_mind_clones:\n  - shigeru-miyamoto",
+    });
+    const scan = readCloneBindings({
+      businessesDir: join(pack, "businesses"),
+      clonesDir: join(pack, "mind-clones"),
+    });
+    expect(scan.bindings.map((x) => x.clone).sort()).toEqual(["jesse-schell", "mark-cerny", "shigeru-miyamoto"]);
+  });
+
   test("a clone the pack does not carry is a binding, not an omission", () => {
     const pack = packFixture();
     business(pack, "biz-b", { "ceo": "assigned_mind_clones:\n  - ghost-expert" });

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -38,6 +38,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { parse as parseYaml } from "yaml";
 import { createRequire } from "node:module";
 import { stamp } from "../../_shared/lib/audit-provenance.ts";
 const requireCjs = createRequire(import.meta.url);
@@ -54,6 +55,8 @@ export type BuildArgs = {
   trace_id?: string;
   /** Clones the USER explicitly asked for (highest priority). Slugs or names. */
   requested_clones?: string[];
+  /** Clones the seat pins (its identity); channeled before anything else. */
+  pinned_clones?: string[];
 };
 
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
@@ -210,24 +213,58 @@ function loadSquadsRegistry(projectRoot?: string): { squads: Record<string, any>
   return { squads: filtered, scopeMode: scope.mode, squadDirs: scope.squadDirs };
 }
 
-/** Parse the squads_authorized list from an employee's YAML frontmatter. */
-function authorizedSquads(employeeContent: string): string[] {
+/** The frontmatter as YAML, or null when it is not valid YAML.
+ *
+ *  A YAML list has two spellings, a `- item` block and an inline `[a, b]`.
+ *  The line readers that used to live here accepted only the block form and
+ *  answered "nothing declared" for the other — and for `squads_authorized`
+ *  that inverted the seat's instruction: a closed set of squads, declared
+ *  inline, became "WITHOUT dispatching squads". The parser reads both. */
+function frontmatterData(employeeContent: string): Record<string, any> | null {
   const fm = employeeContent.match(/^---[\s\S]*?^---/m)?.[0] || "";
-  // Accept both `  - item` and `- item` indentations (YAML allows both at the
-  // top of a mapping value); stop at the next top-level key.
-  const m = fm.match(/^squads_authorized\s*:\s*\n((?:[ \t]*-\s.+\n?)+)/m);
+  if (!fm) return null;
+  try {
+    const d = parseYaml(fm.replace(/^---/, "").replace(/---\s*$/, ""));
+    return d && typeof d === "object" && !Array.isArray(d) ? d : null;
+  } catch { return null; }
+}
+
+/** A list field from the frontmatter: [] when absent, null when the
+ *  frontmatter is not YAML (the caller keeps its old line reader for that). */
+function listField(employeeContent: string, key: string): string[] | null {
+  const d = frontmatterData(employeeContent);
+  if (!d) return null;
+  const v = d[key];
+  if (v == null) return [];
+  return (Array.isArray(v) ? v : [v]).map(x => String(x ?? "").trim()).filter(Boolean);
+}
+
+/** The block-form line reader, kept only for frontmatter that is not YAML. */
+function blockList(employeeContent: string, key: string): string[] {
+  const fm = employeeContent.match(/^---[\s\S]*?^---/m)?.[0] || "";
+  const m = fm.match(new RegExp(`^${key}\\s*:\\s*\\n((?:[ \\t]*-\\s.+\\n?)+)`, "m"));
   if (!m) return [];
   return m[1].split("\n").map(l => l.replace(/^[ \t]*-\s*/, "").trim()).filter(Boolean);
 }
 
+/** Parse the squads_authorized list from an employee's YAML frontmatter. */
+function authorizedSquads(employeeContent: string): string[] {
+  return listField(employeeContent, "squads_authorized") ?? blockList(employeeContent, "squads_authorized");
+}
+
 /** Parse the assigned_mind_clones list from an employee's YAML frontmatter.
- *  Same shape as squads_authorized. Refs may be category-prefixed
- *  (e.g. "21-media-moguls/jane-friedman") or flat ("alex-hormozi"). */
+ *  Refs may be category-prefixed (e.g. "21-media-moguls/jane-friedman") or
+ *  flat ("alex-hormozi"). */
 function assignedMindClones(employeeContent: string): string[] {
-  const fm = employeeContent.match(/^---[\s\S]*?^---/m)?.[0] || "";
-  const m = fm.match(/^assigned_mind_clones\s*:\s*\n((?:[ \t]*-\s.+\n?)+)/m);
-  if (!m) return [];
-  return m[1].split("\n").map(l => l.replace(/^[ \t]*-\s*/, "").trim()).filter(Boolean);
+  return listField(employeeContent, "assigned_mind_clones") ?? blockList(employeeContent, "assigned_mind_clones");
+}
+
+/** The clones a seat PINS (Business Protocol v2 §7.7): the seat whose identity
+ *  is the clone. The validator checked the field and nothing at runtime read
+ *  it, so a typed mind_clone seat ran without its voice unless the author
+ *  repeated the slug under assigned_mind_clones. */
+function pinnedMindClones(employeeContent: string): string[] {
+  return listField(employeeContent, "pinned_mind_clones") ?? blockList(employeeContent, "pinned_mind_clones");
 }
 
 /** Split a clone ref into {category, slug}. "_root" means the clone lives
@@ -285,7 +322,10 @@ function squadCatalogBlock(employeeContent: string, projectRoot?: string): strin
       `> For local projects without their own squads, run in \`merge\` or \`global\` mode to reach the general registry, or create squads under \`<projectRoot>/.nirvana/squads/\` and run \`nrv index\`.`,
     ].join("\n");
   }
-  const authorized = authorizedSquads(employeeContent).filter(s => reg[s]);
+  // The declared set stays declared even when this scope's catalog lacks one of
+  // its squads: filtering them out here turned a closed set of uninstalled
+  // squads into "declared EMPTY", the instruction not to dispatch at all.
+  const authorized = authorizedSquads(employeeContent);
   const lines: string[] = [
     "## AVAILABLE SQUADS (dispatch the specialists — don't improvise what they do better)",
     "",
@@ -298,6 +338,7 @@ function squadCatalogBlock(employeeContent: string, projectRoot?: string): strin
     lines.push("");
     for (const slug of authorized) {
       const s = reg[slug];
+      if (!s) { lines.push(`- **${slug}** — (not in the catalog of this scope; install or activate it before dispatching)`); continue; }
       const doms = (s.domains || []).slice(0, 4).join(", ");
       const caps = (s.capabilities || []).slice(0, 3).map((c: any) => typeof c === "string" ? c : c.id).filter(Boolean).join(" · ");
       lines.push(`- **${slug}** — ${doms || "(no domains)"}${caps ? "\n  - capabilities: " + caps : ""}`);
@@ -444,6 +485,10 @@ function resolveClonesByPriority(args: BuildArgs): CloneInjection {
   };
 
   // 1. REQUESTED
+  // A pinned clone is the seat's identity: channeled whatever the task says,
+  // before the user's requests and before any search.
+  for (const r of (args.pinned_clones || [])) push(parseCloneRef(r).slug, "pinned");
+  const hadPinned = personas.length > 0;
   const requested = new Set<string>();
   for (const r of (args.requested_clones || [])) requested.add(parseCloneRef(r).slug);
   for (const s of scanBriefForClones(args.brief)) requested.add(s);
@@ -466,7 +511,8 @@ function resolveClonesByPriority(args: BuildArgs): CloneInjection {
   // entitled to, and one it contradicts three lines later by listing a strong
   // candidate. Nothing was auto-injected; whether a clone is useful here is the
   // agent's call, made against the ranked list.
-  const decision = hadRequested ? "REQUESTED by the user"
+  const decision = hadPinned ? (personas.some(p => p.reason === "requested") ? "PINNED to the seat + REQUESTED by the user" : "PINNED to the seat")
+    : hadRequested ? "REQUESTED by the user"
     : personas.length ? "found by SEARCH for the task"
     : "YOURS — none auto-injected, pick from the ranked candidates";
 
@@ -573,7 +619,7 @@ export function buildEmployeePrompt(args: BuildArgs): string {
   let clonesInjected = false;
   let contributionsBlock = "";
   if (args.include_dna !== false) {
-    const inj = resolveClonesByPriority(args);
+    const inj = resolveClonesByPriority({ ...args, pinned_clones: [...(args.pinned_clones || []), ...pinnedMindClones(employeeContent)] });
     cloneDecision = inj.decision;
     clonesInjected = inj.personas.length > 0;
     for (const p of inj.personas) {

--- a/skills/businesses/tests/employee-prompt-frontmatter.test.ts
+++ b/skills/businesses/tests/employee-prompt-frontmatter.test.ts
@@ -1,0 +1,99 @@
+// employee-prompt-frontmatter.test.ts — a YAML list means the same thing in
+// both of its spellings, and a pinned clone is channeled.
+//
+// The seat prompt read its frontmatter lists with a regex that accepted only
+// the `- item` block form. `squads_authorized: [brandcraft]` parsed as empty
+// while the "declared" test saw the key, so the seat was told the opposite of
+// what its author wrote: "WITHOUT dispatching squads". And `pinned_mind_clones`
+// was read by the validator and by nothing at runtime, so a typed mind_clone
+// seat ran without its voice. Both are exercised here through the CLI, in the
+// fixture's own project scope, like employee-clone-choice.test.ts.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
+
+const R = mkdtempSync(join(tmpdir(), "seat-fm-"));
+afterAll(() => rmSync(R, { recursive: true, force: true }));
+
+writeFileSync(join(R, ".env"), "NIRVANA_SCOPE=project\n", "utf8");
+const biz = join(R, ".nirvana", "businesses", "atelier");
+mkdirSync(join(biz, "employees"), { recursive: true });
+writeFileSync(join(biz, "business.yaml"), "name: atelier\ndescription: a fixture atelier\n", "utf8");
+
+const seat = (name: string, frontmatter: string) =>
+  writeFileSync(join(biz, "employees", `${name}.md`), `---\n${frontmatter}\n---\n# ${name}\n\nDoes the ${name} work.\n`, "utf8");
+seat("inline-closed", "squads_authorized: [brandcraft]");
+seat("inline-empty", "squads_authorized: []");
+seat("block-closed", "squads_authorized:\n  - brandcraft");
+seat("open", "role: anything");
+seat("pinned", "type: mind_clone\npinned_mind_clones: [fixture-voice]");
+seat("inline-missing", "squads_authorized: [ghost-squad]");
+
+// A project-scoped squad catalog: without one the block is skipped entirely.
+for (const slug of ["brandcraft", "ledgerworks"]) {
+  const d = join(R, ".nirvana", "squads", slug);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, "squad.yaml"), `name: ${slug}\nversion: 1.0.0\ndescription: fixture squad ${slug}\ndomains:\n  - ${slug === "brandcraft" ? "branding" : "finance"}\ncapabilities:\n  - id: ${slug}.work.execute\n    domains: [${slug === "brandcraft" ? "branding" : "finance"}]\n    invoke: task\n`, "utf8");
+}
+
+const agentDir = join(R, "dna", "fixture-voice", "agent");
+mkdirSync(agentDir, { recursive: true });
+writeFileSync(join(agentDir, "AGENT.md"), "# fixture-voice\n\nMethod of the fixture voice.\n", "utf8");
+writeFileSync(join(R, ".nirvana", ".mind-clones-registry.json"), JSON.stringify({
+  mind_clones: {
+    "fixture-voice": {
+      slug: "fixture-voice", display_name: "Fixture Voice", tags: [], dir: join(R, "dna", "fixture-voice"),
+      persona_files: { agent: join(agentDir, "AGENT.md") },
+      match: { one_liner: "the fixture voice", domains: [], serves: "fixture", when_to_use: null, not_for: null, delegates_to: [], refuses: [] },
+    },
+  },
+}), "utf8");
+const briefFile = join(R, "brief.txt");
+writeFileSync(briefFile, "monte o relatório trimestral", "utf8");
+
+function prompt(employee: string): string {
+  const r = spawnSync(process.execPath, [join(import.meta.dir, "..", "lib", "employee-prompt.ts"), "atelier", employee, R, briefFile],
+    { cwd: R, encoding: "utf8", env: { ...process.env, HARNESS_LOGS_DIR: join(R, ".nirvana", "logs", "harness") } });
+  return `${r.stdout ?? ""}`;
+}
+
+describe("squads_authorized means the same in both spellings", () => {
+  test("an inline closed set is a closed set", () => {
+    const p = prompt("inline-closed");
+    expect(p).toContain("YOUR authorized squads (CLOSED set");
+    expect(p).toContain("**brandcraft**");
+    expect(p).not.toContain("declared EMPTY");
+  }, spawnBudgetMs(1));
+
+  test("the block form reads exactly the same", () => {
+    const p = prompt("block-closed");
+    expect(p).toContain("YOUR authorized squads (CLOSED set");
+    expect(p).toContain("**brandcraft**");
+  }, spawnBudgetMs(1));
+
+  test("a closed set the scope cannot serve is still a closed set, named as missing", () => {
+    // Filtering the declared slugs by the catalog turned an uninstalled closed
+    // set into "declared EMPTY": the instruction not to dispatch at all.
+    const p = prompt("inline-missing");
+    expect(p).toContain("YOUR authorized squads (CLOSED set");
+    expect(p).toContain("**ghost-squad** — (not in the catalog of this scope");
+    expect(p).not.toContain("declared EMPTY");
+  }, spawnBudgetMs(1));
+
+  test("an inline empty list is declared-empty, and an absent key is open", () => {
+    expect(prompt("inline-empty")).toContain("declared EMPTY");
+    expect(prompt("open")).toContain("Open authorization");
+  }, spawnBudgetMs(2));
+});
+
+describe("a pinned clone is the seat's identity", () => {
+  test("it is channeled before any search, and the decision says so", () => {
+    const p = prompt("pinned");
+    expect(p).toContain("--- MIND-CLONE: fixture-voice");
+    expect(p).toContain("(pinned;");
+    expect(p).toContain("decision: PINNED to the seat");
+  }, spawnBudgetMs(1));
+});


### PR DESCRIPTION
One defect with two readers and two fields.

- `entity-graph.js` `declaredBy()` and `employee-prompt.ts` (`authorizedSquads`, `assignedMindClones`) parsed frontmatter lists with a block-form-only regex. The inline YAML form `[a, b]` silently read as empty; for `squads_authorized` that inverted the seat's instruction into "WITHOUT dispatching squads" while `nrv validate` admitted the business with zero warnings. Both now parse the frontmatter with `yaml` (already a dependency; `entity-graph.js` already required it) and keep the line reader only when the frontmatter is not valid YAML.
- `pinned_mind_clones` was read by the validator (`pinned_clone_unresolved`) and by nothing at runtime: it never entered the pack closure (`list-clone-refs`, `check-clone-bindings`, `promote_pack`) and the prompt never channeled it. Now the closure reads it, and the prompt channels a pinned clone first (reason `pinned`, decision "PINNED to the seat").
- The authorized-squads block no longer filters the declared set by the catalog: a closed set the scope cannot serve is listed with each missing squad named, instead of collapsing into "declared EMPTY".

Impact on published packs, measured on the sources: zero inline lists and zero `pinned_mind_clones` in `packs-content` and `genesis-content` today, so no shipped prompt changes; the closure now agrees with the protocol for the next pack that pins. Tests: `entity-graph.test.ts` (inline + pinned bindings), `employee-prompt-frontmatter.test.ts` (inline/block closed set, missing-from-catalog closed set, inline empty vs absent, pinned channeled). Businesses + entity-graph 126/126; `check:quick`, english-source, changelog parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk