### PR TITLE
fix(migrate): the normalizer reads gates, groups, phase agent lists and chained event routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 
 ## Unreleased
 
+### The normalizer reads gates, groups, phase agent lists and chained event routes
+
+Five library squads rolled back from the 6.0 migration with `steps.N.agent: Too small`, which the schema defines as a normalizer bug: a step the schema refuses is never authored content. Four dialects were unread. A step with nobody to run it and nothing to run (`type: approval`, `type: human-gate`) is a gate on the edge, not a node: it leaves the graph, the steps that waited on it inherit what it waited for and carry it verbatim in `meta.gate_before`, and a gate nothing waits on lands in `extensions.trailing_gates`. A `type: parallel` group inside a `sequence` is a layer: each child is a step labelled with the group, requiring the step before the group, and the step after requires every child. A phase that lists its `agents:` is one step per entry, all in the phase. An `event_routes` router whose every route names an `agent_chain` is a forest, one chain per route in the author's order with the trigger on the first step; a route without a chain still refuses, because there is no order to derive. The migration backup also skips a socket or FIFO left inside the squad tree (a local test ledger), which `cp` refused with EINVAL and aborted the whole migration.
+
 ### `self_retrieval_miss` reports every missed brief
 
 The `return` sat inside the loop over `example_briefs`, so the validator named one miss and stopped: an author fixing briefs one at a time learned about the next miss only after fixing this one, and "1 warning" could mean fourteen. Misses accumulate now, one finding per brief.

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -8,6 +8,10 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 
 ## Não lançado
 
+### O normalizador lê gates, grupos, listas de agentes por fase e rotas de evento encadeadas
+
+Cinco squads da biblioteca voltavam da migração 6.0 com `steps.N.agent: Too small`, que o schema define como bug do normalizador: um passo que o schema recusa nunca é conteúdo autoral. Quatro dialetos não eram lidos. Um passo sem ninguém para executá-lo e sem nada a executar (`type: approval`, `type: human-gate`) é um gate na aresta, não um nó: sai do grafo, os passos que esperavam por ele herdam o que ele esperava e o carregam verbatim em `meta.gate_before`, e um gate de que ninguém depende vai para `extensions.trailing_gates`. Um grupo `type: parallel` dentro de uma `sequence` é uma camada: cada filho vira um passo rotulado com o grupo, requer o passo anterior ao grupo, e o passo seguinte requer todos os filhos. Uma fase que lista seus `agents:` vira um passo por entrada, todos na fase. Um roteador `event_routes` em que toda rota nomeia um `agent_chain` é uma floresta, uma cadeia por rota na ordem do autor com o gatilho no primeiro passo; uma rota sem cadeia continua recusada, porque não há ordem a derivar. O backup da migração também pula um socket ou FIFO deixado dentro da árvore do squad (um test ledger local), que o `cp` recusava com EINVAL e abortava a migração inteira.
+
 ### `self_retrieval_miss` reporta todos os briefs que erram
 
 O `return` ficava dentro do laço sobre `example_briefs`, então o validador nomeava um erro e parava: quem corrigia um brief por vez só descobria o próximo depois de corrigir este, e "1 aviso" podia significar catorze. Os erros agora acumulam, um achado por brief.

--- a/skills/squads/SQUAD_PROTOCOL_V6.md
+++ b/skills/squads/SQUAD_PROTOCOL_V6.md
@@ -147,6 +147,11 @@ Os fixers **nunca inventam**. Eles renomeiam, movem e reformatam o que já está
 | `sequence[]` solto | um passo por entrada, encadeados | `sequence` |
 | `workflow: {agents: [...]}` (la-bottega) | um passo por agente; `all-as-needed` descartado; `command` → `extensions.command` | `workflow_agents` |
 | `depends_on` nomeando o `output:` de outro passo | o passo que o cria, quando é único | `requires_by_output` |
+| passo sem agente e sem task (`type: approval`, `type: human-gate`) | é um gate na aresta, não um nó: sai do grafo; quem dependia dele herda o que ele esperava e o carrega verbatim em `meta.gate_before[]`; um gate de que ninguém depende vai para `extensions.trailing_gates[]` | `gate_steps` |
+| `{type: parallel, id: x, steps: [...]}` dentro de `sequence[]` | um grupo é uma camada: cada filho vira um passo com `meta.group = x`, requer o passo anterior ao grupo, e o passo seguinte requer todos os filhos | `nested_group` |
+| `phases[].agents[]` | um passo por entrada, todos na mesma camada (a fase) | `phases` |
+| `event_routes` com `agent_chain[]` em toda rota | uma floresta: cada rota é uma cadeia de passos `<rota>-<agente>` na ordem do autor, `meta.route` em todos e o gatilho (o resto da rota) em `meta.event` do primeiro | `event_routes_chained` |
+| `event_routes` sem `agent_chain` em alguma rota | não normaliza: é um roteador, nenhuma ordem pode ser derivada; `nrv migrate` recusa | `event_routes` |
 | `workflow_name` | `name` | `workflow_name` |
 | `success_criteria` | `success_indicators` | `success_criteria` |
 | `on_fail` | `on_failure` | `on_fail` |

--- a/skills/squads/lib/workflow-reader.ts
+++ b/skills/squads/lib/workflow-reader.ts
@@ -224,10 +224,14 @@ export interface NormalizeResult {
   prose: Record<string, string>;
   /** Ids of the steps that carried inline prose (what the `task: |` lint reads). */
   inlineProse: string[];
-  /** `event_routes`: a router, not a DAG. Reported, never guessed at. */
+  /** `event_routes` without an `agent_chain` per route: a router, not a DAG. Reported, never guessed at. */
   unnormalizable: boolean;
   notes: string[];
 }
+
+/** A raw step that names its runner under any of the three spellings. */
+const hasAgent = (v: Record<string, unknown>): boolean =>
+  [v.agent, v.owner, v.role].some((a) => typeof a === "string" && a.trim() !== "");
 
 const isMapping = (v: unknown): v is Record<string, unknown> =>
   !!v && typeof v === "object" && !Array.isArray(v);
@@ -432,10 +436,30 @@ export function normalizeWorkflow(doc: unknown, opts: { stem?: string } = {}): N
   } else if (stepsFromWorkflowKey) {
     rawSteps = stepsFromWorkflowKey;
   } else if (top.event_routes !== undefined) {
-    out.unnormalizable = true;
-    out.notes.push("`event_routes` is a router, not a DAG: no step order can be derived from it");
-    ext.event_routes = top.event_routes;
-    dialect("event_routes");
+    // A route that names its `agent_chain` is a chain: the order inside the
+    // route is the author's, and the routes are independent trees of one
+    // forest. A route without a chain gives no order to derive, so the
+    // router stays reported instead of guessed at.
+    const routes = isMapping(top.event_routes) ? Object.entries(top.event_routes) : [];
+    const chained = routes.length > 0 && routes.every(([, r]) => isMapping(r) && Array.isArray(r.agent_chain) && r.agent_chain.length > 0 && r.agent_chain.every((a) => typeof a === "string" && a.trim()));
+    if (chained) {
+      rawSteps = [];
+      for (const [route, r] of routes) {
+        const { agent_chain, ...event } = r as Record<string, unknown>;
+        (agent_chain as string[]).forEach((agent, i) => {
+          const step: Record<string, unknown> = { id: `${route}-${agent}`, agent, route };
+          if (i === 0) step.event = event;
+          else step.depends_on = [`${route}-${(agent_chain as string[])[i - 1]}`];
+          rawSteps!.push(step);
+        });
+      }
+      dialect("event_routes_chained");
+    } else {
+      out.unnormalizable = true;
+      out.notes.push("`event_routes` is a router, not a DAG: no step order can be derived from it");
+      ext.event_routes = top.event_routes;
+      dialect("event_routes");
+    }
   }
 
   // Every dialect whose steps carry no dependency at all becomes a chain: the
@@ -457,10 +481,32 @@ export function normalizeWorkflow(doc: unknown, opts: { stem?: string } = {}): N
       if (layer.length) previousLayer = layer;
     }
   } else if (rawSteps) {
+    // The layer a linear dialect chains to: one step, or every child of the
+    // group that came before it.
+    let lastLayer: string[] = [];
     for (const raw of rawSteps) {
+      // `{type: parallel, id: x, steps: [...]}` (broadcast-ops): a group is a
+      // layer, not a step. Its children run side by side, each one labelled
+      // with the group so a later `requires: [x]` resolves to all of them.
+      const group = isMapping(raw) && !hasAgent(raw) && Array.isArray(raw.steps) ? raw : null;
+      if (group) {
+        const label = String(group.id ?? group.name ?? `group-${drafts.length + 1}`);
+        const layer: string[] = [];
+        for (const child of group.steps as unknown[]) {
+          const step = normalizeStep(child, drafts.length, out);
+          step.meta.group = label;
+          if (linear && step.requires.length === 0) pushUnique(step.requires, lastLayer);
+          drafts.push({ step, index: drafts.length });
+          layer.push(step.id);
+        }
+        if (layer.length) lastLayer = layer;
+        dialect("nested_group");
+        continue;
+      }
       const step = normalizeStep(raw, drafts.length, out);
-      if (linear && step.requires.length === 0 && drafts.length > 0) step.requires.push(drafts[drafts.length - 1].step.id);
+      if (linear && step.requires.length === 0) pushUnique(step.requires, lastLayer);
       drafts.push({ step, index: drafts.length });
+      lastLayer = [step.id];
     }
   }
 
@@ -479,6 +525,31 @@ export function normalizeWorkflow(doc: unknown, opts: { stem?: string } = {}): N
     const original = d.step.id;
     if (n > 0) d.step.id = `${original}-${n + 1}`;
     latest.set(original, d.step.id);
+  }
+
+  // A step with nobody to run it and nothing to run (`type: approval`,
+  // `type: human-gate`) is a gate on the edge, not a node of the graph: the
+  // steps behind it inherit what it waited for and carry it as
+  // `meta.gate_before`, verbatim. A gate nothing waits on closes the workflow
+  // and lands in `extensions.trailing_gates`.
+  const gates = drafts.filter((d) => !d.step.agent && !d.step.task && d.step.meta.workflow === undefined);
+  if (gates.length) {
+    const gateIds = new Set(gates.map((d) => d.step.id));
+    for (const g of gates) {
+      const gate = { id: g.step.id, ...g.step.meta };
+      let waited = false;
+      for (const d of drafts) {
+        if (gateIds.has(d.step.id) || !d.step.requires.includes(g.step.id)) continue;
+        waited = true;
+        d.step.requires = d.step.requires.filter((r) => r !== g.step.id);
+        pushUnique(d.step.requires, g.step.requires);
+        const before = Array.isArray(d.step.meta.gate_before) ? d.step.meta.gate_before as unknown[] : [];
+        d.step.meta.gate_before = [...before, gate];
+      }
+      if (!waited) ext.trailing_gates = [...(Array.isArray(ext.trailing_gates) ? ext.trailing_gates as unknown[] : []), gate];
+    }
+    for (let i = drafts.length - 1; i >= 0; i--) if (gateIds.has(drafts[i].step.id)) drafts.splice(i, 1);
+    dialect("gate_steps");
   }
 
   out.canonical.steps = drafts.map((d) => d.step);
@@ -553,6 +624,9 @@ function groupPhases(phases: unknown[]): Array<{ label: string; steps: unknown[]
     const label = String(p.phase ?? p.name ?? p.id ?? `phase-${i + 1}`);
     if (Array.isArray(p.steps)) out.push({ label, steps: p.steps });
     else if (Array.isArray(p.tasks)) out.push({ label, steps: p.tasks });
+    // `agents: [{agent, task}, ...]` under a phase (nirvana-context-enricher):
+    // the phase is the layer, and each entry is one step of it.
+    else if (Array.isArray(p.agents)) out.push({ label, steps: p.agents.map((a) => (isMapping(a) ? a : { agent: a })) });
     else out.push({ label, steps: [p] });
   });
   return out;

--- a/skills/squads/scripts/migrate-squad.ts
+++ b/skills/squads/scripts/migrate-squad.ts
@@ -577,7 +577,10 @@ function copyTree(src: string, dst: string): void {
     verbatimSymlinks: true,
     filter: (p) => {
       const rel = path.relative(src, p).split(path.sep).join("/");
-      return rel === "" || !isRunStatePath(rel, "squads");
+      if (rel !== "" && isRunStatePath(rel, "squads")) return false;
+      // A socket or a FIFO left by a tool inside the tree (a local test
+      // ledger) has no bytes to back up, and `cp` refuses it with EINVAL.
+      try { const st = fs.lstatSync(p); return st.isFile() || st.isDirectory() || st.isSymbolicLink(); } catch { return false; }
     },
   });
 }

--- a/skills/squads/tests/migrate-squad.test.ts
+++ b/skills/squads/tests/migrate-squad.test.ts
@@ -660,3 +660,188 @@ describe("usage", () => {
     expect(out.json.every((x: any) => x.mode === "dry-run")).toBe(true);
   }, spawnBudgetMs(2));
 });
+
+// ── shapes the schema calls a normalizer bug ─────────────────────────────────
+//
+// Five library squads rolled back with `steps.N.agent: Too small`: a step the
+// schema refuses is never authored content, it is a dialect the normalizer did
+// not read. Gates (`type: approval`, `type: human-gate`) have nobody to run
+// them; a `type: parallel` group is a layer, not a step; a phase may list its
+// `agents:`; and an event router whose routes carry an `agent_chain` is a forest.
+
+const graphOf = (dir: string, file = "main.md"): any =>
+  parseYaml(fs.readFileSync(path.join(dir, "workflows", file), "utf8").split("---")[1]);
+
+describe("a gate step folds into the edge", () => {
+  test("`type: approval` between two steps: the follower inherits the wait and carries the gate", () => {
+    const r = root();
+    const dir = fixture(r, "gate-steps", { workflows: { "main.yaml": `name: main
+steps:
+  - id: design
+    agent: planner
+    task: plan
+  - id: design-approval
+    type: approval
+    depends_on: [design]
+    message: Review the design before the build starts.
+    on_reject:
+      route_to: design
+  - id: build
+    agent: builder
+    task: build
+    depends_on: [design-approval]
+  - id: final-review
+    type: approval
+    depends_on: [build]
+` } });
+    const applied = runMigrate(r, ["gate-steps", "--to", "6", "--apply", "--json"]);
+    expect(applied.json.refusals).toEqual([]);
+    expect(applied.json.gate.errors).toBe(0);
+    const graph = graphOf(dir);
+    expect(graph.steps.map((s: any) => s.id)).toEqual(["design", "build"]);
+    expect(graph.steps[1].requires).toEqual(["design"]);
+    expect(graph.steps[1].meta.gate_before).toEqual([{ id: "design-approval", type: "approval", message: "Review the design before the build starts.", on_reject: { route_to: "design" } }]);
+    expect(graph.extensions.trailing_gates).toEqual([{ id: "final-review", type: "approval" }]);
+  }, spawnBudgetMs(1));
+
+  test("`type: human-gate` inside a linear `workflow.sequence` chains around itself", () => {
+    const r = root();
+    const dir = fixture(r, "human-gate", { workflows: { "main.yaml": `workflow:
+  id: main
+  sequence:
+    - agent: planner
+      task: plan
+    - type: human-gate
+      id: confirm-analysis
+      prompt: Confirm the analysis.
+    - agent: builder
+      task: build
+` } });
+    const applied = runMigrate(r, ["human-gate", "--to", "6", "--apply", "--json"]);
+    expect(applied.json.refusals).toEqual([]);
+    const graph = graphOf(dir);
+    expect(graph.steps.map((s: any) => s.id)).toEqual(["planner", "builder"]);
+    expect(graph.steps[1].requires).toEqual(["planner"]);
+    expect(graph.steps[1].meta.gate_before[0].id).toBe("confirm-analysis");
+  }, spawnBudgetMs(1));
+});
+
+describe("a parallel group is a layer", () => {
+  test("children require the step before the group; the step after requires every child", () => {
+    const r = root();
+    const dir = fixture(r, "nested-group", { workflows: { "main.yaml": `workflow:
+  id: main
+  sequence:
+    - agent: planner
+      task: plan
+    - type: parallel
+      id: production
+      steps:
+        - agent: builder
+          task: build
+          id: build-a
+        - agent: builder
+          task: build
+          id: build-b
+    - agent: planner
+      task: plan
+      id: review
+` } });
+    const applied = runMigrate(r, ["nested-group", "--to", "6", "--apply", "--json"]);
+    expect(applied.json.refusals).toEqual([]);
+    expect(applied.json.gate.errors).toBe(0);
+    const graph = graphOf(dir);
+    expect(graph.steps.map((s: any) => s.id)).toEqual(["planner", "build-a", "build-b", "review"]);
+    expect(graph.steps[1].requires).toEqual(["planner"]);
+    expect(graph.steps[2].requires).toEqual(["planner"]);
+    expect(graph.steps[1].meta.group).toBe("production");
+    expect(graph.steps[3].requires).toEqual(["build-a", "build-b"]);
+  }, spawnBudgetMs(1));
+});
+
+describe("a phase that lists its agents is one layer", () => {
+  test("`phases[].agents[]` becomes one step per agent, all of them in the phase", () => {
+    const r = root();
+    const dir = fixture(r, "phase-agents", { workflows: { "main.yaml": `workflow_name: main
+phases:
+  - name: parse
+    agent: planner
+    task: plan
+  - name: research
+    parallel: true
+    agents:
+      - agent: builder
+        task: build
+      - agent: planner
+        task: plan
+  - name: synthesize
+    agent: builder
+    task: build
+` } });
+    const applied = runMigrate(r, ["phase-agents", "--to", "6", "--apply", "--json"]);
+    expect(applied.json.refusals).toEqual([]);
+    expect(applied.json.gate.errors).toBe(0);
+    const graph = graphOf(dir);
+    expect(graph.steps.map((s: any) => s.id)).toEqual(["parse", "builder", "planner", "synthesize"]);
+    expect(graph.steps[1].requires).toEqual(["parse"]);
+    expect(graph.steps[2].requires).toEqual(["parse"]);
+    expect(graph.steps[2].meta.phase).toBe("research");
+    expect(graph.steps[3].requires).toEqual(["builder", "planner"]);
+  }, spawnBudgetMs(1));
+});
+
+describe("an event router with agent chains is a forest", () => {
+  test("each route is its own chain; the trigger rides on the first step", () => {
+    const r = root();
+    const dir = fixture(r, "event-chains", { workflows: { "main.yaml": `workflow_name: main
+event_routes:
+  breakout:
+    trigger_condition: event_type=breakout
+    priority: HIGH
+    agent_chain: [planner, builder]
+  price_alert:
+    trigger_condition: event_type=price_alert
+    agent_chain: [builder]
+` } });
+    const applied = runMigrate(r, ["event-chains", "--to", "6", "--apply", "--json"]);
+    expect(applied.json.refusals).toEqual([]);
+    expect(applied.json.gate.errors).toBe(0);
+    const graph = graphOf(dir);
+    expect(graph.steps.map((s: any) => s.id)).toEqual(["breakout-planner", "breakout-builder", "price_alert-builder"]);
+    expect(graph.steps[0].requires ?? []).toEqual([]);
+    expect(graph.steps[0].meta.event).toEqual({ trigger_condition: "event_type=breakout", priority: "HIGH" });
+    expect(graph.steps[0].meta.route).toBe("breakout");
+    expect(graph.steps[1].requires).toEqual(["breakout-planner"]);
+    expect(graph.steps[2].requires ?? []).toEqual([]);
+  }, spawnBudgetMs(1));
+
+  test("a route without an agent chain still refuses: there is no order to derive", () => {
+    const r = root();
+    fixture(r, "event-router", { workflows: { "main.yaml": `workflow_name: main
+event_routes:
+  breakout:
+    trigger_condition: event_type=breakout
+    agent: planner
+` } });
+    const out = runMigrate(r, ["event-router", "--to", "6", "--apply", "--json"]);
+    expect(out.json.refusals.join("\n")).toContain("router, not a DAG");
+  }, spawnBudgetMs(1));
+});
+
+describe("the backup skips what has no bytes", () => {
+  test.skipIf(process.platform === "win32")("a unix socket inside the squad does not abort the migration", async () => {
+    const net = await import("node:net");
+    const r = root();
+    const dir = fixture(r, "with-socket", { workflows: { "main.yaml": STEPS_DEPENDS_ON } });
+    const sockDir = path.join(dir, "examples", "ledger");
+    fs.mkdirSync(sockDir, { recursive: true });
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(path.join(sockDir, "admin.rpc"), resolve));
+    try {
+      const applied = runMigrate(r, ["with-socket", "--to", "6", "--apply", "--json"]);
+      expect(applied.code).toBe(0);
+      expect(applied.json.refusals).toEqual([]);
+      expect(fs.existsSync(path.join(applied.json.backup, "examples", "ledger", "admin.rpc"))).toBe(false);
+    } finally { server.close(); }
+  }, spawnBudgetMs(1));
+});


### PR DESCRIPTION
## What

Five library squads rolled back from the Squad Protocol 6.0 migration with `steps.N.agent: Too small`. The schema's own comment defines that as a normalizer bug: a step the schema refuses is never authored content. Four dialects were unread, and one crash in the backup.

- **Gate steps.** A step with nobody to run it and nothing to run (`type: approval`, `type: human-gate`) is a gate on the edge, not a node. It leaves the graph; the steps that waited on it inherit what it waited for and carry it verbatim in `meta.gate_before[]`; a gate nothing waits on lands in `extensions.trailing_gates[]`. Tag `gate_steps`.
- **Parallel groups.** `{type: parallel, id: x, steps: [...]}` inside a `sequence` is a layer: each child is a step with `meta.group = x`, requiring the step before the group, and the step after requires every child. Tag `nested_group`.
- **Phase agent lists.** `phases[].agents[]` is one step per entry, all in the phase.
- **Chained event routes.** `event_routes` whose every route names an `agent_chain` is a forest: one chain per route in the author's order, `meta.route` on each step and the trigger in `meta.event` of the first. A route without a chain still refuses (no order to derive). Tag `event_routes_chained`.
- **Backup.** `copyTree` skips sockets and FIFOs left inside the squad tree (a local test ledger), which `cp` refused with EINVAL and aborted the whole migration.

Spec table (§28.4) gains the rows; changelog EN/PT.

## Verification

- `bun test skills/squads/tests` (119 pass; 7 new cases: gate mid-chain and trailing, human-gate in a linear sequence, parallel group layering, phase agents, chained routes, router without chain still refuses, socket in the tree).
- `check:quick`, `check:english`, `check:changelog` clean.
- Measured on the installed library: the five squads that rolled back now migrate with `refusals: []` and `gate: ADMITTED`, and a squad with a unix socket in its examples tree no longer aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk