### PR TITLE
feat(team): the clone search reads the step's task, not the whole brief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 ### `self_retrieval_miss` reports every missed brief
 
 The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.
+### The clone search reads the step's task, not the whole brief
+
+A chain brief carries the vocabulary of every seat. Fed with it, the clone search ranked the marketing and press voices for a seat whose job was closing the production macro. `nrv team step` now hands `employee-prompt` the step's own task (`--task-file`), and the search reads that; a seat run outside a chain still searches on the brief.
+
 ### Frontmatter lists read as YAML, and a pinned clone is channeled
 
 The clone closure (`entity-graph`, which `list-clone-refs` and the pack build use) and the seat prompt read their frontmatter lists with a regex that accepted only the `- item` block form. `squads_authorized: [brandcraft]` parsed as empty while the "declared" test saw the key, so the seat was told the opposite of what its author wrote: "WITHOUT dispatching squads". Both readers now parse the frontmatter as YAML, block or inline, and keep the line reader only for frontmatter that is not YAML. A closed set the scope's catalog cannot serve stays a closed set, with the missing squads named, instead of collapsing into "declared EMPTY".

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -11,6 +11,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 ### `self_retrieval_miss` reporta todos os briefs que erram
 
 O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.
+### A busca de clone lê a tarefa do passo, não o brief inteiro
+
+O brief de uma cadeia carrega o vocabulário de todos os cargos. Alimentada com ele, a busca de clone classificava as vozes de marketing e de imprensa para um cargo cujo trabalho era fechar a planilha de macro da produção. O `nrv team step` agora entrega ao `employee-prompt` a tarefa do próprio passo (`--task-file`), e a busca lê isso; um cargo rodado fora de cadeia continua buscando pelo brief.
+
 ### Listas do frontmatter lidas como YAML, e o clone fixado é canalizado
 
 O fecho de clones (`entity-graph`, que o `list-clone-refs` e o build de pack usam) e o prompt do cargo liam as listas do frontmatter com um regex que só aceitava a forma em bloco `- item`. `squads_authorized: [brandcraft]` virava lista vazia enquanto o teste de "declarado" via a chave, e o cargo recebia o oposto do que o autor escreveu: "SEM despachar squads". Os dois leitores agora interpretam o frontmatter como YAML, em bloco ou inline, e só mantêm o leitor de linhas para frontmatter que não é YAML. Um conjunto fechado que o catálogo do escopo não tem continua fechado, com os squads ausentes nomeados, em vez de virar "declarado VAZIO".

--- a/skills/businesses/lib/employee-prompt.ts
+++ b/skills/businesses/lib/employee-prompt.ts
@@ -57,6 +57,11 @@ export type BuildArgs = {
   requested_clones?: string[];
   /** Clones the seat pins (its identity); channeled before anything else. */
   pinned_clones?: string[];
+  /** The step's own task, when the seat runs as one step of a chain. The clone
+   *  SEARCH runs on this, not on the whole brief: a brief carries the vocabulary
+   *  of every seat, and the search fed with it ranked the marketing and press
+   *  voices for a seat closing the production macro. */
+  task?: string;
 };
 
 import { harnessLogsDir } from "../../_shared/lib/log-paths.ts";
@@ -497,7 +502,8 @@ function resolveClonesByPriority(args: BuildArgs): CloneInjection {
 
   // search runs always (for suggestions); injects only when nothing above won
   let suggestions: CloneHit[] = [];
-  try { suggestions = findCloneForTask(args.brief, { limit: 5, cwd: args.project_dir }); } catch { suggestions = []; }
+  const searchQuery = args.task?.trim() ? args.task : args.brief;
+  try { suggestions = findCloneForTask(searchQuery, { limit: 5, cwd: args.project_dir }); } catch { suggestions = []; }
 
   // 2. SEARCH — ranked against the TASK, injected only above the coverage gate.
   if (!hadRequested) {
@@ -817,16 +823,26 @@ ${args.brief}
 
 // CLI wrapper
 if (import.meta.main) {
-  const [, , slug, employee, projectDir, briefFile, outputsRoot] = process.argv;
+  // `--task-file <path>`: the step's task for the clone search (nrv team step).
+  const argv = process.argv.slice(2);
+  let taskFile: string | undefined;
+  const ti = argv.indexOf("--task-file");
+  if (ti !== -1) { taskFile = argv[ti + 1]; argv.splice(ti, 2); }
+  const [slug, employee, projectDir, briefFile, outputsRoot] = argv;
   if (!slug || !employee || !projectDir || !briefFile) {
-    console.error("Usage: bun employee-prompt.ts <business_slug> <employee> <project_dir> <brief_file> [outputs_root]");
+    console.error("Usage: bun employee-prompt.ts <business_slug> <employee> <project_dir> <brief_file> [outputs_root] [--task-file <path>]");
     process.exit(2);
   }
   if (!fs.existsSync(briefFile)) {
     console.error(`Brief file not found: ${briefFile}`);
     process.exit(2);
   }
+  if (taskFile && !fs.existsSync(taskFile)) {
+    console.error(`Task file not found: ${taskFile}`);
+    process.exit(2);
+  }
   const brief = fs.readFileSync(briefFile, "utf8");
+  const task = taskFile ? fs.readFileSync(taskFile, "utf8") : undefined;
   console.log(
     buildEmployeePrompt({
       business_slug: slug,
@@ -836,6 +852,7 @@ if (import.meta.main) {
       include_dna: true,
       include_handoff: true,
       outputs_root: outputsRoot,
+      ...(task ? { task } : {}),
     })
   );
 }

--- a/skills/businesses/tests/employee-prompt-task-search.test.ts
+++ b/skills/businesses/tests/employee-prompt-task-search.test.ts
@@ -1,0 +1,53 @@
+// employee-prompt-task-search.test.ts — the clone search runs on the step's
+// task, not on the whole chain brief.
+//
+// A chain brief carries the vocabulary of every seat. Fed with it, the search
+// ranked the marketing and press voices for a seat whose job was closing the
+// production macro. `nrv team step` now hands the seat its own task, and the
+// search reads that. Same fixture shape as employee-clone-choice.test.ts.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnBudgetMs } from "../../harness/tests/helpers/test-budgets.ts";
+
+const R = mkdtempSync(join(tmpdir(), "seat-task-"));
+afterAll(() => rmSync(R, { recursive: true, force: true }));
+writeFileSync(join(R, ".env"), "NIRVANA_SCOPE=project\n", "utf8");
+const biz = join(R, ".nirvana", "businesses", "studio-co");
+mkdirSync(join(biz, "employees"), { recursive: true });
+writeFileSync(join(biz, "business.yaml"), "name: studio-co\ndescription: a film studio\n", "utf8");
+writeFileSync(join(biz, "employees", "producer.md"), "---\nrole: producer\n---\n# Producer\n\nRuns the schedule.\n", "utf8");
+
+const clone = (slug: string, oneLiner: string, serves: string) => {
+  const d = join(R, "dna", slug, "agent");
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, "AGENT.md"), `# ${slug}\n\nMethod of ${slug}.\n`, "utf8");
+  return { slug, display_name: slug, tags: [], dir: join(R, "dna", slug), persona_files: { agent: join(d, "AGENT.md") },
+    match: { one_liner: oneLiner, domains: [], serves, when_to_use: null, not_for: null, delegates_to: [], refuses: [] } };
+};
+writeFileSync(join(R, ".nirvana", ".mind-clones-registry.json"), JSON.stringify({ mind_clones: {
+  "akira-master": clone("akira-master", "the samurai epic director", "compor um épico de samurai na chuva com múltiplas câmeras e movimento de elenco"),
+  "clinton-scheduler": clone("clinton-scheduler", "the production scheduler", "fechar o cronograma de produção com sprints, marcos e a planilha de macro"),
+} }), "utf8");
+
+// The chain brief is unmistakably the director's; the step's task is the scheduler's.
+const briefFile = join(R, "brief.txt");
+writeFileSync(briefFile, "compor um épico de samurai na chuva com múltiplas câmeras e movimento de elenco", "utf8");
+const taskFile = join(R, "task.txt");
+writeFileSync(taskFile, "fechar o cronograma de produção com sprints, marcos e a planilha de macro", "utf8");
+
+const run = (extra: string[]) => `${spawnSync(process.execPath, [join(import.meta.dir, "..", "lib", "employee-prompt.ts"), "studio-co", "producer", R, briefFile, ...extra],
+  { cwd: R, encoding: "utf8", env: { ...process.env, HARNESS_LOGS_DIR: join(R, ".nirvana", "logs", "harness") } }).stdout ?? ""}`;
+
+describe("the clone search reads the step's task", () => {
+  test("without a task, the brief's vocabulary picks the director", () => {
+    expect(run([])).toContain("--- MIND-CLONE: akira-master");
+  }, spawnBudgetMs(1));
+  test("with --task-file, the seat's own job picks the scheduler", () => {
+    const p = run(["--task-file", taskFile]);
+    expect(p).toContain("--- MIND-CLONE: clinton-scheduler");
+    expect(p).not.toContain("--- MIND-CLONE: akira-master");
+  }, spawnBudgetMs(1));
+});

--- a/skills/harness/scripts/chain.ts
+++ b/skills/harness/scripts/chain.ts
@@ -262,6 +262,10 @@ function cmdStep(argv: string[]): void {
   const stepBrief = buildStepBrief(step, idx, total, { brief, outputsRoot: plan.outputs_root }, priorOutputs, outDir);
   const stepBriefFile = path.join(outDir, ".step-brief.md");
   fs.writeFileSync(stepBriefFile, stepBrief);
+  // The step's task, on its own, for the clone search: the step brief carries
+  // the whole chain brief, whose vocabulary drowns the seat's own job.
+  const stepTaskFile = path.join(outDir, ".step-task.txt");
+  fs.writeFileSync(stepTaskFile, step.task);
 
   const bizDir = plan.businesses_root
     ? path.join(plan.businesses_root, plan.business)
@@ -269,7 +273,7 @@ function cmdStep(argv: string[]): void {
 
   const ep = spawnSync("bun", [
     path.join(SKILLS, "businesses/lib/employee-prompt.ts"),
-    plan.business, step.employee, plan.project_dir, stepBriefFile, outDir,
+    plan.business, step.employee, plan.project_dir, stepBriefFile, outDir, "--task-file", stepTaskFile,
   ], {
     encoding: "utf8", maxBuffer: 32 * 1024 * 1024,
     // The child resolves the business independently; handing it the library root


### PR DESCRIPTION
One behaviour: in a chain, the clone SEARCH step of `resolveClonesByPriority` runs on the step's task instead of the step brief. `BuildArgs.task` is new and optional; the CLI takes `--task-file <path>`; `nrv team step` writes `.step-task.txt` beside `.step-brief.md` and passes it. Requested clones (`scanBriefForClones`) still come from the brief, and a seat run outside a chain is unchanged.

Measured by the owner's agent on 2026-09-09: the same seat got store-marketing and industry-journalism clones from the whole brief, and production/systems-design clones from its own task. The ranker was right; the query was wrong.

Impact on published packs: none (prompt assembly only). Test: `employee-prompt-task-search.test.ts` (brief picks the director, `--task-file` picks the scheduler); clone-choice and chain-cli suites still green (20/20); `check:quick`, english-source, changelog parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk