### PR TITLE
fix(doctor): the protocol census reads the whole manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Five library squads rolled back from the 6.0 migration with `steps.N.agent: Too 
 ### A pack ships Protocol 6.0 squads only
 
 The admission gate (`check-entity-admission.ts --pack`) treats a squad whose manifest is below Squad Protocol 6.0, or has no `protocol` at all, as a hard problem: the pack does not enter. Below 6.0 the workflow graph is a dialect every reader parses differently, and the fix is one command (`nrv migrate <slug> --to 6`), so this is never debt to record. The validator keeps reporting it as advice on an installed library, where `nrv doctor` counts the squads left to migrate.
+### The doctor's protocol census reads the whole manifest
+
+`nrv doctor` counted a squad as `unset` when its `protocol:` line came after the first 4 KB of `squad.yaml` — five library squads declare it after a long description, so a library entirely on 6.0 reported "5 below 6.0". The census now reads the whole manifest.
 
 ### `self_retrieval_miss` reports every missed brief
 

--- a/CHANGELOG.pt-BR.md
+++ b/CHANGELOG.pt-BR.md
@@ -14,6 +14,9 @@ Cinco squads da biblioteca voltavam da migração 6.0 com `steps.N.agent: Too sm
 ### Um pack só embarca squads no Protocolo 6.0
 
 O gate de admissão (`check-entity-admission.ts --pack`) trata um squad cujo manifesto está abaixo do Squad Protocol 6.0, ou sem `protocol` algum, como problema duro: o pack não entra. Abaixo de 6.0 o grafo do workflow é um dialeto que cada leitor interpreta de um jeito, e a correção é um comando (`nrv migrate <slug> --to 6`), então isso nunca é dívida a registrar. O validador continua reportando como aviso numa biblioteca instalada, onde o `nrv doctor` conta os squads que faltam migrar.
+### O censo de protocolo do doctor lê o manifesto inteiro
+
+O `nrv doctor` contava um squad como `unset` quando a linha `protocol:` vinha depois dos primeiros 4 KB do `squad.yaml` — cinco squads da biblioteca a declaram depois de uma descrição longa, então uma biblioteca inteira no 6.0 reportava "5 below 6.0". O censo agora lê o manifesto inteiro.
 
 ### `self_retrieval_miss` reporta todos os briefs que erram
 

--- a/skills/harness/scripts/doctor-system.ts
+++ b/skills/harness/scripts/doctor-system.ts
@@ -801,7 +801,9 @@ if (fs.existsSync(dnaLib)) {
 {
   const RETIRED_SEAT_FIELDS = /^(heartbeat|self_score_contract|draws_from|dna_reference|budget_monthly_usd|mentions|escalation_triggers|disclosure_template|default_tools|project_tool_overrides):/m;
   const declared = (file: string): string | null => {
-    try { return /^protocol:\s*["']?([\d.]+)/m.exec(fs.readFileSync(file, "utf8").slice(0, 4096))?.[1] ?? null; }
+    // The whole manifest: five library squads declare `protocol:` after a
+    // 4 KB description, and a window that short counted them as unset.
+    try { return /^protocol:\s*["']?([\d.]+)/m.exec(fs.readFileSync(file, "utf8"))?.[1] ?? null; }
     catch { return null; }
   };
   const dirsOf = (root: string): string[] => {

--- a/skills/harness/tests/doctor-protocol.test.ts
+++ b/skills/harness/tests/doctor-protocol.test.ts
@@ -79,6 +79,17 @@ describe("the Protocol section counts what the library declares", () => {
     expect(out.protocol["protocol: businesses"].note).toContain("no retired fields");
   }, 60_000);
 
+  test("a protocol declared after a long description still counts", () => {
+    // The census read the first 4 KB of each manifest; a squad whose
+    // `protocol:` came after its description was counted as unset.
+    const home = library({ squads: [["a", "6.0"], ["b", "6.0"]], businesses: [["biz-one", "2.0", false]] });
+    writeFileSync(join(home, "squads", "b", "squad.yaml"),
+      `name: b\nversion: 1.0.0\ndescription: >\n  ${"a long description. ".repeat(300)}\nprotocol: "6.0"\n`, "utf8");
+    const out = doctor(home);
+    expect(out.protocol["protocol: squads"].status).toBe("PASS");
+    expect(out.protocol["protocol: squads"].note).toContain("2 squads, all on 6.0");
+  }, 60_000);
+
   test("it is never a FAIL — the whole point, because CI reads exit >= 2", () => {
     const out = doctor(library({
       squads: [["a", "4.0"], ["b", null]],


### PR DESCRIPTION
## What

Re-opens #245, which was merged into the head branch of #244 instead of `main` (that branch was then deleted with #244), so the fix never reached `main`. Same commit.

`nrv doctor` counted a squad as `unset` when its `protocol:` line came after the first 4 KB of `squad.yaml`. Five library squads declare it after a long description, so a library entirely on Squad Protocol 6.0 reported "5 below 6.0". The census now reads the whole manifest.

## Verification

- `bun test skills/harness/tests/doctor-protocol.test.ts` (4 pass; new case: ~6 KB of description before `protocol: "6.0"` counts as 6.0).
- `check:quick`, `check:english`, `check:changelog` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8LuAjBntkme4U6JfPeVk