### PR TITLE
fix(routing): the digest has no budget by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 ### `self_retrieval_miss` reports every missed brief
 
 The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.
+### The routing digest has no budget by default
+
+`routing.digest_token_budget` defaults to 0, no budget: the digest ships whole and never degrades unless an owner sets a ceiling on purpose. The 50k default that shipped with the knob still degraded a large library to level 4 in silence, which is the behaviour the knob existed to end. A budget is a deliberate setting, not something considered by default.
+
 ### The clone search reads the step's task, not the whole brief
 
 A chain brief carries the vocabulary of every seat. Fed with it, the clone search ranked the marketing and press voices for a seat whose job was closing the production macro. `nrv team step` now hands `employee-prompt` the step's own task (`--task-file`), and the search reads that; a seat run outside a chain still searches on the brief.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -11,6 +11,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 ### `self_retrieval_miss` reporta todos os briefs que erram
 
 O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.
+### O digest de roteamento não tem orçamento por padrão
+
+`routing.digest_token_budget` passa a valer 0 por padrão, sem teto: o digest sai inteiro e nunca degrada, a menos que o dono fixe um teto de propósito. O padrão de 50k que saiu junto com a chave ainda degradava uma biblioteca grande até o nível 4 em silêncio, que era o comportamento que a chave existia para acabar. Orçamento é decisão deliberada, não algo considerado por padrão.
+
 ### A busca de clone lê a tarefa do passo, não o brief inteiro
 
 O brief de uma cadeia carrega o vocabulário de todos os cargos. Alimentada com ele, a busca de clone classificava as vozes de marketing e de imprensa para um cargo cujo trabalho era fechar a planilha de macro da produção. O `nrv team step` agora entrega ao `employee-prompt` a tarefa do próprio passo (`--task-file`), e a busca lê isso; um cargo rodado fora de cadeia continua buscando pelo brief.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -64,7 +64,7 @@ Gerada a partir do schema. `nrv config explain <chave>` mostra a descrição de 
 | `routing.mode` | `NIRVANA_ROUTING_MODE` | `agentic` | global, projeto | agentic / fast |
 | `routing.dense` | `NIRVANA_ROUTER_DENSE` (`1` = fallback, `0` = off) | `off` | global, projeto | off / fallback |
 | `routing.on_router_failure` | nenhuma | `agent-x-only` | global, projeto | cascade / agent-x-only / fail |
-| `routing.digest_token_budget` | nenhuma | `50000` | global, projeto | inteiro >= 0 (tokens); 0 = sem teto |
+| `routing.digest_token_budget` | nenhuma | `0` (sem teto) | global, projeto | inteiro >= 0 (tokens); 0 = sem teto |
 | `supervisor.progress_ping_sec` | `NIRVANA_PROGRESS_PING_SEC` | `1800` | global, projeto | inteiro >= 0 (segundos) |
 | `supervisor.stall_threshold_ms` | `NIRVANA_STALL_THRESHOLD_MS` | `300000` | global, projeto | inteiro > 0 (milissegundos) |
 | `supervisor.touch_events_max` | `NIRVANA_TOUCH_EVENTS_MAX` | `500` | global, projeto | inteiro >= 0 (eventos); 0 = não relata arquivos |

--- a/skills/_shared/lib/settings-schema.ts
+++ b/skills/_shared/lib/settings-schema.ts
@@ -253,8 +253,8 @@ export const SETTINGS = {
     "Quando o roteador agêntico falha no transporte (após 1 retry): agent-x-only = pula direto pro agent-x, BM25 nunca dispara sem --fast explícito (padrão); cascade = tenta BM25 antes do agent-x; fail = encerra sem despachar nada.",
     ["cascade", "agent-x-only", "fail"], { default: "agent-x-only" }),
   "routing.digest_token_budget": numberSetting("routing.digest_token_budget",
-    "Orçamento em tokens do digest de roteamento (chars/4); acima dele o digest degrada por níveis. 0 = sem teto.",
-    { default: 50000, type: nonNegativeInt, expects: "inteiro >= 0 (tokens)" }),
+    "Orçamento em tokens do digest de roteamento (chars/4); acima dele o digest degrada por níveis. 0 = sem teto (padrão).",
+    { default: 0, type: nonNegativeInt, expects: "inteiro >= 0 (tokens); 0 = sem teto" }),
 
   "supervisor.progress_ping_sec": numberSetting("supervisor.progress_ping_sec",
     "Intervalo em segundos do aviso de progresso de um run longo; 0 silencia.",

--- a/skills/harness/scripts/build-routing-digest.ts
+++ b/skills/harness/scripts/build-routing-digest.ts
@@ -7,8 +7,8 @@
  * them into ONE pipe-delimited English file (`.routing-digest.md`, written next
  * to the registries, scope-aware via ROUTING_DIGEST_PATH) that a router LLM can
  * read whole: every business, squad, capability collision and mind-clone, one
- * line each, under the configured token budget (`routing.digest_token_budget`,
- * default 50k, chars/4 heuristic).
+ * line each. A token budget (`routing.digest_token_budget`, chars/4 heuristic)
+ * degrades the digest by levels when set; the default is no budget at all.
  *
  * Budget degradation ladder (entries are NEVER dropped):
  *   L0  full format (2 example briefs, capability one-liners, 160c descriptions)
@@ -127,13 +127,15 @@ export interface DigestResult {
   };
 }
 
-export const TOKEN_BUDGET = 50_000;
+/** No budget. The digest used to be sized by a 50k constant with no knob, and a
+ *  library that outgrew it degraded to the last rung in silence: the domains
+ *  lists the agentic router reads were the first thing dropped. A budget is
+ *  something an owner sets on purpose (`routing.digest_token_budget`); by
+ *  default nothing is considered and the digest ships whole. */
+export const TOKEN_BUDGET = 0;
 
-/** The budget in force: `routing.digest_token_budget` from config, falling back
- *  to the constant. It used to be the constant alone, with no knob, and a
- *  library that outgrew it degraded to the last rung in silence; the one way to
- *  keep the digest whole was to edit the installed file, which the next
- *  `nrv update` reverted. 0 means no budget: level 0, never over budget. */
+/** The budget in force: `routing.digest_token_budget` from config, 0 = none
+ *  (level 0, never over budget). */
 export function configuredTokenBudget(): number {
   try {
     const v = Number(resolveSetting("routing.digest_token_budget").value);

--- a/skills/harness/tests/routing-digest.test.ts
+++ b/skills/harness/tests/routing-digest.test.ts
@@ -13,6 +13,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { spawnBudgetMs } from "./helpers/test-budgets.ts";
+import { getSettingSpec, resolveSetting } from "../../_shared/lib/settings.ts";
 import {
   buildDigest, buildKeywordAliases, splitKeywordGroups, foldKey, detectLang,
   estimateTokens, trunc, TOKEN_BUDGET, loadDigestInput, configuredTokenBudget,
@@ -130,8 +131,11 @@ describe("routing digest — the budget is a knob, and 0 means none", () => {
     expect(open.degradationLevel).toBe(0);
     expect(open.overBudget).toBe(false);
   });
-  test("the configured budget comes from settings, default 50000", () => {
-    expect(configuredTokenBudget()).toBe(50_000);
+  test("the configured budget comes from settings, and the default is none", () => {
+    // The default is pinned on the schema, not on this machine's config: an
+    // owner who set a ceiling must not turn this test red.
+    expect(getSettingSpec("routing.digest_token_budget").default).toBe(0);
+    expect(configuredTokenBudget()).toBe(Number(resolveSetting("routing.digest_token_budget").value));
   });
 });
 
@@ -332,7 +336,7 @@ describe("routing digest — budget degradation ladder", () => {
   });
 
   test("default budget is the documented 50k", () => {
-    expect(TOKEN_BUDGET).toBe(50_000);
+    expect(TOKEN_BUDGET).toBe(0);
   });
 });
 


### PR DESCRIPTION
Owner's rule: a budget is never considered by default. `routing.digest_token_budget` now defaults to `0` (no budget); `TOKEN_BUDGET`, the legacy fallback, is 0 too. The digest ships whole and never degrades unless an owner sets a ceiling on purpose. Docs row, schema description and tests updated; changelog entry EN/PT.

Impact on published packs: none (routing digest is built on the client machine; a small library never hit the old ceiling, a large one no longer degrades). Tests: routing-digest 37/37, settings + glance panel green; `check:quick`, changelog parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk