### PR TITLE
feat(memory): an entity copy edited after the seed is named, not silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 ### `self_retrieval_miss` reports every missed brief
 
 The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.
+### A memory edited in the entity after the seed is named, not silently ignored
+
+An entity's shipped `memory/*.md` is a seed: copied once into the canonical home and never read again. An author who kept editing the entity's copy changed nothing the prompt read, and nothing said so (measured: 53 lines lived only in one business's copy). The memory block now names the shipped files that differ from the home and says the home is what is read; `nrv memory relocate` prints the same line. The policy is unchanged.
+
 ### The routing digest has no budget by default
 
 `routing.digest_token_budget` defaults to 0, no budget: the digest ships whole and never degrades unless an owner sets a ceiling on purpose. The 50k default that shipped with the knob still degraded a large library to level 4 in silence, which is the behaviour the knob existed to end. A budget is a deliberate setting, not something considered by default.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -11,6 +11,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 ### `self_retrieval_miss` reporta todos os briefs que erram
 
 O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.
+### Uma memória editada na entidade depois da semente é nomeada, não ignorada em silêncio
+
+O `memory/*.md` que uma entidade embarca é semente: copiado uma vez para a casa canônica e nunca mais lido. Quem continuava editando a cópia da entidade não mudava nada do que o prompt lia, e nada avisava (medido: 53 linhas viviam só na cópia de uma empresa). O bloco de memória agora nomeia os arquivos embarcados que diferem da casa e diz que a casa é o que se lê; o `nrv memory relocate` imprime a mesma linha. A política não mudou.
+
 ### O digest de roteamento não tem orçamento por padrão
 
 `routing.digest_token_budget` passa a valer 0 por padrão, sem teto: o digest sai inteiro e nunca degrada, a menos que o dono fixe um teto de propósito. O padrão de 50k que saiu junto com a chave ainda degradava uma biblioteca grande até o nível 4 em silêncio, que era o comportamento que a chave existia para acabar. Orçamento é decisão deliberada, não algo considerado por padrão.

--- a/skills/_shared/lib/entity-memory.ts
+++ b/skills/_shared/lib/entity-memory.ts
@@ -132,12 +132,39 @@ export function seedFromEntity(kind: EntityKind, slug: string, entityDir: string
   return seeded;
 }
 
+/**
+ * The shipped memory files whose content no longer matches the canonical home.
+ *
+ * The seed is read once (see `seedFromEntity`). An author who keeps editing the
+ * entity's own `memory/*.md` changes nothing the prompt reads, and nothing said
+ * so: measured on an installed business, 53 lines lived only in the entity's
+ * copy and were never read. This names the files so the prompt, and `nrv
+ * memory`, can say where the truth is being read from.
+ */
+export function seedDivergence(kind: EntityKind, slug: string, entityDir: string): string[] {
+  const dest = entityMemoryDir(kind, slug, "global");
+  const out: string[] = [];
+  for (const name of MEMORY_FILES) {
+    const from = path.join(entityDir, "memory", name);
+    const to = path.join(dest, name);
+    if (!fs.existsSync(from) || !fs.existsSync(to)) continue;
+    try {
+      const shipped = fs.readFileSync(from, "utf8");
+      if (isStub(shipped.trim())) continue;
+      if (shipped !== fs.readFileSync(to, "utf8")) out.push(name);
+    } catch { /* unreadable — nothing to compare */ }
+  }
+  return out;
+}
+
 /** One scope's curated content, already read. */
 export interface ScopedMemory { scope: MemoryScope; dir: string; files: string[]; bytes: number; text: string }
 
 export interface EntityMemory {
   /** Prompt-ready block, or "" when nothing is curated in either scope. */
   block: string;
+  /** Shipped memory files that differ from the canonical home (see `seedDivergence`). */
+  diverged: string[];
   /** What each scope contributed. */
   scopes: ScopedMemory[];
   /** Bytes of memory content carried, both scopes together. */
@@ -184,13 +211,14 @@ export function readEntityMemory(
   opts: { projectRoot?: string; entityDir?: string; noticeBytes?: number } = {},
 ): EntityMemory {
   const seeded = opts.entityDir ? seedFromEntity(kind, slug, opts.entityDir) : [];
+  const diverged = opts.entityDir ? seedDivergence(kind, slug, opts.entityDir) : [];
   const notice = opts.noticeBytes ?? 8_000;
 
   const scopes = [
     readScope(kind, slug, "global"),
     opts.projectRoot ? readScope(kind, slug, "project", opts.projectRoot) : null,
   ].filter((s): s is ScopedMemory => s !== null);
-  if (!scopes.length) return { block: "", scopes: [], bytes: 0, seeded };
+  if (!scopes.length) return { block: "", scopes: [], bytes: 0, seeded, diverged };
 
   const bytes = scopes.reduce((n, s) => n + s.bytes, 0);
   const label: Record<MemoryScope, string> = {
@@ -203,13 +231,18 @@ export function readEntityMemory(
   const over = bytes > notice
     ? `\n\n> Esta memória soma ${bytes} bytes, acima do ponto de atenção de ${notice} — ela chega **inteira** mesmo assim.`
     : "";
+  const drift = diverged.length
+    ? `\n\n> **Atenção:** ${diverged.map((f) => `\`${path.join(opts.entityDir!, "memory", f)}\``).join(", ")} difere da casa canônica `
+      + `\`${entityMemoryDir(kind, slug, "global")}\`. O que você lê acima é a casa; a cópia da entidade foi só a semente inicial e não é relida. `
+      + `Quem editou a entidade precisa levar a mudança para a casa (\`nrv memory add ${slug} "<fato>" --scope global\`).`
+    : "";
 
   const block = `## MEMÓRIA DESTA ENTIDADE — ${slug} (entre sessões)\n\n`
     + `> Lições, decisões e princípios que sobreviveram a execuções anteriores. Honre-os.\n`
     + `> Ficam fora do diretório da entidade, porque a entidade é substituída quando atualiza.\n\n`
-    + `${body}${over}\n\n`
+    + `${body}${over}${drift}\n\n`
     + `> Para registrar algo novo, **você decide o escopo pelo que o fato significa**, não pelo diretório em que está: `
     + `\`nrv memory add ${slug} "<fato>" --scope global\` quando é verdade sobre a entidade em qualquer lugar, `
     + `\`--scope project\` quando só vale nesta execução/cliente. Na dúvida entre os dois, é project.\n\n---\n\n`;
-  return { block, scopes, bytes, seeded };
+  return { block, scopes, bytes, seeded, diverged };
 }

--- a/skills/_shared/tests/entity-memory.test.ts
+++ b/skills/_shared/tests/entity-memory.test.ts
@@ -11,7 +11,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-  MEMORY_FILES, entityMemoryDir, globalMemoryHome, memoryHomeFor, readEntityMemory, seedFromEntity,
+  MEMORY_FILES, entityMemoryDir, globalMemoryHome, memoryHomeFor, readEntityMemory, seedDivergence, seedFromEntity,
 } from "../lib/entity-memory.ts";
 
 let tmp: string;
@@ -182,5 +182,25 @@ describe("seedFromEntity — a shipped memory populates the home once, then stop
     const bizDir = business("acme", { "permanent.md": "# Permanent memory\n" });
     expect(seedFromEntity("businesses", "acme", bizDir)).toEqual([]);
     expect(fs.existsSync(entityMemoryDir("businesses", "acme", "global"))).toBe(false);
+  });
+});
+
+describe("an entity copy edited after the seed is named, not silently ignored", () => {
+  test("the home is what is read, and the block says the entity copy differs", () => {
+    const entity = path.join(tmp, "biz-drift");
+    fs.mkdirSync(path.join(entity, "memory"), { recursive: true });
+    fs.writeFileSync(path.join(entity, "memory", "permanent.md"), "- Decisão original. SEED-MARKER\n");
+    expect(seedFromEntity("businesses", "biz-drift", entity)).toEqual(["permanent.md"]);
+    expect(seedDivergence("businesses", "biz-drift", entity)).toEqual([]);
+
+    // The author keeps editing the shipped copy: the home does not change.
+    fs.writeFileSync(path.join(entity, "memory", "permanent.md"), "- Decisão original. SEED-MARKER\n- Linha nova que ninguém lê. EDIT-MARKER\n");
+    expect(seedDivergence("businesses", "biz-drift", entity)).toEqual(["permanent.md"]);
+    const mem = readEntityMemory("businesses", "biz-drift", { entityDir: entity });
+    expect(mem.diverged).toEqual(["permanent.md"]);
+    expect(mem.block).toContain("SEED-MARKER");
+    expect(mem.block).not.toContain("EDIT-MARKER");
+    expect(mem.block).toContain("difere da casa canônica");
+    expect(mem.block).toContain(path.join(entity, "memory", "permanent.md"));
   });
 });

--- a/skills/harness/scripts/memory.ts
+++ b/skills/harness/scripts/memory.ts
@@ -19,7 +19,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { resolveScope } from "../../_shared/lib/scope.ts";
 import { paths } from "../../_shared/lib/bun-helpers.ts";
-import { MEMORY_FILES, entityMemoryDir, globalMemoryHome, seedFromEntity } from "../../_shared/lib/entity-memory.ts";
+import { MEMORY_FILES, entityMemoryDir, globalMemoryHome, seedFromEntity, seedDivergence } from "../../_shared/lib/entity-memory.ts";
 import { createRequire } from "node:module";
 const db = createRequire(import.meta.url)("../../_shared/lib/state-db.js");
 
@@ -160,6 +160,11 @@ if (sub === "add") {
       if (!fs.existsSync(path.join(memDir, name))) continue;
       if (fs.existsSync(path.join(dest, name))) { skipped++; continue; }
       pending.push(name);
+    }
+    // The home is what is read; an entity copy edited after the seed is silent
+    // drift, so say it here where the owner is looking.
+    for (const name of seedDivergence(kind, slug, entityDir)) {
+      console.log(`! ${slug}: memory/${name} differs from the home (${dest}) — the home is what is read; move the change with \`nrv memory add ${slug} "<fact>" --scope global\``);
     }
     if (!pending.length) { empty++; continue; }
     const bytes = pending.reduce((n, f) => n + fs.statSync(path.join(memDir, f)).size, 0);


### PR DESCRIPTION
One behaviour: `seedDivergence(kind, slug, entityDir)` names the shipped `memory/*.md` files whose content differs from the canonical home; `readEntityMemory` returns them as `diverged` and appends one warning line to the memory block (the home is what is read; move the change with `nrv memory add … --scope global`); `nrv memory relocate` prints the same line. Seeding policy unchanged (copy once, never overwrite, never write back).

Measured by the owner's agent on 2026-09-09: an installed business had 53 lines only in its entity copy, timestamped after the home, never read.

Impact on published packs: none (prompt block only). Test: seed, edit the entity copy, read → `diverged` names the file, the block carries the seed text and the warning, not the edit. entity-memory suite 12/12; `check:quick`, english-source, changelog parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk