### PR TITLE
feat(admission): a pack ships Protocol 6.0 squads only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to the Nirvana-OS engine. Versions map to GitHub releases
 ### The normalizer reads gates, groups, phase agent lists and chained event routes
 
 Five library squads rolled back from the 6.0 migration with `steps.N.agent: Too small`, which the schema defines as a normalizer bug: a step the schema refuses is never authored content. Four dialects were unread. A step with nobody to run it and nothing to run (`type: approval`, `type: human-gate`) is a gate on the edge, not a node: it leaves the graph, the steps that waited on it inherit what it waited for and carry it verbatim in `meta.gate_before`, and a gate nothing waits on lands in `extensions.trailing_gates`. A `type: parallel` group inside a `sequence` is a layer: each child is a step labelled with the group, requiring the step before the group, and the step after requires every child. A phase that lists its `agents:` is one step per entry, all in the phase. An `event_routes` router whose every route names an `agent_chain` is a forest, one chain per route in the author's order with the trigger on the first step; a route without a chain still refuses, because there is no order to derive. The migration backup also skips a socket or FIFO left inside the squad tree (a local test ledger), which `cp` refused with EINVAL and aborted the whole migration.
+### A pack ships Protocol 6.0 squads only
+
+The admission gate (`check-entity-admission.ts --pack`) treats a squad whose manifest is below Squad Protocol 6.0, or has no `protocol` at all, as a hard problem: the pack does not enter. Below 6.0 the workflow graph is a dialect every reader parses differently, and the fix is one command (`nrv migrate <slug> --to 6`), so this is never debt to record. The validator keeps reporting it as advice on an installed library, where `nrv doctor` counts the squads left to migrate.
 
 ### `self_retrieval_miss` reports every missed brief
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -11,6 +11,9 @@ do engine que o `npx @nirvana-os/cli` e as instalações de pack consomem.
 ### O normalizador lê gates, grupos, listas de agentes por fase e rotas de evento encadeadas
 
 Cinco squads da biblioteca voltavam da migração 6.0 com `steps.N.agent: Too small`, que o schema define como bug do normalizador: um passo que o schema recusa nunca é conteúdo autoral. Quatro dialetos não eram lidos. Um passo sem ninguém para executá-lo e sem nada a executar (`type: approval`, `type: human-gate`) é um gate na aresta, não um nó: sai do grafo, os passos que esperavam por ele herdam o que ele esperava e o carregam verbatim em `meta.gate_before`, e um gate de que ninguém depende vai para `extensions.trailing_gates`. Um grupo `type: parallel` dentro de uma `sequence` é uma camada: cada filho vira um passo rotulado com o grupo, requer o passo anterior ao grupo, e o passo seguinte requer todos os filhos. Uma fase que lista seus `agents:` vira um passo por entrada, todos na fase. Um roteador `event_routes` em que toda rota nomeia um `agent_chain` é uma floresta, uma cadeia por rota na ordem do autor com o gatilho no primeiro passo; uma rota sem cadeia continua recusada, porque não há ordem a derivar. O backup da migração também pula um socket ou FIFO deixado dentro da árvore do squad (um test ledger local), que o `cp` recusava com EINVAL e abortava a migração inteira.
+### Um pack só embarca squads no Protocolo 6.0
+
+O gate de admissão (`check-entity-admission.ts --pack`) trata um squad cujo manifesto está abaixo do Squad Protocol 6.0, ou sem `protocol` algum, como problema duro: o pack não entra. Abaixo de 6.0 o grafo do workflow é um dialeto que cada leitor interpreta de um jeito, e a correção é um comando (`nrv migrate <slug> --to 6`), então isso nunca é dívida a registrar. O validador continua reportando como aviso numa biblioteca instalada, onde o `nrv doctor` conta os squads que faltam migrar.
 
 ### `self_retrieval_miss` reporta todos os briefs que erram
 

--- a/scripts/check-entity-admission.ts
+++ b/scripts/check-entity-admission.ts
@@ -129,6 +129,14 @@ for (const report of batch.reports as VerifyReport[]) {
     }
   }
 
+  if (report.kind === "squad") {
+    // A pack ships Protocol 6.0 squads only. Below it the workflow graph is a
+    // dialect every reader parses differently, so this is a hard problem the
+    // migration fixes in one command, never debt to record.
+    const f = byId.get("protocol_below_6");
+    if (f) hard(`${f.message} — a pack ships Protocol 6.0 squads only`);
+  }
+
   if (report.kind === "business") {
     // Keyed by "business/employee.md" so two packs shipping the same business
     // share the debt entry (same rule as clone slugs). Every seat is scanned,

--- a/skills/harness/tests/entity-admission.test.ts
+++ b/skills/harness/tests/entity-admission.test.ts
@@ -45,7 +45,7 @@ function pack(mutate: (root: string) => void = () => {}): string {
   writeFileSync(join(clone, ".nirvana-surface.json"), "{}", "utf8");
   const squad = join(root, "squads", "one-squad");
   mkdirSync(squad, { recursive: true });
-  writeFileSync(join(squad, "squad.yaml"), "name: one-squad\nversion: 1.0.0\n", "utf8");
+  writeFileSync(join(squad, "squad.yaml"), "name: one-squad\nversion: 1.0.0\nprotocol: \"6.0\"\n", "utf8");
   writeFileSync(join(squad, ".nirvana-surface.json"), "{}", "utf8");
   mutate(root);
   return root;
@@ -85,6 +85,20 @@ describe("hard problems always fail", () => {
     const r = run(root, { baseline: {} });
     expect(r.code).toBe(1);
     expect(r.out).toContain("numbered legacy category");
+  }, spawnBudgetMs(2));
+
+  test("a squad below Protocol 6.0 does not enter", () => {
+    const root = pack((r) => {
+      writeFileSync(join(r, "squads", "one-squad", "squad.yaml"), "name: one-squad\nversion: 1.0.0\nprotocol: \"5.0\"\n", "utf8");
+    });
+    const r = run(root, { baseline: {} });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("protocol 5.0");
+    expect(r.out).toContain("Protocol 6.0 squads only");
+    const missing = pack((r) => {
+      writeFileSync(join(r, "squads", "one-squad", "squad.yaml"), "name: one-squad\nversion: 1.0.0\n", "utf8");
+    });
+    expect(run(missing, { baseline: {} }).code).toBe(1);
   }, spawnBudgetMs(2));
 
   test("a missing surface file does not enter", () => {


### PR DESCRIPTION
## What

`scripts/check-entity-admission.ts --pack` now treats a squad whose manifest is below Squad Protocol 6.0, or has no `protocol` at all, as a **hard** problem: the pack does not enter. Below 6.0 the workflow graph is a dialect every reader parses differently, and the fix is one command (`nrv migrate <slug> --to 6`), so this is never debt to record.

The validator's `protocol_below_6` criterion stays a warning on an installed library (a rollout state that must not turn CI red, as `doctor-protocol.test.ts` pins), and `nrv doctor` keeps counting what is left to migrate. Enforcement lives at the pack door only.

## Verification

- `bun test skills/harness/tests/entity-admission.test.ts` (9 pass; new case: protocol 5.0 and missing protocol both exit 1 with the reason; the clean fixture now declares 6.0).
- `check:quick`, `check:english`, `check:changelog` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk